### PR TITLE
Add some tests for configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -350,6 +350,41 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -813,6 +848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +872,7 @@ checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde 1.0.137",
 ]
 
 [[package]]
@@ -1131,7 +1173,7 @@ dependencies = [
  "subprocess",
  "thiserror",
  "time 0.2.27",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1251,6 +1293,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -1827,6 +1878,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89df7a26519371a3cce44fbb914c2819c84d9b897890987fa3ab096491cc0ea8"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde 1.0.137",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.13",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de337f322382fcdfbb21a014f7c224ee041a23785651db67b9827403178f698f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1992,6 +2071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subprocess"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2179,18 @@ dependencies = [
  "time-macros",
  "version_check",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde 1.0.137",
 ]
 
 [[package]]
@@ -2259,9 +2356,11 @@ dependencies = [
  "serde 1.0.137",
  "serde_bencode",
  "serde_json",
+ "serde_with",
  "thiserror",
  "tokio",
  "toml",
+ "uuid 1.1.2",
  "warp",
 ]
 
@@ -2420,6 +2519,15 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.7", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_bencode = "^0.2.3"
 serde_json = "1.0.72"
+serde_with = "2.0.0"
 hex = "0.4.3"
 percent-encoding = "2.1.0"
 binascii = "0.1"
@@ -48,3 +49,4 @@ futures = "0.3.21"
 async-trait = "0.1.52"
 
 aquatic_udp_protocol = "0.2.0"
+uuid = { version = "1.1.2", features = ["v4"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,9 +107,7 @@ impl Configuration {
             }
         }
     }
-}
 
-impl Configuration {
     pub fn default() -> Configuration {
         let mut configuration = Configuration {
             log_level: Option::from(String::from("info")),

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,26 @@ mod tests {
     }
 
     #[test]
+    fn configuration_should_have_default_values() {
+        use crate::Configuration;
+
+        let configuration = Configuration::default();
+
+        let toml = toml::to_string(&configuration).expect("Could not encode TOML value");
+
+        assert_eq!(toml, default_config_toml());
+    }
+
+    #[test]
+    fn configuration_should_contain_the_external_ip() {
+        use crate::Configuration;
+
+        let configuration = Configuration::default();
+
+        assert_eq!(configuration.external_ip, Option::Some(String::from("0.0.0.0")));
+    }
+
+    #[test]
     fn configuration_should_be_saved_in_a_toml_config_file() {
         use std::env;
         use crate::Configuration;
@@ -252,5 +272,14 @@ mod tests {
         let configuration = Configuration::load_from_file(&config_file_path).expect("Could not load configuration from file");
 
         assert_eq!(configuration, Configuration::default());
+    }
+
+    #[test]
+    fn configuration_error_could_be_displayed() {
+        use crate::ConfigurationError;
+
+        let error = ConfigurationError::TrackerModeIncompatible;
+
+        assert_eq!(format!("{}", error), "TrackerModeIncompatible");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -176,7 +176,8 @@ impl Configuration {
     }
 }
 
-mod configuration {
+#[cfg(test)]
+mod tests {
 
     #[cfg(test)]
     fn default_config_toml() -> String {
@@ -216,7 +217,7 @@ mod configuration {
     }
 
     #[test]
-    fn should_have_a_default_value_for_the_log_level() {
+    fn configuration_should_have_a_default_value_for_the_log_level() {
         use crate::Configuration;
 
         let configuration = Configuration::default();
@@ -225,7 +226,7 @@ mod configuration {
     }
 
     #[test]
-    fn should_be_saved_in_a_toml_config_file() {
+    fn configuration_should_be_saved_in_a_toml_config_file() {
         use std::env;
         use crate::Configuration;
         use std::fs;
@@ -271,7 +272,7 @@ mod configuration {
     }
 
     #[test]
-    fn should_be_loaded_from_a_toml_config_file() {
+    fn configuration_should_be_loaded_from_a_toml_config_file() {
         use crate::Configuration;
 
         let config_file_path = create_temp_config_file_with_default_config();

--- a/src/config.rs
+++ b/src/config.rs
@@ -217,15 +217,6 @@ mod tests {
     }
 
     #[test]
-    fn configuration_should_have_a_default_value_for_the_log_level() {
-        use crate::Configuration;
-
-        let configuration = Configuration::default();
-
-        assert_eq!(configuration.log_level, Option::from(String::from("info")), "Expected default log level to be: {:?}, got {:?}", Option::from(String::from("info")), configuration.log_level);
-    }
-
-    #[test]
     fn configuration_should_be_saved_in_a_toml_config_file() {
         use std::env;
         use crate::Configuration;

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,23 +78,6 @@ impl std::fmt::Display for ConfigurationError {
 impl std::error::Error for ConfigurationError {}
 
 impl Configuration {
-    pub fn load(data: &[u8]) -> Result<Configuration, toml::de::Error> {
-        toml::from_slice(data)
-    }
-
-    pub fn load_file(path: &str) -> Result<Configuration, ConfigurationError> {
-        match std::fs::read(path) {
-            Err(e) => Err(ConfigurationError::IOError(e)),
-            Ok(data) => {
-                match Self::load(data.as_slice()) {
-                    Ok(cfg) => {
-                        Ok(cfg)
-                    }
-                    Err(e) => Err(ConfigurationError::ParseError(e)),
-                }
-            }
-        }
-    }
 
     pub fn get_ext_ip(&self) -> Option<IpAddr> {
         match &self.external_ip {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,37 +6,39 @@ use std::path::Path;
 use std::str::FromStr;
 
 use config::{Config, ConfigError, File};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, NoneAsEmptyString};
 use toml;
 
 use crate::databases::database::DatabaseDrivers;
 use crate::mode::TrackerMode;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct UdpTrackerConfig {
     pub enabled: bool,
     pub bind_address: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct HttpTrackerConfig {
     pub enabled: bool,
     pub bind_address: String,
     pub ssl_enabled: bool,
-    #[serde(serialize_with = "none_as_empty_string")]
+    #[serde_as(as = "NoneAsEmptyString")]
     pub ssl_cert_path: Option<String>,
-    #[serde(serialize_with = "none_as_empty_string")]
+    #[serde_as(as = "NoneAsEmptyString")]
     pub ssl_key_path: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct HttpApiConfig {
     pub enabled: bool,
     pub bind_address: String,
     pub access_tokens: HashMap<String, String>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct Configuration {
     pub log_level: Option<String>,
     pub mode: TrackerMode,
@@ -74,18 +76,6 @@ impl std::fmt::Display for ConfigurationError {
 }
 
 impl std::error::Error for ConfigurationError {}
-
-pub fn none_as_empty_string<T, S>(option: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        T: Serialize,
-        S: Serializer,
-{
-    if let Some(value) = option {
-        value.serialize(serializer)
-    } else {
-        "".serialize(serializer)
-    }
-}
 
 impl Configuration {
     pub fn load(data: &[u8]) -> Result<Configuration, toml::de::Error> {
@@ -161,18 +151,16 @@ impl Configuration {
         configuration
     }
 
-    pub fn load_from_file() -> Result<Configuration, ConfigError> {
+    pub fn load_from_file(path: &str) -> Result<Configuration, ConfigError> {
         let mut config = Config::new();
 
-        const CONFIG_PATH: &str = "config.toml";
-
-        if Path::new(CONFIG_PATH).exists() {
-            config.merge(File::with_name(CONFIG_PATH))?;
+        if Path::new(path).exists() {
+            config.merge(File::with_name(path))?;
         } else {
             eprintln!("No config file found.");
             eprintln!("Creating config file..");
             let config = Configuration::default();
-            let _ = config.save_to_file();
+            let _ = config.save_to_file(path);
             return Err(ConfigError::Message(format!("Please edit the config.TOML in the root folder and restart the tracker.")));
         }
 
@@ -181,9 +169,115 @@ impl Configuration {
         Ok(torrust_config)
     }
 
-    pub fn save_to_file(&self) -> Result<(), ()> {
+    pub fn save_to_file(&self, path: &str) -> Result<(), ()> {
         let toml_string = toml::to_string(self).expect("Could not encode TOML value");
-        fs::write("config.toml", toml_string).expect("Could not write to file!");
+        fs::write(path, toml_string).expect("Could not write to file!");
         Ok(())
+    }
+}
+
+mod configuration {
+
+    #[cfg(test)]
+    fn default_config_toml() -> String {
+        let config = r#"log_level = "info"
+                                mode = "public"
+                                db_driver = "Sqlite3"
+                                db_path = "data.db"
+                                announce_interval = 120
+                                min_announce_interval = 120
+                                max_peer_timeout = 900
+                                on_reverse_proxy = false
+                                external_ip = "0.0.0.0"
+                                tracker_usage_statistics = true
+                                persistent_torrent_completed_stat = false
+                                inactive_peer_cleanup_interval = 600
+                                remove_peerless_torrents = true
+
+                                [[udp_trackers]]
+                                enabled = false
+                                bind_address = "0.0.0.0:6969"
+
+                                [[http_trackers]]
+                                enabled = false
+                                bind_address = "0.0.0.0:6969"
+                                ssl_enabled = false
+                                ssl_cert_path = ""
+                                ssl_key_path = ""
+
+                                [http_api]
+                                enabled = true
+                                bind_address = "127.0.0.1:1212"
+
+                                [http_api.access_tokens]
+                                admin = "MyAccessToken"
+        "#.lines().map(|line| line.trim_start()).collect::<Vec<&str>>().join("\n");
+        config
+    }
+
+    #[test]
+    fn should_have_a_default_value_for_the_log_level() {
+        use crate::Configuration;
+
+        let configuration = Configuration::default();
+
+        assert_eq!(configuration.log_level, Option::from(String::from("info")), "Expected default log level to be: {:?}, got {:?}", Option::from(String::from("info")), configuration.log_level);
+    }
+
+    #[test]
+    fn should_be_saved_in_a_toml_config_file() {
+        use std::env;
+        use crate::Configuration;
+        use std::fs;
+        use uuid::Uuid;
+
+        // Build temp config file path
+        let temp_directory = env::temp_dir();
+        let temp_file = temp_directory.join(format!("test_config_{}.toml", Uuid::new_v4()));
+
+        // Convert to argument type for Configuration::save_to_file
+        let config_file_path = temp_file.clone();
+        let path = config_file_path.to_string_lossy().to_string();
+
+        let default_configuration = Configuration::default();
+
+        default_configuration.save_to_file(&path).expect("Could not save configuration to file");
+
+        let contents = fs::read_to_string(&path).expect("Something went wrong reading the file");
+
+        assert_eq!(contents, default_config_toml());
+    }
+
+    #[cfg(test)]
+    fn create_temp_config_file_with_default_config()-> String {
+        use std::env;
+        use std::fs::File;
+        use std::io::Write;
+        use uuid::Uuid;
+
+        // Build temp config file path
+        let temp_directory = env::temp_dir();
+        let temp_file = temp_directory.join(format!("test_config_{}.toml", Uuid::new_v4()));
+        
+        // Convert to argument type for Configuration::load_from_file
+        let config_file_path = temp_file.clone();
+        let path = config_file_path.to_string_lossy().to_string();
+
+        // Write file contents
+        let mut file = File::create(temp_file).unwrap();
+        writeln!(&mut file, "{}", default_config_toml()).unwrap();
+
+        path
+    }
+
+    #[test]
+    fn should_be_loaded_from_a_toml_config_file() {
+        use crate::Configuration;
+
+        let config_file_path = create_temp_config_file_with_default_config();
+
+        let configuration = Configuration::load_from_file(&config_file_path).expect("Could not load configuration from file");
+
+        assert_eq!(configuration, Configuration::default());
     }
 }

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -7,7 +7,7 @@ use crate::tracker::key::AuthKey;
 use crate::databases::mysql::MysqlDatabase;
 use crate::databases::sqlite::SqliteDatabase;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub enum DatabaseDrivers {
     Sqlite3,
     MySQL,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,10 @@ use torrust_tracker::tracker::tracker::TorrentTracker;
 
 #[tokio::main]
 async fn main() {
+    const CONFIG_PATH: &str = "config.toml";
+
     // Initialize Torrust config
-    let config = match Configuration::load_from_file() {
+    let config = match Configuration::load_from_file(CONFIG_PATH) {
         Ok(config) => Arc::new(config),
         Err(error) => {
             panic!("{}", error)


### PR DESCRIPTION
Hi @WarmBeer I have added some tests for the configuration.

### New dependencies

- `uuid`. I needed to create a unique id for a temporary config file like this `test_config_231863df-a1d5-4dfc-a2a9-a8b054c0b8cf.toml`.
- `serde_with`. For the `HttpTrackerConfig`, you are using a custom serializer, but the deserialization is not working. The config options `ssl_cert_path = ""` and `ssl_key_path = ""` are being deserialized like `Some("")` instead of `None`.

### Tests

- For now I have only added a few tests for saving and loading the configuration to and from the `config.toml` file.

### Changes

- I had to add some new attributes to some struts (PartialEq, Debug) to compare two configurations.
- I had to change the signature of two methods: `save_to_file` and `load_from_file`, to make those methods testable. I need to create the config file in a temporary file.

### Questions

1. I've added a tests for check default values only for one option (`should_have_a_default_value_for_the_log_level`). Do you think we should add one for each option or one test for all options, or maybe it does not makes sense to test default values directly?

2. Why are there to `impl Configuration` blocks?

3. I choose those test names in order to get this output when you execute them:

```s
 cargo nextest run
   Compiling torrust-tracker v2.3.0 (/home/josecelano/Documents/github/committer/josecelano/torrust/torrust-tracker)
    Finished test [optimized + debuginfo] target(s) in 12.91s
  Executable unittests src/lib.rs (target/debug/deps/torrust_tracker-d1fbcd787d97cc63)
  Executable unittests src/main.rs (target/debug/deps/torrust_tracker-8d19522d4b2f8cf0)
    Starting 7 tests across 2 binaries
        PASS [   0.002s] torrust-tracker config::configuration::should_be_loaded_from_a_config_file
        PASS [   0.002s] torrust-tracker config::configuration::should_be_saved_in_a_toml_config_file
        PASS [   0.002s] torrust-tracker tracker::key::tests::auth_key_from_buffer
        PASS [   0.002s] torrust-tracker tracker::key::tests::auth_key_from_string
        PASS [   0.002s] torrust-tracker tracker::key::tests::generate_expired_auth_key
        PASS [   0.002s] torrust-tracker config::configuration::should_have_a_default_value_for_the_log_level
        PASS [   0.002s] torrust-tracker tracker::key::tests::generate_valid_auth_key
------------
     Summary [   0.004s] 7 tests run: 7 passed, 0 skipped
```

You read the lines like this: `config::configuration::should_be_loaded_from_a_config_file`

I will add some more tests.