### PR TITLE
refactor: run tests with own udp tracker

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -18,6 +18,8 @@ pub fn setup_logging(cfg: &Configuration) {
         },
     };
 
+    if log_level == log::LevelFilter::Off { return; }
+
     if let Err(_err) = fern::Dispatch::new()
         .format(|out, message, record| {
             out.finish(format_args!(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -18,7 +18,9 @@ pub fn setup_logging(cfg: &Configuration) {
         },
     };
 
-    if log_level == log::LevelFilter::Off { return; }
+    if log_level == log::LevelFilter::Off {
+        return;
+    }
 
     if let Err(_err) = fern::Dispatch::new()
         .format(|out, message, record| {

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,13 +1,12 @@
 /// Integration tests for UDP tracker server
 ///
 /// cargo test udp_tracker_server -- --nocapture
-
 extern crate rand;
 
 mod udp_tracker_server {
     use core::panic;
     use std::io::Cursor;
-    use std::net::{Ipv4Addr};
+    use std::net::Ipv4Addr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
@@ -37,7 +36,7 @@ mod udp_tracker_server {
     pub struct UdpServer {
         pub started: AtomicBool,
         pub job: Option<JoinHandle<()>>,
-        pub bind_address: Option<String>
+        pub bind_address: Option<String>,
     }
 
     impl UdpServer {
@@ -45,7 +44,7 @@ mod udp_tracker_server {
             Self {
                 started: AtomicBool::new(false),
                 job: None,
-                bind_address: None
+                bind_address: None,
             }
         }
 


### PR DESCRIPTION
All tests will start their own udp tracker on an ephemeral port instead of using a singleton tracker.