### PR TITLE
Use nightly toolchain for formatting

### DIFF
--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -13,11 +13,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          components: rustfmt
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
       - name: Check Rust Formatting
-        run: cargo fmt --check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --check
 
   test:
     needs: format


### PR DESCRIPTION
@da2ce7 started using the nightly build for rust formatting in this [PR-99](https://github.com/torrust/torrust-tracker/pull/99)

And the job 'format' in the workflow [did not work](https://github.com/torrust/torrust-tracker/actions/runs/3273393423/jobs/5385541084#step:5:9), showing these warnings:

```
Warning: can't set `imports_granularity = Module`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Module`, unstable features are only available in nightly channel.
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
```

So we needed the nightly channel anyway. I've changed the workflow to use it.