### PR TITLE
located errors: database

### DIFF
--- a/src/apis/handlers.rs
+++ b/src/apis/handlers.rs
@@ -66,8 +66,8 @@ pub async fn add_torrent_to_whitelist_handler(
     match InfoHash::from_str(&info_hash.0) {
         Err(_) => invalid_info_hash_param_response(&info_hash.0),
         Ok(info_hash) => match tracker.add_torrent_to_whitelist(&info_hash).await {
-            Ok(..) => ok_response(),
-            Err(..) => failed_to_whitelist_torrent_response(),
+            Ok(_) => ok_response(),
+            Err(e) => failed_to_whitelist_torrent_response(e),
         },
     }
 }
@@ -79,16 +79,16 @@ pub async fn remove_torrent_from_whitelist_handler(
     match InfoHash::from_str(&info_hash.0) {
         Err(_) => invalid_info_hash_param_response(&info_hash.0),
         Ok(info_hash) => match tracker.remove_torrent_from_whitelist(&info_hash).await {
-            Ok(..) => ok_response(),
-            Err(..) => failed_to_remove_torrent_from_whitelist_response(),
+            Ok(_) => ok_response(),
+            Err(e) => failed_to_remove_torrent_from_whitelist_response(e),
         },
     }
 }
 
 pub async fn reload_whitelist_handler(State(tracker): State<Arc<Tracker>>) -> Response {
     match tracker.load_whitelist().await {
-        Ok(..) => ok_response(),
-        Err(..) => failed_to_reload_whitelist_response(),
+        Ok(_) => ok_response(),
+        Err(e) => failed_to_reload_whitelist_response(e),
     }
 }
 
@@ -96,7 +96,7 @@ pub async fn generate_auth_key_handler(State(tracker): State<Arc<Tracker>>, Path
     let seconds_valid = seconds_valid_or_key;
     match tracker.generate_auth_key(Duration::from_secs(seconds_valid)).await {
         Ok(auth_key) => auth_key_response(&AuthKey::from(auth_key)),
-        Err(_) => failed_to_generate_key_response(),
+        Err(e) => failed_to_generate_key_response(e),
     }
 }
 
@@ -111,15 +111,15 @@ pub async fn delete_auth_key_handler(
         Err(_) => invalid_auth_key_param_response(&seconds_valid_or_key.0),
         Ok(key_id) => match tracker.remove_auth_key(&key_id.to_string()).await {
             Ok(_) => ok_response(),
-            Err(_) => failed_to_delete_key_response(),
+            Err(e) => failed_to_delete_key_response(e),
         },
     }
 }
 
 pub async fn reload_keys_handler(State(tracker): State<Arc<Tracker>>) -> Response {
     match tracker.load_keys().await {
-        Ok(..) => ok_response(),
-        Err(..) => failed_to_reload_keys_response(),
+        Ok(_) => ok_response(),
+        Err(e) => failed_to_reload_keys_response(e),
     }
 }
 

--- a/src/apis/responses.rs
+++ b/src/apis/responses.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
 use serde::Serialize;
@@ -110,33 +112,33 @@ pub fn torrent_not_known_response() -> Response {
 }
 
 #[must_use]
-pub fn failed_to_remove_torrent_from_whitelist_response() -> Response {
-    unhandled_rejection_response("failed to remove torrent from whitelist".to_string())
+pub fn failed_to_remove_torrent_from_whitelist_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to remove torrent from whitelist: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_whitelist_torrent_response() -> Response {
-    unhandled_rejection_response("failed to whitelist torrent".to_string())
+pub fn failed_to_whitelist_torrent_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to whitelist torrent: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_reload_whitelist_response() -> Response {
-    unhandled_rejection_response("failed to reload whitelist".to_string())
+pub fn failed_to_reload_whitelist_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to reload whitelist: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_generate_key_response() -> Response {
-    unhandled_rejection_response("failed to generate key".to_string())
+pub fn failed_to_generate_key_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to generate key: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_delete_key_response() -> Response {
-    unhandled_rejection_response("failed to delete key".to_string())
+pub fn failed_to_delete_key_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to delete key: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_reload_keys_response() -> Response {
-    unhandled_rejection_response("failed to reload keys".to_string())
+pub fn failed_to_reload_keys_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to reload keys: {e}").to_string())
 }
 
 /// This error response is to keep backward compatibility with the old Warp API.

--- a/src/databases/driver.rs
+++ b/src/databases/driver.rs
@@ -1,7 +1,30 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+use super::error::Error;
+use super::mysql::Mysql;
+use super::sqlite::Sqlite;
+use super::{Builder, Database};
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, derive_more::Display, Clone)]
 pub enum Driver {
     Sqlite3,
     MySQL,
+}
+
+impl Driver {
+    /// .
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if unable to connect to the database.
+    pub fn build(&self, db_path: &str) -> Result<Box<dyn Database>, Error> {
+        let database = match self {
+            Driver::Sqlite3 => Builder::<Sqlite>::build(db_path),
+            Driver::MySQL => Builder::<Mysql>::build(db_path),
+        }?;
+
+        database.create_database_tables().expect("Could not create database tables.");
+
+        Ok(database)
+    }
 }

--- a/src/databases/error.rs
+++ b/src/databases/error.rs
@@ -1,21 +1,95 @@
-use derive_more::{Display, Error};
+use std::panic::Location;
+use std::sync::Arc;
 
-#[derive(Debug, Display, PartialEq, Eq, Error)]
-#[allow(dead_code)]
+use r2d2_mysql::mysql::UrlError;
+
+use super::driver::Driver;
+use crate::located_error::{Located, LocatedError};
+
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
-    #[display(fmt = "Query returned no rows.")]
-    QueryReturnedNoRows,
-    #[display(fmt = "Invalid query.")]
-    InvalidQuery,
-    #[display(fmt = "Database error.")]
-    DatabaseError,
+    #[error("The {driver} query unexpectedly returned nothing: {source}")]
+    QueryReturnedNoRows {
+        source: LocatedError<'static, dyn std::error::Error>,
+        driver: Driver,
+    },
+
+    #[error("The {driver} query was malformed: {source}")]
+    InvalidQuery {
+        source: LocatedError<'static, dyn std::error::Error>,
+        driver: Driver,
+    },
+
+    #[error("Unable to insert record into {driver} database, {location}")]
+    InsertFailed {
+        location: &'static Location<'static>,
+        driver: Driver,
+    },
+
+    #[error("Failed to remove record from {driver} database, error-code: {error_code}, {location}")]
+    DeleteFailed {
+        location: &'static Location<'static>,
+        error_code: usize,
+        driver: Driver,
+    },
+
+    #[error("Failed to connect to {driver} database: {source}")]
+    ConnectionError {
+        source: LocatedError<'static, UrlError>,
+        driver: Driver,
+    },
+
+    #[error("Failed to create r2d2 {driver} connection pool: {source}")]
+    ConnectionPool {
+        source: LocatedError<'static, r2d2::Error>,
+        driver: Driver,
+    },
 }
 
 impl From<r2d2_sqlite::rusqlite::Error> for Error {
-    fn from(e: r2d2_sqlite::rusqlite::Error) -> Self {
-        match e {
-            r2d2_sqlite::rusqlite::Error::QueryReturnedNoRows => Error::QueryReturnedNoRows,
-            _ => Error::InvalidQuery,
+    #[track_caller]
+    fn from(err: r2d2_sqlite::rusqlite::Error) -> Self {
+        match err {
+            r2d2_sqlite::rusqlite::Error::QueryReturnedNoRows => Error::QueryReturnedNoRows {
+                source: (Arc::new(err) as Arc<dyn std::error::Error>).into(),
+                driver: Driver::Sqlite3,
+            },
+            _ => Error::InvalidQuery {
+                source: (Arc::new(err) as Arc<dyn std::error::Error>).into(),
+                driver: Driver::Sqlite3,
+            },
+        }
+    }
+}
+
+impl From<r2d2_mysql::mysql::Error> for Error {
+    #[track_caller]
+    fn from(err: r2d2_mysql::mysql::Error) -> Self {
+        let e: Arc<dyn std::error::Error> = Arc::new(err);
+        Error::InvalidQuery {
+            source: e.into(),
+            driver: Driver::MySQL,
+        }
+    }
+}
+
+impl From<UrlError> for Error {
+    #[track_caller]
+    fn from(err: UrlError) -> Self {
+        Self::ConnectionError {
+            source: Located(err).into(),
+            driver: Driver::MySQL,
+        }
+    }
+}
+
+impl From<(r2d2::Error, Driver)> for Error {
+    #[track_caller]
+    fn from(e: (r2d2::Error, Driver)) -> Self {
+        let (err, driver) = e;
+        Self::ConnectionPool {
+            source: Located(err).into(),
+            driver,
         }
     }
 }

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -3,37 +3,48 @@ pub mod error;
 pub mod mysql;
 pub mod sqlite;
 
+use std::marker::PhantomData;
+
 use async_trait::async_trait;
 
-use self::driver::Driver;
 use self::error::Error;
-use crate::databases::mysql::Mysql;
-use crate::databases::sqlite::Sqlite;
 use crate::protocol::info_hash::InfoHash;
 use crate::tracker::auth;
 
-/// # Errors
-///
-/// Will return `r2d2::Error` if `db_path` is not able to create a database.
-pub fn connect(db_driver: &Driver, db_path: &str) -> Result<Box<dyn Database>, r2d2::Error> {
-    let database: Box<dyn Database> = match db_driver {
-        Driver::Sqlite3 => {
-            let db = Sqlite::new(db_path)?;
-            Box::new(db)
-        }
-        Driver::MySQL => {
-            let db = Mysql::new(db_path)?;
-            Box::new(db)
-        }
-    };
+pub(self) struct Builder<T>
+where
+    T: Database,
+{
+    phantom: PhantomData<T>,
+}
 
-    database.create_database_tables().expect("Could not create database tables.");
-
-    Ok(database)
+impl<T> Builder<T>
+where
+    T: Database + 'static,
+{
+    /// .
+    ///
+    /// # Errors
+    ///
+    /// Will return `r2d2::Error` if `db_path` is not able to create a database.
+    pub(self) fn build(db_path: &str) -> Result<Box<dyn Database>, Error> {
+        Ok(Box::new(T::new(db_path)?))
+    }
 }
 
 #[async_trait]
 pub trait Database: Sync + Send {
+    /// .
+    ///
+    /// # Errors
+    ///
+    /// Will return `r2d2::Error` if `db_path` is not able to create a database.
+    fn new(db_path: &str) -> Result<Self, Error>
+    where
+        Self: std::marker::Sized;
+
+    /// .
+    ///
     /// # Errors
     ///
     /// Will return `Error` if unable to create own tables.
@@ -52,27 +63,22 @@ pub trait Database: Sync + Send {
 
     async fn save_persistent_torrent(&self, info_hash: &InfoHash, completed: u32) -> Result<(), Error>;
 
-    async fn get_info_hash_from_whitelist(&self, info_hash: &str) -> Result<InfoHash, Error>;
+    async fn get_info_hash_from_whitelist(&self, info_hash: &str) -> Result<Option<InfoHash>, Error>;
 
     async fn add_info_hash_to_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
     async fn remove_info_hash_from_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
-    async fn get_key_from_keys(&self, key: &str) -> Result<auth::Key, Error>;
+    async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::Key>, Error>;
 
     async fn add_key_to_keys(&self, auth_key: &auth::Key) -> Result<usize, Error>;
 
     async fn remove_key_from_keys(&self, key: &str) -> Result<usize, Error>;
 
     async fn is_info_hash_whitelisted(&self, info_hash: &InfoHash) -> Result<bool, Error> {
-        self.get_info_hash_from_whitelist(&info_hash.clone().to_string())
-            .await
-            .map_or_else(
-                |e| match e {
-                    Error::QueryReturnedNoRows => Ok(false),
-                    e => Err(e),
-                },
-                |_| Ok(true),
-            )
+        Ok(self
+            .get_info_hash_from_whitelist(&info_hash.clone().to_string())
+            .await?
+            .is_some())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod databases;
 pub mod http;
 pub mod jobs;
+pub mod located_error;
 pub mod logging;
 pub mod protocol;
 pub mod setup;

--- a/src/located_error.rs
+++ b/src/located_error.rs
@@ -1,0 +1,103 @@
+// https://stackoverflow.com/questions/74336993/getting-line-numbers-with-when-using-boxdyn-stderrorerror
+
+use std::error::Error;
+use std::panic::Location;
+use std::sync::Arc;
+
+pub struct Located<E>(pub E);
+
+#[derive(Debug)]
+pub struct LocatedError<'a, E>
+where
+    E: Error + ?Sized,
+{
+    source: Arc<E>,
+    location: Box<Location<'a>>,
+}
+
+impl<'a, E> std::fmt::Display for LocatedError<'a, E>
+where
+    E: Error + ?Sized,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}, {}", self.source, self.location)
+    }
+}
+
+impl<'a, E> Error for LocatedError<'a, E>
+where
+    E: Error + ?Sized + 'static,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl<'a, E> Clone for LocatedError<'a, E>
+where
+    E: Error + ?Sized,
+{
+    fn clone(&self) -> Self {
+        LocatedError {
+            source: self.source.clone(),
+            location: self.location.clone(),
+        }
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<'a, E> Into<LocatedError<'a, E>> for Located<E>
+where
+    E: Error,
+    Arc<E>: Clone,
+{
+    #[track_caller]
+    fn into(self) -> LocatedError<'a, E> {
+        let e = LocatedError {
+            source: Arc::new(self.0),
+            location: Box::new(*std::panic::Location::caller()),
+        };
+        log::debug!("{e}");
+        e
+    }
+}
+
+#[allow(clippy::from_over_into)]
+impl<'a> Into<LocatedError<'a, dyn std::error::Error>> for Arc<dyn std::error::Error> {
+    #[track_caller]
+    fn into(self) -> LocatedError<'a, dyn std::error::Error> {
+        LocatedError {
+            source: self,
+            location: Box::new(*std::panic::Location::caller()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::Location;
+
+    use super::LocatedError;
+    use crate::located_error::Located;
+
+    #[derive(thiserror::Error, Debug)]
+    enum TestError {
+        #[error("Test")]
+        Test,
+    }
+
+    #[track_caller]
+    fn get_caller_location() -> Location<'static> {
+        *Location::caller()
+    }
+
+    #[test]
+    fn error_should_include_location() {
+        let e = TestError::Test;
+
+        let b: LocatedError<TestError> = Located(e).into();
+        let l = get_caller_location();
+
+        assert_eq!(b.location.file(), l.file());
+    }
+}

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{RwLock, RwLockReadGuard};
 
 use crate::config::Configuration;
+use crate::databases::driver::Driver;
 use crate::databases::{self, Database};
 use crate::protocol::info_hash::InfoHash;
 
@@ -40,13 +41,13 @@ pub struct TorrentsMetrics {
 impl Tracker {
     /// # Errors
     ///
-    /// Will return a `r2d2::Error` if unable to connect to database.
+    /// Will return a `databases::error::Error` if unable to connect to database.
     pub fn new(
         config: &Arc<Configuration>,
         stats_event_sender: Option<Box<dyn statistics::EventSender>>,
         stats_repository: statistics::Repo,
-    ) -> Result<Tracker, r2d2::Error> {
-        let database = databases::connect(&config.db_driver, &config.db_path)?;
+    ) -> Result<Tracker, databases::error::Error> {
+        let database = Driver::build(&config.db_driver, &config.db_path)?;
 
         Ok(Tracker {
             config: config.clone(),

--- a/tests/api/asserts.rs
+++ b/tests/api/asserts.rs
@@ -118,8 +118,11 @@ pub async fn assert_failed_to_reload_keys(response: Response) {
 async fn assert_unhandled_rejection(response: Response, reason: &str) {
     assert_eq!(response.status(), 500);
     assert_eq!(response.headers().get("content-type").unwrap(), "text/plain; charset=utf-8");
-    assert_eq!(
-        response.text().await.unwrap(),
-        format!("Unhandled rejection: Err {{ reason: \"{reason}\" }}")
+
+    let reason_text = format!("Unhandled rejection: Err {{ reason: \"{reason}");
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains(&reason_text),
+        ":\n  response: `\"{response_text}\"`\n  dose not contain: `\"{reason_text}\"`."
     );
 }

--- a/tests/api/asserts.rs
+++ b/tests/api/asserts.rs
@@ -37,9 +37,20 @@ pub async fn assert_auth_key_utf8(response: Response) -> AuthKey {
 // OK response
 
 pub async fn assert_ok(response: Response) {
-    assert_eq!(response.status(), 200);
-    assert_eq!(response.headers().get("content-type").unwrap(), "application/json");
-    assert_eq!(response.text().await.unwrap(), "{\"status\":\"ok\"}");
+    let response_status = response.status().clone();
+    let response_headers = response.headers().get("content-type").cloned().unwrap();
+    let response_text = response.text().await.unwrap();
+
+    let details = format!(
+        r#"
+   status: ´{response_status}´
+  headers: ´{response_headers:?}´
+     text: ´"{response_text}"´"#
+    );
+
+    assert_eq!(response_status, 200, "details:{details}.");
+    assert_eq!(response_headers, "application/json", "\ndetails:{details}.");
+    assert_eq!(response_text, "{\"status\":\"ok\"}", "\ndetails:{details}.");
 }
 
 // Error responses


### PR DESCRIPTION
Related Issue: #176 

Depends #177 

This is the first in a series of work to add locations to error messages. I have created the [located_error.rs](https://github.com/da2ce7/torrust-tracker/blob/database-error-overhall/src/located_error.rs) class that gathers location from the error call, and make use of it for the database errors.