### PR TITLE
Upload code coverage to `codecov.io`

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,40 @@
+name: Upload code coverage
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+          components: rustfmt, llvm-tools-preview
+      - name: Build
+        run: cargo build --release
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTFLAGS: "-Cinstrument-coverage"
+          RUSTDOCFLAGS: "-Cinstrument-coverage"
+      - name: Test
+        run: cargo test --all-features --no-fail-fast
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTFLAGS: "-Cinstrument-coverage"
+          RUSTDOCFLAGS: "-Cinstrument-coverage"
+      - name: Install grcov
+        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+      - name: Run grcov
+        run: grcov . --binary-path target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../**' --ignore '/*' -o coverage.lcov
+      - uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.lcov
+          flags: rust
+          fail_ci_if_error: true # optional (default = false)


### PR DESCRIPTION
I want to get nicer reports for the code coverage.

We are already generating a report like this:

```s
Filename                           Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
apis/handlers.rs                        75                11    85.33%          22                 0   100.00%          85                 1    98.82%           0                 0         -
apis/middlewares/auth.rs                20                 2    90.00%           8                 1    87.50%          32                 1    96.88%           0                 0         -
apis/resources/auth_key.rs              28                 5    82.14%          14                 1    92.86%          65                 1    98.46%           0                 0         -
apis/resources/peer.rs                  32                 7    78.12%          10                 2    80.00%          26                 2    92.31%           0                 0         -
apis/resources/stats.rs                 29                 2    93.10%           7                 1    85.71%          69                 1    98.55%           0                 0         -
apis/resources/torrent.rs               47                 7    85.11%          21                 4    80.95%          92                 9    90.22%           0                 0         -
apis/responses.rs                       20                 0   100.00%          18                 0   100.00%          72                 0   100.00%           0                 0         -
apis/routes.rs                           1                 0   100.00%           1                 0   100.00%          40                 0   100.00%           0                 0         -
apis/server.rs                          14                10    28.57%           4                 2    50.00%          34                24    29.41%           0                 0         -
config.rs                              131                34    74.05%          41                 6    85.37%         279                32    88.53%           0                 0         -
databases/driver.rs                      7                 2    71.43%           4                 1    75.00%           4                 1    75.00%           0                 0         -
databases/error.rs                       9                 6    33.33%           4                 3    25.00%           8                 4    50.00%           0                 0         -
databases/mod.rs                        27                 6    77.78%           5                 0   100.00%          25                 3    88.00%           0                 0         -
databases/mysql.rs                     172               172     0.00%          43                43     0.00%         206               206     0.00%           0                 0         -
databases/sqlite.rs                    231               104    54.98%          46                21    54.35%         221                78    64.71%           0                 0         -
http/error.rs                            4                 3    25.00%           2                 2     0.00%           2                 1    50.00%           0                 0         -
http/filters.rs                         69                 4    94.20%          23                 1    95.65%         136                 4    97.06%           0                 0         -
http/handlers.rs                        76                17    77.63%          11                 0   100.00%         131                 8    93.89%           0                 0         -
http/request.rs                         12                 2    83.33%           2                 1    50.00%           2                 1    50.00%           0                 0         -
http/response.rs                       114                64    43.86%          15                 8    46.67%          65                11    83.08%           0                 0         -
http/routes.rs                           5                 0   100.00%           4                 0   100.00%          22                 0   100.00%           0                 0         -
http/server.rs                          12                 7    41.67%           6                 3    50.00%          32                20    37.50%           0                 0         -
jobs/http_tracker.rs                    28                18    35.71%           4                 1    75.00%          47                15    68.09%           0                 0         -
jobs/torrent_cleanup.rs                  8                 8     0.00%           3                 3     0.00%          32                32     0.00%           0                 0         -
jobs/tracker_apis.rs                    36                25    30.56%           4                 1    75.00%          46                18    60.87%           0                 0         -
jobs/udp_tracker.rs                     13                 7    46.15%           2                 0   100.00%          15                 4    73.33%           0                 0         -
lib.rs                                   1                 0   100.00%           1                 0   100.00%           1                 0   100.00%           0                 0         -
logging.rs                              19                13    31.58%           5                 3    40.00%          39                29    25.64%           0                 0         -
main.rs                                 19                18     5.26%           4                 3    25.00%          34                33     2.94%           0                 0         -
protocol/clock/mod.rs                   71                16    77.46%          36                 7    80.56%         131                23    82.44%           0                 0         -
protocol/clock/time_extent.rs          151                 1    99.34%          82                 1    98.78%         355                 1    99.72%           0                 0         -
protocol/common.rs                      16                13    18.75%           9                 7    22.22%           9                 7    22.22%           0                 0         -
protocol/crypto.rs                      19                 0   100.00%          13                 0   100.00%          30                 0   100.00%           0                 0         -
protocol/info_hash.rs                   61                 8    86.89%          36                 5    86.11%         141                17    87.94%           0                 0         -
protocol/utils.rs                        1                 0   100.00%           1                 0   100.00%           4                 0   100.00%           0                 0         -
setup.rs                                32                32     0.00%           2                 2     0.00%          37                37     0.00%           0                 0         -
stats.rs                                12                 0   100.00%           7                 0   100.00%          28                 0   100.00%           0                 0         -
tracker/auth.rs                         69                26    62.32%          31                12    61.29%         113                18    84.07%           0                 0         -
tracker/mod.rs                         234                72    69.23%          58                 6    89.66%         256                43    83.20%           0                 0         -
tracker/mode.rs                          8                 3    62.50%           5                 2    60.00%           5                 2    60.00%           0                 0         -
tracker/peer.rs                        166                75    54.82%          51                 6    88.24%         340                71    79.12%           0                 0         -
tracker/services/common.rs               4                 1    75.00%           1                 0   100.00%          12                 2    83.33%           0                 0         -
tracker/services/statistics.rs          20                 4    80.00%           8                 1    87.50%          39                 1    97.44%           0                 0         -
tracker/services/torrent.rs            117                23    80.34%          41                 3    92.68%         233                12    94.85%           0                 0         -
tracker/statistics.rs                  287                70    75.61%          94                 4    95.74%         282                10    96.45%           0                 0         -
tracker/torrent.rs                      94                14    85.11%          53                 7    86.79%         278                10    96.40%           0                 0         -
udp/connection_cookie.rs                42                 0   100.00%          28                 0   100.00%         185                 0   100.00%           0                 0         -
udp/error.rs                            12                 8    33.33%           3                 1    66.67%          11                 9    18.18%           0                 0         -
udp/handlers.rs                        366                73    80.05%         135                 2    98.52%         942                35    96.28%           0                 0         -
udp/request.rs                           1                 0   100.00%           1                 0   100.00%           6                 0   100.00%           0                 0         -
udp/server.rs                           29                10    65.52%           9                 0   100.00%          40                 6    85.00%           0                 0         -
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                 3071              1003    67.34%        1038               177    82.95%        5339               843    84.21%           0                 0         -
```

but I also want to:

- Show the code coverage with a badge on the README.
- Show reports on the PR so you can see if the PR increases or decreases the code cov.

I'm testing integration with https://about.codecov.io/. This is the report I get:

https://app.codecov.io/github/josecelano/torrust-tracker/tree/setup-codecov

![image](https://user-images.githubusercontent.com/58816/216318346-85d74a5f-a9f8-4f4f-b9b7-4544c1624605.png)

But I think the most helpful feature is to know if the code in a PR increases or decreases de coverage.

By the way, I'm not obsessed with code coverage. I think we should cover critical behaviour (important for the user) and not just code lines. But I think a tool like this can make it more visible when we need to cover some critical parts of the application.
