### PR TITLE
refactor: move clock/clock.rs into clock.rs (clippy)

### DIFF
--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -7,7 +7,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 
 use crate::databases::database;
 use crate::databases::database::{Database, Error};
-use crate::protocol::clock::clock::DurationSinceUnixEpoch;
+use crate::protocol::clock::DurationSinceUnixEpoch;
 use crate::tracker::key::AuthKey;
 use crate::InfoHash;
 

--- a/src/protocol/clock.rs
+++ b/src/protocol/clock.rs
@@ -38,7 +38,7 @@ pub trait TimeNow: Time {
 mod tests {
     use std::any::TypeId;
 
-    use crate::protocol::clock::clock::{DefaultClock, StoppedClock, Time, WorkingClock};
+    use crate::protocol::clock::{DefaultClock, StoppedClock, Time, WorkingClock};
 
     #[test]
     fn it_should_be_the_stopped_clock_as_default_when_testing() {
@@ -147,7 +147,7 @@ mod stopped_clock {
         use std::thread;
         use std::time::Duration;
 
-        use crate::protocol::clock::clock::{DurationSinceUnixEpoch, StoppedClock, StoppedTime, Time, TimeNow, WorkingClock};
+        use crate::protocol::clock::{DurationSinceUnixEpoch, StoppedClock, StoppedTime, Time, TimeNow, WorkingClock};
 
         #[test]
         fn it_should_default_to_zero_when_testing() {
@@ -206,7 +206,7 @@ mod stopped_clock {
         use std::cell::RefCell;
         use std::time::SystemTime;
 
-        use crate::protocol::clock::clock::DurationSinceUnixEpoch;
+        use crate::protocol::clock::DurationSinceUnixEpoch;
         use crate::static_time;
 
         pub fn get_app_start_time() -> DurationSinceUnixEpoch {
@@ -231,7 +231,7 @@ mod stopped_clock {
         mod tests {
             use std::time::Duration;
 
-            use crate::protocol::clock::clock::stopped_clock::detail::{get_app_start_time, get_default_fixed_time};
+            use crate::protocol::clock::stopped_clock::detail::{get_app_start_time, get_default_fixed_time};
 
             #[test]
             fn it_should_get_the_zero_start_time_when_testing() {

--- a/src/protocol/clock/mod.rs
+++ b/src/protocol/clock/mod.rs
@@ -1,1 +1,0 @@
-pub mod clock;

--- a/src/protocol/utils.rs
+++ b/src/protocol/utils.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 
 use aquatic_udp_protocol::ConnectionId;
 
-use super::clock::clock::{DefaultClock, DurationSinceUnixEpoch, Time};
+use super::clock::{DefaultClock, DurationSinceUnixEpoch, Time};
 
 pub fn get_connection_id(remote_address: &SocketAddr) -> ConnectionId {
     ConnectionId(((current_time() / 3600) | ((remote_address.port() as u64) << 36)) as i64)

--- a/src/tracker/key.rs
+++ b/src/tracker/key.rs
@@ -6,7 +6,7 @@ use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};
 use serde::Serialize;
 
-use crate::protocol::clock::clock::{DefaultClock, DurationSinceUnixEpoch, Time, TimeNow};
+use crate::protocol::clock::{DefaultClock, DurationSinceUnixEpoch, Time, TimeNow};
 use crate::AUTH_KEY_LENGTH;
 
 pub fn generate_auth_key(lifetime: Duration) -> AuthKey {
@@ -85,7 +85,7 @@ impl From<r2d2_sqlite::rusqlite::Error> for Error {
 mod tests {
     use std::time::Duration;
 
-    use crate::protocol::clock::clock::{DefaultClock, StoppedTime};
+    use crate::protocol::clock::{DefaultClock, StoppedTime};
     use crate::tracker::key;
 
     #[test]

--- a/src/tracker/peer.rs
+++ b/src/tracker/peer.rs
@@ -5,10 +5,9 @@ use serde;
 use serde::Serialize;
 
 use crate::http::AnnounceRequest;
-use crate::protocol::clock::clock::{DefaultClock, DurationSinceUnixEpoch, Time};
-use crate::protocol::common::{AnnounceEventDef, NumberOfBytesDef};
+use crate::protocol::clock::{DefaultClock, DurationSinceUnixEpoch, Time};
+use crate::protocol::common::{AnnounceEventDef, NumberOfBytesDef, PeerId};
 use crate::protocol::utils::ser_unix_time_value;
-use crate::PeerId;
 
 #[derive(PartialEq, Eq, Debug, Clone, Serialize)]
 pub struct TorrentPeer {

--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -5,7 +5,7 @@ use aquatic_udp_protocol::AnnounceEvent;
 use serde::{Deserialize, Serialize};
 
 use crate::peer::TorrentPeer;
-use crate::protocol::clock::clock::{DefaultClock, TimeNow};
+use crate::protocol::clock::{DefaultClock, TimeNow};
 use crate::{PeerId, MAX_SCRAPE_TORRENTS};
 
 #[derive(Serialize, Deserialize, Clone)]


### PR DESCRIPTION
Fix the clippy warning that the module has the same name as it's directory. Will recreate the folder when needed by the interval counter, i.e. #83 