### PR TITLE
Fix vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
         "typenum"
     ],
     "[rust]": {
-        "editor.defaultFormatter": "matklad.rust-analyzer",
         "editor.formatOnSave": true
     },
     "rust-analyzer.checkOnSave.command": "clippy",


### PR DESCRIPTION
The VSCode settings added on [PR 80](https://github.com/torrust/torrust-tracker/pull/80) are not working for me:

```
"[rust]": {
    "editor.defaultFormatter": "matklad.rust-analyzer",
    "editor.formatOnSave": true
},
```

@da2ce7 edit. Now removed the line.

```
"[rust]": {
    "editor.formatOnSave": true
},
```