### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.github
+bin/docker/
+data.db
+storage/
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-/target
 **/*.rs.bk
-/database.json.bz2
-/database.db
 /.idea/
 /config.toml
-/data.db
+/database.db
+/database.json.bz2
+/storage/data.db
+/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM lukemathwalker/cargo-chef:latest-rust-1.62.0 AS chef
+WORKDIR /app
+
+
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin torrust-tracker
+
+
+FROM debian:bullseye-slim AS runtime
+WORKDIR /app
+
+ENV TZ=Etc/UTC \
+    APP_USER=appuser
+
+RUN groupadd $APP_USER \
+    && useradd -g $APP_USER $APP_USER \
+    && mkdir -p /app
+
+RUN chown -R $APP_USER:$APP_USER /app
+
+RUN apt-get -y update \
+  && apt-get -y upgrade \
+  && apt-get install -y sqlite3 libssl1.1
+
+EXPOSE 6969
+EXPOSE 1212
+
+COPY --from=builder /app/target/release/torrust-tracker /app
+
+USER $APP_USER
+
+ENTRYPOINT ["/app/torrust-tracker"]

--- a/bin/docker/build.sh
+++ b/bin/docker/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build -t torrust-tracker .

--- a/bin/docker/run.sh
+++ b/bin/docker/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker run --rm -it \
+    -p 6969:6969 -p 1212:1212 \
+    --volume "$(pwd)/storage":"/app/storage" \
+    --mount type=bind,source="$(pwd)/config.toml",target=/app/config.toml \
+    torrust-tracker


### PR DESCRIPTION
I've added docker configuration. In order to run it with docker you need to execute:

```s
./bin/docker/build.sh && ./bin/docker/run.sh
```

Since I do not know Rust I have followed instructions from this article https://www.lpalmieri.com/posts/fast-rust-docker-builds/ by @LukeMathWalker

I have moved the SQLite data file (`data.db`) to a new directory (`storage`) because I thought I could not mount two files in the same directory but it's possible so I can revert the change. If we want to keep the `data.db` file in the root dir we can run the docker container with:

```s
docker run --rm -it \
    -p 6969:6969 -p 1212:1212 \
    --mount type=bind,source="$(pwd)/data.db",target=/app/data.db \
    --mount type=bind,source="$(pwd)/config.toml",target=/app/config.toml \
    torrust-tracker
```

I would keep the storage folder even if we only have one file now. I think it is a good thing to make it more explicit.

Besides, I would keep in the `config.toml` file only the variables that are read-only. I mean, the variables you need to pass to the program only when you start it. For example, I would move the "Site Name" to the `storage` dir in a new file or even the database.

Other apps have these three different types of data:

- User-generated data at runtime (right now the site name belongs to this category).
- Configuration files that are read-only and included in the git repo.
- Environment variables. Values that depend on the environment. You usually use a `.env` file generated when you deploy/install de environment or env variables. The `.env` file is usually the option for development environments.

Configuration files can contain default values and can also get values from env vars if they are provided when the app starts.

What I would do:

1. Remove values from the config file that can be updated at runtime without restarting the app. We can move them to a new file or the database (eg Site Name).
2. Add the `config.toml` to the Git repo.
3. Allow using env vars in the config file.

We do not need to do those changes in order to merge this PR. And I can also ever the new `storage` folder. I do not think that's a breaking change because the `config.toml` file already allows you to change the path. People using docker would use the new default location (it can be changed anyway but you have to create your own docker "run" command).