### PR TITLE
Remove duplicate code from `announce` request handlers

### DIFF
--- a/src/http/warp_implementation/mod.rs
+++ b/src/http/warp_implementation/mod.rs
@@ -3,6 +3,7 @@ use warp::Rejection;
 pub mod error;
 pub mod filters;
 pub mod handlers;
+pub mod peer_builder;
 pub mod request;
 pub mod response;
 pub mod routes;

--- a/src/http/warp_implementation/peer_builder.rs
+++ b/src/http/warp_implementation/peer_builder.rs
@@ -1,0 +1,32 @@
+use std::net::{IpAddr, SocketAddr};
+
+use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
+
+use super::request::Announce;
+use crate::protocol::clock::{Current, Time};
+use crate::tracker::peer::Peer;
+
+#[must_use]
+pub fn from_request(announce_request: &Announce, peer_ip: &IpAddr) -> Peer {
+    let event: AnnounceEvent = if let Some(event) = &announce_request.event {
+        match event.as_ref() {
+            "started" => AnnounceEvent::Started,
+            "stopped" => AnnounceEvent::Stopped,
+            "completed" => AnnounceEvent::Completed,
+            _ => AnnounceEvent::None,
+        }
+    } else {
+        AnnounceEvent::None
+    };
+
+    #[allow(clippy::cast_possible_truncation)]
+    Peer {
+        peer_id: announce_request.peer_id,
+        peer_addr: SocketAddr::new(*peer_ip, announce_request.port),
+        updated: Current::now(),
+        uploaded: NumberOfBytes(i128::from(announce_request.uploaded) as i64),
+        downloaded: NumberOfBytes(i128::from(announce_request.downloaded) as i64),
+        left: NumberOfBytes(i128::from(announce_request.left) as i64),
+        event,
+    }
+}

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -85,7 +85,7 @@ impl Tracker {
 
     /// It handles an announce request
     pub async fn announce(&self, info_hash: &InfoHash, peer: &mut Peer, remote_client_ip: &IpAddr) -> AnnounceResponse {
-        peer.change_ip(&self.assign_ip_address_to_peer(remote_client_ip));
+        peer.change_ip(&assign_ip_address_to_peer(remote_client_ip, self.config.get_ext_ip()));
 
         let swam_stats = self.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
 
@@ -93,12 +93,6 @@ impl Tracker {
         let peers = self.get_peers_excluding_peers_with_address(info_hash, &peer.peer_addr).await;
 
         AnnounceResponse { peers, swam_stats }
-    }
-
-    /// It assigns an IP address to the peer
-    #[must_use]
-    pub fn assign_ip_address_to_peer(&self, remote_client_ip: &IpAddr) -> IpAddr {
-        assign_ip_address_to_peer(remote_client_ip, self.config.get_ext_ip())
     }
 
     /// # Errors
@@ -407,7 +401,7 @@ impl Tracker {
 }
 
 #[must_use]
-pub fn assign_ip_address_to_peer(remote_client_ip: &IpAddr, tracker_external_ip: Option<IpAddr>) -> IpAddr {
+fn assign_ip_address_to_peer(remote_client_ip: &IpAddr, tracker_external_ip: Option<IpAddr>) -> IpAddr {
     if let Some(host_ip) = tracker_external_ip.filter(|_| remote_client_ip.is_loopback()) {
         host_ip
     } else {

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -279,7 +279,7 @@ impl Tracker {
     }
 
     /// Get all torrent peers for a given torrent filtering out the peer with the client address
-    pub async fn get_torrent_peers(&self, info_hash: &InfoHash, client_addr: &SocketAddr) -> Vec<peer::Peer> {
+    pub async fn get_other_peers(&self, info_hash: &InfoHash, client_addr: &SocketAddr) -> Vec<peer::Peer> {
         let read_lock = self.torrents.read().await;
 
         match read_lock.get(info_hash) {

--- a/src/tracker/peer.rs
+++ b/src/tracker/peer.rs
@@ -6,8 +6,7 @@ use serde;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::http::warp_implementation::request::Announce;
-use crate::protocol::clock::{Current, DurationSinceUnixEpoch, Time};
+use crate::protocol::clock::DurationSinceUnixEpoch;
 use crate::protocol::common::{AnnounceEventDef, NumberOfBytesDef};
 use crate::protocol::utils::ser_unix_time_value;
 
@@ -28,44 +27,6 @@ pub struct Peer {
 }
 
 impl Peer {
-    #[must_use]
-    pub fn from_udp_announce_request(announce_request: &aquatic_udp_protocol::AnnounceRequest, peer_addr: &SocketAddr) -> Self {
-        Peer {
-            peer_id: Id(announce_request.peer_id.0),
-            peer_addr: *peer_addr,
-            updated: Current::now(),
-            uploaded: announce_request.bytes_uploaded,
-            downloaded: announce_request.bytes_downloaded,
-            left: announce_request.bytes_left,
-            event: announce_request.event,
-        }
-    }
-
-    #[must_use]
-    pub fn from_http_announce_request(announce_request: &Announce, peer_addr: &SocketAddr) -> Self {
-        let event: AnnounceEvent = if let Some(event) = &announce_request.event {
-            match event.as_ref() {
-                "started" => AnnounceEvent::Started,
-                "stopped" => AnnounceEvent::Stopped,
-                "completed" => AnnounceEvent::Completed,
-                _ => AnnounceEvent::None,
-            }
-        } else {
-            AnnounceEvent::None
-        };
-
-        #[allow(clippy::cast_possible_truncation)]
-        Peer {
-            peer_id: announce_request.peer_id,
-            peer_addr: *peer_addr,
-            updated: Current::now(),
-            uploaded: NumberOfBytes(i128::from(announce_request.uploaded) as i64),
-            downloaded: NumberOfBytes(i128::from(announce_request.downloaded) as i64),
-            left: NumberOfBytes(i128::from(announce_request.left) as i64),
-            event,
-        }
-    }
-
     #[must_use]
     pub fn is_seeder(&self) -> bool {
         self.left.0 <= 0 && self.event != AnnounceEvent::Stopped
@@ -417,146 +378,6 @@ mod test {
                 // todo: compare using pretty json format to improve readability
                 r#"{"peer_id":{"id":"2d71423030303030303030303030303030303030","client":"qBittorrent"},"peer_addr":"126.0.0.1:8080","updated":0,"uploaded":0,"downloaded":0,"left":0,"event":"Started"}"#
             );
-        }
-    }
-
-    mod torrent_peer_constructor_from_udp_requests {
-
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use aquatic_udp_protocol::{
-            AnnounceEvent, AnnounceRequest, NumberOfBytes, NumberOfPeers, PeerId as AquaticPeerId, PeerKey, Port, TransactionId,
-        };
-
-        use crate::tracker::assign_ip_address_to_peer;
-        use crate::tracker::peer::Peer;
-        use crate::udp::connection_cookie::{into_connection_id, make};
-
-        // todo: duplicate functions is PR 82. Remove duplication once both PR are merged.
-
-        fn sample_ipv4_remote_addr() -> SocketAddr {
-            sample_ipv4_socket_address()
-        }
-
-        fn sample_ipv4_socket_address() -> SocketAddr {
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080)
-        }
-
-        struct AnnounceRequestBuilder {
-            request: AnnounceRequest,
-        }
-
-        impl AnnounceRequestBuilder {
-            pub fn default() -> AnnounceRequestBuilder {
-                let client_ip = Ipv4Addr::new(126, 0, 0, 1);
-                let client_port = 8080;
-                let info_hash_aquatic = aquatic_udp_protocol::InfoHash([0u8; 20]);
-
-                let default_request = AnnounceRequest {
-                    connection_id: into_connection_id(&make(&sample_ipv4_remote_addr())),
-                    transaction_id: TransactionId(0i32),
-                    info_hash: info_hash_aquatic,
-                    peer_id: AquaticPeerId(*b"-qB00000000000000000"),
-                    bytes_downloaded: NumberOfBytes(0i64),
-                    bytes_uploaded: NumberOfBytes(0i64),
-                    bytes_left: NumberOfBytes(0i64),
-                    event: AnnounceEvent::Started,
-                    ip_address: Some(client_ip),
-                    key: PeerKey(0u32),
-                    peers_wanted: NumberOfPeers(1i32),
-                    port: Port(client_port),
-                };
-                AnnounceRequestBuilder {
-                    request: default_request,
-                }
-            }
-
-            pub fn into(self) -> AnnounceRequest {
-                self.request
-            }
-        }
-
-        #[test]
-        fn it_should_use_the_udp_source_ip_as_the_peer_ip_address_instead_of_the_ip_in_the_announce_request() {
-            let remote_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 2));
-            let announce_request = AnnounceRequestBuilder::default().into();
-
-            let peer_ip = assign_ip_address_to_peer(&remote_ip, None);
-            let peer_socket_address = SocketAddr::new(peer_ip, announce_request.port.0);
-
-            let torrent_peer = Peer::from_udp_announce_request(&announce_request, &peer_socket_address);
-
-            assert_eq!(torrent_peer.peer_addr, SocketAddr::new(remote_ip, announce_request.port.0));
-        }
-
-        #[test]
-        fn it_should_always_use_the_port_in_the_announce_request_for_the_peer_port() {
-            let remote_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 2));
-            let announce_request = AnnounceRequestBuilder::default().into();
-
-            let peer_ip = assign_ip_address_to_peer(&remote_ip, None);
-            let peer_socket_address = SocketAddr::new(peer_ip, announce_request.port.0);
-
-            let torrent_peer = Peer::from_udp_announce_request(&announce_request, &peer_socket_address);
-
-            assert_eq!(torrent_peer.peer_addr, SocketAddr::new(remote_ip, announce_request.port.0));
-        }
-    }
-
-    mod torrent_peer_constructor_from_for_http_requests {
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use crate::http::warp_implementation::request::Announce;
-        use crate::protocol::info_hash::InfoHash;
-        use crate::tracker::assign_ip_address_to_peer;
-        use crate::tracker::peer::{self, Peer};
-
-        fn sample_http_announce_request(peer_addr: IpAddr, port: u16) -> Announce {
-            Announce {
-                info_hash: InfoHash([0u8; 20]),
-                peer_addr,
-                downloaded: 0u64,
-                uploaded: 0u64,
-                peer_id: peer::Id(*b"-qB00000000000000000"),
-                port,
-                left: 0u64,
-                event: None,
-                compact: None,
-            }
-        }
-
-        #[test]
-        fn it_should_use_the_source_ip_in_the_udp_header_as_the_peer_ip_address_ignoring_the_peer_ip_in_the_announce_request() {
-            let remote_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 2));
-
-            let ip_in_announce_request = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1));
-            let announce_request = sample_http_announce_request(ip_in_announce_request, 8080);
-
-            let peer_ip = assign_ip_address_to_peer(&remote_ip, None);
-            let peer_socket_address = SocketAddr::new(peer_ip, announce_request.port);
-
-            let torrent_peer = Peer::from_http_announce_request(&announce_request, &peer_socket_address);
-
-            assert_eq!(torrent_peer.peer_addr.ip(), remote_ip);
-            assert_ne!(torrent_peer.peer_addr.ip(), ip_in_announce_request);
-        }
-
-        #[test]
-        fn it_should_always_use_the_port_in_the_announce_request_for_the_peer_port_ignoring_the_port_in_the_udp_header() {
-            let remote_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 2));
-            let remote_port = 8080;
-
-            let port_in_announce_request = 8081;
-            let announce_request =
-                sample_http_announce_request(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), port_in_announce_request);
-
-            let peer_ip = assign_ip_address_to_peer(&remote_ip, None);
-            let peer_socket_address = SocketAddr::new(peer_ip, announce_request.port);
-
-            let torrent_peer = Peer::from_http_announce_request(&announce_request, &peer_socket_address);
-
-            assert_eq!(torrent_peer.peer_addr.port(), announce_request.port);
-            assert_ne!(torrent_peer.peer_addr.port(), remote_port);
         }
     }
 }

--- a/src/tracker/peer.rs
+++ b/src/tracker/peer.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::panic::Location;
 
 use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
@@ -30,6 +30,10 @@ impl Peer {
     #[must_use]
     pub fn is_seeder(&self) -> bool {
         self.left.0 <= 0 && self.event != AnnounceEvent::Stopped
+    }
+
+    pub fn change_ip(&mut self, new_ip: &IpAddr) {
+        self.peer_addr = SocketAddr::new(*new_ip, self.peer_addr.port());
     }
 }
 

--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -49,22 +49,22 @@ impl Entry {
     }
 
     #[must_use]
-    pub fn get_peers(&self, client_addr: Option<&SocketAddr>) -> Vec<&peer::Peer> {
+    pub fn get_peers(&self, optional_excluded_address: Option<&SocketAddr>) -> Vec<&peer::Peer> {
         self.peers
             .values()
-            .filter(|peer| match client_addr {
+            .filter(|peer| match optional_excluded_address {
                 // Don't filter on ip_version
                 None => true,
                 // Filter out different ip_version from remote_addr
-                Some(remote_addr) => {
+                Some(excluded_address) => {
                     // Skip ip address of client
-                    if peer.peer_addr.ip() == remote_addr.ip() {
+                    if peer.peer_addr.ip() == excluded_address.ip() {
                         return false;
                     }
 
                     match peer.peer_addr.ip() {
-                        IpAddr::V4(_) => remote_addr.is_ipv4(),
-                        IpAddr::V6(_) => remote_addr.is_ipv6(),
+                        IpAddr::V4(_) => excluded_address.is_ipv4(),
+                        IpAddr::V6(_) => excluded_address.is_ipv6(),
                     }
                 }
             })

--- a/src/udp/mod.rs
+++ b/src/udp/mod.rs
@@ -1,9 +1,9 @@
 pub mod connection_cookie;
 pub mod error;
 pub mod handlers;
+pub mod peer_builder;
 pub mod request;
 pub mod server;
-pub mod peer_builder;
 
 pub type Bytes = u64;
 pub type Port = u16;

--- a/src/udp/mod.rs
+++ b/src/udp/mod.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod handlers;
 pub mod request;
 pub mod server;
+pub mod peer_builder;
 
 pub type Bytes = u64;
 pub type Port = u16;

--- a/src/udp/peer_builder.rs
+++ b/src/udp/peer_builder.rs
@@ -1,0 +1,18 @@
+use std::net::{IpAddr, SocketAddr};
+
+use super::request::AnnounceWrapper;
+use crate::protocol::clock::{Current, Time};
+use crate::tracker::peer::{Id, Peer};
+
+#[must_use]
+pub fn from_request(announce_wrapper: &AnnounceWrapper, peer_ip: &IpAddr) -> Peer {
+    Peer {
+        peer_id: Id(announce_wrapper.announce_request.peer_id.0),
+        peer_addr: SocketAddr::new(*peer_ip, announce_wrapper.announce_request.port.0),
+        updated: Current::now(),
+        uploaded: announce_wrapper.announce_request.bytes_uploaded,
+        downloaded: announce_wrapper.announce_request.bytes_downloaded,
+        left: announce_wrapper.announce_request.bytes_left,
+        event: announce_wrapper.announce_request.event,
+    }
+}

--- a/src/udp/request.rs
+++ b/src/udp/request.rs
@@ -2,21 +2,6 @@ use aquatic_udp_protocol::AnnounceRequest;
 
 use crate::protocol::info_hash::InfoHash;
 
-// struct AnnounceRequest {
-//     pub connection_id: i64,
-//     pub transaction_id: i32,
-//     pub info_hash: InfoHash,
-//     pub peer_id: PeerId,
-//     pub bytes_downloaded: Bytes,
-//     pub bytes_uploaded: Bytes,
-//     pub bytes_left: Bytes,
-//     pub event: AnnounceEvent,
-//     pub ip_address: Option<Ipv4Addr>,
-//     pub key: u32,
-//     pub peers_wanted: u32,
-//     pub port: Port
-// }
-
 pub struct AnnounceWrapper {
     pub announce_request: AnnounceRequest,
     pub info_hash: InfoHash,


### PR DESCRIPTION
Before implementing the [new](https://github.com/torrust/torrust-tracker/pull/182) `announce` handler for the Axum HTTP tracker, I needed to clean up the current handlers (UDP and HTTP). The code was duplicated, and I did not want to add a third copy.

I planned to do it after migrating to Axum, but I changed my mind. I think the migration to Axum is going to be easier after this refactor.