### PR TITLE
Axum HTTP tracker: extract Axum extractor for URL path auth `key` param

### DIFF
--- a/src/http/axum_implementation/extractors/key.rs
+++ b/src/http/axum_implementation/extractors/key.rs
@@ -1,0 +1,55 @@
+use std::panic::Location;
+
+use axum::async_trait;
+use axum::extract::{FromRequestParts, Path};
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+
+use crate::http::axum_implementation::handlers::auth::{self, KeyIdParam};
+use crate::http::axum_implementation::responses;
+use crate::tracker::auth::KeyId;
+
+pub struct ExtractKeyId(pub KeyId);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for ExtractKeyId
+where
+    S: Send + Sync,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        match Path::<KeyIdParam>::from_request_parts(parts, state).await {
+            Ok(key_id_param) => {
+                let Ok(key_id) = key_id_param.0.value().parse::<KeyId>() else {
+                    return Err(responses::error::Error::from(
+                        auth::Error::InvalidKeyFormat {
+                            location: Location::caller()
+                        })
+                    .into_response())
+                };
+                Ok(ExtractKeyId(key_id))
+            }
+            Err(rejection) => match rejection {
+                axum::extract::rejection::PathRejection::FailedToDeserializePathParams(_) => {
+                    return Err(responses::error::Error::from(auth::Error::InvalidKeyFormat {
+                        location: Location::caller(),
+                    })
+                    .into_response())
+                }
+                axum::extract::rejection::PathRejection::MissingPathParams(_) => {
+                    return Err(responses::error::Error::from(auth::Error::MissingAuthKey {
+                        location: Location::caller(),
+                    })
+                    .into_response())
+                }
+                _ => {
+                    return Err(responses::error::Error::from(auth::Error::CannotExtractKeyParam {
+                        location: Location::caller(),
+                    })
+                    .into_response())
+                }
+            },
+        }
+    }
+}

--- a/src/http/axum_implementation/extractors/mod.rs
+++ b/src/http/axum_implementation/extractors/mod.rs
@@ -1,4 +1,5 @@
 pub mod announce_request;
+pub mod key;
 pub mod peer_ip;
 pub mod remote_client_ip;
 pub mod scrape_request;

--- a/src/http/axum_implementation/handlers/auth.rs
+++ b/src/http/axum_implementation/handlers/auth.rs
@@ -18,10 +18,12 @@ impl KeyIdParam {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Missing authentication key for private tracker. Error in {location}")]
+    #[error("Missing authentication key param for private tracker. Error in {location}")]
     MissingAuthKey { location: &'static Location<'static> },
-    #[error("Invalid format authentication key. Error in {location}")]
+    #[error("Invalid format for authentication key param. Error in {location}")]
     InvalidKeyFormat { location: &'static Location<'static> },
+    #[error("Cannot extract authentication key param from URL path. Error in {location}")]
+    CannotExtractKeyParam { location: &'static Location<'static> },
 }
 
 impl From<Error> for responses::error::Error {

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -1,18 +1,15 @@
-use std::panic::Location;
 use std::sync::Arc;
 
-use axum::extract::{Path, State};
+use axum::extract::State;
 use axum::response::{IntoResponse, Response};
 use log::debug;
 
-use super::auth::KeyIdParam;
+use crate::http::axum_implementation::extractors::key::ExtractKeyId;
 use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
-use crate::http::axum_implementation::handlers::auth;
 use crate::http::axum_implementation::requests::scrape::Scrape;
 use crate::http::axum_implementation::{responses, services};
-use crate::tracker::auth::KeyId;
 use crate::tracker::Tracker;
 
 #[allow(clippy::unused_async)]
@@ -34,19 +31,10 @@ pub async fn handle_without_key(
 pub async fn handle_with_key(
     State(tracker): State<Arc<Tracker>>,
     ExtractRequest(scrape_request): ExtractRequest,
-    Path(key_id_param): Path<KeyIdParam>,
+    ExtractKeyId(key_id): ExtractKeyId,
     remote_client_ip: RemoteClientIp,
 ) -> Response {
     debug!("http scrape request: {:#?}", &scrape_request);
-
-    // todo: extract to Axum extractor. Duplicate code in `announce` handler.
-    let Ok(key_id) = key_id_param.value().parse::<KeyId>() else {
-        return responses::error::Error::from(
-            auth::Error::InvalidKeyFormat {
-                location: Location::caller()
-            })
-        .into_response()
-    };
 
     match tracker.authenticate(&key_id).await {
         Ok(_) => (),


### PR DESCRIPTION
Axum extractor to extract the `key` path param from the URLs:

```rust
Router::new()
    // Announce request
    .route("/announce", get(announce::handle_without_key).with_state(tracker.clone()))
    .route("/announce/:key", get(announce::handle_with_key).with_state(tracker.clone()))
    // Scrape request
    .route("/scrape", get(scrape::handle_without_key).with_state(tracker.clone()))
    .route("/scrape/:key", get(scrape::handle_with_key).with_state(tracker.clone()))
    // Add extension to get the client IP from the connection info
    .layer(SecureClientIpSource::ConnectInfo.into_extension())
```

It extracts the `:key` param. I'm using an extractor because we have a custom error response, and the handlers are much cleaner this way and we remove the duplicate code.