### PR TITLE
Refactor: `auth::Key`

### DIFF
--- a/src/apis/resources/auth_key.rs
+++ b/src/apis/resources/auth_key.rs
@@ -11,9 +11,9 @@ pub struct AuthKey {
     pub valid_until: Option<u64>,
 }
 
-impl From<AuthKey> for auth::Key {
+impl From<AuthKey> for auth::ExpiringKey {
     fn from(auth_key_resource: AuthKey) -> Self {
-        auth::Key {
+        auth::ExpiringKey {
             id: auth_key_resource.key.parse::<KeyId>().unwrap(),
             valid_until: auth_key_resource
                 .valid_until
@@ -22,8 +22,8 @@ impl From<AuthKey> for auth::Key {
     }
 }
 
-impl From<auth::Key> for AuthKey {
-    fn from(auth_key: auth::Key) -> Self {
+impl From<auth::ExpiringKey> for AuthKey {
+    fn from(auth_key: auth::ExpiringKey) -> Self {
         AuthKey {
             key: auth_key.id.to_string(),
             valid_until: auth_key.valid_until.map(|valid_until| valid_until.as_secs()),
@@ -49,8 +49,8 @@ mod tests {
         };
 
         assert_eq!(
-            auth::Key::from(auth_key_resource),
-            auth::Key {
+            auth::ExpiringKey::from(auth_key_resource),
+            auth::ExpiringKey {
                 id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<KeyId>().unwrap(), // cspell:disable-line
                 valid_until: Some(Current::add(&Duration::new(duration_in_secs, 0)).unwrap())
             }
@@ -61,7 +61,7 @@ mod tests {
     fn it_should_be_convertible_from_an_auth_key() {
         let duration_in_secs = 60;
 
-        let auth_key = auth::Key {
+        let auth_key = auth::ExpiringKey {
             id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<KeyId>().unwrap(), // cspell:disable-line
             valid_until: Some(Current::add(&Duration::new(duration_in_secs, 0)).unwrap()),
         };

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -57,7 +57,7 @@ pub trait Database: Sync + Send {
 
     async fn load_persistent_torrents(&self) -> Result<Vec<(InfoHash, u32)>, Error>;
 
-    async fn load_keys(&self) -> Result<Vec<auth::Key>, Error>;
+    async fn load_keys(&self) -> Result<Vec<auth::ExpiringKey>, Error>;
 
     async fn load_whitelist(&self) -> Result<Vec<InfoHash>, Error>;
 
@@ -71,9 +71,9 @@ pub trait Database: Sync + Send {
     async fn remove_info_hash_from_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
     // todo: replace type `&str` with `&KeyId`
-    async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::Key>, Error>;
+    async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::ExpiringKey>, Error>;
 
-    async fn add_key_to_keys(&self, auth_key: &auth::Key) -> Result<usize, Error>;
+    async fn add_key_to_keys(&self, auth_key: &auth::ExpiringKey) -> Result<usize, Error>;
 
     // todo: replace type `&str` with `&KeyId`
     async fn remove_key_from_keys(&self, key: &str) -> Result<usize, Error>;

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -63,16 +63,19 @@ pub trait Database: Sync + Send {
 
     async fn save_persistent_torrent(&self, info_hash: &InfoHash, completed: u32) -> Result<(), Error>;
 
+    // todo: replace type `&str` with `&InfoHash`
     async fn get_info_hash_from_whitelist(&self, info_hash: &str) -> Result<Option<InfoHash>, Error>;
 
     async fn add_info_hash_to_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
     async fn remove_info_hash_from_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
+    // todo: replace type `&str` with `&KeyId`
     async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::Key>, Error>;
 
     async fn add_key_to_keys(&self, auth_key: &auth::Key) -> Result<usize, Error>;
 
+    // todo: replace type `&str` with `&KeyId`
     async fn remove_key_from_keys(&self, key: &str) -> Result<usize, Error>;
 
     async fn is_info_hash_whitelisted(&self, info_hash: &InfoHash) -> Result<bool, Error> {

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -12,7 +12,7 @@ use super::driver::Driver;
 use crate::databases::{Database, Error};
 use crate::protocol::common::AUTH_KEY_LENGTH;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth;
+use crate::tracker::auth::{self, KeyId};
 
 const DRIVER: Driver = Driver::MySQL;
 
@@ -117,7 +117,7 @@ impl Database for Mysql {
         let keys = conn.query_map(
             "SELECT `key`, valid_until FROM `keys`",
             |(key, valid_until): (String, i64)| auth::Key {
-                key,
+                id: key.parse::<KeyId>().unwrap(),
                 valid_until: Some(Duration::from_secs(valid_until.unsigned_abs())),
             },
         )?;
@@ -192,7 +192,7 @@ impl Database for Mysql {
         let key = query?;
 
         Ok(key.map(|(key, expiry)| auth::Key {
-            key,
+            id: key.parse::<KeyId>().unwrap(),
             valid_until: Some(Duration::from_secs(expiry.unsigned_abs())),
         }))
     }
@@ -200,7 +200,7 @@ impl Database for Mysql {
     async fn add_key_to_keys(&self, auth_key: &auth::Key) -> Result<usize, Error> {
         let mut conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
-        let key = auth_key.key.to_string();
+        let key = auth_key.id.to_string();
         let valid_until = auth_key.valid_until.unwrap_or(Duration::ZERO).as_secs().to_string();
 
         conn.exec_drop(

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -102,7 +102,7 @@ impl Database for Sqlite {
         Ok(torrents)
     }
 
-    async fn load_keys(&self) -> Result<Vec<auth::Key>, Error> {
+    async fn load_keys(&self) -> Result<Vec<auth::ExpiringKey>, Error> {
         let conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
         let mut stmt = conn.prepare("SELECT key, valid_until FROM keys")?;
@@ -111,13 +111,13 @@ impl Database for Sqlite {
             let key: String = row.get(0)?;
             let valid_until: i64 = row.get(1)?;
 
-            Ok(auth::Key {
+            Ok(auth::ExpiringKey {
                 id: key.parse::<KeyId>().unwrap(),
                 valid_until: Some(DurationSinceUnixEpoch::from_secs(valid_until.unsigned_abs())),
             })
         })?;
 
-        let keys: Vec<auth::Key> = keys_iter.filter_map(std::result::Result::ok).collect();
+        let keys: Vec<auth::ExpiringKey> = keys_iter.filter_map(std::result::Result::ok).collect();
 
         Ok(keys)
     }
@@ -200,7 +200,7 @@ impl Database for Sqlite {
         }
     }
 
-    async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::Key>, Error> {
+    async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::ExpiringKey>, Error> {
         let conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
         let mut stmt = conn.prepare("SELECT key, valid_until FROM keys WHERE key = ?")?;
@@ -212,14 +212,14 @@ impl Database for Sqlite {
         Ok(key.map(|f| {
             let expiry: i64 = f.get(1).unwrap();
             let id: String = f.get(0).unwrap();
-            auth::Key {
+            auth::ExpiringKey {
                 id: id.parse::<KeyId>().unwrap(),
                 valid_until: Some(DurationSinceUnixEpoch::from_secs(expiry.unsigned_abs())),
             }
         }))
     }
 
-    async fn add_key_to_keys(&self, auth_key: &auth::Key) -> Result<usize, Error> {
+    async fn add_key_to_keys(&self, auth_key: &auth::ExpiringKey) -> Result<usize, Error> {
         let conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
         let insert = conn.execute(

--- a/src/http/warp_implementation/routes.rs
+++ b/src/http/warp_implementation/routes.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use warp::{Filter, Rejection};
 
-use super::filters::{with_announce_request, with_auth_key, with_scrape_request, with_tracker};
+use super::filters::{with_announce_request, with_auth_key_id, with_scrape_request, with_tracker};
 use super::handlers::{handle_announce, handle_scrape, send_error};
 use crate::tracker;
 
@@ -20,7 +20,7 @@ fn announce(tracker: Arc<tracker::Tracker>) -> impl Filter<Extract = impl warp::
     warp::path::path("announce")
         .and(warp::filters::method::get())
         .and(with_announce_request(tracker.config.on_reverse_proxy))
-        .and(with_auth_key())
+        .and(with_auth_key_id())
         .and(with_tracker(tracker))
         .and_then(handle_announce)
 }
@@ -30,7 +30,7 @@ fn scrape(tracker: Arc<tracker::Tracker>) -> impl Filter<Extract = impl warp::Re
     warp::path::path("scrape")
         .and(warp::filters::method::get())
         .and(with_scrape_request(tracker.config.on_reverse_proxy))
-        .and(with_auth_key())
+        .and(with_auth_key_id())
         .and(with_tracker(tracker))
         .and_then(handle_scrape)
 }

--- a/src/tracker/error.rs
+++ b/src/tracker/error.rs
@@ -4,9 +4,9 @@ use crate::located_error::LocatedError;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
-    #[error("The supplied key: {key:?}, is not valid: {source}")]
+    #[error("The supplied key: {key_id:?}, is not valid: {source}")]
     PeerKeyNotValid {
-        key: super::auth::Key,
+        key_id: super::auth::KeyId,
         source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
     #[error("The peer is not authenticated, {location}")]

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -28,7 +28,7 @@ use crate::protocol::info_hash::InfoHash;
 pub struct Tracker {
     pub config: Arc<Configuration>,
     mode: mode::Mode,
-    keys: RwLock<std::collections::HashMap<KeyId, auth::Key>>,
+    keys: RwLock<std::collections::HashMap<KeyId, auth::ExpiringKey>>,
     whitelist: RwLock<std::collections::HashSet<InfoHash>>,
     torrents: RwLock<std::collections::BTreeMap<InfoHash, torrent::Entry>>,
     stats_event_sender: Option<Box<dyn statistics::EventSender>>,
@@ -153,7 +153,7 @@ impl Tracker {
     /// # Errors
     ///
     /// Will return a `database::Error` if unable to add the `auth_key` to the database.
-    pub async fn generate_auth_key(&self, lifetime: Duration) -> Result<auth::Key, databases::error::Error> {
+    pub async fn generate_auth_key(&self, lifetime: Duration) -> Result<auth::ExpiringKey, databases::error::Error> {
         let auth_key = auth::generate(lifetime);
         self.database.add_key_to_keys(&auth_key).await?;
         self.keys.write().await.insert(auth_key.id.clone(), auth_key.clone());

--- a/tests/tracker_api.rs
+++ b/tests/tracker_api.rs
@@ -638,7 +638,7 @@ mod tracker_apis {
     mod for_key_resources {
         use std::time::Duration;
 
-        use torrust_tracker::tracker::auth::Key;
+        use torrust_tracker::tracker::auth::KeyId;
 
         use crate::api::asserts::{
             assert_auth_key_utf8, assert_failed_to_delete_key, assert_failed_to_generate_key, assert_failed_to_reload_keys,
@@ -665,7 +665,7 @@ mod tracker_apis {
             // Verify the key with the tracker
             assert!(api_server
                 .tracker
-                .verify_auth_key(&Key::from(auth_key_resource))
+                .verify_auth_key(&auth_key_resource.key.parse::<KeyId>().unwrap())
                 .await
                 .is_ok());
         }
@@ -734,7 +734,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(api_server.get_connection_info())
-                .delete_auth_key(&auth_key.key)
+                .delete_auth_key(&auth_key.id.to_string())
                 .await;
 
             assert_ok(response).await;
@@ -777,7 +777,7 @@ mod tracker_apis {
             force_database_error(&api_server.tracker);
 
             let response = Client::new(api_server.get_connection_info())
-                .delete_auth_key(&auth_key.key)
+                .delete_auth_key(&auth_key.id.to_string())
                 .await;
 
             assert_failed_to_delete_key(response).await;
@@ -797,7 +797,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(connection_with_invalid_token(&api_server.get_bind_address()))
-                .delete_auth_key(&auth_key.key)
+                .delete_auth_key(&auth_key.id.to_string())
                 .await;
 
             assert_token_not_valid(response).await;
@@ -810,7 +810,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(connection_with_no_token(&api_server.get_bind_address()))
-                .delete_auth_key(&auth_key.key)
+                .delete_auth_key(&auth_key.id.to_string())
                 .await;
 
             assert_unauthorized(response).await;


### PR DESCRIPTION
The struct `KeyId` was extracted to wrap the primitive type, but it was not being used in the `auth::Key` struct yet.

`Key` before this PR:

```rust
pub struct Key {
    pub key: String,
    pub valid_until: Option<DurationSinceUnixEpoch>,
}
```

After this PR:

```rust
pub struct ExpiringKey {
    pub id: KeyId,
    pub valid_until: Option<DurationSinceUnixEpoch>,
}
``` 

- [x] Use the new struct `auth::KeyId`in the `auth::Key` struct.
- [x] Rename `auth::Key` to `auth::ExpiringKey`.