### PR TITLE
Axum HTTP tracker: `scrape` request in `private` mode

### DIFF
--- a/src/http/axum_implementation/handlers/auth.rs
+++ b/src/http/axum_implementation/handlers/auth.rs
@@ -1,16 +1,29 @@
 use std::panic::Location;
 use std::sync::Arc;
 
+use serde::Deserialize;
 use thiserror::Error;
 
 use crate::http::axum_implementation::responses;
 use crate::tracker::auth::{self, KeyId};
 use crate::tracker::Tracker;
 
+#[derive(Deserialize)]
+pub struct KeyIdParam(String);
+
+impl KeyIdParam {
+    #[must_use]
+    pub fn value(&self) -> String {
+        self.0.clone()
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Missing authentication key for private tracker. Error in {location}")]
     MissingAuthKey { location: &'static Location<'static> },
+    #[error("Invalid format authentication key. Error in {location}")]
+    InvalidKeyFormat { location: &'static Location<'static> },
 }
 
 /// # Errors

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -1,29 +1,69 @@
 use std::sync::Arc;
 
-use axum::extract::State;
+use axum::extract::{Path, State};
 use axum::response::{IntoResponse, Response};
 use log::debug;
 
 use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
+use crate::http::axum_implementation::handlers::auth;
+use crate::http::axum_implementation::requests::scrape::Scrape;
 use crate::http::axum_implementation::{responses, services};
+use crate::tracker::auth::KeyId;
 use crate::tracker::Tracker;
 
 #[allow(clippy::unused_async)]
-pub async fn handle(
+pub async fn handle_without_key(
     State(tracker): State<Arc<Tracker>>,
     ExtractRequest(scrape_request): ExtractRequest,
     remote_client_ip: RemoteClientIp,
 ) -> Response {
     debug!("http scrape request: {:#?}", &scrape_request);
 
-    let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, &remote_client_ip) {
+    if tracker.is_private() {
+        return handle_fake_scrape(&tracker, &scrape_request, &remote_client_ip).await;
+    }
+
+    handle_real_scrape(&tracker, &scrape_request, &remote_client_ip).await
+}
+
+#[allow(clippy::unused_async)]
+pub async fn handle_with_key(
+    State(tracker): State<Arc<Tracker>>,
+    ExtractRequest(scrape_request): ExtractRequest,
+    Path(key_id): Path<KeyId>,
+    remote_client_ip: RemoteClientIp,
+) -> Response {
+    debug!("http scrape request: {:#?}", &scrape_request);
+
+    match auth::authenticate(&key_id, &tracker).await {
+        Ok(_) => (),
+        Err(_) => return handle_fake_scrape(&tracker, &scrape_request, &remote_client_ip).await,
+    }
+
+    handle_real_scrape(&tracker, &scrape_request, &remote_client_ip).await
+}
+
+async fn handle_real_scrape(tracker: &Arc<Tracker>, scrape_request: &Scrape, remote_client_ip: &RemoteClientIp) -> Response {
+    let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, remote_client_ip) {
         Ok(peer_ip) => peer_ip,
         Err(err) => return err,
     };
 
-    let scrape_data = services::scrape::invoke(tracker.clone(), &scrape_request.info_hashes, &peer_ip).await;
+    let scrape_data = services::scrape::invoke(tracker, &scrape_request.info_hashes, &peer_ip).await;
+
+    responses::scrape::Bencoded::from(scrape_data).into_response()
+}
+
+/// When authentication fails in `private` mode the tracker returns empty swarm metadata for all the requested infohashes.
+async fn handle_fake_scrape(tracker: &Arc<Tracker>, scrape_request: &Scrape, remote_client_ip: &RemoteClientIp) -> Response {
+    let peer_ip = match peer_ip::resolve(tracker.config.on_reverse_proxy, remote_client_ip) {
+        Ok(peer_ip) => peer_ip,
+        Err(err) => return err,
+    };
+
+    let scrape_data = services::scrape::fake_invoke(tracker, &scrape_request.info_hashes, &peer_ip).await;
 
     responses::scrape::Bencoded::from(scrape_data).into_response()
 }

--- a/src/http/axum_implementation/routes.rs
+++ b/src/http/axum_implementation/routes.rs
@@ -15,7 +15,8 @@ pub fn router(tracker: &Arc<Tracker>) -> Router {
         .route("/announce", get(announce::handle_without_key).with_state(tracker.clone()))
         .route("/announce/:key", get(announce::handle_with_key).with_state(tracker.clone()))
         // Scrape request
-        .route("/scrape", get(scrape::handle).with_state(tracker.clone()))
+        .route("/scrape", get(scrape::handle_without_key).with_state(tracker.clone()))
+        .route("/scrape/:key", get(scrape::handle_with_key).with_state(tracker.clone()))
         // Add extension to get the client IP from the connection info
         .layer(SecureClientIpSource::ConnectInfo.into_extension())
 }

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -142,6 +142,17 @@ impl Tracker {
         scrape_data
     }
 
+    // It return empty swarm metadata for all the infohashes.
+    pub fn empty_scrape_for(&self, info_hashes: &Vec<InfoHash>) -> ScrapeData {
+        let mut scrape_data = ScrapeData::empty();
+
+        for info_hash in info_hashes {
+            scrape_data.add_file(info_hash, SwarmMetadata::default());
+        }
+
+        scrape_data
+    }
+
     async fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
         let torrents = self.get_torrents().await;
         match torrents.get(info_hash) {

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -2606,8 +2606,7 @@ mod axum_http_tracker_server {
             use crate::http::responses::scrape::{File, ResponseBuilder};
             use crate::http::server::start_private_http_tracker;
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_zeroed_file_when_the_client_is_not_authenticated() {
                 let http_tracker = start_private_http_tracker(Version::Axum).await;
 
@@ -2636,8 +2635,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_real_file_stats_when_the_client_is_authenticated() {
                 let http_tracker = start_private_http_tracker(Version::Axum).await;
 
@@ -2677,10 +2675,10 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_zeroed_file_when_the_authentication_key_provided_by_the_client_is_invalid() {
                 // There is not authentication error
+                // code-review: should this really be this way?
 
                 let http_tracker = start_private_http_tracker(Version::Axum).await;
 


### PR DESCRIPTION
`scrape` request implementation for tracker in `private` mode.