### PR TITLE
Axum HTTP tracker: `scrape` response in public mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1478,6 +1478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "multipart"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2945,6 +2954,7 @@ dependencies = [
  "local-ip-address",
  "log",
  "mockall",
+ "multimap",
  "openssl",
  "percent-encoding",
  "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ axum = "0.6.1"
 axum-server = { version = "0.4.4", features = ["tls-rustls"] }
 axum-client-ip = "0.4.0"
 bip_bencode = "0.4.4"
+multimap = "0.8.3"
 
 
 [dev-dependencies]

--- a/cSpell.json
+++ b/cSpell.json
@@ -37,6 +37,7 @@
         "Lphant",
         "middlewares",
         "mockall",
+        "multimap",
         "myacicontext",
         "nanos",
         "nextest",

--- a/src/http/axum_implementation/extractors/mod.rs
+++ b/src/http/axum_implementation/extractors/mod.rs
@@ -1,3 +1,4 @@
 pub mod announce_request;
 pub mod peer_ip;
 pub mod remote_client_ip;
+pub mod scrape_request;

--- a/src/http/axum_implementation/extractors/peer_ip.rs
+++ b/src/http/axum_implementation/extractors/peer_ip.rs
@@ -31,7 +31,7 @@ impl From<ResolutionError> for responses::error::Error {
 ///
 /// Will return an error if the peer IP cannot be obtained according to the configuration.
 /// For example, if the IP is extracted from an HTTP header which is missing in the request.
-pub fn assign_ip_address_to_peer(on_reverse_proxy: bool, remote_client_ip: &RemoteClientIp) -> Result<IpAddr, Response> {
+pub fn resolve(on_reverse_proxy: bool, remote_client_ip: &RemoteClientIp) -> Result<IpAddr, Response> {
     if on_reverse_proxy {
         if let Some(ip) = remote_client_ip.right_most_x_forwarded_for {
             Ok(ip)

--- a/src/http/axum_implementation/extractors/scrape_request.rs
+++ b/src/http/axum_implementation/extractors/scrape_request.rs
@@ -1,0 +1,45 @@
+use std::panic::Location;
+
+use axum::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+
+use crate::http::axum_implementation::query::Query;
+use crate::http::axum_implementation::requests::scrape::{ParseScrapeQueryError, Scrape};
+use crate::http::axum_implementation::responses;
+
+pub struct ExtractRequest(pub Scrape);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for ExtractRequest
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let raw_query = parts.uri.query();
+
+        if raw_query.is_none() {
+            return Err(responses::error::Error::from(ParseScrapeQueryError::MissingParams {
+                location: Location::caller(),
+            })
+            .into_response());
+        }
+
+        let query = raw_query.unwrap().parse::<Query>();
+
+        if let Err(error) = query {
+            return Err(responses::error::Error::from(error).into_response());
+        }
+
+        let scrape_request = Scrape::try_from(query.unwrap());
+
+        if let Err(error) = scrape_request {
+            return Err(responses::error::Error::from(error).into_response());
+        }
+
+        Ok(ExtractRequest(scrape_request.unwrap()))
+    }
+}

--- a/src/http/axum_implementation/handlers/announce.rs
+++ b/src/http/axum_implementation/handlers/announce.rs
@@ -7,7 +7,7 @@ use axum::response::{IntoResponse, Response};
 use log::debug;
 
 use crate::http::axum_implementation::extractors::announce_request::ExtractRequest;
-use crate::http::axum_implementation::extractors::peer_ip::assign_ip_address_to_peer;
+use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::requests::announce::{Announce, Compact, Event};
 use crate::http::axum_implementation::responses::announce;
@@ -24,7 +24,7 @@ pub async fn handle(
 ) -> Response {
     debug!("http announce request: {:#?}", announce_request);
 
-    let peer_ip = match assign_ip_address_to_peer(tracker.config.on_reverse_proxy, &remote_client_ip) {
+    let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, &remote_client_ip) {
         Ok(peer_ip) => peer_ip,
         Err(err) => return err,
     };

--- a/src/http/axum_implementation/handlers/mod.rs
+++ b/src/http/axum_implementation/handlers/mod.rs
@@ -1,2 +1,3 @@
 pub mod announce;
+pub mod scrape;
 pub mod status;

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use log::debug;
+
+use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
+use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
+use crate::tracker::Tracker;
+
+#[allow(clippy::unused_async)]
+pub async fn handle(
+    State(_tracker): State<Arc<Tracker>>,
+    ExtractRequest(scrape_request): ExtractRequest,
+    _remote_client_ip: RemoteClientIp,
+) -> String {
+    debug!("http scrape request: {:#?}", &scrape_request);
+
+    format!("{:#?}", &scrape_request)
+}

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -9,11 +9,21 @@ use crate::tracker::Tracker;
 
 #[allow(clippy::unused_async)]
 pub async fn handle(
-    State(_tracker): State<Arc<Tracker>>,
+    State(tracker): State<Arc<Tracker>>,
     ExtractRequest(scrape_request): ExtractRequest,
     _remote_client_ip: RemoteClientIp,
 ) -> String {
     debug!("http scrape request: {:#?}", &scrape_request);
 
-    format!("{:#?}", &scrape_request)
+    /*
+    todo:
+        - Add the service that sends the event for statistics.
+        - Build the HTTP bencoded response.
+    */
+
+    let scrape_data = tracker.scrape(&scrape_request.info_hashes).await;
+
+    debug!("scrape data: {:#?}", &scrape_data);
+
+    "todo".to_string()
 }

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use log::debug;
 
 use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
-use crate::http::axum_implementation::services;
+use crate::http::axum_implementation::{responses, services};
 use crate::tracker::Tracker;
 
 #[allow(clippy::unused_async)]
@@ -19,12 +18,6 @@ pub async fn handle(
 ) -> Response {
     debug!("http scrape request: {:#?}", &scrape_request);
 
-    /*
-    todo:
-        - [x] Add the service that sends the event for statistics.
-        - [ ] Build the HTTP bencoded response.
-    */
-
     let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, &remote_client_ip) {
         Ok(peer_ip) => peer_ip,
         Err(err) => return err,
@@ -32,7 +25,5 @@ pub async fn handle(
 
     let scrape_data = services::scrape::invoke(tracker.clone(), &scrape_request.info_hashes, &peer_ip).await;
 
-    debug!("scrape data: {:#?}", &scrape_data);
-
-    (StatusCode::OK, "todo").into_response()
+    responses::scrape::Bencoded::from(scrape_data).into_response()
 }

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -1,29 +1,38 @@
 use std::sync::Arc;
 
 use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
 use log::debug;
 
+use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
+use crate::http::axum_implementation::services;
 use crate::tracker::Tracker;
 
 #[allow(clippy::unused_async)]
 pub async fn handle(
     State(tracker): State<Arc<Tracker>>,
     ExtractRequest(scrape_request): ExtractRequest,
-    _remote_client_ip: RemoteClientIp,
-) -> String {
+    remote_client_ip: RemoteClientIp,
+) -> Response {
     debug!("http scrape request: {:#?}", &scrape_request);
 
     /*
     todo:
-        - Add the service that sends the event for statistics.
-        - Build the HTTP bencoded response.
+        - [x] Add the service that sends the event for statistics.
+        - [ ] Build the HTTP bencoded response.
     */
 
-    let scrape_data = tracker.scrape(&scrape_request.info_hashes).await;
+    let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, &remote_client_ip) {
+        Ok(peer_ip) => peer_ip,
+        Err(err) => return err,
+    };
+
+    let scrape_data = services::scrape::invoke(tracker.clone(), &scrape_request.info_hashes, &peer_ip).await;
 
     debug!("scrape data: {:#?}", &scrape_data);
 
-    "todo".to_string()
+    (StatusCode::OK, "todo").into_response()
 }

--- a/src/http/axum_implementation/handlers/status.rs
+++ b/src/http/axum_implementation/handlers/status.rs
@@ -7,6 +7,6 @@ use crate::http::axum_implementation::resources::ok::Ok;
 use crate::http::axum_implementation::responses::ok;
 
 #[allow(clippy::unused_async)]
-pub async fn get_status_handler(remote_client_ip: RemoteClientIp) -> Json<Ok> {
+pub async fn handle(remote_client_ip: RemoteClientIp) -> Json<Ok> {
     ok::response(&remote_client_ip)
 }

--- a/src/http/axum_implementation/requests/mod.rs
+++ b/src/http/axum_implementation/requests/mod.rs
@@ -1,1 +1,2 @@
 pub mod announce;
+pub mod scrape;

--- a/src/http/axum_implementation/requests/scrape.rs
+++ b/src/http/axum_implementation/requests/scrape.rs
@@ -1,0 +1,137 @@
+use std::panic::Location;
+
+use thiserror::Error;
+
+use crate::http::axum_implementation::query::Query;
+use crate::http::axum_implementation::responses;
+use crate::http::percent_encoding::percent_decode_info_hash;
+use crate::located_error::{Located, LocatedError};
+use crate::protocol::info_hash::{ConversionError, InfoHash};
+
+pub type NumberOfBytes = i64;
+
+// Query param name
+const INFO_HASH_SCRAPE_PARAM: &str = "info_hash";
+
+#[derive(Debug, PartialEq)]
+pub struct Scrape {
+    pub info_hashes: Vec<InfoHash>,
+}
+
+#[derive(Error, Debug)]
+pub enum ParseScrapeQueryError {
+    #[error("missing query params for scrape request in {location}")]
+    MissingParams { location: &'static Location<'static> },
+    #[error("missing param {param_name} in {location}")]
+    MissingParam {
+        location: &'static Location<'static>,
+        param_name: String,
+    },
+    #[error("invalid param value {param_value} for {param_name} in {location}")]
+    InvalidParam {
+        param_name: String,
+        param_value: String,
+        location: &'static Location<'static>,
+    },
+    #[error("invalid param value {param_value} for {param_name} in {source}")]
+    InvalidInfoHashParam {
+        param_name: String,
+        param_value: String,
+        source: LocatedError<'static, ConversionError>,
+    },
+}
+
+impl From<ParseScrapeQueryError> for responses::error::Error {
+    fn from(err: ParseScrapeQueryError) -> Self {
+        responses::error::Error {
+            failure_reason: format!("Cannot parse query params for scrape request: {err}"),
+        }
+    }
+}
+
+impl TryFrom<Query> for Scrape {
+    type Error = ParseScrapeQueryError;
+
+    fn try_from(query: Query) -> Result<Self, Self::Error> {
+        Ok(Self {
+            info_hashes: extract_info_hashes(&query)?,
+        })
+    }
+}
+
+fn extract_info_hashes(query: &Query) -> Result<Vec<InfoHash>, ParseScrapeQueryError> {
+    match query.get_param(INFO_HASH_SCRAPE_PARAM) {
+        Some(raw_param) => {
+            let mut info_hashes = vec![];
+
+            // todo: multiple infohashes
+
+            let info_hash = percent_decode_info_hash(&raw_param).map_err(|err| ParseScrapeQueryError::InvalidInfoHashParam {
+                param_name: INFO_HASH_SCRAPE_PARAM.to_owned(),
+                param_value: raw_param.clone(),
+                source: Located(err).into(),
+            })?;
+
+            info_hashes.push(info_hash);
+
+            Ok(info_hashes)
+        }
+        None => {
+            return Err(ParseScrapeQueryError::MissingParam {
+                location: Location::caller(),
+                param_name: INFO_HASH_SCRAPE_PARAM.to_owned(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod scrape_request {
+
+        use crate::http::axum_implementation::query::Query;
+        use crate::http::axum_implementation::requests::scrape::{Scrape, INFO_HASH_SCRAPE_PARAM};
+        use crate::protocol::info_hash::InfoHash;
+
+        #[test]
+        fn should_be_instantiated_from_the_url_query_with_only_one_infohash() {
+            let raw_query = Query::from(vec![(
+                INFO_HASH_SCRAPE_PARAM,
+                "%3B%24U%04%CF%5F%11%BB%DB%E1%20%1C%EAjk%F4Z%EE%1B%C0",
+            )])
+            .to_string();
+
+            let query = raw_query.parse::<Query>().unwrap();
+
+            let scrape_request = Scrape::try_from(query).unwrap();
+
+            assert_eq!(
+                scrape_request,
+                Scrape {
+                    info_hashes: vec!["3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap()],
+                }
+            );
+        }
+
+        mod when_it_is_instantiated_from_the_url_query_params {
+
+            use crate::http::axum_implementation::query::Query;
+            use crate::http::axum_implementation::requests::scrape::{Scrape, INFO_HASH_SCRAPE_PARAM};
+
+            #[test]
+            fn it_should_fail_if_the_query_does_not_include_the_info_hash_param() {
+                let raw_query_without_info_hash = "another_param=NOT_RELEVANT";
+
+                assert!(Scrape::try_from(raw_query_without_info_hash.parse::<Query>().unwrap()).is_err());
+            }
+
+            #[test]
+            fn it_should_fail_if_the_info_hash_param_is_invalid() {
+                let raw_query = Query::from(vec![(INFO_HASH_SCRAPE_PARAM, "INVALID_INFO_HASH_VALUE")]).to_string();
+
+                assert!(Scrape::try_from(raw_query.parse::<Query>().unwrap()).is_err());
+            }
+        }
+    }
+}

--- a/src/http/axum_implementation/requests/scrape.rs
+++ b/src/http/axum_implementation/requests/scrape.rs
@@ -60,19 +60,20 @@ impl TryFrom<Query> for Scrape {
 }
 
 fn extract_info_hashes(query: &Query) -> Result<Vec<InfoHash>, ParseScrapeQueryError> {
-    match query.get_param(INFO_HASH_SCRAPE_PARAM) {
-        Some(raw_param) => {
+    match query.get_param_vec(INFO_HASH_SCRAPE_PARAM) {
+        Some(raw_params) => {
             let mut info_hashes = vec![];
 
-            // todo: multiple infohashes
+            for raw_param in raw_params {
+                let info_hash =
+                    percent_decode_info_hash(&raw_param).map_err(|err| ParseScrapeQueryError::InvalidInfoHashParam {
+                        param_name: INFO_HASH_SCRAPE_PARAM.to_owned(),
+                        param_value: raw_param.clone(),
+                        source: Located(err).into(),
+                    })?;
 
-            let info_hash = percent_decode_info_hash(&raw_param).map_err(|err| ParseScrapeQueryError::InvalidInfoHashParam {
-                param_name: INFO_HASH_SCRAPE_PARAM.to_owned(),
-                param_value: raw_param.clone(),
-                source: Located(err).into(),
-            })?;
-
-            info_hashes.push(info_hash);
+                info_hashes.push(info_hash);
+            }
 
             Ok(info_hashes)
         }

--- a/src/http/axum_implementation/responses/mod.rs
+++ b/src/http/axum_implementation/responses/mod.rs
@@ -1,3 +1,4 @@
 pub mod announce;
 pub mod error;
 pub mod ok;
+pub mod scrape;

--- a/src/http/axum_implementation/responses/scrape.rs
+++ b/src/http/axum_implementation/responses/scrape.rs
@@ -1,0 +1,106 @@
+use std::borrow::Cow;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use bip_bencode::{ben_int, ben_map, BMutAccess};
+
+use crate::tracker::ScrapeData;
+
+#[derive(Debug, PartialEq, Default)]
+pub struct Bencoded {
+    scrape_data: ScrapeData,
+}
+
+impl Bencoded {
+    /// # Panics
+    ///
+    /// Will return an error if it can't access the bencode as a mutable `BDictAccess`.    
+    #[must_use]
+    pub fn body(&self) -> Vec<u8> {
+        let mut scrape_list = ben_map!();
+
+        let scrape_list_mut = scrape_list.dict_mut().unwrap();
+
+        for (info_hash, value) in &self.scrape_data.files {
+            scrape_list_mut.insert(
+                Cow::from(info_hash.bytes().to_vec()),
+                ben_map! {
+                    "complete" => ben_int!(i64::from(value.complete)),
+                    "downloaded" => ben_int!(i64::from(value.downloaded)),
+                    "incomplete" => ben_int!(i64::from(value.incomplete))
+                },
+            );
+        }
+
+        (ben_map! {
+            "files" => scrape_list
+        })
+        .encode()
+    }
+}
+
+impl From<ScrapeData> for Bencoded {
+    fn from(scrape_data: ScrapeData) -> Self {
+        Self { scrape_data }
+    }
+}
+
+impl IntoResponse for Bencoded {
+    fn into_response(self) -> Response {
+        (StatusCode::OK, self.body()).into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod scrape_response {
+        use crate::http::axum_implementation::responses::scrape::Bencoded;
+        use crate::protocol::info_hash::InfoHash;
+        use crate::tracker::torrent::SwarmMetadata;
+        use crate::tracker::ScrapeData;
+
+        fn sample_scrape_data() -> ScrapeData {
+            let info_hash = InfoHash([0x69; 20]);
+            let mut scrape_data = ScrapeData::empty();
+            scrape_data.add_file(
+                &info_hash,
+                SwarmMetadata {
+                    complete: 1,
+                    downloaded: 2,
+                    incomplete: 3,
+                },
+            );
+            scrape_data
+        }
+
+        #[test]
+        fn should_be_converted_from_scrape_data() {
+            let response = Bencoded::from(sample_scrape_data());
+
+            assert_eq!(
+                response,
+                Bencoded {
+                    scrape_data: sample_scrape_data()
+                }
+            );
+        }
+
+        #[test]
+        fn should_be_bencoded() {
+            let response = Bencoded {
+                scrape_data: sample_scrape_data(),
+            };
+
+            let bytes = response.body();
+
+            // cspell:disable-next-line
+            let expected_bytes = b"d5:filesd20:iiiiiiiiiiiiiiiiiiiid8:completei1e10:downloadedi2e10:incompletei3eeee";
+
+            assert_eq!(
+                String::from_utf8(bytes).unwrap(),
+                String::from_utf8(expected_bytes.to_vec()).unwrap()
+            );
+        }
+    }
+}

--- a/src/http/axum_implementation/routes.rs
+++ b/src/http/axum_implementation/routes.rs
@@ -4,15 +4,17 @@ use axum::routing::get;
 use axum::Router;
 use axum_client_ip::SecureClientIpSource;
 
-use super::handlers::announce::handle;
-use super::handlers::status::get_status_handler;
+use super::handlers::{announce, scrape, status};
 use crate::tracker::Tracker;
 
 pub fn router(tracker: &Arc<Tracker>) -> Router {
     Router::new()
         // Status
-        .route("/status", get(get_status_handler))
+        .route("/status", get(status::handle))
         // Announce request
-        .route("/announce", get(handle).with_state(tracker.clone()))
+        .route("/announce", get(announce::handle).with_state(tracker.clone()))
+        // Scrape request
+        .route("/scrape", get(scrape::handle).with_state(tracker.clone()))
+        // Add extension to get the client IP from the connection info
         .layer(SecureClientIpSource::ConnectInfo.into_extension())
 }

--- a/src/http/axum_implementation/services/announce.rs
+++ b/src/http/axum_implementation/services/announce.rs
@@ -9,7 +9,7 @@ pub async fn invoke(tracker: Arc<Tracker>, info_hash: InfoHash, peer: &mut Peer)
     let original_peer_ip = peer.peer_addr.ip();
 
     // The tracker could change the original peer ip
-    let response = tracker.announce(&info_hash, peer, &original_peer_ip).await;
+    let announce_data = tracker.announce(&info_hash, peer, &original_peer_ip).await;
 
     match original_peer_ip {
         IpAddr::V4(_) => {
@@ -20,5 +20,5 @@ pub async fn invoke(tracker: Arc<Tracker>, info_hash: InfoHash, peer: &mut Peer)
         }
     }
 
-    response
+    announce_data
 }

--- a/src/http/axum_implementation/services/mod.rs
+++ b/src/http/axum_implementation/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod announce;
+pub mod scrape;

--- a/src/http/axum_implementation/services/scrape.rs
+++ b/src/http/axum_implementation/services/scrape.rs
@@ -1,0 +1,20 @@
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use crate::protocol::info_hash::InfoHash;
+use crate::tracker::{statistics, ScrapeData, Tracker};
+
+pub async fn invoke(tracker: Arc<Tracker>, info_hashes: &Vec<InfoHash>, original_peer_ip: &IpAddr) -> ScrapeData {
+    let scrape_data = tracker.scrape(info_hashes).await;
+
+    match original_peer_ip {
+        IpAddr::V4(_) => {
+            tracker.send_stats_event(statistics::Event::Tcp4Scrape).await;
+        }
+        IpAddr::V6(_) => {
+            tracker.send_stats_event(statistics::Event::Tcp6Scrape).await;
+        }
+    }
+
+    scrape_data
+}

--- a/src/http/percent_encoding.rs
+++ b/src/http/percent_encoding.rs
@@ -3,7 +3,7 @@ use crate::tracker::peer::{self, IdConversionError};
 
 /// # Errors
 ///
-/// Will return `Err` if if the decoded bytes do not represent a valid `InfoHash`.
+/// Will return `Err` if the decoded bytes do not represent a valid `InfoHash`.
 pub fn percent_decode_info_hash(raw_info_hash: &str) -> Result<InfoHash, ConversionError> {
     let bytes = percent_encoding::percent_decode_str(raw_info_hash).collect::<Vec<u8>>();
     InfoHash::try_from(bytes)

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -52,7 +52,7 @@ pub struct AnnounceData {
 
 #[derive(Debug, PartialEq, Default)]
 pub struct ScrapeData {
-    files: HashMap<InfoHash, SwarmMetadata>,
+    pub files: HashMap<InfoHash, SwarmMetadata>,
 }
 
 impl ScrapeData {

--- a/src/tracker/statistics.rs
+++ b/src/tracker/statistics.rs
@@ -11,6 +11,8 @@ const CHANNEL_BUFFER_SIZE: usize = 65_535;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Event {
+    // code-review: consider one single event for request type with data: Event::Announce { scheme: HTTPorUDP, ip_version: V4orV6 }
+    // Attributes are enums too.
     Tcp4Announce,
     Tcp4Scrape,
     Tcp6Announce,

--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -16,9 +16,9 @@ pub struct Entry {
 
 #[derive(Debug, PartialEq, Default)]
 pub struct SwarmMetadata {
-    pub complete: u32,   // The number of active peers that have completed downloading
+    pub complete: u32,   // The number of active peers that have completed downloading (seeders)
     pub downloaded: u32, // The number of peers that have ever completed downloading
-    pub incomplete: u32, // The number of active peers that have not completed downloading
+    pub incomplete: u32, // The number of active peers that have not completed downloading (leechers)
 }
 
 impl Entry {

--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -14,6 +14,13 @@ pub struct Entry {
     pub completed: u32,
 }
 
+#[derive(Debug, PartialEq, Default)]
+pub struct SwarmMetadata {
+    pub complete: u32,   // The number of active peers that have completed downloading
+    pub downloaded: u32, // The number of peers that have ever completed downloading
+    pub incomplete: u32, // The number of active peers that have not completed downloading
+}
+
 impl Entry {
     #[must_use]
     pub fn new() -> Entry {
@@ -72,6 +79,17 @@ impl Entry {
         let seeders: u32 = self.peers.values().filter(|peer| peer.is_seeder()).count() as u32;
         let leechers: u32 = self.peers.len() as u32 - seeders;
         (seeders, self.completed, leechers)
+    }
+
+    #[must_use]
+    pub fn get_swarm_metadata(&self) -> SwarmMetadata {
+        // code-review: consider using always this function instead of `get_stats`.
+        let (seeders, completed, leechers) = self.get_stats();
+        SwarmMetadata {
+            complete: seeders,
+            downloaded: completed,
+            incomplete: leechers,
+        }
     }
 
     pub fn remove_inactive_peers(&mut self, max_peer_timeout: u32) {

--- a/tests/http/asserts.rs
+++ b/tests/http/asserts.rs
@@ -78,6 +78,36 @@ pub async fn assert_is_announce_response(response: Response) {
 
 // Error responses
 
+// Specific errors for announce request
+
+pub async fn assert_missing_query_params_for_announce_request_error_response(response: Response) {
+    assert_eq!(response.status(), 200);
+
+    assert_bencoded_error(
+        &response.text().await.unwrap(),
+        "missing query params for announce request",
+        Location::caller(),
+    );
+}
+
+pub async fn assert_bad_announce_request_error_response(response: Response, failure: &str) {
+    assert_cannot_parse_query_params_error_response(response, &format!(" for announce request: {failure}")).await;
+}
+
+// Specific errors for scrape request
+
+pub async fn assert_missing_query_params_for_scrape_request_error_response(response: Response) {
+    assert_eq!(response.status(), 200);
+
+    assert_bencoded_error(
+        &response.text().await.unwrap(),
+        "missing query params for scrape request",
+        Location::caller(),
+    );
+}
+
+// Other errors
+
 pub async fn assert_internal_server_error_response(response: Response) {
     assert_eq!(response.status(), 200);
 
@@ -154,22 +184,6 @@ pub async fn assert_invalid_remote_address_on_xff_header_error_response(response
         "could not find remote address: on remote proxy and unable to parse the last x-forwarded-ip",
         Location::caller(),
     );
-}
-
-// Specific errors for announce request
-
-pub async fn assert_missing_query_params_for_announce_request_error_response(response: Response) {
-    assert_eq!(response.status(), 200);
-
-    assert_bencoded_error(
-        &response.text().await.unwrap(),
-        "missing query params for announce request",
-        Location::caller(),
-    );
-}
-
-pub async fn assert_bad_announce_request_error_response(response: Response, failure: &str) {
-    assert_cannot_parse_query_params_error_response(response, &format!(" for announce request: {failure}")).await;
 }
 
 pub async fn assert_cannot_parse_query_param_error_response(response: Response, failure: &str) {

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -2354,8 +2354,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_increase_the_number_ot_tcp4_scrape_requests_handled_in_statistics() {
                 let http_tracker = start_public_http_tracker(Version::Axum).await;
 
@@ -2374,8 +2373,7 @@ mod axum_http_tracker_server {
                 assert_eq!(stats.tcp4_scrapes_handled, 1);
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_increase_the_number_ot_tcp6_scrape_requests_handled_in_statistics() {
                 let http_tracker = start_ipv6_http_tracker(Version::Axum).await;
 

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -2198,24 +2198,25 @@ mod axum_http_tracker_server {
             use torrust_tracker::tracker::peer;
 
             use crate::common::fixtures::{invalid_info_hashes, PeerBuilder};
-            use crate::http::asserts::{assert_internal_server_error_response, assert_scrape_response};
+            use crate::http::asserts::{
+                assert_cannot_parse_query_params_error_response, assert_missing_query_params_for_scrape_request_error_response,
+                assert_scrape_response,
+            };
             use crate::http::client::Client;
             use crate::http::requests;
             use crate::http::requests::scrape::QueryBuilder;
             use crate::http::responses::scrape::{self, File, ResponseBuilder};
             use crate::http::server::{start_ipv6_http_tracker, start_public_http_tracker};
 
-            //#[tokio::test]
-            #[allow(dead_code)]
-            async fn should_fail_when_the_request_is_empty() {
+            #[tokio::test]
+            async fn should_fail_when_the_url_query_component_is_empty() {
                 let http_tracker_server = start_public_http_tracker(Version::Axum).await;
                 let response = Client::new(http_tracker_server.get_connection_info()).get("scrape").await;
 
-                assert_internal_server_error_response(response).await;
+                assert_missing_query_params_for_scrape_request_error_response(response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_fail_when_the_info_hash_param_is_invalid() {
                 let http_tracker_server = start_public_http_tracker(Version::Axum).await;
 
@@ -2228,13 +2229,11 @@ mod axum_http_tracker_server {
                         .get(&format!("announce?{params}"))
                         .await;
 
-                    // code-review: it's not returning the invalid info hash error
-                    assert_internal_server_error_response(response).await;
+                    assert_cannot_parse_query_params_error_response(response, "").await;
                 }
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download() {
                 let http_tracker = start_public_http_tracker(Version::Axum).await;
 
@@ -2272,8 +2271,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_file_with_the_complete_peer_when_there_is_one_peer_with_no_bytes_pending_to_download() {
                 let http_tracker = start_public_http_tracker(Version::Axum).await;
 
@@ -2311,8 +2309,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_a_file_with_zeroed_values_when_there_are_no_peers() {
                 let http_tracker = start_public_http_tracker(Version::Axum).await;
 
@@ -2329,8 +2326,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &scrape::Response::with_one_file(info_hash.bytes(), File::zeroed())).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_accept_multiple_infohashes() {
                 let http_tracker = start_public_http_tracker(Version::Axum).await;
 


### PR DESCRIPTION
`scrape` request in the new Axum HTTP tracker implementation. Only por `public` mode.