### PR TITLE
Add tests for `udp::handlers:handle_scrape`

### DIFF
--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -8,7 +8,7 @@ use crate::peer::TorrentPeer;
 use crate::protocol::clock::clock::{DefaultClock, TimeNow};
 use crate::{PeerId, MAX_SCRAPE_TORRENTS};
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TorrentEntry {
     #[serde(skip)]
     pub peers: std::collections::BTreeMap<PeerId, TorrentPeer>,

--- a/src/tracker/tracker.rs
+++ b/src/tracker/tracker.rs
@@ -90,9 +90,18 @@ impl TorrentTracker {
 
     // Adding torrents is not relevant to public trackers.
     pub async fn add_torrent_to_whitelist(&self, info_hash: &InfoHash) -> Result<(), database::Error> {
-        self.database.add_info_hash_to_whitelist(info_hash.clone()).await?;
-        self.whitelist.write().await.insert(info_hash.clone());
+        self.add_torrent_to_database_whitelist(info_hash).await?;
+        self.add_torrent_to_memory_whitelist(info_hash).await;
         Ok(())
+    }
+
+    async fn add_torrent_to_database_whitelist(&self, info_hash: &InfoHash) -> Result<(), database::Error> {
+        self.database.add_info_hash_to_whitelist(*info_hash).await?;
+        Ok(())
+    }
+
+    pub async fn add_torrent_to_memory_whitelist(&self, info_hash: &InfoHash) -> bool {
+        self.whitelist.write().await.insert(*info_hash)
     }
 
     // Removing torrents is not relevant to public trackers.


### PR DESCRIPTION
Depends on: https://github.com/torrust/torrust-tracker/pull/91

It adds tests for `udp::handlers:handle_scrape`.