### PR TITLE
Setting Overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@
 /data.db
 /.vscode/launch.json
 /storage/
-
-
+/config/
+/config.*/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
     "[rust]": {
         "editor.formatOnSave": true
     },
-    "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.checkOnSave.allTargets": true,
-    "rust-analyzer.checkOnSave.extraArgs": ["--","-W","clippy::pedantic"],
+    "rust-analyzer.checkOnSave": true,
+    "rust-analyzer.check.allTargets": true,
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.check.extraArgs": ["--","-W","clippy::pedantic"],
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-getters"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +2878,7 @@ dependencies = [
  "binascii",
  "chrono",
  "config",
+ "derive-getters",
  "derive_builder",
  "derive_more",
  "fern",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,6 +532,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d67778784b508018359cbc8696edb3db78160bab2c2a28ba7f56ef6932997f8"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcda35c7a396850a55ffeac740804b40ffec779b98fffbb1738f4033f0ee79e"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2836,6 +2867,7 @@ dependencies = [
  "binascii",
  "chrono",
  "config",
+ "derive_builder",
  "derive_more",
  "fern",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ axum = "0.6.1"
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 
 derive_builder = "0.12"
+derive-getters = "0.2"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ uuid = { version = "1", features = ["v4"] }
 axum = "0.6.1"
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 
+derive_builder = "0.12"
+
 
 [dev-dependencies]
 mockall = "0.11"

--- a/cSpell.json
+++ b/cSpell.json
@@ -69,6 +69,7 @@
         "trackerid",
         "typenum",
         "Unamed",
+        "unnested",
         "untuple",
         "uroot",
         "Vagaa",

--- a/src/apis/error.rs
+++ b/src/apis/error.rs
@@ -1,0 +1,12 @@
+use std::panic::Location;
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("failed to parse settings {message}, {location}")]
+    ParseConfig {
+        location: &'static Location<'static>,
+        message: String,
+    },
+}

--- a/src/apis/mod.rs
+++ b/src/apis/mod.rs
@@ -1,6 +1,8 @@
+pub mod error;
 pub mod handlers;
 pub mod middlewares;
 pub mod resources;
 pub mod responses;
 pub mod routes;
 pub mod server;
+pub mod settings;

--- a/src/apis/resources/mod.rs
+++ b/src/apis/resources/mod.rs
@@ -1,4 +1,67 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use crate::errors::settings::ServiceSettingsError;
+use crate::settings::{Service, ServiceProtocol};
+use crate::{check_field_is_not_empty, check_field_is_not_none};
+
 pub mod auth_key;
 pub mod peer;
 pub mod stats;
 pub mod torrent;
+
+pub type ApiTokens = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ApiServiceSettings {
+    pub id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub socket: SocketAddr,
+    pub access_tokens: ApiTokens,
+}
+
+impl Default for ApiServiceSettings {
+    fn default() -> Self {
+        let mut access_tokens = BTreeMap::new();
+        access_tokens.insert("admin".to_string(), "password".to_string());
+
+        Self {
+            id: "default_api".to_string(),
+            enabled: false,
+            display_name: "HTTP API (default)".to_string(),
+            socket: SocketAddr::from_str("127.0.0.1:1212").unwrap(),
+            access_tokens,
+        }
+    }
+}
+
+impl TryFrom<(&String, &Service)> for ApiServiceSettings {
+    type Error = ServiceSettingsError;
+
+    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
+        check_field_is_not_none!(value.1 => ServiceSettingsError;
+            enabled, service);
+
+        if value.1.service.unwrap() != ServiceProtocol::Api {
+            return Err(ServiceSettingsError::WrongService {
+                field: "service".to_string(),
+                expected: ServiceProtocol::Api,
+                found: value.1.service.unwrap(),
+                data: value.1.into(),
+            });
+        }
+
+        check_field_is_not_empty!(value.1 => ServiceSettingsError;
+                display_name: String);
+
+        Ok(Self {
+            id: value.0.to_owned(),
+            enabled: value.1.enabled.unwrap(),
+            display_name: value.1.display_name.to_owned().unwrap(),
+            socket: value.1.get_socket()?,
+            access_tokens: value.1.get_api_tokens()?,
+        })
+    }
+}

--- a/src/apis/resources/mod.rs
+++ b/src/apis/resources/mod.rs
@@ -1,10 +1,4 @@
 use std::collections::BTreeMap;
-use std::net::SocketAddr;
-use std::str::FromStr;
-
-use crate::errors::settings::ServiceSettingsError;
-use crate::settings::{Service, ServiceProtocol};
-use crate::{check_field_is_not_empty, check_field_is_not_none};
 
 pub mod auth_key;
 pub mod peer;
@@ -12,56 +6,3 @@ pub mod stats;
 pub mod torrent;
 
 pub type ApiTokens = BTreeMap<String, String>;
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct ApiServiceSettings {
-    pub id: String,
-    pub enabled: bool,
-    pub display_name: String,
-    pub socket: SocketAddr,
-    pub access_tokens: ApiTokens,
-}
-
-impl Default for ApiServiceSettings {
-    fn default() -> Self {
-        let mut access_tokens = BTreeMap::new();
-        access_tokens.insert("admin".to_string(), "password".to_string());
-
-        Self {
-            id: "default_api".to_string(),
-            enabled: false,
-            display_name: "HTTP API (default)".to_string(),
-            socket: SocketAddr::from_str("127.0.0.1:1212").unwrap(),
-            access_tokens,
-        }
-    }
-}
-
-impl TryFrom<(&String, &Service)> for ApiServiceSettings {
-    type Error = ServiceSettingsError;
-
-    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
-        check_field_is_not_none!(value.1 => ServiceSettingsError;
-            enabled, service);
-
-        if value.1.service.unwrap() != ServiceProtocol::Api {
-            return Err(ServiceSettingsError::WrongService {
-                field: "service".to_string(),
-                expected: ServiceProtocol::Api,
-                found: value.1.service.unwrap(),
-                data: value.1.into(),
-            });
-        }
-
-        check_field_is_not_empty!(value.1 => ServiceSettingsError;
-                display_name: String);
-
-        Ok(Self {
-            id: value.0.clone(),
-            enabled: value.1.enabled.unwrap(),
-            display_name: value.1.display_name.clone().unwrap(),
-            socket: value.1.get_socket()?,
-            access_tokens: value.1.get_api_tokens()?,
-        })
-    }
-}

--- a/src/apis/resources/mod.rs
+++ b/src/apis/resources/mod.rs
@@ -57,9 +57,9 @@ impl TryFrom<(&String, &Service)> for ApiServiceSettings {
                 display_name: String);
 
         Ok(Self {
-            id: value.0.to_owned(),
+            id: value.0.clone(),
             enabled: value.1.enabled.unwrap(),
-            display_name: value.1.display_name.to_owned().unwrap(),
+            display_name: value.1.display_name.clone().unwrap(),
             socket: value.1.get_socket()?,
             access_tokens: value.1.get_api_tokens()?,
         })

--- a/src/apis/settings.rs
+++ b/src/apis/settings.rs
@@ -1,0 +1,128 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::panic::Location;
+use std::path::Path;
+use std::str::FromStr;
+
+use derive_builder::Builder;
+use derive_getters::Getters;
+use serde::{Deserialize, Serialize};
+
+use super::error::Error;
+use crate::config::HttpApi;
+use crate::errors::settings::ServiceSettingsError;
+use crate::settings::{Service, ServiceProtocol};
+use crate::tracker::services::common::{Tls, TlsBuilder};
+use crate::{check_field_is_not_empty, check_field_is_not_none};
+
+pub type ApiTokens = BTreeMap<String, String>;
+
+#[derive(Builder, Getters, Default, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+#[builder(default, pattern = "immutable")]
+pub struct Settings {
+    #[builder(setter(into), default = "\"default_api\".to_string()")]
+    #[getter(rename = "get_id")]
+    id: String,
+    #[builder(default = "false")]
+    #[getter(rename = "is_enabled")]
+    enabled: bool,
+    #[builder(setter(into), default = "\"HTTP API (default)\".to_string()")]
+    #[getter(rename = "get_display_name")]
+    display_name: String,
+    #[builder(default = "Some(SocketAddr::from_str(\"127.0.0.1:1212\").unwrap())")]
+    #[getter(rename = "get_socket")]
+    socket: Option<SocketAddr>,
+    #[builder(default = "self.api_token_default()")]
+    #[getter(rename = "get_access_tokens")]
+    access_tokens: ApiTokens,
+    #[getter(rename = "get_tls_settings")]
+    tls: Option<Tls>,
+}
+
+impl SettingsBuilder {
+    // Private helper method that will set the default database path if the database is Sqlite.
+    #[allow(clippy::unused_self)]
+    fn api_token_default(&self) -> ApiTokens {
+        let mut access_tokens = BTreeMap::new();
+        access_tokens.insert("admin".to_string(), "password".to_string());
+        access_tokens
+    }
+}
+
+impl TryFrom<&HttpApi> for Settings {
+    type Error = Error;
+
+    fn try_from(api: &HttpApi) -> Result<Self, Self::Error> {
+        let tls = if api.ssl_enabled {
+            let cert = Path::new(match &api.ssl_cert_path {
+                Some(p) => p,
+                None => {
+                    return Err(Error::ParseConfig {
+                        location: Location::caller(),
+                        message: "ssl_cert_path is none and tls is enabled!".to_string(),
+                    })
+                }
+            });
+
+            let key = Path::new(match &api.ssl_key_path {
+                Some(p) => p,
+                None => {
+                    return Err(Error::ParseConfig {
+                        location: Location::caller(),
+                        message: "ssl_key_path is none and tls is enabled!".to_string(),
+                    })
+                }
+            });
+
+            Some(
+                TlsBuilder::default()
+                    .certificate_file_path(cert.into())
+                    .key_file_path(key.into())
+                    .build()
+                    .expect("failed to build tls settings"),
+            )
+        } else {
+            None
+        };
+
+        Ok(SettingsBuilder::default()
+            .id("imported_api")
+            .enabled(api.enabled)
+            .display_name("Imported API")
+            .socket(SocketAddr::from_str(api.bind_address.as_str()).ok())
+            .access_tokens(api.access_tokens.clone())
+            .tls(tls)
+            .build()
+            .expect("failed to import settings"))
+    }
+}
+
+impl TryFrom<(&String, &Service)> for Settings {
+    type Error = ServiceSettingsError;
+
+    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
+        check_field_is_not_none!(value.1 => ServiceSettingsError;
+            enabled, service);
+
+        if value.1.service.unwrap() != ServiceProtocol::Api {
+            return Err(ServiceSettingsError::WrongService {
+                field: "service".to_string(),
+                expected: ServiceProtocol::Api,
+                found: value.1.service.unwrap(),
+                data: value.1.into(),
+            });
+        }
+
+        check_field_is_not_empty!(value.1 => ServiceSettingsError;
+                display_name: String);
+
+        Ok(Self {
+            id: value.0.clone(),
+            enabled: value.1.enabled.unwrap(),
+            display_name: value.1.display_name.clone().unwrap(),
+            socket: Some(value.1.get_socket()?),
+            access_tokens: value.1.get_api_tokens()?,
+            tls: value.1.get_tls()?,
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use std::panic::Location;
 use std::path::Path;
@@ -46,14 +46,14 @@ pub struct HttpApi {
     pub ssl_cert_path: Option<String>,
     #[serde_as(as = "NoneAsEmptyString")]
     pub ssl_key_path: Option<String>,
-    pub access_tokens: HashMap<String, String>,
+    pub access_tokens: BTreeMap<String, String>,
 }
 
 impl HttpApi {
     #[must_use]
     pub fn contains_token(&self, token: &str) -> bool {
-        let tokens: HashMap<String, String> = self.access_tokens.clone();
-        let tokens: HashSet<String> = tokens.into_values().collect();
+        let tokens: BTreeMap<String, String> = self.access_tokens.clone();
+        let tokens: BTreeSet<String> = tokens.into_values().collect();
         tokens.contains(token)
     }
 }

--- a/src/databases/driver.rs
+++ b/src/databases/driver.rs
@@ -2,11 +2,13 @@ use serde::{Deserialize, Serialize};
 
 use super::error::Error;
 use super::mysql::Mysql;
+use super::settings::Settings;
 use super::sqlite::Sqlite;
 use super::{Builder, Database};
 
-#[derive(Serialize, Deserialize, Hash, PartialEq, PartialOrd, Ord, Eq, Copy, Debug, Clone)]
+#[derive(Default, Serialize, Deserialize, Hash, PartialEq, PartialOrd, Ord, Eq, Copy, Debug, Clone)]
 pub enum Driver {
+    #[default]
     Sqlite3,
     MySQL,
 }
@@ -17,10 +19,10 @@ impl Driver {
     /// # Errors
     ///
     /// This function will return an error if unable to connect to the database.
-    pub fn build(&self, db_path: &str) -> Result<Box<dyn Database>, Error> {
-        let database = match self {
-            Driver::Sqlite3 => Builder::<Sqlite>::build(db_path),
-            Driver::MySQL => Builder::<Mysql>::build(db_path),
+    pub fn build(settings: &Settings) -> Result<Box<dyn Database>, Error> {
+        let database = match settings.driver {
+            Driver::Sqlite3 => Builder::<Sqlite>::build(settings),
+            Driver::MySQL => Builder::<Mysql>::build(settings),
         }?;
 
         database.create_database_tables().expect("Could not create database tables.");
@@ -35,11 +37,5 @@ impl std::fmt::Display for Driver {
             Self::Sqlite3 => write!(f, "sqllite3"),
             Self::MySQL => write!(f, "my_sql"),
         }
-    }
-}
-
-impl Default for Driver {
-    fn default() -> Self {
-        Driver::Sqlite3
     }
 }

--- a/src/databases/driver.rs
+++ b/src/databases/driver.rs
@@ -5,7 +5,7 @@ use super::mysql::Mysql;
 use super::sqlite::Sqlite;
 use super::{Builder, Database};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, derive_more::Display, Clone)]
+#[derive(Serialize, Deserialize, Hash, PartialEq, PartialOrd, Ord, Eq, Copy, Debug, Clone)]
 pub enum Driver {
     Sqlite3,
     MySQL,
@@ -26,5 +26,20 @@ impl Driver {
         database.create_database_tables().expect("Could not create database tables.");
 
         Ok(database)
+    }
+}
+
+impl std::fmt::Display for Driver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Sqlite3 => write!(f, "sqllite3"),
+            Self::MySQL => write!(f, "my_sql"),
+        }
+    }
+}
+
+impl Default for Driver {
+    fn default() -> Self {
+        Driver::Sqlite3
     }
 }

--- a/src/databases/error.rs
+++ b/src/databases/error.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use r2d2_mysql::mysql::UrlError;
 
 use super::driver::Driver;
+use super::settings::Settings;
 use crate::located_error::{Located, LocatedError};
 
 #[derive(thiserror::Error, Debug, Clone)]
@@ -43,6 +44,20 @@ pub enum Error {
     ConnectionPool {
         source: LocatedError<'static, r2d2::Error>,
         driver: Driver,
+    },
+
+    #[error("Failed to convert to driver settings, expected: {expected}, actual {actual}, settings: {settings:?}, {location}")]
+    WrongDriver {
+        location: &'static Location<'static>,
+        expected: Driver,
+        actual: Driver,
+        settings: Settings,
+    },
+
+    #[error("Failed to get required felid from settings: {felid}, {location}")]
+    MissingFelid {
+        location: &'static Location<'static>,
+        felid: String,
     },
 }
 

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -1,6 +1,7 @@
 pub mod driver;
 pub mod error;
 pub mod mysql;
+pub mod settings;
 pub mod sqlite;
 
 use std::marker::PhantomData;
@@ -8,6 +9,7 @@ use std::marker::PhantomData;
 use async_trait::async_trait;
 
 use self::error::Error;
+use self::settings::Settings;
 use crate::protocol::info_hash::InfoHash;
 use crate::tracker::auth;
 
@@ -27,8 +29,8 @@ where
     /// # Errors
     ///
     /// Will return `r2d2::Error` if `db_path` is not able to create a database.
-    pub(self) fn build(db_path: &str) -> Result<Box<dyn Database>, Error> {
-        Ok(Box::new(T::new(db_path)?))
+    pub(self) fn build(settings: &Settings) -> Result<Box<dyn Database>, Error> {
+        Ok(Box::new(T::new(settings)?))
     }
 }
 
@@ -39,7 +41,7 @@ pub trait Database: Sync + Send {
     /// # Errors
     ///
     /// Will return `r2d2::Error` if `db_path` is not able to create a database.
-    fn new(db_path: &str) -> Result<Self, Error>
+    fn new(settings: &Settings) -> Result<Self, Error>
     where
         Self: std::marker::Sized;
 

--- a/src/databases/settings.rs
+++ b/src/databases/settings.rs
@@ -1,0 +1,141 @@
+use std::panic::Location;
+use std::path::Path;
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use super::driver::Driver::{self, Sqlite3};
+use super::driver::{self};
+use super::error::Error;
+use super::{mysql, sqlite};
+
+#[derive(Builder, Default, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+#[builder(default, pattern = "immutable")]
+pub struct Settings {
+    #[builder(default = "driver::Driver::default()")]
+    pub driver: driver::Driver,
+    #[builder(default = "self.sql_lite_path_default()")]
+    sql_lite_3_db_file_path: Option<Box<Path>>,
+    my_sql_connection_url: Option<String>,
+}
+
+impl SettingsBuilder {
+    // Private helper method that will set the default database path if the database is Sqlite.
+    #[allow(clippy::unused_self)]
+    fn sql_lite_path_default(&self) -> Option<Box<Path>> {
+        if let Sqlite3 = driver::Driver::default() {
+            Some(Path::new("data.db").into())
+        } else {
+            None
+        }
+    }
+}
+
+impl Settings {
+    /// Returns the check of this [`Settings`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if unable to transform into a definite database setting.
+    pub fn check(&self) -> Result<(), Error> {
+        match self.driver {
+            Driver::Sqlite3 => {
+                sqlite::Settings::try_from(self)?;
+            }
+            Driver::MySQL => {
+                mysql::Settings::try_from(self)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn get_sqlite_settings(&self) -> Result<sqlite::Settings, Error> {
+        sqlite::Settings::try_from(self)
+    }
+
+    pub fn get_mysql_settings(&self) -> Result<mysql::Settings, Error> {
+        mysql::Settings::try_from(self)
+    }
+}
+
+#[derive(PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct OldConfig {
+    pub db_driver: driver::Driver,
+    pub db_path: String,
+}
+
+impl TryFrom<&OldConfig> for Settings {
+    type Error = Error;
+
+    fn try_from(value: &OldConfig) -> Result<Self, Self::Error> {
+        Ok(match value.db_driver {
+            Driver::Sqlite3 => SettingsBuilder::default()
+                .driver(Driver::Sqlite3)
+                .sql_lite_3_db_file_path(Some(Path::new(&value.db_path).into()))
+                .build()
+                .unwrap(),
+            Driver::MySQL => SettingsBuilder::default()
+                .driver(Driver::MySQL)
+                .my_sql_connection_url(Some(value.db_path.clone()))
+                .build()
+                .unwrap(),
+        })
+    }
+}
+
+impl TryFrom<&Settings> for sqlite::Settings {
+    type Error = Error;
+
+    fn try_from(value: &Settings) -> Result<Self, Self::Error> {
+        Ok(Self {
+            database_file_path: match value.driver {
+                Driver::Sqlite3 => match &value.sql_lite_3_db_file_path {
+                    Some(path) => path.clone(),
+                    None => {
+                        return Err(Error::MissingFelid {
+                            location: Location::caller(),
+                            felid: "sql_lite_3_db_file_path".to_string(),
+                        })
+                    }
+                },
+                driver => {
+                    return Err(Error::WrongDriver {
+                        location: Location::caller(),
+                        expected: Driver::Sqlite3,
+                        actual: driver,
+                        settings: value.clone(),
+                    })
+                }
+            },
+        })
+    }
+}
+
+impl TryFrom<&Settings> for mysql::Settings {
+    type Error = Error;
+
+    fn try_from(value: &Settings) -> Result<Self, Self::Error> {
+        Ok(Self {
+            connection_url: match value.driver {
+                Driver::MySQL => match &value.my_sql_connection_url {
+                    Some(url) => url.clone(),
+                    None => {
+                        return Err(Error::MissingFelid {
+                            location: Location::caller(),
+                            felid: "my_sql_connection_url".to_string(),
+                        })
+                    }
+                },
+                driver => {
+                    return Err(Error::WrongDriver {
+                        location: Location::caller(),
+                        expected: Driver::MySQL,
+                        actual: driver,
+                        settings: value.clone(),
+                    })
+                }
+            },
+        })
+    }
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+pub mod settings;
+pub mod settings_manager;
+pub mod wrappers;
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum FilePathError {
+    #[error("File Path failed to Canonicalize: {input} : {source}.")]
+    FilePathIsUnresolvable {
+        input: Box<Path>,
+        source: Arc<wrappers::IoError>,
+    },
+
+    #[error("File Path destination is not a file: {input} : {source}.")]
+    FilePathIsNotAvailable {
+        input: Box<Path>,
+        source: Arc<wrappers::IoError>,
+    },
+}

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -1,23 +1,24 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use thiserror::Error;
+
+use crate::located_error::LocatedError;
 
 pub mod settings;
 pub mod settings_manager;
 pub mod wrappers;
 
-#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Error, Clone, Debug)]
 pub enum FilePathError {
     #[error("File Path failed to Canonicalize: {input} : {source}.")]
     FilePathIsUnresolvable {
         input: Box<Path>,
-        source: Arc<wrappers::IoError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 
     #[error("File Path destination is not a file: {input} : {source}.")]
     FilePathIsNotAvailable {
         input: Box<Path>,
-        source: Arc<wrappers::IoError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 }

--- a/src/errors/settings.rs
+++ b/src/errors/settings.rs
@@ -1,0 +1,243 @@
+use thiserror::Error;
+
+use super::FilePathError;
+use crate::databases;
+use crate::settings::{
+    CommonSettings, DatabaseSettings, GlobalSettings, ServiceNoSecrets, ServiceProtocol, TlsSettings, TrackerSettings,
+};
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SettingsError {
+    #[error("Bad Namespace: \".{field}\" {message}")]
+    NamespaceError { message: String, field: String },
+
+    // Todo: Expand this for Semantic Versioning 2.0.0
+    #[error("Bad Version: \".{field}\" {message}")]
+    VersionError { message: String, field: String },
+
+    #[error("Tracker Settings Error: \".tracker.{field}\": {message}")]
+    TrackerSettingsError {
+        message: String,
+        field: String,
+        source: TrackerSettingsError,
+    },
+
+    #[error("Global Settings Error: \".tracker.global.{field}\": {message}")]
+    GlobalSettingsError {
+        message: String,
+        field: String,
+        source: GlobalSettingsError,
+    },
+
+    #[error("Common Settings Error: \".tracker.common.{field}\": {message}")]
+    CommonSettingsError {
+        message: String,
+        field: String,
+        source: CommonSettingsError,
+    },
+
+    #[error("Database Settings Error: \".tracker.database.{field}\": {message}")]
+    DatabaseSettingsError {
+        message: String,
+        field: String,
+        source: DatabaseSettingsError,
+    },
+
+    #[error("Service Settings Error: \".tracker.service.{id}.{field}\": {message}")]
+    ServiceSettingsError {
+        message: String,
+        field: String,
+        id: String,
+        source: ServiceSettingsError,
+    },
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum TrackerSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: TrackerSettings },
+}
+
+impl TrackerSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+        }
+        .to_owned()
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum GlobalSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: GlobalSettings },
+
+    #[error("Bad Socket String: \"{input}\", {message}")]
+    ExternalIpBadSyntax {
+        field: String,
+        input: String,
+        message: String,
+        data: GlobalSettings,
+    },
+}
+
+impl GlobalSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+            Self::ExternalIpBadSyntax {
+                field,
+                input: _,
+                message: _,
+                data: _,
+            } => field,
+        }
+        .to_owned()
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum CommonSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: CommonSettings },
+
+    #[error("Required Field is empty (0 or \"\")!")]
+    EmptyRequiredField { field: String, data: CommonSettings },
+}
+
+impl CommonSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+            Self::EmptyRequiredField { field, data: _ } => field,
+        }
+        .to_owned()
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum DatabaseSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: DatabaseSettings },
+
+    #[error("Required Field is empty (0 or \"\")!")]
+    EmptyRequiredField { field: String, data: DatabaseSettings },
+
+    #[error("Want {expected}, but have {actual}!")]
+    WrongDriver {
+        field: String,
+        expected: databases::driver::Driver,
+        actual: databases::driver::Driver,
+        data: DatabaseSettings,
+    },
+}
+
+impl DatabaseSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+            Self::EmptyRequiredField { field, data: _ } => field,
+            Self::WrongDriver {
+                field,
+                expected: _,
+                actual: _,
+                data: _,
+            } => field,
+        }
+        .to_owned()
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ServiceSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: ServiceNoSecrets },
+
+    #[error("Required Field is empty (0 or \"\")!")]
+    EmptyRequiredField { field: String, data: ServiceNoSecrets },
+
+    #[error("Api Services Requires at least one Access Token!")]
+    ApiRequiresAccessToken { field: String, data: ServiceNoSecrets },
+
+    #[error("TLS Services Requires TLS Settings!")]
+    TlsRequiresTlsConfig { field: String, data: ServiceNoSecrets },
+
+    #[error("Bad TLS Configuration: {source}.")]
+    TlsSettingsError {
+        field: String,
+        source: TlsSettingsError,
+        data: ServiceNoSecrets,
+    },
+
+    #[error("Bad Socket String: \"{input}\".")]
+    BindingAddressBadSyntax {
+        field: String,
+        input: String,
+        message: String,
+        data: ServiceNoSecrets,
+    },
+    #[error("Unexpected Service. Expected: {expected}, Found {found}.")]
+    WrongService {
+        field: String,
+        expected: ServiceProtocol,
+        found: ServiceProtocol,
+        data: ServiceNoSecrets,
+    },
+}
+
+impl ServiceSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+            Self::EmptyRequiredField { field, data: _ } => field,
+            Self::ApiRequiresAccessToken { field, data: _ } => field,
+            Self::TlsRequiresTlsConfig { field, data: _ } => field,
+            Self::TlsSettingsError {
+                field,
+                source: _,
+                data: _,
+            } => field,
+            Self::BindingAddressBadSyntax {
+                field,
+                input: _,
+                message: _,
+                data: _,
+            } => field,
+
+            Self::WrongService {
+                field,
+                expected: _,
+                found: _,
+                data: _,
+            } => field,
+        }
+        .to_owned()
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum TlsSettingsError {
+    #[error("Required Field is missing (null)!")]
+    MissingRequiredField { field: String, data: TlsSettings },
+
+    #[error("Required Field is empty (0 or \"\")!")]
+    EmptyRequiredField { field: String, data: TlsSettings },
+
+    #[error("Unable to find TLS Certificate File: {source}")]
+    BadCertificateFilePath { field: String, source: FilePathError },
+
+    #[error("Unable to find TLS Key File: {source}")]
+    BadKeyFilePath { field: String, source: FilePathError },
+}
+
+impl TlsSettingsError {
+    pub fn get_field(&self) -> String {
+        match self {
+            Self::MissingRequiredField { field, data: _ } => field,
+            Self::EmptyRequiredField { field, data: _ } => field,
+            Self::BadCertificateFilePath { field, source: _ } => field,
+            Self::BadKeyFilePath { field, source: _ } => field,
+        }
+        .to_owned()
+    }
+}

--- a/src/errors/settings.rs
+++ b/src/errors/settings.rs
@@ -2,9 +2,7 @@ use thiserror::Error;
 
 use super::FilePathError;
 use crate::databases;
-use crate::settings::{
-    CommonSettings, DatabaseSettings, GlobalSettings, ServiceNoSecrets, ServiceProtocol, TlsSettings, TrackerSettings,
-};
+use crate::settings::{CommonSettings, GlobalSettings, ServiceNoSecrets, ServiceProtocol, TlsSettings, TrackerSettings};
 
 #[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum SettingsError {
@@ -59,11 +57,12 @@ pub enum TrackerSettingsError {
 }
 
 impl TrackerSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
             Self::MissingRequiredField { field, data: _ } => field,
         }
-        .to_owned()
+        .clone()
     }
 }
 
@@ -82,17 +81,18 @@ pub enum GlobalSettingsError {
 }
 
 impl GlobalSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
-            Self::MissingRequiredField { field, data: _ } => field,
-            Self::ExternalIpBadSyntax {
+            Self::MissingRequiredField { field, data: _ }
+            | Self::ExternalIpBadSyntax {
                 field,
                 input: _,
                 message: _,
                 data: _,
             } => field,
         }
-        .to_owned()
+        .clone()
     }
 }
 
@@ -106,45 +106,52 @@ pub enum CommonSettingsError {
 }
 
 impl CommonSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
-            Self::MissingRequiredField { field, data: _ } => field,
-            Self::EmptyRequiredField { field, data: _ } => field,
+            Self::MissingRequiredField { field, data: _ } | Self::EmptyRequiredField { field, data: _ } => field,
         }
-        .to_owned()
+        .clone()
     }
 }
 
 #[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DatabaseSettingsError {
     #[error("Required Field is missing (null)!")]
-    MissingRequiredField { field: String, data: DatabaseSettings },
+    MissingRequiredField {
+        field: String,
+        data: databases::settings::Settings,
+    },
 
     #[error("Required Field is empty (0 or \"\")!")]
-    EmptyRequiredField { field: String, data: DatabaseSettings },
+    EmptyRequiredField {
+        field: String,
+        data: databases::settings::Settings,
+    },
 
     #[error("Want {expected}, but have {actual}!")]
     WrongDriver {
         field: String,
         expected: databases::driver::Driver,
         actual: databases::driver::Driver,
-        data: DatabaseSettings,
+        data: databases::settings::Settings,
     },
 }
 
 impl DatabaseSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
-            Self::MissingRequiredField { field, data: _ } => field,
-            Self::EmptyRequiredField { field, data: _ } => field,
-            Self::WrongDriver {
+            Self::MissingRequiredField { field, data: _ }
+            | Self::EmptyRequiredField { field, data: _ }
+            | Self::WrongDriver {
                 field,
                 expected: _,
                 actual: _,
                 data: _,
             } => field,
         }
-        .to_owned()
+        .clone()
     }
 }
 
@@ -186,32 +193,32 @@ pub enum ServiceSettingsError {
 }
 
 impl ServiceSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
-            Self::MissingRequiredField { field, data: _ } => field,
-            Self::EmptyRequiredField { field, data: _ } => field,
-            Self::ApiRequiresAccessToken { field, data: _ } => field,
-            Self::TlsRequiresTlsConfig { field, data: _ } => field,
-            Self::TlsSettingsError {
+            Self::MissingRequiredField { field, data: _ }
+            | Self::EmptyRequiredField { field, data: _ }
+            | Self::ApiRequiresAccessToken { field, data: _ }
+            | Self::TlsRequiresTlsConfig { field, data: _ }
+            | Self::TlsSettingsError {
                 field,
                 source: _,
                 data: _,
-            } => field,
-            Self::BindingAddressBadSyntax {
+            }
+            | Self::BindingAddressBadSyntax {
                 field,
                 input: _,
                 message: _,
                 data: _,
-            } => field,
-
-            Self::WrongService {
+            }
+            | Self::WrongService {
                 field,
                 expected: _,
                 found: _,
                 data: _,
             } => field,
         }
-        .to_owned()
+        .clone()
     }
 }
 
@@ -231,13 +238,14 @@ pub enum TlsSettingsError {
 }
 
 impl TlsSettingsError {
+    #[must_use]
     pub fn get_field(&self) -> String {
         match self {
-            Self::MissingRequiredField { field, data: _ } => field,
-            Self::EmptyRequiredField { field, data: _ } => field,
-            Self::BadCertificateFilePath { field, source: _ } => field,
-            Self::BadKeyFilePath { field, source: _ } => field,
+            Self::BadKeyFilePath { field, source: _ }
+            | Self::BadCertificateFilePath { field, source: _ }
+            | Self::EmptyRequiredField { field, data: _ }
+            | Self::MissingRequiredField { field, data: _ } => field,
         }
-        .to_owned()
+        .clone()
     }
 }

--- a/src/errors/settings_manager.rs
+++ b/src/errors/settings_manager.rs
@@ -1,25 +1,35 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use thiserror::Error;
 
-use super::wrappers::{self, IoError, TomlDeError};
-use super::{settings, FilePathError};
+use crate::located_error::LocatedError;
 
-#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+#[derive(Error, Clone, Debug)]
 pub enum SettingsManagerError {
     #[error("Unable to open file for reading : \".{source}\"")]
-    FailedToOpenFileForReading { source: FilePathError },
+    FailedToOpenFileForReading {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
     #[error("Unable to open file for writing : \".{source}\"")]
-    FailedToOpenFileForWriting { source: FilePathError },
+    FailedToOpenFileForWriting {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
     #[error("Unable to open new file at:: {source}!")]
-    FailedToCreateNewFile { source: FilePathError },
+    FailedToCreateNewFile {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Unable to resolve path at: \"{at}\"!")]
-    FailedToResolvePath { at: Box<Path>, source: Arc<wrappers::IoError> },
+    FailedToResolvePath {
+        at: Box<Path>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Unable to prepare directory at: \"{at}\" : {source}!")]
-    FailedToPrepareDirectory { at: Box<Path>, source: Arc<wrappers::IoError> },
+    FailedToPrepareDirectory {
+        at: Box<Path>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Unable to resolve a directory at: \"{at}\"!")]
     FailedToResolveDirectory { at: Box<Path> },
@@ -28,50 +38,58 @@ pub enum SettingsManagerError {
     FailedToReadFromFile {
         message: String,
         from: Box<Path>,
-        source: Box<Self>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
     #[error("Unable to write file, {message}: \"{to}\": {source}.")]
     FailedToWriteToFile {
         message: String,
         to: Box<Path>,
-        source: Box<Self>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 
     #[error("Unable to read buffer: {source}")]
-    FailedToReadFromBuffer { source: Arc<IoError> },
+    FailedToReadFromBuffer {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
     #[error("Unable to write buffer: {source}")]
-    FailedToWriteIntoBuffer { source: Arc<IoError> },
+    FailedToWriteIntoBuffer {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Unable to read json, {message}: {source}")]
     FailedToSerializeIntoJson {
         message: String,
-        source: Arc<wrappers::SerdeJsonError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
     #[error("Unable to write json, {message}: {source}")]
     FailedToDeserializeFromJson {
         message: String,
-        source: Arc<wrappers::SerdeJsonError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 
     #[error("Unable to read toml: {source}")]
-    FailedToDeserializeFromToml { source: TomlDeError },
+    FailedToDeserializeFromToml {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Decoded json with unknown namespace: \"{namespace}\"")]
     FailedToMatchNamespace { namespace: String },
 
     #[error("Unable to process old settings from : \"{source}\"")]
-    FailedToProcessOldSettings { source: Box<Self> },
+    FailedToProcessOldSettings {
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
+    },
 
     #[error("Unable to import old settings from: \"{from}\" : \"{source}\"")]
     FailedToImportOldSettings {
         from: Box<Path>,
-        source: Box<settings::SettingsError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 
     #[error("Unable to successfully move file from: {from} to: {to} \"{source}\"")]
     FailedToMoveFile {
         from: Box<Path>,
         to: Box<Path>,
-        source: Arc<IoError>,
+        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 }

--- a/src/errors/settings_manager.rs
+++ b/src/errors/settings_manager.rs
@@ -1,0 +1,77 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use thiserror::Error;
+
+use super::wrappers::{self, IoError, TomlDeError};
+use super::{settings, FilePathError};
+
+#[derive(Error, Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SettingsManagerError {
+    #[error("Unable to open file for reading : \".{source}\"")]
+    FailedToOpenFileForReading { source: FilePathError },
+    #[error("Unable to open file for writing : \".{source}\"")]
+    FailedToOpenFileForWriting { source: FilePathError },
+    #[error("Unable to open new file at:: {source}!")]
+    FailedToCreateNewFile { source: FilePathError },
+
+    #[error("Unable to resolve path at: \"{at}\"!")]
+    FailedToResolvePath { at: Box<Path>, source: Arc<wrappers::IoError> },
+
+    #[error("Unable to prepare directory at: \"{at}\" : {source}!")]
+    FailedToPrepareDirectory { at: Box<Path>, source: Arc<wrappers::IoError> },
+
+    #[error("Unable to resolve a directory at: \"{at}\"!")]
+    FailedToResolveDirectory { at: Box<Path> },
+
+    #[error("Unable to read file, {message}: \"{from}\" : {source}.")]
+    FailedToReadFromFile {
+        message: String,
+        from: Box<Path>,
+        source: Box<Self>,
+    },
+    #[error("Unable to write file, {message}: \"{to}\": {source}.")]
+    FailedToWriteToFile {
+        message: String,
+        to: Box<Path>,
+        source: Box<Self>,
+    },
+
+    #[error("Unable to read buffer: {source}")]
+    FailedToReadFromBuffer { source: Arc<IoError> },
+    #[error("Unable to write buffer: {source}")]
+    FailedToWriteIntoBuffer { source: Arc<IoError> },
+
+    #[error("Unable to read json, {message}: {source}")]
+    FailedToSerializeIntoJson {
+        message: String,
+        source: Arc<wrappers::SerdeJsonError>,
+    },
+    #[error("Unable to write json, {message}: {source}")]
+    FailedToDeserializeFromJson {
+        message: String,
+        source: Arc<wrappers::SerdeJsonError>,
+    },
+
+    #[error("Unable to read toml: {source}")]
+    FailedToDeserializeFromToml { source: TomlDeError },
+
+    #[error("Decoded json with unknown namespace: \"{namespace}\"")]
+    FailedToMatchNamespace { namespace: String },
+
+    #[error("Unable to process old settings from : \"{source}\"")]
+    FailedToProcessOldSettings { source: Box<Self> },
+
+    #[error("Unable to import old settings from: \"{from}\" : \"{source}\"")]
+    FailedToImportOldSettings {
+        from: Box<Path>,
+        source: Box<settings::SettingsError>,
+    },
+
+    #[error("Unable to successfully move file from: {from} to: {to} \"{source}\"")]
+    FailedToMoveFile {
+        from: Box<Path>,
+        to: Box<Path>,
+        source: Arc<IoError>,
+    },
+}

--- a/src/errors/wrappers.rs
+++ b/src/errors/wrappers.rs
@@ -1,0 +1,69 @@
+use derive_more::{Deref, Display, From, Into};
+use thiserror::Error;
+
+#[derive(Error, Debug, Display, From, Into, Deref)]
+pub struct IoError {
+    pub(crate) repr: std::io::Error,
+}
+
+impl std::hash::Hash for IoError {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.repr.kind().hash(state);
+    }
+}
+
+impl Eq for IoError {}
+
+impl PartialEq for IoError {
+    fn eq(&self, other: &Self) -> bool {
+        self.repr.kind() == other.repr.kind()
+    }
+}
+
+impl PartialOrd for IoError {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.repr.kind().partial_cmp(&other.repr.kind())
+    }
+}
+
+#[derive(Error, Debug, Display, From, Into, Deref)]
+pub struct SerdeJsonError {
+    pub(crate) repr: serde_json::Error,
+}
+
+impl std::hash::Hash for SerdeJsonError {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.repr.to_string().hash(state);
+    }
+}
+
+impl Eq for SerdeJsonError {}
+
+impl PartialEq for SerdeJsonError {
+    fn eq(&self, other: &Self) -> bool {
+        self.repr.to_string() == other.repr.to_string()
+    }
+}
+
+impl PartialOrd for SerdeJsonError {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.repr.to_string().partial_cmp(&other.repr.to_string())
+    }
+}
+
+#[derive(Error, Clone, Debug, Eq, Display, From, Into, Deref)]
+pub struct TomlDeError {
+    pub(crate) repr: toml::de::Error,
+}
+
+impl PartialEq for TomlDeError {
+    fn eq(&self, other: &Self) -> bool {
+        self.repr.to_string() == other.repr.to_string()
+    }
+}
+
+impl std::hash::Hash for TomlDeError {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.repr.to_string().hash(state);
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,20 +1,25 @@
 use std::fs::{File, OpenOptions};
 use std::path::Path;
+use std::sync::Arc;
 
-use crate::errors::wrappers::IoError;
 use crate::errors::FilePathError;
 
+/// .
+///
+/// # Errors
+///
+/// This function will return an error if .
 pub fn get_file_at(at: &Path, mode: &OpenOptions) -> Result<(File, Box<Path>), FilePathError> {
-    let file = mode.open(at).map_err(|error| FilePathError::FilePathIsNotAvailable {
+    let file = mode.open(at).map_err(|err| FilePathError::FilePathIsNotAvailable {
         input: at.into(),
-        source: IoError::from(error).into(),
+        source: (Arc::new(err) as Arc<dyn std::error::Error + Send + Sync>).into(),
     })?;
 
     let at = Path::new(at)
         .canonicalize()
-        .map_err(|error| FilePathError::FilePathIsUnresolvable {
+        .map_err(|err| FilePathError::FilePathIsUnresolvable {
             input: at.into(),
-            source: IoError::from(error).into(),
+            source: (Arc::new(err) as Arc<dyn std::error::Error + Send + Sync>).into(),
         })?;
 
     Ok((file, at.into_boxed_path()))

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,21 @@
+use std::fs::{File, OpenOptions};
+use std::path::Path;
+
+use crate::errors::wrappers::IoError;
+use crate::errors::FilePathError;
+
+pub fn get_file_at(at: &Path, mode: &OpenOptions) -> Result<(File, Box<Path>), FilePathError> {
+    let file = mode.open(at).map_err(|error| FilePathError::FilePathIsNotAvailable {
+        input: at.into(),
+        source: IoError::from(error).into(),
+    })?;
+
+    let at = Path::new(at)
+        .canonicalize()
+        .map_err(|error| FilePathError::FilePathIsUnresolvable {
+            input: at.into(),
+            source: IoError::from(error).into(),
+        })?;
+
+    Ok((file, at.into_boxed_path()))
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -10,7 +10,15 @@
 //! - <https://wiki.theory.org/BitTorrent_Tracker_Protocol>
 //!
 
+use std::net::SocketAddr;
+use std::path::Path;
+use std::str::FromStr;
+
 use serde::{Deserialize, Serialize};
+
+use crate::errors::settings::ServiceSettingsError;
+use crate::settings::{Service, ServiceProtocol};
+use crate::{check_field_is_not_empty, check_field_is_not_none};
 
 pub mod axum_implementation;
 pub mod percent_encoding;
@@ -20,4 +28,120 @@ pub mod warp_implementation;
 pub enum Version {
     Warp,
     Axum,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct HttpServiceSettings {
+    pub id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub socket: SocketAddr,
+}
+
+impl Default for HttpServiceSettings {
+    fn default() -> Self {
+        Self {
+            id: "default_http".to_string(),
+            enabled: false,
+            display_name: "HTTP (default)".to_string(),
+            socket: SocketAddr::from_str("0.0.0.0:6969").unwrap(),
+        }
+    }
+}
+
+impl TryFrom<(&String, &Service)> for HttpServiceSettings {
+    type Error = ServiceSettingsError;
+
+    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
+        check_field_is_not_none!(value.1 => ServiceSettingsError;
+            enabled, service);
+
+        if value.1.service.unwrap() != ServiceProtocol::Http {
+            return Err(ServiceSettingsError::WrongService {
+                field: "service".to_string(),
+                expected: ServiceProtocol::Http,
+                found: value.1.service.unwrap(),
+                data: value.1.into(),
+            });
+        }
+
+        check_field_is_not_empty!(value.1 => ServiceSettingsError;
+                display_name: String);
+
+        Ok(Self {
+            id: value.0.to_owned(),
+            enabled: value.1.enabled.unwrap(),
+            display_name: value.1.display_name.to_owned().unwrap(),
+            socket: value.1.get_socket()?,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct TlsServiceSettings {
+    pub id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub socket: SocketAddr,
+    pub certificate_file_path: Box<Path>,
+    pub key_file_path: Box<Path>,
+}
+
+impl Default for TlsServiceSettings {
+    fn default() -> Self {
+        Self {
+            id: "default_http".to_string(),
+            enabled: false,
+            display_name: "HTTP (default)".to_string(),
+            socket: SocketAddr::from_str("0.0.0.0:6969").unwrap(),
+            certificate_file_path: Path::new("").into(),
+            key_file_path: Path::new("").into(),
+        }
+    }
+}
+
+impl TryFrom<(&String, &Service)> for TlsServiceSettings {
+    type Error = ServiceSettingsError;
+
+    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
+        check_field_is_not_none!(value.1 => ServiceSettingsError;
+            enabled, service, tls);
+
+        if value.1.service.unwrap() != ServiceProtocol::Tls {
+            return Err(ServiceSettingsError::WrongService {
+                field: "service".to_string(),
+                expected: ServiceProtocol::Tls,
+                found: value.1.service.unwrap(),
+                data: value.1.into(),
+            });
+        }
+
+        check_field_is_not_empty!(value.1 => ServiceSettingsError;
+                display_name: String);
+
+        let tls = value.1.tls.to_owned().unwrap();
+
+        Ok(Self {
+            id: value.0.to_owned(),
+            enabled: value.1.enabled.unwrap(),
+            display_name: value.1.display_name.to_owned().unwrap(),
+            socket: value.1.get_socket()?,
+
+            certificate_file_path: tls
+                .get_certificate_file_path()
+                .map_err(|err| ServiceSettingsError::TlsSettingsError {
+                    field: value.0.to_owned(),
+                    source: err,
+                    data: value.1.into(),
+                })?,
+
+            key_file_path: tls
+                .get_key_file_path()
+                .map_err(|err| ServiceSettingsError::TlsSettingsError {
+                    field: value.0.to_owned(),
+                    source: err,
+                    data: value.1.into(),
+                })?,
+        })
+    }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -69,9 +69,9 @@ impl TryFrom<(&String, &Service)> for HttpServiceSettings {
                 display_name: String);
 
         Ok(Self {
-            id: value.0.to_owned(),
+            id: value.0.clone(),
             enabled: value.1.enabled.unwrap(),
-            display_name: value.1.display_name.to_owned().unwrap(),
+            display_name: value.1.display_name.clone().unwrap(),
             socket: value.1.get_socket()?,
         })
     }
@@ -119,18 +119,18 @@ impl TryFrom<(&String, &Service)> for TlsServiceSettings {
         check_field_is_not_empty!(value.1 => ServiceSettingsError;
                 display_name: String);
 
-        let tls = value.1.tls.to_owned().unwrap();
+        let tls = value.1.tls.clone().unwrap();
 
         Ok(Self {
-            id: value.0.to_owned(),
+            id: value.0.clone(),
             enabled: value.1.enabled.unwrap(),
-            display_name: value.1.display_name.to_owned().unwrap(),
+            display_name: value.1.display_name.clone().unwrap(),
             socket: value.1.get_socket()?,
 
             certificate_file_path: tls
                 .get_certificate_file_path()
                 .map_err(|err| ServiceSettingsError::TlsSettingsError {
-                    field: value.0.to_owned(),
+                    field: value.0.clone(),
                     source: err,
                     data: value.1.into(),
                 })?,
@@ -138,7 +138,7 @@ impl TryFrom<(&String, &Service)> for TlsServiceSettings {
             key_file_path: tls
                 .get_key_file_path()
                 .map_err(|err| ServiceSettingsError::TlsSettingsError {
-                    field: value.0.to_owned(),
+                    field: value.0.clone(),
                     source: err,
                     data: value.1.into(),
                 })?,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -13,6 +13,7 @@
 use std::net::SocketAddr;
 use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -131,7 +132,7 @@ impl TryFrom<(&String, &Service)> for TlsServiceSettings {
                 .get_certificate_file_path()
                 .map_err(|err| ServiceSettingsError::TlsSettingsError {
                     field: value.0.clone(),
-                    source: err,
+                    source: (Arc::new(err) as Arc<dyn std::error::Error + Send + Sync>).into(),
                     data: value.1.into(),
                 })?,
 
@@ -139,7 +140,7 @@ impl TryFrom<(&String, &Service)> for TlsServiceSettings {
                 .get_key_file_path()
                 .map_err(|err| ServiceSettingsError::TlsSettingsError {
                     field: value.0.clone(),
-                    source: err,
+                    source: (Arc::new(err) as Arc<dyn std::error::Error + Send + Sync>).into(),
                     data: value.1.into(),
                 })?,
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,28 @@
 pub mod apis;
 pub mod config;
 pub mod databases;
+pub mod errors;
+pub mod helpers;
 pub mod http;
 pub mod jobs;
 pub mod located_error;
 pub mod logging;
 pub mod protocol;
+pub mod settings;
 pub mod setup;
 pub mod stats;
 pub mod tracker;
 pub mod udp;
+
+pub mod config_const {
+    pub const CONFIG_FOLDER: &str = "config";
+    pub const CONFIG_BACKUP_FOLDER: &str = "config.backup";
+    pub const CONFIG_ERROR_FOLDER: &str = "config.error";
+    pub const CONFIG_DEFAULT: &str = "default";
+    pub const CONFIG_LOCAL: &str = "local";
+    pub const CONFIG_OVERRIDE: &str = "override";
+    pub const CONFIG_OLD: &str = "../config";
+}
 
 #[macro_use]
 extern crate lazy_static;
@@ -31,4 +44,8 @@ pub mod ephemeral_instance_keys {
     lazy_static! {
         pub static ref RANDOM_SEED: Seed = Rng::gen(&mut ThreadRng::default());
     }
+}
+
+pub trait Empty: Sized {
+    fn empty() -> Self;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod config_const {
 
 #[macro_use]
 extern crate lazy_static;
+extern crate derive_builder;
 
 pub mod static_time {
     use std::time::SystemTime;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@ pub mod config_const {
 
 #[macro_use]
 extern crate lazy_static;
-extern crate derive_builder;
 
 pub mod static_time {
     use std::time::SystemTime;

--- a/src/settings/manager.rs
+++ b/src/settings/manager.rs
@@ -1,0 +1,569 @@
+use std::collections::hash_map::DefaultHasher;
+use std::ffi::OsString;
+use std::fs::{self, OpenOptions};
+use std::hash::{Hash, Hasher};
+use std::io::{Cursor, Read, Write};
+use std::path::Path;
+
+use log::{info, warn};
+
+use super::{
+    Settings, SettingsErrored, SettingsNamespace, TrackerSettings, TrackerSettingsBuilder, SETTINGS_NAMESPACE,
+    SETTINGS_NAMESPACE_ERRORED,
+};
+use crate::config_const::{CONFIG_BACKUP_FOLDER, CONFIG_DEFAULT, CONFIG_ERROR_FOLDER, CONFIG_FOLDER, CONFIG_LOCAL, CONFIG_OLD};
+use crate::errors::settings_manager::SettingsManagerError;
+use crate::errors::wrappers::{IoError, SerdeJsonError};
+use crate::helpers::get_file_at;
+use crate::settings::{Clean, Fix};
+use crate::Empty;
+
+#[derive(PartialEq, Eq, Debug, Clone, Hash)]
+pub struct SettingsManager {
+    settings: Result<Settings, SettingsErrored>,
+}
+
+impl Default for SettingsManager {
+    fn default() -> Self {
+        Self {
+            settings: Ok(Default::default()),
+        }
+    }
+}
+
+impl From<Settings> for SettingsManager {
+    fn from(okay: Settings) -> Self {
+        Self { settings: Ok(okay) }
+    }
+}
+
+impl TryFrom<SettingsManager> for Settings {
+    type Error = SettingsErrored;
+
+    fn try_from(manager: SettingsManager) -> Result<Self, Self::Error> {
+        manager.settings
+    }
+}
+
+impl From<SettingsErrored> for SettingsManager {
+    fn from(error: SettingsErrored) -> Self {
+        Self { settings: Err(error) }
+    }
+}
+
+impl SettingsManager {
+    pub fn empty() -> Self {
+        Self {
+            settings: Ok(Empty::empty()),
+        }
+    }
+
+    pub fn error(errored: &SettingsErrored) -> Self {
+        Self {
+            settings: Err(errored.to_owned()),
+        }
+    }
+
+    pub fn setup() -> Result<Self, SettingsManagerError> {
+        let config = Path::new(CONFIG_FOLDER);
+        let backup = Path::new(CONFIG_BACKUP_FOLDER);
+        let error = Path::new(CONFIG_ERROR_FOLDER);
+
+        let default = Path::new(CONFIG_FOLDER).join(CONFIG_DEFAULT).with_extension("json");
+        let old = Path::new(CONFIG_FOLDER).join(CONFIG_OLD).with_extension("toml");
+        let local = Path::new(CONFIG_FOLDER).join(CONFIG_LOCAL).with_extension("json");
+
+        Self::make_folder(config)?;
+
+        Self::write_default(default.as_path())?;
+        let manager = Self::load(old.as_path(), local.as_path(), backup, error)?;
+
+        manager.save(local.as_path(), &Some(backup.into()))?;
+
+        Ok(manager)
+    }
+
+    pub fn load(old: &Path, local: &Path, backup_folder: &Path, error_folder: &Path) -> Result<Self, SettingsManagerError> {
+        if let Some(res) = Self::import_old(old, backup_folder, error_folder)? {
+            return Ok(res);
+        }
+
+        // If no old settings, lets try the local settings.
+        let local_settings = match Self::read(local) {
+            Ok(settings) => Some(settings),
+            Err(err) => match err {
+                SettingsManagerError::FailedToOpenFileForReading { .. } => {
+                    info!("No Configuration To Load: {err}");
+                    None
+                }
+                err => {
+                    return Err(err);
+                }
+            },
+        };
+
+        if let Some(res) = local_settings {
+            return Ok(res);
+        };
+
+        // if nothing else, lets load the default.
+        Ok(Default::default())
+    }
+
+    pub fn save(&self, to: &Path, archive_folder: &Option<Box<Path>>) -> Result<(), SettingsManagerError> {
+        // lets backup the previous configuration, if we have any...
+        let existing = get_file_at(to, OpenOptions::new().read(true)).ok();
+
+        if let Some(existing) = existing {
+            if let Some(archive_folder) = archive_folder {
+                Self::archive(existing.0, &existing.1, archive_folder)?
+            }
+        }
+
+        let dest = get_file_at(to, OpenOptions::new().write(true).create(true).truncate(true))
+            .map_err(|err| SettingsManagerError::FailedToOpenFileForWriting { source: err })?;
+
+        self.write(dest.0)
+    }
+
+    pub fn write_default(to: &Path) -> Result<(), SettingsManagerError> {
+        let dest = get_file_at(to, OpenOptions::new().write(true).create(true).truncate(true))
+            .map_err(|err| SettingsManagerError::FailedToOpenFileForWriting { source: err })?;
+
+        Self::default().write(dest.0)
+    }
+
+    pub fn read(from: &Path) -> Result<Self, SettingsManagerError> {
+        let source = get_file_at(from, OpenOptions::new().read(true))
+            .map_err(|err| SettingsManagerError::FailedToOpenFileForReading { source: err })?;
+
+        Self::read_json(source.0)
+    }
+
+    pub fn write(&self, writer: impl Write) -> Result<(), SettingsManagerError> {
+        self.write_json(writer)
+    }
+
+    pub fn read_json<R>(mut rdr: R) -> Result<Self, SettingsManagerError>
+    where
+        R: Read,
+    {
+        let data: &mut Vec<u8> = &mut Default::default();
+
+        rdr.read_to_end(data)
+            .map_err(|err| SettingsManagerError::FailedToReadFromBuffer {
+                source: IoError::from(err).into(),
+            })?;
+
+        let settings = serde_json::from_reader::<Cursor<&mut Vec<u8>>, SettingsNamespace>(Cursor::new(data)).map_err(|err| {
+            SettingsManagerError::FailedToDeserializeFromJson {
+                message: "(read as \"SettingsNamespace\")".to_string(),
+                source: SerdeJsonError::from(err).into(),
+            }
+        })?;
+        {
+            match settings.namespace.as_str() {
+                SETTINGS_NAMESPACE => serde_json::from_reader::<Cursor<&mut Vec<u8>>, Settings>(Cursor::new(data))
+                    .map_err(|err| SettingsManagerError::FailedToDeserializeFromJson {
+                        message: "(read as \"Settings\")".to_string(),
+                        source: SerdeJsonError::from(err).into(),
+                    })
+                    .map(SettingsManager::from),
+
+                SETTINGS_NAMESPACE_ERRORED => serde_json::from_reader::<Cursor<&mut Vec<u8>>, SettingsErrored>(Cursor::new(data))
+                    .map_err(|err| SettingsManagerError::FailedToDeserializeFromJson {
+                        message: "(read as \"SettingsErrored\")".to_string(),
+                        source: SerdeJsonError::from(err).into(),
+                    })
+                    .map(SettingsManager::from),
+
+                namespace => Err(SettingsManagerError::FailedToMatchNamespace {
+                    namespace: namespace.to_string(),
+                }),
+            }
+        }
+    }
+
+    pub fn write_json<W>(&self, writer: W) -> Result<(), SettingsManagerError>
+    where
+        W: Write,
+    {
+        match &self.settings {
+            Ok(okay) => {
+                serde_json::to_writer_pretty(writer, okay).map_err(|err| SettingsManagerError::FailedToDeserializeFromJson {
+                    message: "(read as \"Settings\")".to_string(),
+                    source: SerdeJsonError::from(err).into(),
+                })
+            }
+            Err(err) => {
+                serde_json::to_writer_pretty(writer, err).map_err(|err| SettingsManagerError::FailedToDeserializeFromJson {
+                    message: "(read as \"SettingsErrored\")".to_string(),
+                    source: SerdeJsonError::from(err).into(),
+                })
+            }
+        }
+    }
+
+    fn backup(&self, to: &Path, folder: &Path) -> Result<(), SettingsManagerError> {
+        let ext = match to.extension().map(|f| f.to_os_string()) {
+            Some(mut ext) => {
+                ext.push(".json");
+                ext
+            }
+            None => OsString::from("json"),
+        };
+
+        let data: &mut Vec<u8> = &mut Default::default();
+
+        self.write_json(data.by_ref())
+            .map_err(|err| SettingsManagerError::FailedToWriteToFile {
+                message: "(backup)".to_string(),
+                to: to.into(),
+
+                source: err.into(),
+            })?;
+
+        Self::archive(Cursor::new(data), &to.with_extension(ext), folder)?;
+        Ok(())
+    }
+
+    fn archive(mut rdr: impl Read, from: &Path, to_folder: &Path) -> Result<(), SettingsManagerError> {
+        Self::make_folder(to_folder)?;
+
+        let to_folder = to_folder
+            .canonicalize()
+            .map_err(|err| SettingsManagerError::FailedToResolvePath {
+                at: to_folder.into(),
+                source: IoError::from(err).into(),
+            })?;
+
+        let mut hasher: DefaultHasher = Default::default();
+        let data: &mut Vec<u8> = &mut Default::default();
+
+        // todo: lock and stream the file instead of loading the full file into memory.
+        let _size = rdr
+            .read_to_end(data)
+            .map_err(|err| SettingsManagerError::FailedToReadFromBuffer {
+                source: IoError::from(err).into(),
+            })
+            .map_err(|err| SettingsManagerError::FailedToReadFromFile {
+                message: "(archive, read into)".to_string(),
+                from: from.into(),
+                source: err.into(),
+            })?;
+
+        data.hash(&mut hasher);
+
+        let ext = match from.extension() {
+            Some(ext) => {
+                let mut ostr = OsString::from(format!("{}.", hasher.finish()));
+                ostr.push(ext);
+                ostr
+            }
+            None => OsString::from(hasher.finish().to_string()),
+        };
+
+        let to = to_folder.join(from.file_name().unwrap()).with_extension(ext);
+
+        // if we do not have a backup already, lets make one.
+        if to.canonicalize().is_err() {
+            let mut dest = get_file_at(&to, OpenOptions::new().write(true).create_new(true))
+                .map_err(|err| SettingsManagerError::FailedToCreateNewFile { source: err })?;
+
+            dest.0
+                .write_all(data)
+                .map_err(|err| SettingsManagerError::FailedToWriteToFile {
+                    to: dest.1,
+                    message: "(archive, making backup)".to_string(),
+                    source: SettingsManagerError::FailedToWriteIntoBuffer {
+                        source: IoError::from(err).into(),
+                    }
+                    .into(),
+                })?;
+        };
+
+        Ok(())
+    }
+
+    pub fn import_old(from: &Path, backup_folder: &Path, error_folder: &Path) -> Result<Option<Self>, SettingsManagerError> {
+        let import_error_folder = error_folder.join("import");
+
+        let mut file = match get_file_at(from, OpenOptions::new().read(true)) {
+            Ok(rdr) => rdr,
+            Err(_) => {
+                return Ok(None);
+            }
+        };
+
+        let data: &mut Vec<u8> = &mut Default::default();
+
+        let _ = file
+            .0
+            .read_to_end(data)
+            .map_err(|err| SettingsManagerError::FailedToProcessOldSettings {
+                source: SettingsManagerError::FailedToReadFromFile {
+                    message: "(old_file)".to_string(),
+                    from: file.1.to_owned(),
+                    source: SettingsManagerError::FailedToReadFromBuffer {
+                        source: IoError::from(err).into(),
+                    }
+                    .into(),
+                }
+                .into(),
+            })?;
+
+        let parsed = toml::de::from_slice(data.as_slice()).map_err(|err| SettingsManagerError::FailedToProcessOldSettings {
+            source: SettingsManagerError::FailedToReadFromFile {
+                message: "(old settings toml)".to_string(),
+                from: file.1.to_owned(),
+                source: SettingsManagerError::FailedToDeserializeFromToml { source: err.into() }.into(),
+            }
+            .into(),
+        })?;
+
+        let mut builder = TrackerSettingsBuilder::empty();
+
+        // Attempt One
+        let test_builder = builder.to_owned().import_old(&parsed);
+        {
+            if let Err(err) = TryInto::<TrackerSettings>::try_into(test_builder.to_owned()) {
+                Self::make_folder(error_folder)?;
+                Self::make_folder(&import_error_folder)?;
+                let test = "First";
+
+                warn!(
+                    "{} import attempt failed: {}\nWith Error: {}",
+                    test,
+                    import_error_folder.to_string_lossy(),
+                    err
+                );
+
+                let broken = Self::error(&SettingsErrored::new(&test_builder.tracker_settings, &err));
+
+                let ext = match file.1.extension().map(|f| f.to_os_string()) {
+                    Some(mut ext) => {
+                        ext.push(format!(".{}", test.to_lowercase()));
+                        ext
+                    }
+                    None => OsString::from(test.to_lowercase()),
+                };
+
+                broken.backup(&file.1.with_extension(ext), import_error_folder.as_path())?;
+            }
+
+            // Replace broken with default, and remove everything else.
+
+            builder = test_builder.tracker_settings.empty_fix().into();
+        }
+
+        // Attempt with Defaults
+        let test_builder = builder.to_owned().import_old(&parsed);
+        {
+            if let Err(err) = TryInto::<TrackerSettings>::try_into(test_builder.to_owned()) {
+                Self::make_folder(error_folder)?;
+                Self::make_folder(&import_error_folder)?;
+                let test = "Second";
+
+                warn!(
+                    "{} import attempt failed: {}\nWith Error: {}",
+                    test,
+                    import_error_folder.to_string_lossy(),
+                    err
+                );
+
+                let broken = Self::error(&SettingsErrored::new(&test_builder.tracker_settings, &err));
+
+                let ext = match file.1.extension().map(|f| f.to_os_string()) {
+                    Some(mut ext) => {
+                        ext.push(format!(".{}", test.to_lowercase()));
+                        ext
+                    }
+                    None => OsString::from(test.to_lowercase()),
+                };
+
+                broken.backup(&file.1.with_extension(ext), import_error_folder.as_path())?;
+            }
+
+            builder = test_builder.tracker_settings.clean().into();
+        }
+
+        // Final Attempt
+        let settings = match TryInto::<TrackerSettings>::try_into(builder.to_owned()) {
+            Ok(tracker) => Self {
+                settings: Ok(tracker.into()),
+            },
+
+            Err(err) => {
+                Self::make_folder(error_folder)?;
+                Self::make_folder(&import_error_folder)?;
+                let test = "Final";
+
+                warn!(
+                    "{} import attempt failed: {}\nWith Error: {}",
+                    test,
+                    import_error_folder.to_string_lossy(),
+                    err
+                );
+
+                let broken = Self::error(&SettingsErrored::new(&builder.tracker_settings, &err));
+
+                let ext = match file.1.extension().map(|f| f.to_os_string()) {
+                    Some(mut ext) => {
+                        ext.push(format!(".{}", test.to_lowercase()));
+                        ext
+                    }
+                    None => OsString::from(test.to_lowercase()),
+                };
+
+                broken.backup(&file.1.with_extension(ext), import_error_folder.as_path())?;
+
+                return Err(SettingsManagerError::FailedToImportOldSettings {
+                    from: file.1,
+                    source: Box::new(err),
+                });
+            }
+        };
+
+        let ext = match file.1.extension() {
+            Some(ext) => {
+                let mut ostr = OsString::from("old.");
+                ostr.push(ext);
+                ostr
+            }
+            None => OsString::from("old"),
+        };
+
+        // import was successful, lets rename the extension to ".toml.old".
+        let backup = backup_folder.join(file.1.file_name().unwrap()).with_extension(ext);
+        Self::make_folder(backup_folder)?;
+
+        match fs::rename(&file.1, &backup) {
+            Ok(_) => {
+                info!(
+                    "\nOld Settings Was Successfully Imported!\n And moved from: \"{}\", to: \"{}\".\n",
+                    file.1.display(),
+                    backup.display()
+                );
+                Ok(Some(settings))
+            }
+            Err(err) => Err(SettingsManagerError::FailedToMoveFile {
+                from: file.1,
+                to: backup.into_boxed_path(),
+                source: IoError::from(err).into(),
+            }),
+        }
+    }
+
+    pub fn make_folder(folder: &Path) -> Result<(), SettingsManagerError> {
+        if let Ok(path) = folder.canonicalize() {
+            if path.is_dir() {
+                return Ok(());
+            } else {
+                return Err(SettingsManagerError::FailedToResolveDirectory { at: folder.into() });
+            }
+        }
+        match fs::create_dir(folder) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(SettingsManagerError::FailedToPrepareDirectory {
+                at: folder.into(),
+                source: IoError::from(err).into(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env;
+    use std::fs::OpenOptions;
+    use std::io::{Seek, Write};
+
+    use thiserror::Error;
+    use uuid::Uuid;
+
+    use super::SettingsManager;
+    use crate::helpers::get_file_at;
+    use crate::settings::old_settings::OLD_DEFAULT;
+    use crate::settings::{Settings, SettingsErrored, TrackerSettings};
+
+    #[test]
+    fn it_should_attempt_the_default_setup() {
+        SettingsManager::setup().unwrap();
+    }
+
+    #[test]
+    fn it_should_import_the_old_default_settings() {
+        let tmp_dir = env::temp_dir();
+        let old = tmp_dir.join(format!("old_default_{}.json", Uuid::new_v4()));
+        let backup = tmp_dir.join("backup");
+        let error = tmp_dir.join("error");
+
+        let mut dest = get_file_at(old.as_path(), OpenOptions::new().write(true).create_new(true)).unwrap();
+
+        dest.0.write_all(OLD_DEFAULT.as_bytes()).unwrap();
+
+        SettingsManager::import_old(old.as_path(), backup.as_path(), error.as_path()).unwrap();
+    }
+
+    #[test]
+    fn it_should_write_and_read_the_default() {
+        let temp = env::temp_dir().as_path().join(format!("test_config_{}.json", Uuid::new_v4()));
+
+        assert!(!temp.exists());
+
+        SettingsManager::write_default(&temp).unwrap();
+
+        assert!(temp.is_file());
+
+        let manager = SettingsManager::read(&temp).unwrap();
+
+        assert_eq!(manager, Default::default())
+    }
+
+    #[test]
+    fn it_should_make_config_folder() {
+        let temp = env::temp_dir().as_path().join(format!("test_config_{}", Uuid::new_v4()));
+
+        assert!(!temp.exists());
+
+        SettingsManager::make_folder(&temp).unwrap();
+
+        assert!(temp.is_dir());
+    }
+
+    #[test]
+    fn it_should_write_and_read_errored_settings() {
+        let path = env::temp_dir().as_path().join(format!("test_errored.{}", Uuid::new_v4()));
+        let mut file_rw = get_file_at(&path, OpenOptions::new().write(true).read(true).create_new(true)).unwrap();
+
+        #[derive(Error, Debug)]
+        enum TestErrors {
+            #[error("Test Error!")]
+            Error,
+        }
+
+        let errored: SettingsManager = SettingsErrored::new(&TrackerSettings::default(), &TestErrors::Error).into();
+
+        errored.write_json(std::io::Write::by_ref(&mut file_rw.0)).unwrap();
+        file_rw.0.rewind().unwrap();
+
+        let error_returned = SettingsManager::read_json(file_rw.0).unwrap();
+
+        assert_eq!(errored, error_returned)
+    }
+
+    #[test]
+    fn it_should_write_and_read_settings() {
+        let path = env::temp_dir().as_path().join(format!("test_errored.{}", Uuid::new_v4()));
+        let mut file_rw = get_file_at(&path, OpenOptions::new().write(true).read(true).create_new(true)).unwrap();
+
+        let settings: SettingsManager = Settings::default().into();
+
+        settings.write_json(std::io::Write::by_ref(&mut file_rw.0)).unwrap();
+        file_rw.0.rewind().unwrap();
+
+        let settings_returned = SettingsManager::read_json(file_rw.0).unwrap();
+
+        assert_eq!(settings, settings_returned)
+    }
+}

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,0 +1,1145 @@
+use std::collections::btree_map::Entry::Vacant;
+use std::collections::hash_map::RandomState;
+use std::collections::{BTreeMap, HashSet};
+use std::fs::OpenOptions;
+use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use derive_more::{Deref, DerefMut, Display};
+use serde::{Deserialize, Serialize};
+
+use self::old_settings::DatabaseDriversOld;
+use crate::apis::resources::{ApiServiceSettings, ApiTokens};
+use crate::databases::mysql::MySqlDatabaseSettings;
+use crate::databases::sqlite::Sqlite3DatabaseSettings;
+use crate::errors::settings::{
+    CommonSettingsError, DatabaseSettingsError, GlobalSettingsError, ServiceSettingsError, SettingsError, TlsSettingsError,
+    TrackerSettingsError,
+};
+use crate::helpers::get_file_at;
+use crate::http::{HttpServiceSettings, TlsServiceSettings};
+use crate::tracker::mode::Mode;
+use crate::udp::UdpServiceSettings;
+use crate::{databases, Empty};
+
+pub mod manager;
+pub mod old_settings;
+
+#[macro_export]
+macro_rules! old_to_new {
+    ( $( $base_old:expr, $base_new:expr;  $($old:ident: $new:ident),+ )? ) => {
+        {
+            $( $(
+                if let Some(val) = $base_old.$old{
+                    $base_new.$new = Some(val)
+                }
+            )+
+        )?
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! check_field_is_not_none {
+    ( $(  $ctx:expr => $error:ident; $($value:ident),+ )? ) => {
+        {
+            $( $(
+                if $ctx.$value.is_none() {
+                    return Err($error::MissingRequiredField {
+                        field: format!("{}", stringify!($value)),
+                        data: $ctx.into(),
+                    })
+                };
+            )+
+            )?
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! check_field_is_not_empty {
+    ( $( $ctx:expr => $error:ident;$($value:ident : $value_type:ty),+ )? ) => {
+        {
+            $( $(
+                match &$ctx.$value {
+                    Some(value) => {
+                        if value == &<$value_type>::default(){
+                        return Err($error::EmptyRequiredField {
+                            field: format!("{}", stringify!($value)),
+                            data: $ctx.into()});
+                        }
+                    },
+                    None => {
+                        return Err($error::MissingRequiredField {
+                            field: format!("{}", stringify!($value)),
+                            data: $ctx.into(),
+                        });
+                    },
+                }
+            )+
+            )?
+        }
+    };
+}
+
+trait Clean {
+    fn clean(self) -> Self;
+}
+
+trait Fix {
+    fn fix(self) -> Self;
+    fn empty_fix(self) -> Self;
+}
+
+const SETTINGS_NAMESPACE: &str = "org.torrust.tracker.config";
+const SETTINGS_NAMESPACE_ERRORED: &str = "org.torrust.tracker.config.errored";
+const SETTINGS_VERSION: &str = "1.0.0";
+
+/// Only used to check what is the namespace when deserializing.
+#[derive(Deserialize)]
+pub struct SettingsNamespace {
+    pub namespace: String,
+}
+
+/// With an extra 'error' field, used when there are deserializing problems.
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct SettingsErrored {
+    pub namespace: String,
+    pub version: String,
+    pub error: String,
+    pub tracker: TrackerSettings,
+}
+
+impl SettingsErrored {
+    pub fn new(tracker: &TrackerSettings, error: &impl std::error::Error) -> Self {
+        Self {
+            namespace: SETTINGS_NAMESPACE_ERRORED.to_string(),
+            version: SETTINGS_VERSION.to_string(),
+            error: error.to_string(),
+            tracker: tracker.to_owned(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct Settings {
+    pub namespace: String,
+    pub version: String,
+    tracker: TrackerSettings,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            namespace: SETTINGS_NAMESPACE.to_string(),
+            version: SETTINGS_VERSION.to_string(),
+            tracker: Default::default(),
+        }
+    }
+}
+
+impl Empty for Settings {
+    fn empty() -> Self {
+        Self {
+            namespace: Default::default(),
+            version: Default::default(),
+            tracker: Empty::empty(),
+        }
+    }
+}
+
+impl From<TrackerSettings> for Settings {
+    fn from(tracker: TrackerSettings) -> Self {
+        Self {
+            namespace: SETTINGS_NAMESPACE.to_string(),
+            version: SETTINGS_VERSION.to_string(),
+            tracker,
+        }
+    }
+}
+
+impl From<Settings> for TrackerSettings {
+    fn from(settings: Settings) -> Self {
+        settings.tracker
+    }
+}
+
+impl Settings {
+    pub fn check(&self) -> Result<(), SettingsError> {
+        if self.namespace != *SETTINGS_NAMESPACE {
+            return Err(SettingsError::NamespaceError {
+                message: format!("Actual: \"{}\", Expected: \"{}\"", self.namespace, SETTINGS_NAMESPACE),
+                field: "tracker".to_string(),
+            });
+        }
+
+        // Todo: Make this Check use Semantic Versioning 2.0.0
+        if self.version != *SETTINGS_VERSION {
+            return Err(SettingsError::VersionError {
+                message: format!("Actual: \"{}\", Expected: \"{}\"", self.version, SETTINGS_NAMESPACE),
+                field: "version".to_string(),
+            });
+        }
+
+        if let Err(source) = self.tracker.check() {
+            return Err(SettingsError::TrackerSettingsError {
+                message: source.to_string(),
+                field: source.get_field(),
+                source,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct TrackerSettings {
+    pub global: Option<GlobalSettings>,
+    pub common: Option<CommonSettings>,
+    pub database: Option<DatabaseSettings>,
+    pub services: Option<Services>,
+}
+
+impl Default for TrackerSettings {
+    fn default() -> Self {
+        Self {
+            global: Some(Default::default()),
+            common: Some(Default::default()),
+            database: Some(Default::default()),
+            services: Some(Default::default()),
+        }
+    }
+}
+
+impl Empty for TrackerSettings {
+    fn empty() -> Self {
+        Self {
+            global: None,
+            common: None,
+            database: None,
+            services: None,
+        }
+    }
+}
+
+impl TrackerSettings {
+    fn check(&self) -> Result<(), TrackerSettingsError> {
+        check_field_is_not_none!(self.to_owned() => TrackerSettingsError;
+            global, common, database, services
+        );
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, Clone, Hash)]
+pub struct TrackerSettingsBuilder {
+    tracker_settings: TrackerSettings,
+}
+
+impl Empty for TrackerSettingsBuilder {
+    fn empty() -> Self {
+        Self {
+            tracker_settings: Empty::empty(),
+        }
+    }
+}
+
+impl From<TrackerSettings> for TrackerSettingsBuilder {
+    fn from(tracker_settings: TrackerSettings) -> Self {
+        Self { tracker_settings }
+    }
+}
+
+impl From<Arc<TrackerSettings>> for TrackerSettingsBuilder {
+    fn from(tracker_settings: Arc<TrackerSettings>) -> Self {
+        Self {
+            tracker_settings: (*tracker_settings).to_owned(),
+        }
+    }
+}
+
+impl Fix for TrackerSettings {
+    /// Replaces with Defaults.
+    fn fix(self) -> Self {
+        Self {
+            global: Some(self.global.filter(|p| p.check().is_ok()).unwrap_or_default()),
+            common: Some(self.common.filter(|p| p.check().is_ok()).unwrap_or_default()),
+            database: Some(self.database.filter(|p| p.check().is_ok()).unwrap_or_default()),
+            services: Some(self.services.filter(|p| p.check().is_ok()).unwrap_or_default()),
+        }
+    }
+
+    /// Replaces problems, removing everything else, all services are removed.
+    fn empty_fix(self) -> Self {
+        Self {
+            global: self
+                .global
+                .filter(|p| p.check().is_ok())
+                .map_or_else(|| Some(Default::default()), |_f| None),
+            common: self
+                .common
+                .filter(|p| p.check().is_ok())
+                .map_or_else(|| Some(Default::default()), |_f| None),
+            database: self
+                .database
+                .filter(|p| p.check().is_ok())
+                .map_or_else(|| Some(Default::default()), |_f| None),
+            services: None,
+        }
+    }
+}
+
+impl Clean for TrackerSettings {
+    /// Removes Problems
+    fn clean(self) -> Self {
+        Self {
+            global: self.global.filter(|p| p.check().is_ok()),
+            common: self.common.filter(|p| p.check().is_ok()),
+            database: self.database.filter(|p| p.check().is_ok()),
+            services: self.services.map(|p| p.clean()),
+        }
+    }
+}
+
+impl TryInto<TrackerSettings> for TrackerSettingsBuilder {
+    type Error = SettingsError;
+
+    fn try_into(self) -> Result<TrackerSettings, Self::Error> {
+        if let Err(source) = self.tracker_settings.check() {
+            return Err(SettingsError::TrackerSettingsError {
+                message: source.to_string(),
+                field: source.get_field(),
+                source,
+            });
+        }
+
+        let settings = TrackerSettings {
+            global: Some(GlobalSettingsBuilder::from(self.tracker_settings.global.unwrap()).try_into()?),
+            common: Some(CommonSettingsBuilder::from(self.tracker_settings.common.unwrap()).try_into()?),
+            database: Some(DatabaseSettingsBuilder::from(self.tracker_settings.database.unwrap()).try_into()?),
+            services: match self.tracker_settings.services {
+                Some(services) => Some(ServicesBuilder::from(services).try_into()?),
+                None => None,
+            },
+        };
+
+        Ok(settings)
+    }
+}
+
+impl TrackerSettingsBuilder {
+    pub fn with_global(self, global: &GlobalSettings) -> Self {
+        Self {
+            tracker_settings: TrackerSettings {
+                global: Some(global.to_owned()),
+                common: self.tracker_settings.common,
+                database: self.tracker_settings.database,
+                services: self.tracker_settings.services,
+            },
+        }
+    }
+
+    pub fn with_common(self, common: &CommonSettings) -> Self {
+        Self {
+            tracker_settings: TrackerSettings {
+                global: self.tracker_settings.global,
+                common: Some(common.to_owned()),
+                database: self.tracker_settings.database,
+                services: self.tracker_settings.services,
+            },
+        }
+    }
+
+    pub fn with_database(self, database: &DatabaseSettings) -> Self {
+        Self {
+            tracker_settings: TrackerSettings {
+                global: self.tracker_settings.global,
+                common: self.tracker_settings.common,
+                database: Some(database.to_owned()),
+                services: self.tracker_settings.services,
+            },
+        }
+    }
+
+    pub fn with_services(self, services: &Services) -> Self {
+        Self {
+            tracker_settings: TrackerSettings {
+                global: self.tracker_settings.global,
+                common: self.tracker_settings.common,
+                database: self.tracker_settings.database,
+                services: Some(services.to_owned()),
+            },
+        }
+    }
+
+    pub fn import_old(mut self, old_settings: &old_settings::Settings) -> Self {
+        // Global
+        let mut builder = match self.tracker_settings.global.as_ref() {
+            Some(settings) => GlobalSettingsBuilder::from(settings.to_owned()),
+            None => GlobalSettingsBuilder::empty(),
+        };
+        builder = builder.import_old(old_settings);
+
+        self.tracker_settings.global = Some(builder.global_settings);
+
+        // Common
+        let mut builder = match self.tracker_settings.common.as_ref() {
+            Some(settings) => CommonSettingsBuilder::from(settings.to_owned()),
+            None => CommonSettingsBuilder::empty(),
+        };
+        builder = builder.import_old(old_settings);
+
+        self.tracker_settings.common = Some(builder.common_settings);
+
+        // Database
+        if let Some(driver) = old_settings.db_driver {
+            self.tracker_settings.database = Some(DatabaseSettingsBuilder::empty().database_settings);
+
+            self.tracker_settings.database.as_mut().unwrap().driver = Some(match driver {
+                DatabaseDriversOld::Sqlite3 => databases::driver::Driver::Sqlite3,
+                DatabaseDriversOld::MySQL => databases::driver::Driver::MySQL,
+            });
+
+            if let Some(val) = old_settings.db_path.as_ref() {
+                match driver {
+                    DatabaseDriversOld::Sqlite3 => {
+                        self.tracker_settings.database.as_mut().unwrap().sql_lite_3_db_file_path = Some(Path::new(val).into());
+                    }
+                    DatabaseDriversOld::MySQL => {
+                        self.tracker_settings.database.as_mut().unwrap().my_sql_connection_url = Some(val.to_owned())
+                    }
+                }
+            }
+        }
+
+        // Services
+        let mut builder = match self.tracker_settings.services.as_ref() {
+            Some(settings) => ServicesBuilder::from(settings.to_owned()),
+            None => ServicesBuilder::empty(),
+        };
+        builder = builder.import_old(old_settings);
+
+        self.tracker_settings.services = Some(builder.services);
+
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct GlobalSettings {
+    tracker_mode: Option<Mode>,
+    log_filter_level: Option<LogFilterLevel>,
+    external_ip: Option<IpAddr>,
+    on_reverse_proxy: Option<bool>,
+}
+
+impl Default for GlobalSettings {
+    fn default() -> Self {
+        Self {
+            tracker_mode: Some(Mode::Listed),
+            log_filter_level: Some(LogFilterLevel::Info),
+            external_ip: None,
+            on_reverse_proxy: Some(false),
+        }
+    }
+}
+
+impl Empty for GlobalSettings {
+    fn empty() -> Self {
+        Self {
+            tracker_mode: None,
+            log_filter_level: None,
+            external_ip: None,
+            on_reverse_proxy: None,
+        }
+    }
+}
+
+impl GlobalSettings {
+    fn check(&self) -> Result<(), GlobalSettingsError> {
+        self.is_on_reverse_proxy()?;
+
+        Ok(())
+    }
+
+    pub fn get_tracker_mode(&self) -> Mode {
+        self.tracker_mode.unwrap_or_default()
+    }
+
+    pub fn get_log_filter_level(&self) -> log::LevelFilter {
+        match self.log_filter_level.unwrap_or(LogFilterLevel::Info) {
+            LogFilterLevel::Off => log::LevelFilter::Off,
+            LogFilterLevel::Error => log::LevelFilter::Error,
+            LogFilterLevel::Warn => log::LevelFilter::Warn,
+            LogFilterLevel::Info => log::LevelFilter::Info,
+            LogFilterLevel::Debug => log::LevelFilter::Debug,
+            LogFilterLevel::Trace => log::LevelFilter::Trace,
+        }
+    }
+
+    pub fn get_external_ip_opt(&self) -> Option<IpAddr> {
+        self.external_ip
+    }
+
+    pub fn is_on_reverse_proxy(&self) -> Result<bool, GlobalSettingsError> {
+        check_field_is_not_none!(self.to_owned() => GlobalSettingsError; on_reverse_proxy);
+
+        Ok(self.on_reverse_proxy.unwrap())
+    }
+}
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash, Default)]
+pub struct GlobalSettingsBuilder {
+    global_settings: GlobalSettings,
+}
+
+impl Empty for GlobalSettingsBuilder {
+    fn empty() -> Self {
+        Self {
+            global_settings: Empty::empty(),
+        }
+    }
+}
+
+impl From<GlobalSettings> for GlobalSettingsBuilder {
+    fn from(global_settings: GlobalSettings) -> Self {
+        Self { global_settings }
+    }
+}
+
+impl From<Arc<GlobalSettings>> for GlobalSettingsBuilder {
+    fn from(global_settings: Arc<GlobalSettings>) -> Self {
+        Self {
+            global_settings: (*global_settings).to_owned(),
+        }
+    }
+}
+
+impl TryInto<GlobalSettings> for GlobalSettingsBuilder {
+    type Error = SettingsError;
+
+    fn try_into(self) -> Result<GlobalSettings, Self::Error> {
+        match self.global_settings.check() {
+            Ok(_) => Ok(self.global_settings),
+            Err(source) => Err(SettingsError::GlobalSettingsError {
+                message: source.to_string(),
+                field: source.get_field(),
+                source,
+            }),
+        }
+    }
+}
+
+impl GlobalSettingsBuilder {
+    pub fn with_external_ip(mut self, external_ip: &IpAddr) -> Self {
+        self.global_settings.external_ip = Some(external_ip.to_owned());
+        self
+    }
+
+    pub fn with_log_filter(mut self, log_filter: &LogFilterLevel) -> Self {
+        self.global_settings.log_filter_level = Some(*log_filter);
+        self
+    }
+
+    pub fn with_mode(mut self, mode: Mode) -> Self {
+        self.global_settings.tracker_mode = Some(mode);
+        self
+    }
+
+    pub fn with_reverse_proxy(mut self, reverse_proxy: bool) -> Self {
+        self.global_settings.on_reverse_proxy = Some(reverse_proxy);
+        self
+    }
+
+    pub fn import_old(mut self, old_settings: &old_settings::Settings) -> Self {
+        if let Some(val) = old_settings.mode.as_ref() {
+            self.global_settings.tracker_mode = Some(match val {
+                old_settings::TrackerModeOld::Public => Mode::Public,
+                old_settings::TrackerModeOld::Listed => Mode::Listed,
+                old_settings::TrackerModeOld::Private => Mode::Private,
+                old_settings::TrackerModeOld::PrivateListed => Mode::PrivateListed,
+            })
+        }
+
+        if let Some(val) = old_settings.log_level.as_ref() {
+            self.global_settings.log_filter_level = match val.to_lowercase().as_str() {
+                "off" => Some(LogFilterLevel::Off),
+                "trace" => Some(LogFilterLevel::Trace),
+                "debug" => Some(LogFilterLevel::Debug),
+                "info" => Some(LogFilterLevel::Info),
+                "warn" => Some(LogFilterLevel::Warn),
+                "error" => Some(LogFilterLevel::Error),
+                _ => None,
+            }
+        }
+
+        if let Some(val) = old_settings.external_ip.as_ref() {
+            if let Ok(ip) = IpAddr::from_str(val) {
+                self.global_settings.external_ip = Some(ip);
+            };
+        }
+
+        if let Some(val) = old_settings.on_reverse_proxy {
+            self.global_settings.on_reverse_proxy = Some(val);
+        }
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct CommonSettings {
+    pub announce_interval_seconds: Option<u32>,
+    pub announce_interval_seconds_minimum: Option<u32>,
+    pub peer_timeout_seconds_maximum: Option<u32>,
+    pub enable_tracker_usage_statistics: Option<bool>,
+    pub enable_persistent_statistics: Option<bool>,
+    pub cleanup_inactive_peers_interval_seconds: Option<u64>,
+    pub enable_peerless_torrent_pruning: Option<bool>,
+}
+
+impl Default for CommonSettings {
+    fn default() -> Self {
+        Self {
+            announce_interval_seconds: Some(120),
+            announce_interval_seconds_minimum: Some(120),
+            peer_timeout_seconds_maximum: Some(900),
+            enable_tracker_usage_statistics: Some(true),
+            enable_persistent_statistics: Some(false),
+            cleanup_inactive_peers_interval_seconds: Some(600),
+            enable_peerless_torrent_pruning: Some(false),
+        }
+    }
+}
+
+impl Empty for CommonSettings {
+    fn empty() -> Self {
+        Self {
+            announce_interval_seconds: None,
+            announce_interval_seconds_minimum: None,
+            peer_timeout_seconds_maximum: None,
+            enable_tracker_usage_statistics: None,
+            enable_persistent_statistics: None,
+            cleanup_inactive_peers_interval_seconds: None,
+            enable_peerless_torrent_pruning: None,
+        }
+    }
+}
+
+impl CommonSettings {
+    fn check(&self) -> Result<(), CommonSettingsError> {
+        check_field_is_not_none!(self.to_owned() => CommonSettingsError;
+            enable_tracker_usage_statistics,
+            enable_persistent_statistics,
+            enable_peerless_torrent_pruning
+        );
+
+        check_field_is_not_empty!(self.to_owned() => CommonSettingsError;
+            announce_interval_seconds: u32,
+            announce_interval_seconds_minimum: u32,
+            peer_timeout_seconds_maximum: u32,
+            cleanup_inactive_peers_interval_seconds: u64
+        );
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+pub struct CommonSettingsBuilder {
+    common_settings: CommonSettings,
+}
+
+impl Empty for CommonSettingsBuilder {
+    fn empty() -> Self {
+        Self {
+            common_settings: Empty::empty(),
+        }
+    }
+}
+
+impl From<CommonSettings> for CommonSettingsBuilder {
+    fn from(common_settings: CommonSettings) -> Self {
+        Self { common_settings }
+    }
+}
+
+impl TryInto<CommonSettings> for CommonSettingsBuilder {
+    type Error = SettingsError;
+
+    fn try_into(self) -> Result<CommonSettings, Self::Error> {
+        match self.common_settings.check() {
+            Ok(_) => Ok(self.common_settings),
+            Err(source) => Err(SettingsError::CommonSettingsError {
+                message: source.to_string(),
+                field: source.get_field(),
+                source,
+            }),
+        }
+    }
+}
+
+impl CommonSettingsBuilder {
+    pub fn import_old(mut self, old_settings: &old_settings::Settings) -> Self {
+        old_to_new!(old_settings, self.common_settings;
+         announce_interval: announce_interval_seconds,
+         max_peer_timeout: peer_timeout_seconds_maximum,
+         tracker_usage_statistics: enable_tracker_usage_statistics,
+         persistent_torrent_completed_stat: enable_persistent_statistics,
+         inactive_peer_cleanup_interval: cleanup_inactive_peers_interval_seconds,
+         remove_peerless_torrents: enable_peerless_torrent_pruning
+        );
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct DatabaseSettings {
+    driver: Option<databases::driver::Driver>,
+    sql_lite_3_db_file_path: Option<Box<Path>>,
+    my_sql_connection_url: Option<String>,
+}
+
+impl Default for DatabaseSettings {
+    fn default() -> Self {
+        Self {
+            driver: Some(databases::driver::Driver::default()),
+            sql_lite_3_db_file_path: Some(Path::new("data.db").into()),
+            my_sql_connection_url: None,
+        }
+    }
+}
+
+impl Empty for DatabaseSettings {
+    fn empty() -> Self {
+        Self {
+            driver: None,
+            sql_lite_3_db_file_path: None,
+            my_sql_connection_url: None,
+        }
+    }
+}
+
+impl DatabaseSettings {
+    fn check(&self) -> Result<(), DatabaseSettingsError> {
+        match self.get_driver()? {
+            databases::driver::Driver::Sqlite3 => {
+                Sqlite3DatabaseSettings::try_from(self)?;
+            }
+            databases::driver::Driver::MySQL => {
+                MySqlDatabaseSettings::try_from(self)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn get_driver(&self) -> Result<databases::driver::Driver, DatabaseSettingsError> {
+        check_field_is_not_none!(self.to_owned() => DatabaseSettingsError; driver);
+
+        Ok(self.driver.unwrap())
+    }
+
+    pub fn get_slq_lite_3_file_path(&self) -> Result<Box<Path>, DatabaseSettingsError> {
+        check_field_is_not_none!(self.to_owned() => DatabaseSettingsError; sql_lite_3_db_file_path);
+
+        // todo: more checks here.
+        Ok(self.sql_lite_3_db_file_path.as_deref().unwrap().into())
+    }
+
+    pub fn get_my_sql_connection_url(&self) -> Result<String, DatabaseSettingsError> {
+        check_field_is_not_empty!(self.to_owned() => DatabaseSettingsError; my_sql_connection_url: String);
+
+        // todo: more checks here.
+        Ok(self.my_sql_connection_url.to_owned().unwrap())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+pub struct DatabaseSettingsBuilder {
+    database_settings: DatabaseSettings,
+}
+
+impl Empty for DatabaseSettingsBuilder {
+    fn empty() -> Self {
+        Self {
+            database_settings: Empty::empty(),
+        }
+    }
+}
+
+impl From<DatabaseSettings> for DatabaseSettingsBuilder {
+    fn from(database_settings: DatabaseSettings) -> Self {
+        Self { database_settings }
+    }
+}
+
+impl TryInto<DatabaseSettings> for DatabaseSettingsBuilder {
+    type Error = SettingsError;
+
+    fn try_into(self) -> Result<DatabaseSettings, Self::Error> {
+        match self.database_settings.check() {
+            Ok(_) => Ok(self.database_settings),
+            Err(source) => Err(SettingsError::DatabaseSettingsError {
+                message: source.to_string(),
+                field: source.get_field(),
+                source,
+            }),
+        }
+    }
+}
+
+/// Special Service Settings with the Private Access Secrets Removed
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct ServiceNoSecrets {
+    pub enabled: Option<bool>,
+    pub display_name: Option<String>,
+    pub service: Option<ServiceProtocol>,
+    pub socket: Option<SocketAddr>,
+    pub tls: Option<TlsSettings>,
+    pub access_tokens: Option<ApiTokens>,
+}
+
+impl From<&Service> for ServiceNoSecrets {
+    fn from(services: &Service) -> Self {
+        Self {
+            enabled: services.enabled,
+            display_name: services.display_name.to_owned(),
+            service: services.service,
+            socket: services.socket,
+            tls: services.tls.to_owned(),
+            access_tokens: {
+                services.api_tokens.as_ref().map(|access_tokens| {
+                    access_tokens
+                        .iter()
+                        .map(|pair| (pair.0.to_owned(), "SECRET_REMOVED".to_string()))
+                        .collect()
+                })
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct Service {
+    pub enabled: Option<bool>,
+    pub display_name: Option<String>,
+    pub service: Option<ServiceProtocol>,
+    pub socket: Option<SocketAddr>,
+    pub tls: Option<TlsSettings>,
+    pub api_tokens: Option<ApiTokens>,
+}
+
+impl Empty for Service {
+    fn empty() -> Self {
+        Self {
+            enabled: None,
+            display_name: None,
+            service: None,
+            socket: None,
+            tls: None,
+            api_tokens: None,
+        }
+    }
+}
+
+impl From<ApiServiceSettings> for Service {
+    fn from(service: ApiServiceSettings) -> Self {
+        Self {
+            enabled: Some(service.enabled),
+            display_name: Some(service.display_name),
+            service: Some(ServiceProtocol::Api),
+            socket: Some(service.socket),
+            tls: None,
+            api_tokens: Some(service.access_tokens),
+        }
+    }
+}
+
+impl From<UdpServiceSettings> for Service {
+    fn from(service: UdpServiceSettings) -> Self {
+        Self {
+            enabled: Some(service.enabled),
+            display_name: Some(service.display_name),
+            service: Some(ServiceProtocol::Udp),
+            socket: Some(service.socket),
+            tls: None,
+            api_tokens: None,
+        }
+    }
+}
+
+impl From<HttpServiceSettings> for Service {
+    fn from(service: HttpServiceSettings) -> Self {
+        Self {
+            enabled: Some(service.enabled),
+            display_name: Some(service.display_name),
+            service: Some(ServiceProtocol::Http),
+            socket: Some(service.socket),
+            tls: None,
+            api_tokens: None,
+        }
+    }
+}
+
+impl From<TlsServiceSettings> for Service {
+    fn from(service: TlsServiceSettings) -> Self {
+        Self {
+            enabled: Some(service.enabled),
+            display_name: Some(service.display_name),
+            service: Some(ServiceProtocol::Tls),
+            socket: Some(service.socket),
+            tls: Some(TlsSettings {
+                certificate_file_path: Some(service.certificate_file_path),
+                key_file_path: Some(service.key_file_path),
+            }),
+            api_tokens: None,
+        }
+    }
+}
+
+impl Service {
+    pub fn check(&self, id: &String) -> Result<(), ServiceSettingsError> {
+        check_field_is_not_none!(self => ServiceSettingsError;
+        enabled, service, socket);
+
+        check_field_is_not_empty!(self => ServiceSettingsError;
+            display_name: String);
+
+        match self.service.unwrap() {
+            ServiceProtocol::Api => {
+                ApiServiceSettings::try_from((id, self))?;
+            }
+            ServiceProtocol::Udp => {
+                UdpServiceSettings::try_from((id, self))?;
+            }
+            ServiceProtocol::Http => {
+                HttpServiceSettings::try_from((id, self))?;
+            }
+            ServiceProtocol::Tls => {
+                TlsServiceSettings::try_from((id, self))?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn get_socket(&self) -> Result<SocketAddr, ServiceSettingsError> {
+        check_field_is_not_none!(self => ServiceSettingsError; socket);
+
+        Ok(self.socket.unwrap())
+    }
+
+    pub fn get_api_tokens(&self) -> Result<ApiTokens, ServiceSettingsError> {
+        check_field_is_not_empty!(self => ServiceSettingsError; api_tokens : ApiTokens);
+
+        Ok(self.api_tokens.to_owned().unwrap())
+    }
+
+    pub fn get_tls_settings(&self) -> Result<ApiTokens, ServiceSettingsError> {
+        check_field_is_not_empty!(self => ServiceSettingsError; api_tokens : ApiTokens);
+
+        Ok(self.api_tokens.to_owned().unwrap())
+    }
+}
+
+#[derive(Serialize, Deserialize, Ord, PartialOrd, PartialEq, Eq, Debug, Clone, Hash, Deref, DerefMut)]
+pub struct Services(BTreeMap<String, Service>);
+
+impl Default for Services {
+    fn default() -> Self {
+        let api = ApiServiceSettings::default();
+        let udp = UdpServiceSettings::default();
+        let http = HttpServiceSettings::default();
+        let tls = TlsServiceSettings::default();
+
+        let mut services = Services::empty();
+
+        services.insert(api.id.to_owned(), api.into());
+        services.insert(udp.id.to_owned(), udp.into());
+        services.insert(http.id.to_owned(), http.into());
+        services.insert(tls.id.to_owned(), tls.into());
+
+        services
+    }
+}
+
+impl Empty for Services {
+    fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+}
+
+/// will remove the services that failed the configuration check, returns removed services.
+impl Clean for Services {
+    fn clean(self) -> Self {
+        Self(
+            self.iter()
+                .filter(|service| service.1.check(service.0).is_ok())
+                .map(|pair| (pair.0.to_owned(), pair.1.to_owned()))
+                .collect(),
+        )
+    }
+}
+
+impl Services {
+    pub fn check(&self) -> Result<(), ServiceSettingsError> {
+        for service in self.iter() {
+            service.1.check(service.0)?
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Default)]
+pub struct ServicesBuilder {
+    services: Services,
+}
+
+impl Empty for ServicesBuilder {
+    fn empty() -> Self {
+        Self {
+            services: Empty::empty(),
+        }
+    }
+}
+
+impl TryInto<Services> for ServicesBuilder {
+    type Error = SettingsError;
+
+    fn try_into(self) -> Result<Services, Self::Error> {
+        for service in &self.services.0 {
+            if let Err(source) = service.1.check(service.0) {
+                return Err(SettingsError::ServiceSettingsError {
+                    id: service.0.into(),
+                    field: source.get_field(),
+                    message: source.to_string(),
+                    source,
+                });
+            }
+        }
+
+        Ok(self.services)
+    }
+}
+
+impl From<Services> for ServicesBuilder {
+    fn from(services: Services) -> Self {
+        Self { services }
+    }
+}
+
+impl ServicesBuilder {
+    pub fn import_old(mut self, old_settings: &old_settings::Settings) -> Self {
+        let existing_service_map = self.services.clone();
+        let existing_services: HashSet<&Service, RandomState> = HashSet::from_iter(existing_service_map.0.values());
+
+        let mut new_values: HashSet<(Service, String)> = HashSet::new();
+
+        if let Some(service) = old_settings.http_api.as_ref() {
+            new_values.insert(service.to_owned().into());
+        };
+
+        if let Some(services) = old_settings.udp_trackers.as_ref() {
+            for service in services {
+                new_values.insert(service.to_owned().into());
+            }
+        };
+
+        if let Some(services) = old_settings.http_trackers.as_ref() {
+            for service in services {
+                new_values.insert(service.to_owned().into());
+            }
+        };
+
+        for (value, name) in new_values {
+            // Lets not import something we already have...
+            if !existing_services.contains(&value) {
+                for count in 0.. {
+                    let key = format!("{name}_{count}");
+                    if let Vacant(e) = self.services.0.entry(key) {
+                        e.insert(value.clone());
+                        break;
+                    } else {
+                        continue;
+                    }
+                }
+            }
+        }
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+pub struct TlsSettings {
+    pub certificate_file_path: Option<Box<Path>>,
+    pub key_file_path: Option<Box<Path>>,
+}
+
+impl Empty for TlsSettings {
+    fn empty() -> Self {
+        Self {
+            certificate_file_path: None,
+            key_file_path: None,
+        }
+    }
+}
+
+impl TlsSettings {
+    pub fn check(&self) -> Result<(), TlsSettingsError> {
+        self.get_certificate_file_path()?;
+        self.get_key_file_path()?;
+
+        Ok(())
+    }
+
+    pub fn get_certificate_file_path(&self) -> Result<Box<Path>, TlsSettingsError> {
+        check_field_is_not_none!(self.to_owned() => TlsSettingsError; certificate_file_path);
+
+        get_file_at(self.certificate_file_path.as_ref().unwrap(), OpenOptions::new().read(true))
+            .map(|at| at.1)
+            .map_err(|source| TlsSettingsError::BadCertificateFilePath {
+                field: "certificate_file_path".to_string(),
+                source,
+            })
+    }
+
+    pub fn get_key_file_path(&self) -> Result<Box<Path>, TlsSettingsError> {
+        check_field_is_not_none!(self.to_owned() => TlsSettingsError; key_file_path);
+
+        get_file_at(self.key_file_path.as_ref().unwrap(), OpenOptions::new().read(true))
+            .map(|at| at.1)
+            .map_err(|source| TlsSettingsError::BadKeyFilePath {
+                field: "key_file_path".to_string(),
+                source,
+            })
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Copy, Clone, Hash, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum LogFilterLevel {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Default for LogFilterLevel {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Copy, Clone, Hash, Display)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceProtocol {
+    Udp,
+    Http,
+    Tls,
+    Api,
+}

--- a/src/settings/old_settings.rs
+++ b/src/settings/old_settings.rs
@@ -76,8 +76,7 @@ impl From<UdpTrackerConfig> for (Service, String) {
                 socket: val
                     .bind_address
                     .as_ref()
-                    .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
-                    .unwrap_or(None),
+                    .and_then(|socket| SocketAddr::from_str(socket.as_str()).ok()),
                 tls: None,
                 api_tokens: None,
             },
@@ -108,8 +107,7 @@ impl From<HttpTrackerConfig> for (Service, String) {
                     socket: val
                         .bind_address
                         .as_ref()
-                        .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
-                        .unwrap_or(None),
+                        .and_then(|socket| SocketAddr::from_str(socket.as_str()).ok()),
                     tls: Some(TlsSettings {
                         certificate_file_path: { val.ssl_cert_path.as_ref().map(|path| Path::new(path).into()) },
                         key_file_path: { val.ssl_key_path.as_ref().map(|path| Path::new(path).into()) },
@@ -127,8 +125,7 @@ impl From<HttpTrackerConfig> for (Service, String) {
                     socket: val
                         .bind_address
                         .as_ref()
-                        .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
-                        .unwrap_or(None),
+                        .and_then(|socket| SocketAddr::from_str(socket.as_str()).ok()),
                     tls: None,
                     api_tokens: None,
                 },
@@ -155,8 +152,7 @@ impl From<HttpApiConfig> for (Service, String) {
                 socket: val
                     .bind_address
                     .as_ref()
-                    .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
-                    .unwrap_or(None),
+                    .and_then(|socket| SocketAddr::from_str(socket.as_str()).ok()),
                 tls: None,
                 api_tokens: val.access_tokens,
             },

--- a/src/settings/old_settings.rs
+++ b/src/settings/old_settings.rs
@@ -1,0 +1,231 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::str::FromStr;
+
+use serde::Deserialize;
+use serde_with::serde_as;
+
+use super::{Service, ServiceProtocol, TlsSettings};
+
+#[cfg(test)]
+pub const OLD_DEFAULT: &str = r#"
+log_level = "info"
+mode = "public"
+db_driver = "Sqlite3"
+db_path = "data.db"
+announce_interval = 120
+min_announce_interval = 120
+max_peer_timeout = 900
+on_reverse_proxy = false
+external_ip = "0.0.0.0"
+tracker_usage_statistics = true
+persistent_torrent_completed_stat = false
+inactive_peer_cleanup_interval = 600
+remove_peerless_torrents = true
+
+[[udp_trackers]]
+enabled = false
+bind_address = "0.0.0.0:6969"
+
+[[http_trackers]]
+enabled = false
+bind_address = "0.0.0.0:6969"
+ssl_enabled = false
+ssl_cert_path = ""
+ssl_key_path = ""
+
+[http_api]
+enabled = true
+bind_address = "127.0.0.1:1212"
+
+[http_api.access_tokens]
+admin = "MyAccessToken"
+"#;
+
+#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum TrackerModeOld {
+    Public,
+    Listed,
+    Private,
+    PrivateListed,
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug, Copy, Clone, Hash)]
+pub enum DatabaseDriversOld {
+    Sqlite3,
+    MySQL,
+}
+
+#[serde_as]
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct UdpTrackerConfig {
+    pub display_name: Option<String>,
+    pub enabled: Option<bool>,
+    pub bind_address: Option<String>,
+}
+
+impl From<UdpTrackerConfig> for (Service, String) {
+    fn from(val: UdpTrackerConfig) -> Self {
+        (
+            Service {
+                enabled: val.enabled,
+                display_name: Some("UDP Service (imported)".to_string()),
+                service: Some(ServiceProtocol::Udp),
+                socket: val
+                    .bind_address
+                    .as_ref()
+                    .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
+                    .unwrap_or(None),
+                tls: None,
+                api_tokens: None,
+            },
+            "udp_imported".to_string(),
+        )
+    }
+}
+
+#[serde_as]
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct HttpTrackerConfig {
+    pub display_name: Option<String>,
+    pub enabled: Option<bool>,
+    pub bind_address: Option<String>,
+    pub ssl_enabled: Option<bool>,
+    pub ssl_cert_path: Option<String>,
+    pub ssl_key_path: Option<String>,
+}
+
+impl From<HttpTrackerConfig> for (Service, String) {
+    fn from(val: HttpTrackerConfig) -> Self {
+        if val.ssl_enabled.unwrap_or_default() {
+            (
+                Service {
+                    enabled: val.enabled,
+                    display_name: Some("TLS Service (imported)".to_string()),
+                    service: Some(ServiceProtocol::Tls),
+                    socket: val
+                        .bind_address
+                        .as_ref()
+                        .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
+                        .unwrap_or(None),
+                    tls: Some(TlsSettings {
+                        certificate_file_path: { val.ssl_cert_path.as_ref().map(|path| Path::new(path).into()) },
+                        key_file_path: { val.ssl_key_path.as_ref().map(|path| Path::new(path).into()) },
+                    }),
+                    api_tokens: None,
+                },
+                "tls_imported".to_string(),
+            )
+        } else {
+            (
+                Service {
+                    enabled: val.enabled,
+                    display_name: Some("HTTP Service(imported)".to_string()),
+                    service: Some(ServiceProtocol::Http),
+                    socket: val
+                        .bind_address
+                        .as_ref()
+                        .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
+                        .unwrap_or(None),
+                    tls: None,
+                    api_tokens: None,
+                },
+                "http_imported".to_string(),
+            )
+        }
+    }
+}
+
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct HttpApiConfig {
+    pub enabled: Option<bool>,
+    pub bind_address: Option<String>,
+    pub access_tokens: Option<BTreeMap<String, String>>,
+}
+
+impl From<HttpApiConfig> for (Service, String) {
+    fn from(val: HttpApiConfig) -> Self {
+        (
+            Service {
+                enabled: val.enabled,
+                display_name: Some("HTTP API (imported)".to_string()),
+                service: Some(ServiceProtocol::Api),
+                socket: val
+                    .bind_address
+                    .as_ref()
+                    .map(|socket| SocketAddr::from_str(socket.as_str()).ok())
+                    .unwrap_or(None),
+                tls: None,
+                api_tokens: val.access_tokens,
+            },
+            "api_imported".to_string(),
+        )
+    }
+}
+
+#[serde_as]
+#[derive(Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct Settings {
+    pub log_level: Option<String>,
+    pub mode: Option<TrackerModeOld>,
+    pub db_driver: Option<DatabaseDriversOld>,
+    pub db_path: Option<String>,
+    pub announce_interval: Option<u32>,
+    pub min_announce_interval: Option<u32>,
+    pub max_peer_timeout: Option<u32>,
+    pub on_reverse_proxy: Option<bool>,
+    pub external_ip: Option<String>,
+    pub tracker_usage_statistics: Option<bool>,
+    pub persistent_torrent_completed_stat: Option<bool>,
+    pub inactive_peer_cleanup_interval: Option<u64>,
+    pub remove_peerless_torrents: Option<bool>,
+    pub udp_trackers: Option<Vec<UdpTrackerConfig>>,
+    pub http_trackers: Option<Vec<HttpTrackerConfig>>,
+    pub http_api: Option<HttpApiConfig>,
+}
+
+#[cfg(not)]
+mod tests {
+
+    use std::path::Path;
+    use std::{env, fs};
+
+    use uuid::Uuid;
+
+    use crate::config_const::{CONFIG_FOLDER, CONFIG_LOCAL};
+    use crate::settings::old_settings::Settings;
+
+    #[test]
+    fn default_settings_should_contain_an_external_ip() {
+        let settings = Settings::default().unwrap();
+        assert_eq!(settings.external_ip, Option::Some(String::from("0.0.0.0")));
+    }
+
+    #[test]
+    fn settings_should_be_automatically_saved_into_local_config() {
+        let local_source = Path::new(CONFIG_FOLDER).join(CONFIG_LOCAL).with_extension("toml");
+
+        let settings = Settings::new().unwrap();
+
+        let contents = fs::read_to_string(&local_source).unwrap();
+
+        assert_eq!(contents, toml::to_string(&settings).unwrap());
+    }
+
+    #[test]
+    fn configuration_should_be_saved_in_a_toml_config_file() {
+        let temp_config_path = env::temp_dir().as_path().join(format!("test_config_{}.toml", Uuid::new_v4()));
+
+        let settings = Settings::default().unwrap();
+
+        settings
+            .write(temp_config_path.as_ref())
+            .expect("Could not save configuration to file");
+
+        let contents = fs::read_to_string(&temp_config_path).unwrap();
+
+        assert_eq!(contents, toml::to_string(&settings).unwrap());
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -6,7 +6,7 @@ use tokio::task::JoinHandle;
 use crate::config::Configuration;
 use crate::http::Version;
 use crate::jobs::{http_tracker, torrent_cleanup, tracker_apis, udp_tracker};
-use crate::tracker;
+use crate::{apis, tracker};
 
 /// # Panics
 ///
@@ -53,7 +53,13 @@ pub async fn setup(config: &Configuration, tracker: Arc<tracker::Tracker>) -> Ve
 
     // Start HTTP API
     if config.http_api.enabled {
-        jobs.push(tracker_apis::start_job(&config.http_api, tracker.clone()).await);
+        jobs.push(
+            tracker_apis::start_job(
+                &Arc::new(apis::settings::Settings::try_from(&config.http_api).expect("failed to make api settings")),
+                tracker.clone(),
+            )
+            .await,
+        );
     }
 
     // Remove torrents without peers, every interval

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -19,6 +19,7 @@ use tokio::sync::{RwLock, RwLockReadGuard};
 use self::error::Error;
 use crate::config::Configuration;
 use crate::databases::driver::Driver;
+use crate::databases::settings::OldConfig;
 use crate::databases::{self, Database};
 use crate::protocol::info_hash::InfoHash;
 
@@ -50,7 +51,11 @@ impl Tracker {
         stats_event_sender: Option<Box<dyn statistics::EventSender>>,
         stats_repository: statistics::Repo,
     ) -> Result<Tracker, databases::error::Error> {
-        let database = Driver::build(&config.db_driver, &config.db_path)?;
+        let db_settings = databases::settings::Settings::try_from(&OldConfig {
+            db_driver: config.db_driver,
+            db_path: config.db_path.clone(),
+        })?;
+        let database = Driver::build(&db_settings)?;
 
         Ok(Tracker {
             config: config.clone(),

--- a/src/tracker/mode.rs
+++ b/src/tracker/mode.rs
@@ -1,21 +1,25 @@
+use derive_more::Display;
 use serde;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Display)]
+#[serde(rename_all = "snake_case")]
 pub enum Mode {
     // Will track every new info hash and serve every peer.
-    #[serde(rename = "public")]
     Public,
 
     // Will only track whitelisted info hashes.
-    #[serde(rename = "listed")]
     Listed,
 
     // Will only serve authenticated peers
-    #[serde(rename = "private")]
     Private,
 
     // Will only track whitelisted info hashes and serve authenticated peers
-    #[serde(rename = "private_listed")]
     PrivateListed,
+}
+
+impl Default for Mode {
+    fn default() -> Self {
+        Mode::Listed
+    }
 }

--- a/src/tracker/mode.rs
+++ b/src/tracker/mode.rs
@@ -2,13 +2,14 @@ use derive_more::Display;
 use serde;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Display)]
+#[derive(Default, Serialize, Deserialize, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Display)]
 #[serde(rename_all = "snake_case")]
 pub enum Mode {
     // Will track every new info hash and serve every peer.
     Public,
 
     // Will only track whitelisted info hashes.
+    #[default]
     Listed,
 
     // Will only serve authenticated peers
@@ -16,10 +17,4 @@ pub enum Mode {
 
     // Will only track whitelisted info hashes and serve authenticated peers
     PrivateListed,
-}
-
-impl Default for Mode {
-    fn default() -> Self {
-        Mode::Listed
-    }
 }

--- a/src/tracker/services/common.rs
+++ b/src/tracker/services/common.rs
@@ -1,8 +1,22 @@
+use std::path::Path;
 use std::sync::Arc;
+
+use derive_builder::Builder;
+use derive_getters::Getters;
+use serde::{Deserialize, Serialize};
 
 use crate::config::Configuration;
 use crate::tracker::statistics::Keeper;
 use crate::tracker::Tracker;
+
+#[derive(Builder, Getters, Serialize, Deserialize, PartialEq, PartialOrd, Ord, Eq, Debug, Clone, Hash)]
+#[builder(pattern = "immutable")]
+pub struct Tls {
+    #[getter(rename = "get_certificate_file_path")]
+    certificate_file_path: Box<Path>,
+    #[getter(rename = "get_key_file_path")]
+    key_file_path: Box<Path>,
+}
 
 /// # Panics
 ///

--- a/src/udp/mod.rs
+++ b/src/udp/mod.rs
@@ -57,9 +57,9 @@ impl TryFrom<(&String, &Service)> for UdpServiceSettings {
                 display_name: String);
 
         Ok(Self {
-            id: value.0.to_owned(),
+            id: value.0.clone(),
             enabled: value.1.enabled.unwrap(),
-            display_name: value.1.display_name.to_owned().unwrap(),
+            display_name: value.1.display_name.clone().unwrap(),
             socket: value.1.get_socket()?,
         })
     }

--- a/src/udp/mod.rs
+++ b/src/udp/mod.rs
@@ -1,3 +1,10 @@
+use std::net::SocketAddr;
+use std::str::FromStr;
+
+use crate::errors::settings::ServiceSettingsError;
+use crate::settings::{Service, ServiceProtocol};
+use crate::{check_field_is_not_empty, check_field_is_not_none};
+
 pub mod connection_cookie;
 pub mod error;
 pub mod handlers;
@@ -10,3 +17,50 @@ pub type TransactionId = i64;
 
 pub const MAX_PACKET_SIZE: usize = 1496;
 pub const PROTOCOL_ID: i64 = 0x0417_2710_1980;
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct UdpServiceSettings {
+    pub id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub socket: SocketAddr,
+}
+
+impl Default for UdpServiceSettings {
+    fn default() -> Self {
+        Self {
+            id: "default_udp".to_string(),
+            enabled: false,
+            display_name: "UDP (default)".to_string(),
+            socket: SocketAddr::from_str("0.0.0.0:6969").unwrap(),
+        }
+    }
+}
+
+impl TryFrom<(&String, &Service)> for UdpServiceSettings {
+    type Error = ServiceSettingsError;
+
+    fn try_from(value: (&String, &Service)) -> Result<Self, Self::Error> {
+        check_field_is_not_none!(value.1 => ServiceSettingsError;
+            enabled, service);
+
+        if value.1.service.unwrap() != ServiceProtocol::Udp {
+            return Err(ServiceSettingsError::WrongService {
+                field: "service".to_string(),
+                expected: ServiceProtocol::Udp,
+                found: value.1.service.unwrap(),
+                data: value.1.into(),
+            });
+        }
+
+        check_field_is_not_empty!(value.1 => ServiceSettingsError;
+                display_name: String);
+
+        Ok(Self {
+            id: value.0.to_owned(),
+            enabled: value.1.enabled.unwrap(),
+            display_name: value.1.display_name.to_owned().unwrap(),
+            socket: value.1.get_socket()?,
+        })
+    }
+}

--- a/tests/api/server.rs
+++ b/tests/api/server.rs
@@ -6,7 +6,7 @@ use torrust_tracker::jobs::tracker_apis;
 use torrust_tracker::protocol::info_hash::InfoHash;
 use torrust_tracker::tracker::peer::Peer;
 use torrust_tracker::tracker::statistics::Keeper;
-use torrust_tracker::{ephemeral_instance_keys, logging, static_time, tracker};
+use torrust_tracker::{apis, ephemeral_instance_keys, logging, static_time, tracker};
 
 use super::connection_info::ConnectionInfo;
 
@@ -21,7 +21,11 @@ pub async fn start_default_api() -> Server {
 
 pub async fn start_custom_api(configuration: Arc<Configuration>) -> Server {
     let server = start(&configuration);
-    tracker_apis::start_job(&configuration.http_api, server.tracker.clone()).await;
+    tracker_apis::start_job(
+        &Arc::new(apis::settings::Settings::try_from(&configuration.http_api).expect("failed to make api settings")),
+        server.tracker.clone(),
+    )
+    .await;
     server
 }
 


### PR DESCRIPTION
* Move internal vocabulary from  'Configuration' with 'Settings'.
* Make use of a 'config' folder. Will generate new config files when needed.
* New Config is stored in json. And parsed without the need of the config crate.
* Automatically finds and moves old configuration to new format, (keeping a backup).