### PR TITLE
Publish docker image only when secrets are available

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -15,7 +15,21 @@ env:
   TORRUST_TRACKER_RUN_AS_USER: appuser
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    environment: dockerhub-torrust
+    outputs:
+      publish: ${{ steps.check.outputs.publish }}
+    steps:
+      - id: check
+        env:
+          DOCKER_HUB_USERNAME: "${{ secrets.DOCKER_HUB_USERNAME }}"
+        if: "${{ env.DOCKER_HUB_USERNAME != '' }}"
+        run: echo "publish=true" >> $GITHUB_OUTPUT
+
   test:
+    needs: check-secret
+    if: needs.check-secret.outputs.publish == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,6 +44,7 @@ jobs:
 
   dockerhub:
     needs: test
+    if: needs.check-secret.outputs.publish == 'true'
     runs-on: ubuntu-latest
     environment: dockerhub-torrust
     steps:


### PR DESCRIPTION
See: https://github.com/torrust/torrust-tracker/discussions/132#discussioncomment-4475603

https://hub.docker.com/ does not have scoped tokens. They only have personal tokens. If you want to deploy the docker image with a workflow, you have to use your personal token.

To avoid sharing your personal tokens with all the maintainers, we agreed on using forks. I've changed the workflow. now it is only executed if the secret "DOCKER_HUB_USERNAME" is set in the "dockerhub-torrust" environment.

We can disable the workflow in this repo just by deleting the env vars:

- DOCKER_HUB_USERNAME
- DOCKER_HUB_REPOSITORY_NAME
- DOCKER_HUB_ACCESS_TOKEN

I only check for `DOCKER_HUB_USERNAME`.

We can use the same approach for publishing the crate on https://crates.io