### PR TITLE
Fix API bug: Torrent cannot be whitelisted twice

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -34,6 +34,7 @@
         "Pando",
         "Rasterbar",
         "repr",
+        "reqwest",
         "rngs",
         "rusqlite",
         "rustfmt",

--- a/cSpell.json
+++ b/cSpell.json
@@ -30,6 +30,7 @@
         "nanos",
         "nextest",
         "nocapture",
+        "oneshot",
         "ostr",
         "Pando",
         "Rasterbar",

--- a/src/api/server.rs
+++ b/src/api/server.rs
@@ -5,11 +5,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tokio::sync::oneshot::Sender;
 use warp::{filters, reply, serve, Filter};
 
 use super::resources::auth_key_resource::AuthKeyResource;
-use crate::jobs::tracker_api::ApiReady;
 use crate::peer::TorrentPeer;
 use crate::protocol::common::*;
 use crate::tracker::TorrentTracker;
@@ -90,11 +88,7 @@ fn authenticate(tokens: HashMap<String, String>) -> impl Filter<Extract = (), Er
         .untuple_one()
 }
 
-pub fn start(
-    socket_addr: SocketAddr,
-    tracker: Arc<TorrentTracker>,
-    messenger_to_initiator: Sender<ApiReady>,
-) -> impl warp::Future<Output = ()> {
+pub fn start(socket_addr: SocketAddr, tracker: Arc<TorrentTracker>) -> impl warp::Future<Output = ()> {
     // GET /api/torrents?offset=:u32&limit=:u32
     // View torrent list
     let api_torrents = tracker.clone();
@@ -348,11 +342,6 @@ pub fn start(
     );
 
     let server = api_routes.and(authenticate(tracker.config.http_api.access_tokens.clone()));
-
-    // Send a message to the initiator to notify the API is ready to accept requests
-    if messenger_to_initiator.send(ApiReady()).is_err() {
-        panic!("the receiver dropped");
-    }
 
     let (_addr, api_server) = serve(server).bind_with_graceful_shutdown(socket_addr, async move {
         tokio::signal::ctrl_c().await.expect("Failed to listen to shutdown signal.");

--- a/src/databases/database.rs
+++ b/src/databases/database.rs
@@ -53,6 +53,17 @@ pub trait Database: Sync + Send {
     async fn add_key_to_keys(&self, auth_key: &AuthKey) -> Result<usize, Error>;
 
     async fn remove_key_from_keys(&self, key: &str) -> Result<usize, Error>;
+
+    async fn is_info_hash_whitelisted(&self, info_hash: &InfoHash) -> Result<bool, Error> {
+        if let Err(e) = self.get_info_hash_from_whitelist(&info_hash.to_owned().to_string()).await {
+            if let Error::QueryReturnedNoRows = e {
+                return Ok(false);
+            } else {
+                return Err(e);
+            }
+        }
+        Ok(true)
+    }
 }
 
 #[derive(Debug, Display, PartialEq, Eq, Error)]

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -141,10 +141,10 @@ impl Database for MysqlDatabase {
                 "SELECT info_hash FROM whitelist WHERE info_hash = :info_hash",
                 params! { info_hash },
             )
-            .map_err(|_| database::Error::QueryReturnedNoRows)?
+            .map_err(|_| database::Error::DatabaseError)?
         {
             Some(info_hash) => Ok(InfoHash::from_str(&info_hash).unwrap()),
-            None => Err(database::Error::InvalidQuery),
+            None => Err(database::Error::QueryReturnedNoRows),
         }
     }
 

--- a/src/jobs/tracker_api.rs
+++ b/src/jobs/tracker_api.rs
@@ -1,21 +1,30 @@
 use std::sync::Arc;
 
 use log::info;
+use tokio::sync::oneshot::{self, Receiver};
 use tokio::task::JoinHandle;
 
 use crate::api::server;
 use crate::tracker::TorrentTracker;
 use crate::Configuration;
 
-pub fn start_job(config: &Configuration, tracker: Arc<TorrentTracker>) -> JoinHandle<()> {
+#[derive(Debug)]
+pub struct ApiReady();
+
+pub fn start_job(config: &Configuration, tracker: Arc<TorrentTracker>) -> (JoinHandle<()>, Receiver<ApiReady>) {
     let bind_addr = config
         .http_api
         .bind_address
         .parse::<std::net::SocketAddr>()
         .expect("Tracker API bind_address invalid.");
+
+    let (tx, rx) = oneshot::channel::<ApiReady>();
+
     info!("Starting Torrust API server on: {}", bind_addr);
 
-    tokio::spawn(async move {
-        server::start(bind_addr, tracker).await;
-    })
+    let join_handle = tokio::spawn(async move {
+        server::start(bind_addr, tracker, tx).await;
+    });
+
+    (join_handle, rx)
 }

--- a/src/jobs/tracker_api.rs
+++ b/src/jobs/tracker_api.rs
@@ -24,10 +24,13 @@ pub async fn start_job(config: &Configuration, tracker: Arc<TorrentTracker>) -> 
 
     // Run the API server
     let join_handle = tokio::spawn(async move {
+        let handel = server::start(bind_addr, tracker);
+
         if tx.send(ApiServerJobStarted()).is_err() {
             panic!("the start job dropped");
         }
-        server::start(bind_addr, tracker).await;
+
+        handel.await;
     });
 
     // Wait until the API server job is running

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,7 +49,8 @@ pub async fn setup(config: &Configuration, tracker: Arc<TorrentTracker>) -> Vec<
 
     // Start HTTP API server
     if config.http_api.enabled {
-        jobs.push(tracker_api::start_job(config, tracker.clone()));
+        let (join_handle, _receiver) = tracker_api::start_job(config, tracker.clone());
+        jobs.push(join_handle);
     }
 
     // Remove torrents without peers, every interval

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,8 +49,7 @@ pub async fn setup(config: &Configuration, tracker: Arc<TorrentTracker>) -> Vec<
 
     // Start HTTP API server
     if config.http_api.enabled {
-        let (join_handle, _receiver) = tracker_api::start_job(config, tracker.clone());
-        jobs.push(join_handle);
+        jobs.push(tracker_api::start_job(config, tracker.clone()).await);
     }
 
     // Remove torrents without peers, every interval

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -108,17 +108,19 @@ impl TorrentTracker {
 
     /// It adds a torrent to the whitelist if it has not been whitelisted previously
     async fn add_torrent_to_database_whitelist(&self, info_hash: &InfoHash) -> Result<(), database::Error> {
-        match self
+        if let Err(e) = self
             .database
             .get_info_hash_from_whitelist(&info_hash.to_owned().to_string())
             .await
         {
-            Ok(_preexisting_info_hash) => Ok(()),
-            _ => {
+            if let database::Error::QueryReturnedNoRows = e {
                 self.database.add_info_hash_to_whitelist(*info_hash).await?;
-                Ok(())
+            } else {
+                eprintln!("{e}");
+                return Err(e);
             }
         }
+        Ok(())
     }
 
     pub async fn add_torrent_to_memory_whitelist(&self, info_hash: &InfoHash) -> bool {

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -106,9 +106,19 @@ impl TorrentTracker {
         Ok(())
     }
 
+    /// It adds a torrent to the whitelist if it has not been whitelisted previously
     async fn add_torrent_to_database_whitelist(&self, info_hash: &InfoHash) -> Result<(), database::Error> {
-        self.database.add_info_hash_to_whitelist(*info_hash).await?;
-        Ok(())
+        match self
+            .database
+            .get_info_hash_from_whitelist(&info_hash.to_owned().to_string())
+            .await
+        {
+            Ok(_preexisting_info_hash) => Ok(()),
+            _ => {
+                self.database.add_info_hash_to_whitelist(*info_hash).await?;
+                Ok(())
+            }
+        }
     }
 
     pub async fn add_torrent_to_memory_whitelist(&self, info_hash: &InfoHash) -> bool {

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -108,18 +108,12 @@ impl TorrentTracker {
 
     /// It adds a torrent to the whitelist if it has not been whitelisted previously
     async fn add_torrent_to_database_whitelist(&self, info_hash: &InfoHash) -> Result<(), database::Error> {
-        if let Err(e) = self
-            .database
-            .get_info_hash_from_whitelist(&info_hash.to_owned().to_string())
-            .await
-        {
-            if let database::Error::QueryReturnedNoRows = e {
-                self.database.add_info_hash_to_whitelist(*info_hash).await?;
-            } else {
-                eprintln!("{e}");
-                return Err(e);
-            }
+        if self.database.is_info_hash_whitelisted(info_hash).await.unwrap() {
+            return Ok(());
         }
+
+        self.database.add_info_hash_to_whitelist(*info_hash).await?;
+
         Ok(())
     }
 

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -152,16 +152,9 @@ mod tracker_api {
                 logging::setup_logging(&configuration);
 
                 // Start the HTTP API job
-                let (join_handle, api_receiver) = tracker_api::start_job(&configuration, tracker.clone());
-                self.job = Some(join_handle);
+                self.job = Some(tracker_api::start_job(&configuration, tracker).await);
 
                 self.started.store(true, Ordering::Relaxed);
-
-                // Wait until the API is ready
-                match api_receiver.await {
-                    Ok(msg) => println!("Message received from API server: {:?}", msg),
-                    Err(_) => panic!("the api server dropped"),
-                }
             }
         }
     }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -8,6 +8,7 @@ mod common;
 mod tracker_api {
     use core::panic;
     use std::env;
+    use std::str::FromStr;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
 
@@ -18,7 +19,7 @@ mod tracker_api {
     use torrust_tracker::tracker::key::AuthKey;
     use torrust_tracker::tracker::statistics::StatsTracker;
     use torrust_tracker::tracker::TorrentTracker;
-    use torrust_tracker::{ephemeral_instance_keys, logging, static_time, Configuration};
+    use torrust_tracker::{ephemeral_instance_keys, logging, static_time, Configuration, InfoHash};
 
     use crate::common::ephemeral_random_port;
 
@@ -58,6 +59,13 @@ mod tracker_api {
         let res = reqwest::Client::new().post(url.clone()).send().await.unwrap();
 
         assert_eq!(res.status(), 200);
+        assert!(
+            api_server
+                .tracker
+                .unwrap()
+                .is_info_hash_whitelisted(&InfoHash::from_str(&info_hash).unwrap())
+                .await
+        );
     }
 
     #[tokio::test]

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -24,7 +24,7 @@ mod tracker_api {
     use crate::common::ephemeral_random_port;
 
     #[tokio::test]
-    async fn should_generate_a_new_auth_key() {
+    async fn should_allow_generating_a_new_auth_key() {
         let configuration = tracker_configuration();
         let api_server = new_running_api_server(configuration.clone()).await;
 
@@ -46,7 +46,7 @@ mod tracker_api {
     }
 
     #[tokio::test]
-    async fn should_whitelist_a_torrent() {
+    async fn should_allow_whitelisting_a_torrent() {
         let configuration = tracker_configuration();
         let api_server = new_running_api_server(configuration.clone()).await;
 
@@ -69,7 +69,7 @@ mod tracker_api {
     }
 
     #[tokio::test]
-    async fn should_whitelist_a_torrent_that_has_been_already_whitelisted() {
+    async fn should_allow_whitelisting_a_torrent_that_has_been_already_whitelisted() {
         let configuration = tracker_configuration();
         let api_server = new_running_api_server(configuration.clone()).await;
 


### PR DESCRIPTION
- [x] Reproduce the error with an e2e test.
- [x] Fix it.
- [x] Rename test to `should_allow_to_whitelist_a_torrent`
- [x] Refactor: extract function `is_info_hash_whitelisted` as described [here](https://github.com/torrust/torrust-tracker/pull/118#issuecomment-1326847691).