### PR TITLE
Refactor `StatsTracker`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +515,12 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
@@ -571,6 +583,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +620,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frunk"
@@ -1009,6 +1036,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1245,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "multipart"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1411,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -1625,6 +1694,36 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2286,6 +2385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2509,6 +2614,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log",
+ "mockall",
  "openssl",
  "percent-encoding",
  "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,6 @@ async-trait = "0.1"
 
 aquatic_udp_protocol = "0.2"
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+mockall = "0.11.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,4 +61,4 @@ aquatic_udp_protocol = "0.2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
-mockall = "0.11.3"
+mockall = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod jobs;
 pub mod logging;
 pub mod protocol;
 pub mod setup;
+pub mod stats;
 pub mod tracker;
 pub mod udp;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,10 @@ async fn main() {
     };
 
     // Initialize statistics
-    let (stats_tracker, stats_event_sender) = setup_statistics(config.tracker_usage_statistics);
+    let (stats_event_sender, stats_repository) = setup_statistics(config.tracker_usage_statistics);
 
     // Initialize Torrust tracker
-    let tracker = match TorrentTracker::new(config.clone(), Box::new(stats_tracker), stats_event_sender) {
+    let tracker = match TorrentTracker::new(config.clone(), stats_event_sender, stats_repository) {
         Ok(tracker) => Arc::new(tracker),
         Err(error) => {
             panic!("{}", error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,10 +24,16 @@ async fn main() {
     };
 
     // Initialize stats tracker
-    let stats_tracker = StatsTracker::new_instance(config.tracker_usage_statistics);
+    let mut stats_tracker = StatsTracker::new_inactive_instance();
+
+    let mut stats_event_sender = None;
+
+    if config.tracker_usage_statistics {
+        stats_event_sender = Some(stats_tracker.run_worker());
+    }
 
     // Initialize Torrust tracker
-    let tracker = match TorrentTracker::new(config.clone(), Box::new(stats_tracker)) {
+    let tracker = match TorrentTracker::new(config.clone(), Box::new(stats_tracker), stats_event_sender) {
         Ok(tracker) => Arc::new(tracker),
         Err(error) => {
             panic!("{}", error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use log::info;
-use torrust_tracker::tracker::statistics::StatsTracker;
+use torrust_tracker::stats::setup_statistics;
 use torrust_tracker::tracker::tracker::TorrentTracker;
 use torrust_tracker::{ephemeral_instance_keys, logging, setup, static_time, Configuration};
 
@@ -23,14 +23,8 @@ async fn main() {
         }
     };
 
-    // Initialize stats tracker
-    let mut stats_tracker = StatsTracker::new_inactive_instance();
-
-    let mut stats_event_sender = None;
-
-    if config.tracker_usage_statistics {
-        stats_event_sender = Some(stats_tracker.run_worker());
-    }
+    // Initialize statistics:wq
+    let (stats_tracker, stats_event_sender) = setup_statistics(config.tracker_usage_statistics);
 
     // Initialize Torrust tracker
     let tracker = match TorrentTracker::new(config.clone(), Box::new(stats_tracker), stats_event_sender) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ async fn main() {
         }
     };
 
-    // Initialize statistics:wq
+    // Initialize statistics
     let (stats_tracker, stats_event_sender) = setup_statistics(config.tracker_usage_statistics);
 
     // Initialize Torrust tracker

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,36 @@
+use crate::statistics::{StatsTracker, TrackerStatisticsEventSender};
+
+pub fn setup_statistics(tracker_usage_statistics: bool) -> (StatsTracker, Option<Box<dyn TrackerStatisticsEventSender>>) {
+    let mut stats_tracker = StatsTracker::new_inactive_instance();
+
+    let mut stats_event_sender = None;
+
+    if tracker_usage_statistics {
+        stats_event_sender = Some(stats_tracker.run_worker());
+    }
+
+    (stats_tracker, stats_event_sender)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::stats::setup_statistics;
+
+    #[tokio::test]
+    async fn should_not_send_any_event_when_statistics_are_disabled() {
+        let tracker_usage_statistics = false;
+
+        let (_stats_tracker, stats_event_sender) = setup_statistics(tracker_usage_statistics);
+
+        assert!(stats_event_sender.is_none());
+    }
+
+    #[tokio::test]
+    async fn should_send_events_when_statistics_are_enabled() {
+        let tracker_usage_statistics = true;
+
+        let (_stats_tracker, stats_event_sender) = setup_statistics(tracker_usage_statistics);
+
+        assert!(stats_event_sender.is_some());
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,15 +1,15 @@
-use crate::statistics::{StatsTracker, TrackerStatisticsEventSender};
+use crate::statistics::{StatsRepository, StatsTracker, TrackerStatisticsEventSender};
 
-pub fn setup_statistics(tracker_usage_statistics: bool) -> (StatsTracker, Option<Box<dyn TrackerStatisticsEventSender>>) {
-    let mut stats_tracker = StatsTracker::new_inactive_instance();
-
+pub fn setup_statistics(tracker_usage_statistics: bool) -> (Option<Box<dyn TrackerStatisticsEventSender>>, StatsRepository) {
     let mut stats_event_sender = None;
 
+    let mut stats_tracker = StatsTracker::new();
+
     if tracker_usage_statistics {
-        stats_event_sender = Some(stats_tracker.run_worker());
+        stats_event_sender = Some(stats_tracker.run_event_listener());
     }
 
-    (stats_tracker, stats_event_sender)
+    (stats_event_sender, stats_tracker.stats_repository)
 }
 
 #[cfg(test)]
@@ -20,7 +20,7 @@ mod test {
     async fn should_not_send_any_event_when_statistics_are_disabled() {
         let tracker_usage_statistics = false;
 
-        let (_stats_tracker, stats_event_sender) = setup_statistics(tracker_usage_statistics);
+        let (stats_event_sender, _stats_repository) = setup_statistics(tracker_usage_statistics);
 
         assert!(stats_event_sender.is_none());
     }
@@ -29,7 +29,7 @@ mod test {
     async fn should_send_events_when_statistics_are_enabled() {
         let tracker_usage_statistics = true;
 
-        let (_stats_tracker, stats_event_sender) = setup_statistics(tracker_usage_statistics);
+        let (stats_event_sender, _stats_repository) = setup_statistics(tracker_usage_statistics);
 
         assert!(stats_event_sender.is_some());
     }

--- a/src/tracker/statistics.rs
+++ b/src/tracker/statistics.rs
@@ -270,6 +270,30 @@ impl StatsRepository {
 #[cfg(test)]
 mod tests {
 
+    mod stats_tracker {
+        use crate::statistics::{StatsTracker, TrackerStatistics, TrackerStatisticsEvent};
+
+        #[tokio::test]
+        async fn should_contain_the_tracker_statistics() {
+            let stats_tracker = StatsTracker::new();
+
+            let stats = stats_tracker.stats_repository.get_stats().await;
+
+            assert_eq!(stats.tcp4_announces_handled, TrackerStatistics::new().tcp4_announces_handled);
+        }
+
+        #[tokio::test]
+        async fn should_create_an_event_sender_to_send_statistical_events() {
+            let mut stats_tracker = StatsTracker::new();
+
+            let event_sender = stats_tracker.run_event_listener();
+
+            let result = event_sender.send_event(TrackerStatisticsEvent::Udp4Connect).await;
+
+            assert!(result.is_some());
+        }
+    }
+
     mod event_handler {
         use crate::statistics::{event_handler, StatsRepository, TrackerStatisticsEvent};
 

--- a/src/tracker/statistics.rs
+++ b/src/tracker/statistics.rs
@@ -62,7 +62,7 @@ pub struct StatsTracker {
 }
 
 impl StatsTracker {
-    pub fn new_active_instance() -> (Self, StatsEventSender) {
+    pub fn new_active_instance() -> (Self, Box<dyn TrackerStatisticsEventSender>) {
         let mut stats_tracker = Self {
             channel_sender: None,
             stats: Arc::new(RwLock::new(TrackerStatistics::new())),
@@ -97,7 +97,7 @@ impl StatsTracker {
         }
     }
 
-    pub fn run_worker(&mut self) -> StatsEventSender {
+    pub fn run_worker(&mut self) -> Box<dyn TrackerStatisticsEventSender> {
         let (tx, mut rx) = mpsc::channel::<TrackerStatisticsEvent>(CHANNEL_BUFFER_SIZE);
 
         // set send channel on stats_tracker
@@ -150,7 +150,7 @@ impl StatsTracker {
             }
         });
 
-        StatsEventSender { sender: tx }
+        Box::new(StatsEventSender { sender: tx })
     }
 }
 

--- a/src/tracker/statistics.rs
+++ b/src/tracker/statistics.rs
@@ -2,6 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use log::debug;
+#[cfg(test)]
+use mockall::{automock, predicate::*};
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::{mpsc, RwLock, RwLockReadGuard};
@@ -153,6 +155,7 @@ async fn event_listener(mut rx: Receiver<TrackerStatisticsEvent>, stats: Arc<RwL
 }
 
 #[async_trait]
+#[cfg_attr(test, automock)]
 pub trait TrackerStatisticsEventSender: Sync + Send {
     async fn send_event(&self, event: TrackerStatisticsEvent) -> Option<Result<(), SendError<TrackerStatisticsEvent>>>;
 }

--- a/src/tracker/tracker.rs
+++ b/src/tracker/tracker.rs
@@ -12,7 +12,7 @@ use crate::databases::database::Database;
 use crate::mode::TrackerMode;
 use crate::peer::TorrentPeer;
 use crate::protocol::common::InfoHash;
-use crate::statistics::{TrackerStatistics, TrackerStatisticsEvent, TrackerStatsService};
+use crate::statistics::{TrackerStatistics, TrackerStatisticsEvent, TrackerStatisticsEventSender, TrackerStatsService};
 use crate::tracker::key;
 use crate::tracker::key::AuthKey;
 use crate::tracker::torrent::{TorrentEntry, TorrentError, TorrentStats};
@@ -25,11 +25,16 @@ pub struct TorrentTracker {
     whitelist: RwLock<std::collections::HashSet<InfoHash>>,
     torrents: RwLock<std::collections::BTreeMap<InfoHash, TorrentEntry>>,
     stats_tracker: Box<dyn TrackerStatsService>,
+    _stats_event_sender: Option<Box<dyn TrackerStatisticsEventSender>>,
     database: Box<dyn Database>,
 }
 
 impl TorrentTracker {
-    pub fn new(config: Arc<Configuration>, stats_tracker: Box<dyn TrackerStatsService>) -> Result<TorrentTracker, r2d2::Error> {
+    pub fn new(
+        config: Arc<Configuration>,
+        stats_tracker: Box<dyn TrackerStatsService>,
+        _stats_event_sender: Option<Box<dyn TrackerStatisticsEventSender>>,
+    ) -> Result<TorrentTracker, r2d2::Error> {
         let database = database::connect_database(&config.db_driver, &config.db_path)?;
 
         Ok(TorrentTracker {
@@ -39,6 +44,7 @@ impl TorrentTracker {
             whitelist: RwLock::new(std::collections::HashSet::new()),
             torrents: RwLock::new(std::collections::BTreeMap::new()),
             stats_tracker,
+            _stats_event_sender,
             database,
         })
     }

--- a/src/udp/handlers.rs
+++ b/src/udp/handlers.rs
@@ -271,18 +271,23 @@ mod tests {
 
     fn initialized_public_tracker() -> Arc<TorrentTracker> {
         let configuration = Arc::new(TrackerConfigurationBuilder::default().with_mode(TrackerMode::Public).into());
-        Arc::new(TorrentTracker::new(configuration, Box::new(StatsTracker::new_active_instance())).unwrap())
+        initialized_tracker(configuration)
     }
 
     fn initialized_private_tracker() -> Arc<TorrentTracker> {
         let configuration = Arc::new(TrackerConfigurationBuilder::default().with_mode(TrackerMode::Private).into());
-        Arc::new(TorrentTracker::new(configuration, Box::new(StatsTracker::new_active_instance())).unwrap())
+        initialized_tracker(configuration)
     }
 
     fn initialized_whitelisted_tracker() -> Arc<TorrentTracker> {
         let configuration = Arc::new(TrackerConfigurationBuilder::default().with_mode(TrackerMode::Listed).into());
-        Arc::new(TorrentTracker::new(configuration, Box::new(StatsTracker::new_active_instance())).unwrap())
+        initialized_tracker(configuration)
     }
+
+    fn initialized_tracker(configuration: Arc<Configuration>) -> Arc<TorrentTracker> {
+        let (stats_tracker, _stats_event_sender) = StatsTracker::new_active_instance();
+        Arc::new(TorrentTracker::new(configuration, Box::new(stats_tracker)).unwrap())
+    }    
 
     fn sample_ipv4_remote_addr() -> SocketAddr {
         sample_ipv4_socket_address()
@@ -969,8 +974,8 @@ mod tests {
                 #[tokio::test]
                 async fn the_peer_ip_should_be_changed_to_the_external_ip_in_the_tracker_configuration() {
                     let configuration = Arc::new(TrackerConfigurationBuilder::default().with_external_ip("::126.0.0.1").into());
-                    let tracker =
-                        Arc::new(TorrentTracker::new(configuration, Box::new(StatsTracker::new_active_instance())).unwrap());
+                    let (stats_tracker, _stats_event_sender) = StatsTracker::new_active_instance();
+                    let tracker = Arc::new(TorrentTracker::new(configuration, Box::new(stats_tracker)).unwrap());
 
                     let loopback_ipv4 = Ipv4Addr::new(127, 0, 0, 1);
                     let loopback_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);

--- a/src/udp/handlers.rs
+++ b/src/udp/handlers.rs
@@ -345,29 +345,13 @@ mod tests {
 
     struct TrackerStatsServiceMock {
         stats: Arc<RwLock<TrackerStatistics>>,
-        expected_event: Option<TrackerStatisticsEvent>,
     }
 
     impl TrackerStatsServiceMock {
         fn new() -> Self {
             Self {
                 stats: Arc::new(RwLock::new(TrackerStatistics::new())),
-                expected_event: None,
             }
-        }
-
-        fn should_throw_event(&mut self, expected_event: TrackerStatisticsEvent) {
-            self.expected_event = Some(expected_event);
-        }
-    }
-
-    #[async_trait]
-    impl TrackerStatisticsEventSender for TrackerStatsServiceMock {
-        async fn send_event(&self, _event: TrackerStatisticsEvent) -> Option<Result<(), SendError<TrackerStatisticsEvent>>> {
-            if self.expected_event.is_some() {
-                assert_eq!(_event, *self.expected_event.as_ref().unwrap());
-            }
-            None
         }
     }
 
@@ -387,9 +371,9 @@ mod tests {
 
     #[async_trait]
     impl TrackerStatisticsEventSender for StatsEventSenderMock {
-        async fn send_event(&self, _event: TrackerStatisticsEvent) -> Option<Result<(), SendError<TrackerStatisticsEvent>>> {
+        async fn send_event(&self, event: TrackerStatisticsEvent) -> Option<Result<(), SendError<TrackerStatisticsEvent>>> {
             if self.expected_event.is_some() {
-                assert_eq!(_event, *self.expected_event.as_ref().unwrap());
+                assert_eq!(event, *self.expected_event.as_ref().unwrap());
             }
             None
         }
@@ -493,11 +477,11 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_send_the_upd4_connect_event_when_a_client_tries_to_connect_using_a_ip4_socket_address() {
-            let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-            let stats_event_sender = Box::new(StatsEventSenderMock::new());
+            let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+            let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
             let client_socket_address = sample_ipv4_socket_address();
-            tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp4Connect);
+            stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp4Connect);
 
             let torrent_tracker =
                 Arc::new(TorrentTracker::new(default_tracker_config(), tracker_stats_service, Some(stats_event_sender)).unwrap());
@@ -508,10 +492,10 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_send_the_upd6_connect_event_when_a_client_tries_to_connect_using_a_ip6_socket_address() {
-            let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-            let stats_event_sender = Box::new(StatsEventSenderMock::new());
+            let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+            let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
-            tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp6Connect);
+            stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp6Connect);
 
             let torrent_tracker =
                 Arc::new(TorrentTracker::new(default_tracker_config(), tracker_stats_service, Some(stats_event_sender)).unwrap());
@@ -748,10 +732,10 @@ mod tests {
 
             #[tokio::test]
             async fn should_send_the_upd4_announce_event() {
-                let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-                let stats_event_sender = Box::new(StatsEventSenderMock::new());
+                let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+                let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
-                tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp4Announce);
+                stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp4Announce);
 
                 let tracker = Arc::new(
                     TorrentTracker::new(default_tracker_config(), tracker_stats_service, Some(stats_event_sender)).unwrap(),
@@ -975,10 +959,10 @@ mod tests {
 
             #[tokio::test]
             async fn should_send_the_upd6_announce_event() {
-                let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-                let stats_event_sender = Box::new(StatsEventSenderMock::new());
+                let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+                let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
-                tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp6Announce);
+                stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp6Announce);
 
                 let tracker = Arc::new(
                     TorrentTracker::new(default_tracker_config(), tracker_stats_service, Some(stats_event_sender)).unwrap(),
@@ -1287,10 +1271,10 @@ mod tests {
 
             #[tokio::test]
             async fn should_send_the_upd4_scrape_event() {
-                let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-                let stats_event_sender = Box::new(StatsEventSenderMock::new());
+                let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+                let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
-                tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp4Scrape);
+                stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp4Scrape);
 
                 let remote_addr = sample_ipv4_remote_addr();
                 let tracker = Arc::new(
@@ -1316,10 +1300,10 @@ mod tests {
 
             #[tokio::test]
             async fn should_send_the_upd6_scrape_event() {
-                let mut tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
-                let stats_event_sender = Box::new(StatsEventSenderMock::new());
+                let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
+                let mut stats_event_sender = Box::new(StatsEventSenderMock::new());
 
-                tracker_stats_service.should_throw_event(TrackerStatisticsEvent::Udp6Scrape);
+                stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp6Scrape);
 
                 let remote_addr = sample_ipv6_remote_addr();
                 let tracker = Arc::new(

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -51,10 +51,11 @@ mod udp_tracker_server {
                 lazy_static::initialize(&static_time::TIME_AT_APP_START);
 
                 // Initialize stats tracker
-                let stats_tracker = StatsTracker::new_active_instance();
+                let (stats_tracker, stats_event_sender) = StatsTracker::new_active_instance();
 
                 // Initialize Torrust tracker
-                let tracker = match TorrentTracker::new(configuration.clone(), Box::new(stats_tracker)) {
+                let tracker = match TorrentTracker::new(configuration.clone(), Box::new(stats_tracker), Some(stats_event_sender))
+                {
                     Ok(tracker) => Arc::new(tracker),
                     Err(error) => {
                         panic!("{}", error)

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -51,11 +51,10 @@ mod udp_tracker_server {
                 lazy_static::initialize(&static_time::TIME_AT_APP_START);
 
                 // Initialize stats tracker
-                let (stats_tracker, stats_event_sender) = StatsTracker::new_active_instance();
+                let (stats_event_sender, stats_repository) = StatsTracker::new_active_instance();
 
                 // Initialize Torrust tracker
-                let tracker = match TorrentTracker::new(configuration.clone(), Box::new(stats_tracker), Some(stats_event_sender))
-                {
+                let tracker = match TorrentTracker::new(configuration.clone(), Some(stats_event_sender), stats_repository) {
                     Ok(tracker) => Arc::new(tracker),
                     Err(error) => {
                         panic!("{}", error)


### PR DESCRIPTION
This is an experimental refactor of the [StatsTracker](https://github.com/torrust/torrust-tracker/blob/develop/src/tracker/statistics.rs).

It's still a WIP.

Tracker statistics are optional, and we had [problems testing that behaviour](https://github.com/torrust/torrust-tracker/pull/102).

I decided to try to make that code more testable. My idea is:

- Convert the StatsTracker into a StatsService that only creates the communication channel and the other services (EventSender, EventListener, ...)
- A EventSender to send the events.
- A EventListener that updates the statistics.
- A StatisticsRepository that contains the stats.

The high-level service (StatsService) only creates the StatisticsRepository used by the EventListener and the TorrusTracker. And the communication channel (with the sender and listener).

TODO:

- [X] Extract EventSender
- [X] Extract EventListener
- [x] Extract StatisticsRepository
- [x] Fix StatsEventSenderMock
- [x] Add tests for EnventListener

Once we have the EventListener, we can add tests to check if it updates the stats correctly, which is something we did not test on [PR-112](https://github.com/torrust/torrust-tracker/pull/102).

While working on the refactor, I realized the `StatsEventSenderMock` does not work correctly. It only works when the event is sent, but it does not fail if no event is sent. The obvious solution would be to store the event sent in the Mock, but the method is not mutable. 

```rust
    struct StatsEventSenderMock {
        expected_event: Option<TrackerStatisticsEvent>,
    }

    impl StatsEventSenderMock {
        fn new() -> Self {
            Self { expected_event: None }
        }

        fn should_throw_event(&mut self, expected_event: TrackerStatisticsEvent) {
            self.expected_event = Some(expected_event);
        }
    }

    #[async_trait]
    impl TrackerStatisticsEventSender for StatsEventSenderMock {
        async fn send_event(&self, event: TrackerStatisticsEvent) -> Option<Result<(), SendError<TrackerStatisticsEvent>>> {
            if self.expected_event.is_some() {
                assert_eq!(event, *self.expected_event.as_ref().unwrap());
            }
            None
        }
    }

    #[tokio::test]
    async fn it_should_send_the_upd4_connect_event_when_a_client_tries_to_connect_using_a_ip4_socket_address() {
        let tracker_stats_service = Box::new(TrackerStatsServiceMock::new());
        let mut stats_event_sender = Box::new(StatsEventSenderMock::new());

        let client_socket_address = sample_ipv4_socket_address();
        stats_event_sender.should_throw_event(TrackerStatisticsEvent::Udp4Connect);

        let torrent_tracker =
            Arc::new(TorrentTracker::new(default_tracker_config(), tracker_stats_service, Some(stats_event_sender)).unwrap());
        handle_connect(client_socket_address, &sample_connect_request(), torrent_tracker)
            .await
            .unwrap();
    }

```

I did not want to add a mocking library only for this case. That's why I did it manually. And I do not want to make that function mutable only for the test.
