### PR TITLE
Memory consumption benchmark for connection ID generation (UDP tracker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+
+[[package]]
 name = "funty"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1100,27 @@ name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.1+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2b313609b95939cb0c5a5c6917fb9b7c9394562aa3ef44eb66ffa51736432"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2618,6 +2645,9 @@ dependencies = [
  "fern",
  "futures",
  "hex",
+ "jemalloc-sys",
+ "jemallocator",
+ "libc",
  "log",
  "openssl",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,8 @@ async-trait = "0.1.52"
 aquatic_udp_protocol = "0.2.0"
 uuid = { version = "1.1.2", features = ["v4"] }
 arraytools = "0.1.5"
+
+# Dependencies for memory consumption benchmark
+jemallocator = "0.5"
+jemalloc-sys = {version = "0.5", features = ["stats"]}
+libc = "0.2"

--- a/src/bin/conn_id_benchmark.rs
+++ b/src/bin/conn_id_benchmark.rs
@@ -1,0 +1,83 @@
+use libc::{c_char, c_void};
+use torrust_tracker::udp::byte_array_32::ByteArray32;
+use torrust_tracker::udp::connection_id::get_connection_id;
+use std::ptr::{null, null_mut};
+use std::net::{SocketAddr, IpAddr, Ipv4Addr};
+
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
+extern "C" fn write_cb(_: *mut c_void, message: *const c_char) {
+    print!("{}", String::from_utf8_lossy(unsafe {
+        std::ffi::CStr::from_ptr(message as *const i8).to_bytes()
+    }));
+}
+
+fn mem_print() {
+    unsafe { jemalloc_sys::malloc_stats_print(Some(write_cb), null_mut(), null()) }
+}
+
+/// Test function to locate the result in the output
+fn test_function() {
+    let _heap = Vec::<u8>::with_capacity (1024 * 128); // 131072 bytes
+    mem_print();
+}
+
+const SALT: &str = "SALT";
+
+/// First implementation by @WarmBeer
+fn test_old_get_connection_id(remote_address: &SocketAddr, time_as_seconds: u64) -> i64 {
+    let peer_ip_as_bytes = match remote_address.ip() {
+        IpAddr::V4(ip) => ip.octets().to_vec(),
+        IpAddr::V6(ip) => ip.octets().to_vec(),
+    };
+
+    let input: Vec<u8> = [
+        (time_as_seconds / 120).to_be_bytes().as_slice(),
+        peer_ip_as_bytes.as_slice(),
+        remote_address.port().to_be_bytes().as_slice(),
+        SALT.as_bytes()
+    ].concat();
+
+    let hash = blake3::hash(&input);
+
+    let mut truncated_hash: [u8; 8] = [0u8; 8];
+
+    truncated_hash.copy_from_slice(&hash.as_bytes()[..8]);
+
+    let connection_id = i64::from_le_bytes(truncated_hash);
+
+    mem_print();
+
+    connection_id
+}
+
+/// New implementation by @josecelano
+fn test_new_implementation() {
+    let server_secret = ByteArray32::new([0u8;32]);
+
+    let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+    let now_as_timestamp = 946684800u64; // GMT/UTC date and time is: 01-01-2000 00:00:00
+
+    let _connection_id = get_connection_id(&server_secret, &client_addr, now_as_timestamp);
+
+    mem_print();
+}
+
+/// cargo run --bin conn_id_benchmark -q
+fn main() {
+
+    // Total allocated: 99808 bytes
+    mem_print();
+    
+    // Total allocated: 230880 bytes
+    test_function();
+
+    // Total allocated: 103008 bytes
+    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    test_old_get_connection_id(&address, 0);
+
+    // Total allocated: 107104 bytes
+    test_new_implementation()
+}

--- a/src/bin/conn_id_benchmark.rs
+++ b/src/bin/conn_id_benchmark.rs
@@ -19,6 +19,7 @@ fn mem_print() {
 
 /// Test function to locate the result in the output
 fn test_function() {
+    mem_print();
     let _heap = Vec::<u8>::with_capacity (1024 * 128); // 131072 bytes
     mem_print();
 }
@@ -27,6 +28,8 @@ const SALT: &str = "SALT";
 
 /// First implementation by @WarmBeer
 fn test_old_get_connection_id(remote_address: &SocketAddr, time_as_seconds: u64) -> i64 {
+    mem_print();
+
     let peer_ip_as_bytes = match remote_address.ip() {
         IpAddr::V4(ip) => ip.octets().to_vec(),
         IpAddr::V6(ip) => ip.octets().to_vec(),
@@ -54,6 +57,8 @@ fn test_old_get_connection_id(remote_address: &SocketAddr, time_as_seconds: u64)
 
 /// New implementation by @josecelano
 fn test_new_implementation() {
+    mem_print();
+
     let server_secret = ByteArray32::new([0u8;32]);
 
     let client_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
@@ -67,17 +72,13 @@ fn test_new_implementation() {
 
 /// cargo run --bin conn_id_benchmark -q
 fn main() {
-
-    // Total allocated: 99808 bytes
-    mem_print();
-    
-    // Total allocated: 230880 bytes
+    // Total allocated: 241120 - 99808 = 141312 bytes
     test_function();
 
-    // Total allocated: 103008 bytes
+    // Total allocated: 113248 - 99808 = 13440 bytes
     let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
     test_old_get_connection_id(&address, 0);
 
-    // Total allocated: 107104 bytes
+    // Total allocated: 117344 - 99808 = 17536 bytes
     test_new_implementation()
 }


### PR DESCRIPTION
As we were discussing [here](https://github.com/torrust/torrust-tracker/pull/60#issuecomment-1219383694) we want to know if the new function to generate the connection ID (UDP tracker) consumes more memory (which leads to less request per second).

Following this [example](https://stackoverflow.com/a/30983834/3012842), I've created a new binary to get the memory consumption.

You have to run the binary with:

```s
cargo run --bin conn_id_benchmark -q
```

You have to comment all the tests except the sample you want to run:

```rust
/// cargo run --bin conn_id_benchmark -q
fn main() {

    // Total allocated: 99808 bytes
    mem_print();
    
    // Total allocated: 230880 bytes
    test_function();

    // Total allocated: 103008 bytes
    let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
    test_old_get_connection_id(&address, 0);

    // Total allocated: 107104 bytes
    test_new_implementation()
}
```

The output is very big but I suppose the total memory allocated is this line:

```s
                            allocated         nmalloc   (#/sec)         ndalloc   (#/sec)       nrequests   (#/sec)           nfill   (#/sec)          nflush   (#/sec)
small:                          12896             364         0               0         0               0         0               4         0               0         0
large:                          94208               2         0               0         0               2         0               2         0               0         0
total:                         107104             366         0               0         0               2         0               6         0               0         0
```

The new implementation uses 4096 bytes (107104-103008) more than the previous one. We should check if that is what we need for each function call. It seems like a maximum memory block (4K), so it probably consumes less memory.

I've printed the result before returning the function, but even then, most of the memory used by the function could already be released.

I suppose I have to calculate the total consumed only by the function in order to know how much will decrease the number of requests we could handle per second with a certain amount of RAM.

