### PR TITLE
Compiling time test with one test binary

### DIFF
--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -25,6 +25,8 @@ use crate::databases::driver::Driver;
 use crate::databases::{self, Database};
 use crate::protocol::info_hash::InfoHash;
 
+// force build
+
 pub struct Tracker {
     pub config: Arc<Configuration>,
     mode: mode::Mode,

--- a/tests/api/integrations_tests.rs
+++ b/tests/api/integrations_tests.rs
@@ -3,11 +3,6 @@
 /// ```text
 /// cargo test tracker_apis -- --nocapture
 /// ```
-extern crate rand;
-
-mod api;
-mod common;
-
 mod tracker_apis {
 
     use crate::common::fixtures::invalid_info_hashes;

--- a/tests/api/mod.rs
+++ b/tests/api/mod.rs
@@ -6,6 +6,7 @@ pub mod asserts;
 pub mod client;
 pub mod connection_info;
 pub mod server;
+pub mod integrations_tests;
 
 /// It forces a database error by dropping all tables.
 /// That makes any query fail.

--- a/tests/http/integration_tests.rs
+++ b/tests/http/integration_tests.rs
@@ -9,9 +9,6 @@
 /// ```text
 /// cargo test `warp_http_tracker_server` -- --nocapture
 /// ```
-mod common;
-mod http;
-
 mod warp_http_tracker_server {
 
     mod for_all_config_modes {

--- a/tests/http/mod.rs
+++ b/tests/http/mod.rs
@@ -5,6 +5,7 @@ pub mod connection_info;
 pub mod requests;
 pub mod responses;
 pub mod server;
+pub mod integration_tests;
 
 use percent_encoding::NON_ALPHANUMERIC;
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,6 @@
+extern crate rand;
+
+mod api;
+mod common;
+mod http;
+mod udp;

--- a/tests/udp/integration_tests.rs
+++ b/tests/udp/integration_tests.rs
@@ -1,11 +1,6 @@
 /// Integration tests for UDP tracker server
 ///
 /// cargo test `udp_tracker_server` -- --nocapture
-extern crate rand;
-
-mod common;
-mod udp;
-
 mod udp_tracker_server {
 
     // UDP tracker documentation:
@@ -97,8 +92,8 @@ mod udp_tracker_server {
 
         use crate::udp::asserts::is_ipv4_announce_response;
         use crate::udp::client::new_udp_tracker_client_connected;
+        use crate::udp::integration_tests::udp_tracker_server::send_connection_request;
         use crate::udp::server::{start_udp_tracker, tracker_configuration};
-        use crate::udp_tracker_server::send_connection_request;
 
         #[tokio::test]
         async fn should_return_an_announce_response() {
@@ -140,8 +135,8 @@ mod udp_tracker_server {
 
         use crate::udp::asserts::is_scrape_response;
         use crate::udp::client::new_udp_tracker_client_connected;
+        use crate::udp::integration_tests::udp_tracker_server::send_connection_request;
         use crate::udp::server::{start_udp_tracker, tracker_configuration};
-        use crate::udp_tracker_server::send_connection_request;
 
         #[tokio::test]
         async fn should_return_a_scrape_response() {

--- a/tests/udp/mod.rs
+++ b/tests/udp/mod.rs
@@ -1,3 +1,4 @@
 pub mod asserts;
 pub mod client;
 pub mod server;
+pub mod integration_tests;


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/discussions/188

Hi @da2ce7 @WarmBeer, I've merged the integrations test binaries into one binary to see if the build time decreases, but it takes even longer for some reason.

Maybe I need to do something differently, or maybe it's because we have more tests now.

![build-time-with-one-test-binary](https://user-images.githubusercontent.com/58816/222951866-782d0653-e099-4220-add0-b7b0a4101ed7.png)
