### PR TITLE
dev: pass through errors to api handlers

### DIFF
--- a/src/apis/handlers.rs
+++ b/src/apis/handlers.rs
@@ -66,8 +66,8 @@ pub async fn add_torrent_to_whitelist_handler(
     match InfoHash::from_str(&info_hash.0) {
         Err(_) => invalid_info_hash_param_response(&info_hash.0),
         Ok(info_hash) => match tracker.add_torrent_to_whitelist(&info_hash).await {
-            Ok(..) => ok_response(),
-            Err(..) => failed_to_whitelist_torrent_response(),
+            Ok(_) => ok_response(),
+            Err(e) => failed_to_whitelist_torrent_response(e),
         },
     }
 }
@@ -79,16 +79,16 @@ pub async fn remove_torrent_from_whitelist_handler(
     match InfoHash::from_str(&info_hash.0) {
         Err(_) => invalid_info_hash_param_response(&info_hash.0),
         Ok(info_hash) => match tracker.remove_torrent_from_whitelist(&info_hash).await {
-            Ok(..) => ok_response(),
-            Err(..) => failed_to_remove_torrent_from_whitelist_response(),
+            Ok(_) => ok_response(),
+            Err(e) => failed_to_remove_torrent_from_whitelist_response(e),
         },
     }
 }
 
 pub async fn reload_whitelist_handler(State(tracker): State<Arc<Tracker>>) -> Response {
     match tracker.load_whitelist().await {
-        Ok(..) => ok_response(),
-        Err(..) => failed_to_reload_whitelist_response(),
+        Ok(_) => ok_response(),
+        Err(e) => failed_to_reload_whitelist_response(e),
     }
 }
 
@@ -96,7 +96,7 @@ pub async fn generate_auth_key_handler(State(tracker): State<Arc<Tracker>>, Path
     let seconds_valid = seconds_valid_or_key;
     match tracker.generate_auth_key(Duration::from_secs(seconds_valid)).await {
         Ok(auth_key) => auth_key_response(&AuthKey::from(auth_key)),
-        Err(_) => failed_to_generate_key_response(),
+        Err(e) => failed_to_generate_key_response(e),
     }
 }
 
@@ -111,15 +111,15 @@ pub async fn delete_auth_key_handler(
         Err(_) => invalid_auth_key_param_response(&seconds_valid_or_key.0),
         Ok(key_id) => match tracker.remove_auth_key(&key_id.to_string()).await {
             Ok(_) => ok_response(),
-            Err(_) => failed_to_delete_key_response(),
+            Err(e) => failed_to_delete_key_response(e),
         },
     }
 }
 
 pub async fn reload_keys_handler(State(tracker): State<Arc<Tracker>>) -> Response {
     match tracker.load_keys().await {
-        Ok(..) => ok_response(),
-        Err(..) => failed_to_reload_keys_response(),
+        Ok(_) => ok_response(),
+        Err(e) => failed_to_reload_keys_response(e),
     }
 }
 

--- a/src/apis/responses.rs
+++ b/src/apis/responses.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Json, Response};
 use serde::Serialize;
@@ -110,33 +112,33 @@ pub fn torrent_not_known_response() -> Response {
 }
 
 #[must_use]
-pub fn failed_to_remove_torrent_from_whitelist_response() -> Response {
-    unhandled_rejection_response("failed to remove torrent from whitelist".to_string())
+pub fn failed_to_remove_torrent_from_whitelist_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to remove torrent from whitelist: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_whitelist_torrent_response() -> Response {
-    unhandled_rejection_response("failed to whitelist torrent".to_string())
+pub fn failed_to_whitelist_torrent_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to whitelist torrent: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_reload_whitelist_response() -> Response {
-    unhandled_rejection_response("failed to reload whitelist".to_string())
+pub fn failed_to_reload_whitelist_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to reload whitelist: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_generate_key_response() -> Response {
-    unhandled_rejection_response("failed to generate key".to_string())
+pub fn failed_to_generate_key_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to generate key: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_delete_key_response() -> Response {
-    unhandled_rejection_response("failed to delete key".to_string())
+pub fn failed_to_delete_key_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to delete key: {e}").to_string())
 }
 
 #[must_use]
-pub fn failed_to_reload_keys_response() -> Response {
-    unhandled_rejection_response("failed to reload keys".to_string())
+pub fn failed_to_reload_keys_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to reload keys: {e}").to_string())
 }
 
 /// This error response is to keep backward compatibility with the old Warp API.

--- a/tests/api/asserts.rs
+++ b/tests/api/asserts.rs
@@ -118,8 +118,11 @@ pub async fn assert_failed_to_reload_keys(response: Response) {
 async fn assert_unhandled_rejection(response: Response, reason: &str) {
     assert_eq!(response.status(), 500);
     assert_eq!(response.headers().get("content-type").unwrap(), "text/plain; charset=utf-8");
-    assert_eq!(
-        response.text().await.unwrap(),
-        format!("Unhandled rejection: Err {{ reason: \"{reason}\" }}")
+
+    let reason_text = format!("Unhandled rejection: Err {{ reason: \"{reason}");
+    let response_text = response.text().await.unwrap();
+    assert!(
+        response_text.contains(&reason_text),
+        ":\n  response: `\"{response_text}\"`\n  dose not contain: `\"{reason_text}\"`."
     );
 }


### PR DESCRIPTION
Allow the messages from underlying errors to be passed through to the api handlers.