### PR TITLE
Axum HTTP tracker: `scrape` request in `listed` mode

### DIFF
--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -140,7 +140,11 @@ impl Tracker {
         let mut scrape_data = ScrapeData::empty();
 
         for info_hash in info_hashes {
-            scrape_data.add_file(info_hash, self.get_swarm_metadata(info_hash).await);
+            let swarm_metadata = match self.authorize(info_hash).await {
+                Ok(_) => self.get_swarm_metadata(info_hash).await,
+                Err(_) => SwarmMetadata::zeroed(),
+            };
+            scrape_data.add_file(info_hash, swarm_metadata);
         }
 
         scrape_data

--- a/src/tracker/torrent.rs
+++ b/src/tracker/torrent.rs
@@ -21,6 +21,13 @@ pub struct SwarmMetadata {
     pub incomplete: u32, // The number of active peers that have not completed downloading (leechers)
 }
 
+impl SwarmMetadata {
+    #[must_use]
+    pub fn zeroed() -> Self {
+        Self::default()
+    }
+}
+
 impl Entry {
     #[must_use]
     pub fn new() -> Entry {

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -2450,8 +2450,7 @@ mod axum_http_tracker_server {
             use crate::http::responses::scrape::{File, ResponseBuilder};
             use crate::http::server::start_whitelisted_http_tracker;
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_zeroed_file_when_the_requested_file_is_not_whitelisted() {
                 let http_tracker = start_whitelisted_http_tracker(Version::Axum).await;
 
@@ -2480,8 +2479,7 @@ mod axum_http_tracker_server {
                 assert_scrape_response(response, &expected_scrape_response).await;
             }
 
-            //#[tokio::test]
-            #[allow(dead_code)]
+            #[tokio::test]
             async fn should_return_the_file_stats_when_the_requested_file_is_whitelisted() {
                 let http_tracker = start_whitelisted_http_tracker(Version::Axum).await;
 


### PR DESCRIPTION
For the new Auxm HTTP tracker implementation.