### PR TITLE
Refactor `ExpiringKey`

### DIFF
--- a/src/apis/handlers.rs
+++ b/src/apis/handlers.rs
@@ -101,15 +101,15 @@ pub async fn generate_auth_key_handler(State(tracker): State<Arc<Tracker>>, Path
 }
 
 #[derive(Deserialize)]
-pub struct KeyIdParam(String);
+pub struct KeyParam(String);
 
 pub async fn delete_auth_key_handler(
     State(tracker): State<Arc<Tracker>>,
-    Path(seconds_valid_or_key): Path<KeyIdParam>,
+    Path(seconds_valid_or_key): Path<KeyParam>,
 ) -> Response {
     match Key::from_str(&seconds_valid_or_key.0) {
         Err(_) => invalid_auth_key_param_response(&seconds_valid_or_key.0),
-        Ok(key_id) => match tracker.remove_auth_key(&key_id.to_string()).await {
+        Ok(key) => match tracker.remove_auth_key(&key.to_string()).await {
             Ok(_) => ok_response(),
             Err(e) => failed_to_delete_key_response(e),
         },

--- a/src/apis/handlers.rs
+++ b/src/apis/handlers.rs
@@ -17,7 +17,7 @@ use crate::apis::resources::auth_key::AuthKey;
 use crate::apis::resources::stats::Stats;
 use crate::apis::resources::torrent::ListItem;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth::KeyId;
+use crate::tracker::auth::Key;
 use crate::tracker::services::statistics::get_metrics;
 use crate::tracker::services::torrent::{get_torrent_info, get_torrents, Pagination};
 use crate::tracker::Tracker;
@@ -107,7 +107,7 @@ pub async fn delete_auth_key_handler(
     State(tracker): State<Arc<Tracker>>,
     Path(seconds_valid_or_key): Path<KeyIdParam>,
 ) -> Response {
-    match KeyId::from_str(&seconds_valid_or_key.0) {
+    match Key::from_str(&seconds_valid_or_key.0) {
         Err(_) => invalid_auth_key_param_response(&seconds_valid_or_key.0),
         Ok(key_id) => match tracker.remove_auth_key(&key_id.to_string()).await {
             Ok(_) => ok_response(),

--- a/src/apis/resources/auth_key.rs
+++ b/src/apis/resources/auth_key.rs
@@ -19,7 +19,7 @@ impl From<AuthKey> for auth::ExpiringKey {
         };
 
         auth::ExpiringKey {
-            id: auth_key_resource.key.parse::<Key>().unwrap(),
+            key: auth_key_resource.key.parse::<Key>().unwrap(),
             valid_until,
         }
     }
@@ -28,7 +28,7 @@ impl From<AuthKey> for auth::ExpiringKey {
 impl From<auth::ExpiringKey> for AuthKey {
     fn from(auth_key: auth::ExpiringKey) -> Self {
         AuthKey {
-            key: auth_key.id.to_string(),
+            key: auth_key.key.to_string(),
             valid_until: Some(auth_key.valid_until.as_secs()),
         }
     }
@@ -54,7 +54,7 @@ mod tests {
         assert_eq!(
             auth::ExpiringKey::from(auth_key_resource),
             auth::ExpiringKey {
-                id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
+                key: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
                 valid_until: Current::add(&Duration::new(duration_in_secs, 0)).unwrap()
             }
         );
@@ -65,7 +65,7 @@ mod tests {
         let duration_in_secs = 60;
 
         let auth_key = auth::ExpiringKey {
-            id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
+            key: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
             valid_until: Current::add(&Duration::new(duration_in_secs, 0)).unwrap(),
         };
 

--- a/src/apis/resources/auth_key.rs
+++ b/src/apis/resources/auth_key.rs
@@ -3,11 +3,11 @@ use std::convert::From;
 use serde::{Deserialize, Serialize};
 
 use crate::protocol::clock::DurationSinceUnixEpoch;
-use crate::tracker::auth::{self, KeyId};
+use crate::tracker::auth::{self, Key};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct AuthKey {
-    pub key: String, // todo: rename to `id` (API breaking change!)
+    pub key: String,              // todo: rename to `id` (API breaking change!)
     pub valid_until: Option<u64>, // todo: `auth::ExpiringKey` has now always a value (API breaking change!)
 }
 
@@ -19,7 +19,7 @@ impl From<AuthKey> for auth::ExpiringKey {
         };
 
         auth::ExpiringKey {
-            id: auth_key_resource.key.parse::<KeyId>().unwrap(),
+            id: auth_key_resource.key.parse::<Key>().unwrap(),
             valid_until,
         }
     }
@@ -40,7 +40,7 @@ mod tests {
 
     use super::AuthKey;
     use crate::protocol::clock::{Current, TimeNow};
-    use crate::tracker::auth::{self, KeyId};
+    use crate::tracker::auth::{self, Key};
 
     #[test]
     fn it_should_be_convertible_into_an_auth_key() {
@@ -54,7 +54,7 @@ mod tests {
         assert_eq!(
             auth::ExpiringKey::from(auth_key_resource),
             auth::ExpiringKey {
-                id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<KeyId>().unwrap(), // cspell:disable-line
+                id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
                 valid_until: Current::add(&Duration::new(duration_in_secs, 0)).unwrap()
             }
         );
@@ -65,7 +65,7 @@ mod tests {
         let duration_in_secs = 60;
 
         let auth_key = auth::ExpiringKey {
-            id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<KeyId>().unwrap(), // cspell:disable-line
+            id: "IaWDneuFNZi8IB4MPA3qW1CD0M30EZSM".parse::<Key>().unwrap(), // cspell:disable-line
             valid_until: Current::add(&Duration::new(duration_in_secs, 0)).unwrap(),
         };
 

--- a/src/databases/mod.rs
+++ b/src/databases/mod.rs
@@ -70,12 +70,12 @@ pub trait Database: Sync + Send {
 
     async fn remove_info_hash_from_whitelist(&self, info_hash: InfoHash) -> Result<usize, Error>;
 
-    // todo: replace type `&str` with `&KeyId`
+    // todo: replace type `&str` with `&Key`
     async fn get_key_from_keys(&self, key: &str) -> Result<Option<auth::ExpiringKey>, Error>;
 
     async fn add_key_to_keys(&self, auth_key: &auth::ExpiringKey) -> Result<usize, Error>;
 
-    // todo: replace type `&str` with `&KeyId`
+    // todo: replace type `&str` with `&Key`
     async fn remove_key_from_keys(&self, key: &str) -> Result<usize, Error>;
 
     async fn is_info_hash_whitelisted(&self, info_hash: &InfoHash) -> Result<bool, Error> {

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -118,7 +118,7 @@ impl Database for Mysql {
             "SELECT `key`, valid_until FROM `keys`",
             |(key, valid_until): (String, i64)| auth::ExpiringKey {
                 id: key.parse::<KeyId>().unwrap(),
-                valid_until: Some(Duration::from_secs(valid_until.unsigned_abs())),
+                valid_until: Duration::from_secs(valid_until.unsigned_abs()),
             },
         )?;
 
@@ -193,7 +193,7 @@ impl Database for Mysql {
 
         Ok(key.map(|(key, expiry)| auth::ExpiringKey {
             id: key.parse::<KeyId>().unwrap(),
-            valid_until: Some(Duration::from_secs(expiry.unsigned_abs())),
+            valid_until: Duration::from_secs(expiry.unsigned_abs()),
         }))
     }
 
@@ -201,7 +201,7 @@ impl Database for Mysql {
         let mut conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
         let key = auth_key.id.to_string();
-        let valid_until = auth_key.valid_until.unwrap_or(Duration::ZERO).as_secs().to_string();
+        let valid_until = auth_key.valid_until.as_secs().to_string();
 
         conn.exec_drop(
             "INSERT INTO `keys` (`key`, valid_until) VALUES (:key, :valid_until)",

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -117,7 +117,7 @@ impl Database for Mysql {
         let keys = conn.query_map(
             "SELECT `key`, valid_until FROM `keys`",
             |(key, valid_until): (String, i64)| auth::ExpiringKey {
-                id: key.parse::<Key>().unwrap(),
+                key: key.parse::<Key>().unwrap(),
                 valid_until: Duration::from_secs(valid_until.unsigned_abs()),
             },
         )?;
@@ -192,7 +192,7 @@ impl Database for Mysql {
         let key = query?;
 
         Ok(key.map(|(key, expiry)| auth::ExpiringKey {
-            id: key.parse::<Key>().unwrap(),
+            key: key.parse::<Key>().unwrap(),
             valid_until: Duration::from_secs(expiry.unsigned_abs()),
         }))
     }
@@ -200,7 +200,7 @@ impl Database for Mysql {
     async fn add_key_to_keys(&self, auth_key: &auth::ExpiringKey) -> Result<usize, Error> {
         let mut conn = self.pool.get().map_err(|e| (e, DRIVER))?;
 
-        let key = auth_key.id.to_string();
+        let key = auth_key.key.to_string();
         let valid_until = auth_key.valid_until.as_secs().to_string();
 
         conn.exec_drop(

--- a/src/databases/mysql.rs
+++ b/src/databases/mysql.rs
@@ -12,7 +12,7 @@ use super::driver::Driver;
 use crate::databases::{Database, Error};
 use crate::protocol::common::AUTH_KEY_LENGTH;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth::{self, KeyId};
+use crate::tracker::auth::{self, Key};
 
 const DRIVER: Driver = Driver::MySQL;
 
@@ -117,7 +117,7 @@ impl Database for Mysql {
         let keys = conn.query_map(
             "SELECT `key`, valid_until FROM `keys`",
             |(key, valid_until): (String, i64)| auth::ExpiringKey {
-                id: key.parse::<KeyId>().unwrap(),
+                id: key.parse::<Key>().unwrap(),
                 valid_until: Duration::from_secs(valid_until.unsigned_abs()),
             },
         )?;
@@ -192,7 +192,7 @@ impl Database for Mysql {
         let key = query?;
 
         Ok(key.map(|(key, expiry)| auth::ExpiringKey {
-            id: key.parse::<KeyId>().unwrap(),
+            id: key.parse::<Key>().unwrap(),
             valid_until: Duration::from_secs(expiry.unsigned_abs()),
         }))
     }

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -113,7 +113,7 @@ impl Database for Sqlite {
 
             Ok(auth::ExpiringKey {
                 id: key.parse::<KeyId>().unwrap(),
-                valid_until: Some(DurationSinceUnixEpoch::from_secs(valid_until.unsigned_abs())),
+                valid_until: DurationSinceUnixEpoch::from_secs(valid_until.unsigned_abs()),
             })
         })?;
 
@@ -214,7 +214,7 @@ impl Database for Sqlite {
             let id: String = f.get(0).unwrap();
             auth::ExpiringKey {
                 id: id.parse::<KeyId>().unwrap(),
-                valid_until: Some(DurationSinceUnixEpoch::from_secs(expiry.unsigned_abs())),
+                valid_until: DurationSinceUnixEpoch::from_secs(expiry.unsigned_abs()),
             }
         }))
     }
@@ -224,7 +224,7 @@ impl Database for Sqlite {
 
         let insert = conn.execute(
             "INSERT INTO keys (key, valid_until) VALUES (?1, ?2)",
-            [auth_key.id.to_string(), auth_key.valid_until.unwrap().as_secs().to_string()],
+            [auth_key.id.to_string(), auth_key.valid_until.as_secs().to_string()],
         )?;
 
         if insert == 0 {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -112,7 +112,7 @@ impl Database for Sqlite {
             let valid_until: i64 = row.get(1)?;
 
             Ok(auth::ExpiringKey {
-                id: key.parse::<Key>().unwrap(),
+                key: key.parse::<Key>().unwrap(),
                 valid_until: DurationSinceUnixEpoch::from_secs(valid_until.unsigned_abs()),
             })
         })?;
@@ -213,7 +213,7 @@ impl Database for Sqlite {
             let expiry: i64 = f.get(1).unwrap();
             let id: String = f.get(0).unwrap();
             auth::ExpiringKey {
-                id: id.parse::<Key>().unwrap(),
+                key: id.parse::<Key>().unwrap(),
                 valid_until: DurationSinceUnixEpoch::from_secs(expiry.unsigned_abs()),
             }
         }))
@@ -224,7 +224,7 @@ impl Database for Sqlite {
 
         let insert = conn.execute(
             "INSERT INTO keys (key, valid_until) VALUES (?1, ?2)",
-            [auth_key.id.to_string(), auth_key.valid_until.as_secs().to_string()],
+            [auth_key.key.to_string(), auth_key.valid_until.as_secs().to_string()],
         )?;
 
         if insert == 0 {

--- a/src/databases/sqlite.rs
+++ b/src/databases/sqlite.rs
@@ -9,7 +9,7 @@ use super::driver::Driver;
 use crate::databases::{Database, Error};
 use crate::protocol::clock::DurationSinceUnixEpoch;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth::{self, KeyId};
+use crate::tracker::auth::{self, Key};
 
 const DRIVER: Driver = Driver::Sqlite3;
 
@@ -112,7 +112,7 @@ impl Database for Sqlite {
             let valid_until: i64 = row.get(1)?;
 
             Ok(auth::ExpiringKey {
-                id: key.parse::<KeyId>().unwrap(),
+                id: key.parse::<Key>().unwrap(),
                 valid_until: DurationSinceUnixEpoch::from_secs(valid_until.unsigned_abs()),
             })
         })?;
@@ -213,7 +213,7 @@ impl Database for Sqlite {
             let expiry: i64 = f.get(1).unwrap();
             let id: String = f.get(0).unwrap();
             auth::ExpiringKey {
-                id: id.parse::<KeyId>().unwrap(),
+                id: id.parse::<Key>().unwrap(),
                 valid_until: DurationSinceUnixEpoch::from_secs(expiry.unsigned_abs()),
             }
         }))

--- a/src/http/axum_implementation/extractors/key.rs
+++ b/src/http/axum_implementation/extractors/key.rs
@@ -7,9 +7,9 @@ use axum::response::{IntoResponse, Response};
 
 use crate::http::axum_implementation::handlers::auth::{self, KeyIdParam};
 use crate::http::axum_implementation::responses;
-use crate::tracker::auth::KeyId;
+use crate::tracker::auth::Key;
 
-pub struct ExtractKeyId(pub KeyId);
+pub struct ExtractKeyId(pub Key);
 
 #[async_trait]
 impl<S> FromRequestParts<S> for ExtractKeyId
@@ -21,7 +21,7 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         match Path::<KeyIdParam>::from_request_parts(parts, state).await {
             Ok(key_id_param) => {
-                let Ok(key_id) = key_id_param.0.value().parse::<KeyId>() else {
+                let Ok(key_id) = key_id_param.0.value().parse::<Key>() else {
                     return Err(responses::error::Error::from(
                         auth::Error::InvalidKeyFormat {
                             location: Location::caller()

--- a/src/http/axum_implementation/extractors/key.rs
+++ b/src/http/axum_implementation/extractors/key.rs
@@ -5,30 +5,30 @@ use axum::extract::{FromRequestParts, Path};
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 
-use crate::http::axum_implementation::handlers::auth::{self, KeyIdParam};
+use crate::http::axum_implementation::handlers::auth::{self, KeyParam};
 use crate::http::axum_implementation::responses;
 use crate::tracker::auth::Key;
 
-pub struct ExtractKeyId(pub Key);
+pub struct Extract(pub Key);
 
 #[async_trait]
-impl<S> FromRequestParts<S> for ExtractKeyId
+impl<S> FromRequestParts<S> for Extract
 where
     S: Send + Sync,
 {
     type Rejection = Response;
 
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        match Path::<KeyIdParam>::from_request_parts(parts, state).await {
-            Ok(key_id_param) => {
-                let Ok(key_id) = key_id_param.0.value().parse::<Key>() else {
+        match Path::<KeyParam>::from_request_parts(parts, state).await {
+            Ok(key_param) => {
+                let Ok(key) = key_param.0.value().parse::<Key>() else {
                     return Err(responses::error::Error::from(
                         auth::Error::InvalidKeyFormat {
                             location: Location::caller()
                         })
                     .into_response())
                 };
-                Ok(ExtractKeyId(key_id))
+                Ok(Extract(key))
             }
             Err(rejection) => match rejection {
                 axum::extract::rejection::PathRejection::FailedToDeserializePathParams(_) => {

--- a/src/http/axum_implementation/handlers/announce.rs
+++ b/src/http/axum_implementation/handlers/announce.rs
@@ -8,7 +8,7 @@ use axum::response::{IntoResponse, Response};
 use log::debug;
 
 use crate::http::axum_implementation::extractors::announce_request::ExtractRequest;
-use crate::http::axum_implementation::extractors::key::ExtractKeyId;
+use crate::http::axum_implementation::extractors::key::Extract;
 use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::handlers::auth;
@@ -41,12 +41,12 @@ pub async fn handle_without_key(
 pub async fn handle_with_key(
     State(tracker): State<Arc<Tracker>>,
     ExtractRequest(announce_request): ExtractRequest,
-    ExtractKeyId(key_id): ExtractKeyId,
+    Extract(key): Extract,
     remote_client_ip: RemoteClientIp,
 ) -> Response {
     debug!("http announce request: {:#?}", announce_request);
 
-    match tracker.authenticate(&key_id).await {
+    match tracker.authenticate(&key).await {
         Ok(_) => (),
         Err(error) => return responses::error::Error::from(error).into_response(),
     }

--- a/src/http/axum_implementation/handlers/auth.rs
+++ b/src/http/axum_implementation/handlers/auth.rs
@@ -7,9 +7,9 @@ use crate::http::axum_implementation::responses;
 use crate::tracker::auth;
 
 #[derive(Deserialize)]
-pub struct KeyIdParam(String);
+pub struct KeyParam(String);
 
-impl KeyIdParam {
+impl KeyParam {
     #[must_use]
     pub fn value(&self) -> String {
         self.0.clone()

--- a/src/http/axum_implementation/handlers/scrape.rs
+++ b/src/http/axum_implementation/handlers/scrape.rs
@@ -4,7 +4,7 @@ use axum::extract::State;
 use axum::response::{IntoResponse, Response};
 use log::debug;
 
-use crate::http::axum_implementation::extractors::key::ExtractKeyId;
+use crate::http::axum_implementation::extractors::key::Extract;
 use crate::http::axum_implementation::extractors::peer_ip;
 use crate::http::axum_implementation::extractors::remote_client_ip::RemoteClientIp;
 use crate::http::axum_implementation::extractors::scrape_request::ExtractRequest;
@@ -31,12 +31,12 @@ pub async fn handle_without_key(
 pub async fn handle_with_key(
     State(tracker): State<Arc<Tracker>>,
     ExtractRequest(scrape_request): ExtractRequest,
-    ExtractKeyId(key_id): ExtractKeyId,
+    Extract(key): Extract,
     remote_client_ip: RemoteClientIp,
 ) -> Response {
     debug!("http scrape request: {:#?}", &scrape_request);
 
-    match tracker.authenticate(&key_id).await {
+    match tracker.authenticate(&key).await {
         Ok(_) => (),
         Err(_) => return handle_fake_scrape(&tracker, &scrape_request, &remote_client_ip).await,
     }

--- a/src/http/warp_implementation/filters.rs
+++ b/src/http/warp_implementation/filters.rs
@@ -37,11 +37,11 @@ pub fn with_peer_id() -> impl Filter<Extract = (peer::Id,), Error = Rejection> +
 
 /// Pass Arc<tracker::TorrentTracker> along
 #[must_use]
-pub fn with_auth_key_id() -> impl Filter<Extract = (Option<Key>,), Error = Infallible> + Clone {
+pub fn with_auth_key() -> impl Filter<Extract = (Option<Key>,), Error = Infallible> + Clone {
     warp::path::param::<String>()
         .map(|key: String| {
-            let key_id = Key::from_str(&key);
-            match key_id {
+            let key = Key::from_str(&key);
+            match key {
                 Ok(id) => Some(id),
                 Err(_) => None,
             }

--- a/src/http/warp_implementation/filters.rs
+++ b/src/http/warp_implementation/filters.rs
@@ -12,7 +12,7 @@ use super::{request, WebResult};
 use crate::http::percent_encoding::{percent_decode_info_hash, percent_decode_peer_id};
 use crate::protocol::common::MAX_SCRAPE_TORRENTS;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth::KeyId;
+use crate::tracker::auth::Key;
 use crate::tracker::{self, peer};
 
 /// Pass Arc<tracker::TorrentTracker> along
@@ -37,16 +37,16 @@ pub fn with_peer_id() -> impl Filter<Extract = (peer::Id,), Error = Rejection> +
 
 /// Pass Arc<tracker::TorrentTracker> along
 #[must_use]
-pub fn with_auth_key_id() -> impl Filter<Extract = (Option<KeyId>,), Error = Infallible> + Clone {
+pub fn with_auth_key_id() -> impl Filter<Extract = (Option<Key>,), Error = Infallible> + Clone {
     warp::path::param::<String>()
         .map(|key: String| {
-            let key_id = KeyId::from_str(&key);
+            let key_id = Key::from_str(&key);
             match key_id {
                 Ok(id) => Some(id),
                 Err(_) => None,
             }
         })
-        .or_else(|_| async { Ok::<(Option<KeyId>,), Infallible>((None,)) })
+        .or_else(|_| async { Ok::<(Option<Key>,), Infallible>((None,)) })
 }
 
 /// Check for `PeerAddress`

--- a/src/http/warp_implementation/handlers.rs
+++ b/src/http/warp_implementation/handlers.rs
@@ -12,7 +12,7 @@ use super::error::Error;
 use super::{request, response, WebResult};
 use crate::http::warp_implementation::peer_builder;
 use crate::protocol::info_hash::InfoHash;
-use crate::tracker::auth::KeyId;
+use crate::tracker::auth::Key;
 use crate::tracker::{self, auth, peer, statistics, torrent};
 
 /// Authenticate `InfoHash` using optional `auth::Key`
@@ -22,7 +22,7 @@ use crate::tracker::{self, auth, peer, statistics, torrent};
 /// Will return `ServerError` that wraps the `tracker::error::Error` if unable to `authenticate_request`.
 pub async fn authenticate(
     info_hash: &InfoHash,
-    auth_key_id: &Option<auth::KeyId>,
+    auth_key_id: &Option<auth::Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> Result<(), Error> {
     tracker
@@ -38,7 +38,7 @@ pub async fn authenticate(
 /// Will return `warp::Rejection` that wraps the `ServerError` if unable to `send_announce_response`.
 pub async fn handle_announce(
     announce_request: request::Announce,
-    auth_key_id: Option<KeyId>,
+    auth_key_id: Option<Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> WebResult<impl Reply> {
     debug!("http announce request: {:#?}", announce_request);
@@ -78,7 +78,7 @@ pub async fn handle_announce(
 /// Will return `warp::Rejection` that wraps the `ServerError` if unable to `send_scrape_response`.
 pub async fn handle_scrape(
     scrape_request: request::Scrape,
-    auth_key_id: Option<KeyId>,
+    auth_key_id: Option<Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> WebResult<impl Reply> {
     let mut files: HashMap<InfoHash, response::ScrapeEntry> = HashMap::new();

--- a/src/http/warp_implementation/handlers.rs
+++ b/src/http/warp_implementation/handlers.rs
@@ -22,11 +22,11 @@ use crate::tracker::{self, auth, peer, statistics, torrent};
 /// Will return `ServerError` that wraps the `tracker::error::Error` if unable to `authenticate_request`.
 pub async fn authenticate(
     info_hash: &InfoHash,
-    auth_key_id: &Option<auth::Key>,
+    auth_key: &Option<auth::Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> Result<(), Error> {
     tracker
-        .authenticate_request(info_hash, auth_key_id)
+        .authenticate_request(info_hash, auth_key)
         .await
         .map_err(|e| Error::TrackerError {
             source: (Arc::new(e) as Arc<dyn std::error::Error + Send + Sync>).into(),
@@ -38,7 +38,7 @@ pub async fn authenticate(
 /// Will return `warp::Rejection` that wraps the `ServerError` if unable to `send_announce_response`.
 pub async fn handle_announce(
     announce_request: request::Announce,
-    auth_key_id: Option<Key>,
+    auth_key: Option<Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> WebResult<impl Reply> {
     debug!("http announce request: {:#?}", announce_request);
@@ -46,7 +46,7 @@ pub async fn handle_announce(
     let info_hash = announce_request.info_hash;
     let remote_client_ip = announce_request.peer_addr;
 
-    authenticate(&info_hash, &auth_key_id, tracker.clone()).await?;
+    authenticate(&info_hash, &auth_key, tracker.clone()).await?;
 
     let mut peer = peer_builder::from_request(&announce_request, &remote_client_ip);
 
@@ -78,7 +78,7 @@ pub async fn handle_announce(
 /// Will return `warp::Rejection` that wraps the `ServerError` if unable to `send_scrape_response`.
 pub async fn handle_scrape(
     scrape_request: request::Scrape,
-    auth_key_id: Option<Key>,
+    auth_key: Option<Key>,
     tracker: Arc<tracker::Tracker>,
 ) -> WebResult<impl Reply> {
     let mut files: HashMap<InfoHash, response::ScrapeEntry> = HashMap::new();
@@ -87,7 +87,7 @@ pub async fn handle_scrape(
     for info_hash in &scrape_request.info_hashes {
         let scrape_entry = match db.get(info_hash) {
             Some(torrent_info) => {
-                if authenticate(info_hash, &auth_key_id, tracker.clone()).await.is_ok() {
+                if authenticate(info_hash, &auth_key, tracker.clone()).await.is_ok() {
                     let (seeders, completed, leechers) = torrent_info.get_stats();
                     response::ScrapeEntry {
                         complete: seeders,

--- a/src/http/warp_implementation/routes.rs
+++ b/src/http/warp_implementation/routes.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use warp::{Filter, Rejection};
 
-use super::filters::{with_announce_request, with_auth_key_id, with_scrape_request, with_tracker};
+use super::filters::{with_announce_request, with_auth_key, with_scrape_request, with_tracker};
 use super::handlers::{handle_announce, handle_scrape, send_error};
 use crate::tracker;
 
@@ -20,7 +20,7 @@ fn announce(tracker: Arc<tracker::Tracker>) -> impl Filter<Extract = impl warp::
     warp::path::path("announce")
         .and(warp::filters::method::get())
         .and(with_announce_request(tracker.config.on_reverse_proxy))
-        .and(with_auth_key_id())
+        .and(with_auth_key())
         .and(with_tracker(tracker))
         .and_then(handle_announce)
 }
@@ -30,7 +30,7 @@ fn scrape(tracker: Arc<tracker::Tracker>) -> impl Filter<Extract = impl warp::Re
     warp::path::path("scrape")
         .and(warp::filters::method::get())
         .and(with_scrape_request(tracker.config.on_reverse_proxy))
-        .and(with_auth_key_id())
+        .and(with_auth_key())
         .and(with_tracker(tracker))
         .and_then(handle_scrape)
 }

--- a/src/tracker/auth.rs
+++ b/src/tracker/auth.rs
@@ -29,7 +29,7 @@ pub fn generate(lifetime: Duration) -> ExpiringKey {
     debug!("Generated key: {}, valid for: {:?} seconds", random_id, lifetime);
 
     ExpiringKey {
-        id: random_id.parse::<KeyId>().unwrap(),
+        id: random_id.parse::<Key>().unwrap(),
         valid_until: Current::add(&lifetime).unwrap(),
     }
 }
@@ -53,7 +53,7 @@ pub fn verify(auth_key: &ExpiringKey) -> Result<(), Error> {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct ExpiringKey {
-    pub id: KeyId,
+    pub id: Key,
     pub valid_until: DurationSinceUnixEpoch,
 }
 
@@ -76,18 +76,18 @@ impl std::fmt::Display for ExpiringKey {
 
 impl ExpiringKey {
     #[must_use]
-    pub fn id(&self) -> KeyId {
+    pub fn id(&self) -> Key {
         self.id.clone()
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Display, Hash)]
-pub struct KeyId(String);
+pub struct Key(String);
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ParseKeyIdError;
 
-impl FromStr for KeyId {
+impl FromStr for Key {
     type Err = ParseKeyIdError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -109,7 +109,7 @@ pub enum Error {
     #[error("Failed to read key: {key_id}, {location}")]
     UnableToReadKey {
         location: &'static Location<'static>,
-        key_id: Box<KeyId>,
+        key_id: Box<Key>,
     },
     #[error("Key has expired, {location}")]
     KeyExpired { location: &'static Location<'static> },
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn auth_key_id_from_string() {
         let key_string = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ";
-        let auth_key_id = auth::KeyId::from_str(key_string);
+        let auth_key_id = auth::Key::from_str(key_string);
 
         assert!(auth_key_id.is_ok());
         assert_eq!(auth_key_id.unwrap().to_string(), key_string);

--- a/src/tracker/auth.rs
+++ b/src/tracker/auth.rs
@@ -85,14 +85,14 @@ impl ExpiringKey {
 pub struct Key(String);
 
 #[derive(Debug, PartialEq, Eq)]
-pub struct ParseKeyIdError;
+pub struct ParseKeyError;
 
 impl FromStr for Key {
-    type Err = ParseKeyIdError;
+    type Err = ParseKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() != AUTH_KEY_LENGTH {
-            return Err(ParseKeyIdError);
+            return Err(ParseKeyError);
         }
 
         Ok(Self(s.to_string()))
@@ -106,10 +106,10 @@ pub enum Error {
     KeyVerificationError {
         source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
-    #[error("Failed to read key: {key_id}, {location}")]
+    #[error("Failed to read key: {key}, {location}")]
     UnableToReadKey {
         location: &'static Location<'static>,
-        key_id: Box<Key>,
+        key: Box<Key>,
     },
     #[error("Key has expired, {location}")]
     KeyExpired { location: &'static Location<'static> },
@@ -132,12 +132,12 @@ mod tests {
     use crate::tracker::auth;
 
     #[test]
-    fn auth_key_id_from_string() {
+    fn auth_key_from_string() {
         let key_string = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ";
-        let auth_key_id = auth::Key::from_str(key_string);
+        let auth_key = auth::Key::from_str(key_string);
 
-        assert!(auth_key_id.is_ok());
-        assert_eq!(auth_key_id.unwrap().to_string(), key_string);
+        assert!(auth_key.is_ok());
+        assert_eq!(auth_key.unwrap().to_string(), key_string);
     }
 
     #[test]

--- a/src/tracker/auth.rs
+++ b/src/tracker/auth.rs
@@ -29,7 +29,7 @@ pub fn generate(lifetime: Duration) -> ExpiringKey {
     debug!("Generated key: {}, valid for: {:?} seconds", random_id, lifetime);
 
     ExpiringKey {
-        id: random_id.parse::<Key>().unwrap(),
+        key: random_id.parse::<Key>().unwrap(),
         valid_until: Current::add(&lifetime).unwrap(),
     }
 }
@@ -53,7 +53,7 @@ pub fn verify(auth_key: &ExpiringKey) -> Result<(), Error> {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct ExpiringKey {
-    pub id: Key,
+    pub key: Key,
     pub valid_until: DurationSinceUnixEpoch,
 }
 
@@ -62,7 +62,7 @@ impl std::fmt::Display for ExpiringKey {
         write!(
             f,
             "key: `{}`, valid until `{}`",
-            self.id,
+            self.key,
             DateTime::<Utc>::from_utc(
                 NaiveDateTime::from_timestamp(
                     i64::try_from(self.valid_until.as_secs()).expect("Overflow of i64 seconds, very future!"),
@@ -77,7 +77,7 @@ impl std::fmt::Display for ExpiringKey {
 impl ExpiringKey {
     #[must_use]
     pub fn id(&self) -> Key {
-        self.id.clone()
+        self.key.clone()
     }
 }
 

--- a/src/tracker/error.rs
+++ b/src/tracker/error.rs
@@ -6,7 +6,7 @@ use crate::located_error::LocatedError;
 pub enum Error {
     #[error("The supplied key: {key_id:?}, is not valid: {source}")]
     PeerKeyNotValid {
-        key_id: super::auth::KeyId,
+        key_id: super::auth::Key,
         source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
     #[error("The peer is not authenticated, {location}")]

--- a/src/tracker/error.rs
+++ b/src/tracker/error.rs
@@ -4,9 +4,9 @@ use crate::located_error::LocatedError;
 
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum Error {
-    #[error("The supplied key: {key_id:?}, is not valid: {source}")]
+    #[error("The supplied key: {key:?}, is not valid: {source}")]
     PeerKeyNotValid {
-        key_id: super::auth::Key,
+        key: super::auth::Key,
         source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
     #[error("The peer is not authenticated, {location}")]

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -1147,7 +1147,7 @@ mod tests {
 
                     let key = tracker.generate_auth_key(Duration::from_secs(100)).await.unwrap();
 
-                    assert_eq!(key.valid_until.unwrap(), Duration::from_secs(100));
+                    assert_eq!(key.valid_until, Duration::from_secs(100));
                 }
 
                 #[tokio::test]

--- a/src/tracker/mod.rs
+++ b/src/tracker/mod.rs
@@ -190,7 +190,7 @@ impl Tracker {
     pub async fn generate_auth_key(&self, lifetime: Duration) -> Result<auth::ExpiringKey, databases::error::Error> {
         let auth_key = auth::generate(lifetime);
         self.database.add_key_to_keys(&auth_key).await?;
-        self.keys.write().await.insert(auth_key.id.clone(), auth_key.clone());
+        self.keys.write().await.insert(auth_key.key.clone(), auth_key.clone());
         Ok(auth_key)
     }
 
@@ -233,7 +233,7 @@ impl Tracker {
         keys.clear();
 
         for key in keys_from_database {
-            keys.insert(key.id.clone(), key);
+            keys.insert(key.key.clone(), key);
         }
 
         Ok(())

--- a/tests/http/client.rs
+++ b/tests/http/client.rs
@@ -11,7 +11,7 @@ use super::requests::scrape;
 pub struct Client {
     connection_info: ConnectionInfo,
     reqwest_client: ReqwestClient,
-    key_id: Option<Key>,
+    key: Option<Key>,
 }
 
 /// URL components in this context:
@@ -27,7 +27,7 @@ impl Client {
         Self {
             connection_info,
             reqwest_client: reqwest::Client::builder().build().unwrap(),
-            key_id: None,
+            key: None,
         }
     }
 
@@ -36,15 +36,15 @@ impl Client {
         Self {
             connection_info,
             reqwest_client: reqwest::Client::builder().local_address(local_address).build().unwrap(),
-            key_id: None,
+            key: None,
         }
     }
 
-    pub fn authenticated(connection_info: ConnectionInfo, key_id: Key) -> Self {
+    pub fn authenticated(connection_info: ConnectionInfo, key: Key) -> Self {
         Self {
             connection_info,
             reqwest_client: reqwest::Client::builder().build().unwrap(),
-            key_id: Some(key_id),
+            key: Some(key),
         }
     }
 
@@ -56,8 +56,8 @@ impl Client {
         self.get(&self.build_scrape_path_and_query(query)).await
     }
 
-    pub async fn announce_with_header(&self, query: &Query, key_id: &str, value: &str) -> Response {
-        self.get_with_header(&self.build_announce_path_and_query(query), key_id, value)
+    pub async fn announce_with_header(&self, query: &Query, key: &str, value: &str) -> Response {
+        self.get_with_header(&self.build_announce_path_and_query(query), key, value)
             .await
     }
 
@@ -83,8 +83,8 @@ impl Client {
     }
 
     fn build_path(&self, path: &str) -> String {
-        match &self.key_id {
-            Some(key_id) => format!("{path}/{key_id}"),
+        match &self.key {
+            Some(key) => format!("{path}/{key}"),
             None => path.to_string(),
         }
     }

--- a/tests/http/client.rs
+++ b/tests/http/client.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 
 use reqwest::{Client as ReqwestClient, Response};
-use torrust_tracker::tracker::auth::KeyId;
+use torrust_tracker::tracker::auth::Key;
 
 use super::connection_info::ConnectionInfo;
 use super::requests::announce::{self, Query};
@@ -11,7 +11,7 @@ use super::requests::scrape;
 pub struct Client {
     connection_info: ConnectionInfo,
     reqwest_client: ReqwestClient,
-    key_id: Option<KeyId>,
+    key_id: Option<Key>,
 }
 
 /// URL components in this context:
@@ -40,7 +40,7 @@ impl Client {
         }
     }
 
-    pub fn authenticated(connection_info: ConnectionInfo, key_id: KeyId) -> Self {
+    pub fn authenticated(connection_info: ConnectionInfo, key_id: Key) -> Self {
         Self {
             connection_info,
             reqwest_client: reqwest::Client::builder().build().unwrap(),

--- a/tests/http/connection_info.rs
+++ b/tests/http/connection_info.rs
@@ -1,9 +1,9 @@
-use torrust_tracker::tracker::auth::KeyId;
+use torrust_tracker::tracker::auth::Key;
 
 #[derive(Clone, Debug)]
 pub struct ConnectionInfo {
     pub bind_address: String,
-    pub key_id: Option<KeyId>,
+    pub key_id: Option<Key>,
 }
 
 impl ConnectionInfo {

--- a/tests/http/connection_info.rs
+++ b/tests/http/connection_info.rs
@@ -3,14 +3,14 @@ use torrust_tracker::tracker::auth::Key;
 #[derive(Clone, Debug)]
 pub struct ConnectionInfo {
     pub bind_address: String,
-    pub key_id: Option<Key>,
+    pub key: Option<Key>,
 }
 
 impl ConnectionInfo {
     pub fn anonymous(bind_address: &str) -> Self {
         Self {
             bind_address: bind_address.to_string(),
-            key_id: None,
+            key: None,
         }
     }
 }

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -1083,7 +1083,7 @@ mod warp_http_tracker_server {
 
             use torrust_tracker::http::Version;
             use torrust_tracker::protocol::info_hash::InfoHash;
-            use torrust_tracker::tracker::auth::KeyId;
+            use torrust_tracker::tracker::auth::Key;
 
             use crate::http::asserts::assert_is_announce_response;
             use crate::http::asserts_warp::{
@@ -1128,7 +1128,7 @@ mod warp_http_tracker_server {
                 let http_tracker_server = start_private_http_tracker(Version::Warp).await;
 
                 // The tracker does not have this key
-                let unregistered_key_id = KeyId::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
+                let unregistered_key_id = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
 
                 let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key_id)
                     .announce(&QueryBuilder::default().query())
@@ -1145,7 +1145,7 @@ mod warp_http_tracker_server {
 
             use torrust_tracker::http::Version;
             use torrust_tracker::protocol::info_hash::InfoHash;
-            use torrust_tracker::tracker::auth::KeyId;
+            use torrust_tracker::tracker::auth::Key;
             use torrust_tracker::tracker::peer;
 
             use crate::common::fixtures::PeerBuilder;
@@ -1242,7 +1242,7 @@ mod warp_http_tracker_server {
                     )
                     .await;
 
-                let false_key_id: KeyId = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
+                let false_key_id: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
 
                 let response = Client::authenticated(http_tracker.get_connection_info(), false_key_id)
                     .scrape(
@@ -2396,7 +2396,7 @@ mod axum_http_tracker_server {
 
             use torrust_tracker::http::Version;
             use torrust_tracker::protocol::info_hash::InfoHash;
-            use torrust_tracker::tracker::auth::KeyId;
+            use torrust_tracker::tracker::auth::Key;
 
             use crate::http::asserts::{assert_authentication_error_response, assert_is_announce_response};
             use crate::http::client::Client;
@@ -2453,7 +2453,7 @@ mod axum_http_tracker_server {
                 let http_tracker_server = start_private_http_tracker(Version::Axum).await;
 
                 // The tracker does not have this key
-                let unregistered_key_id = KeyId::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
+                let unregistered_key_id = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
 
                 let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key_id)
                     .announce(&QueryBuilder::default().query())
@@ -2470,7 +2470,7 @@ mod axum_http_tracker_server {
 
             use torrust_tracker::http::Version;
             use torrust_tracker::protocol::info_hash::InfoHash;
-            use torrust_tracker::tracker::auth::KeyId;
+            use torrust_tracker::tracker::auth::Key;
             use torrust_tracker::tracker::peer;
 
             use crate::common::fixtures::PeerBuilder;
@@ -2583,7 +2583,7 @@ mod axum_http_tracker_server {
                     )
                     .await;
 
-                let false_key_id: KeyId = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
+                let false_key_id: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
 
                 let response = Client::authenticated(http_tracker.get_connection_info(), false_key_id)
                     .scrape(

--- a/tests/http_tracker.rs
+++ b/tests/http_tracker.rs
@@ -1128,9 +1128,9 @@ mod warp_http_tracker_server {
                 let http_tracker_server = start_private_http_tracker(Version::Warp).await;
 
                 // The tracker does not have this key
-                let unregistered_key_id = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
+                let unregistered_key = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
 
-                let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key_id)
+                let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key)
                     .announce(&QueryBuilder::default().query())
                     .await;
 
@@ -1242,9 +1242,9 @@ mod warp_http_tracker_server {
                     )
                     .await;
 
-                let false_key_id: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
+                let false_key: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
 
-                let response = Client::authenticated(http_tracker.get_connection_info(), false_key_id)
+                let response = Client::authenticated(http_tracker.get_connection_info(), false_key)
                     .scrape(
                         &requests::scrape::QueryBuilder::default()
                             .with_one_info_hash(&info_hash)
@@ -2437,11 +2437,11 @@ mod axum_http_tracker_server {
             async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
                 let http_tracker_server = start_private_http_tracker(Version::Axum).await;
 
-                let invalid_key_id = "INVALID_KEY_ID";
+                let invalid_key = "INVALID_KEY";
 
                 let response = Client::new(http_tracker_server.get_connection_info())
                     .get(&format!(
-                        "announce/{invalid_key_id}?info_hash=%81%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00&peer_addr=2.137.87.41&downloaded=0&uploaded=0&peer_id=-qB00000000000000001&port=17548&left=0&event=completed&compact=0"
+                        "announce/{invalid_key}?info_hash=%81%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00&peer_addr=2.137.87.41&downloaded=0&uploaded=0&peer_id=-qB00000000000000001&port=17548&left=0&event=completed&compact=0"
                     ))
                     .await;
 
@@ -2453,9 +2453,9 @@ mod axum_http_tracker_server {
                 let http_tracker_server = start_private_http_tracker(Version::Axum).await;
 
                 // The tracker does not have this key
-                let unregistered_key_id = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
+                let unregistered_key = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
 
-                let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key_id)
+                let response = Client::authenticated(http_tracker_server.get_connection_info(), unregistered_key)
                     .announce(&QueryBuilder::default().query())
                     .await;
 
@@ -2484,11 +2484,11 @@ mod axum_http_tracker_server {
             async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
                 let http_tracker_server = start_private_http_tracker(Version::Axum).await;
 
-                let invalid_key_id = "INVALID_KEY_ID";
+                let invalid_key = "INVALID_KEY";
 
                 let response = Client::new(http_tracker_server.get_connection_info())
                     .get(&format!(
-                        "scrape/{invalid_key_id}?info_hash=%3B%24U%04%CF%5F%11%BB%DB%E1%20%1C%EAjk%F4Z%EE%1B%C0"
+                        "scrape/{invalid_key}?info_hash=%3B%24U%04%CF%5F%11%BB%DB%E1%20%1C%EAjk%F4Z%EE%1B%C0"
                     ))
                     .await;
 
@@ -2583,9 +2583,9 @@ mod axum_http_tracker_server {
                     )
                     .await;
 
-                let false_key_id: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
+                let false_key: Key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ".parse().unwrap();
 
-                let response = Client::authenticated(http_tracker.get_connection_info(), false_key_id)
+                let response = Client::authenticated(http_tracker.get_connection_info(), false_key)
                     .scrape(
                         &requests::scrape::QueryBuilder::default()
                             .with_one_info_hash(&info_hash)

--- a/tests/tracker_api.rs
+++ b/tests/tracker_api.rs
@@ -734,7 +734,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(api_server.get_connection_info())
-                .delete_auth_key(&auth_key.id.to_string())
+                .delete_auth_key(&auth_key.key.to_string())
                 .await;
 
             assert_ok(response).await;
@@ -777,7 +777,7 @@ mod tracker_apis {
             force_database_error(&api_server.tracker);
 
             let response = Client::new(api_server.get_connection_info())
-                .delete_auth_key(&auth_key.id.to_string())
+                .delete_auth_key(&auth_key.key.to_string())
                 .await;
 
             assert_failed_to_delete_key(response).await;
@@ -797,7 +797,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(connection_with_invalid_token(&api_server.get_bind_address()))
-                .delete_auth_key(&auth_key.id.to_string())
+                .delete_auth_key(&auth_key.key.to_string())
                 .await;
 
             assert_token_not_valid(response).await;
@@ -810,7 +810,7 @@ mod tracker_apis {
                 .unwrap();
 
             let response = Client::new(connection_with_no_token(&api_server.get_bind_address()))
-                .delete_auth_key(&auth_key.id.to_string())
+                .delete_auth_key(&auth_key.key.to_string())
                 .await;
 
             assert_unauthorized(response).await;

--- a/tests/tracker_api.rs
+++ b/tests/tracker_api.rs
@@ -741,10 +741,10 @@ mod tracker_apis {
         }
 
         #[tokio::test]
-        async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
+        async fn should_fail_deleting_an_auth_key_when_the_key_is_invalid() {
             let api_server = start_default_api().await;
 
-            let invalid_auth_key_ids = [
+            let invalid_auth_keys = [
                 // "", it returns a 404
                 // " ", it returns a 404
                 "0",
@@ -754,12 +754,12 @@ mod tracker_apis {
                 "IrweYtVuQPGbG9Jzx1DihcPmJGGpVy8zs", // 34 char key cspell:disable-line
             ];
 
-            for invalid_auth_key_id in &invalid_auth_key_ids {
+            for invalid_auth_key in &invalid_auth_keys {
                 let response = Client::new(api_server.get_connection_info())
-                    .delete_auth_key(invalid_auth_key_id)
+                    .delete_auth_key(invalid_auth_key)
                     .await;
 
-                assert_invalid_auth_key_param(response, invalid_auth_key_id).await;
+                assert_invalid_auth_key_param(response, invalid_auth_key).await;
             }
         }
 

--- a/tests/tracker_api.rs
+++ b/tests/tracker_api.rs
@@ -638,7 +638,7 @@ mod tracker_apis {
     mod for_key_resources {
         use std::time::Duration;
 
-        use torrust_tracker::tracker::auth::KeyId;
+        use torrust_tracker::tracker::auth::Key;
 
         use crate::api::asserts::{
             assert_auth_key_utf8, assert_failed_to_delete_key, assert_failed_to_generate_key, assert_failed_to_reload_keys,
@@ -665,7 +665,7 @@ mod tracker_apis {
             // Verify the key with the tracker
             assert!(api_server
                 .tracker
-                .verify_auth_key(&auth_key_resource.key.parse::<KeyId>().unwrap())
+                .verify_auth_key(&auth_key_resource.key.parse::<Key>().unwrap())
                 .await
                 .is_ok());
         }


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/issues/171

The `ExpiringKey::valid_until` (duration) does not need to be optional anymore since we introduced the `KeyId` struct.

Besides, after renaming the `Key` struct to `ExpiringKey`, there is no longer a conflict with the `KeyId`, so we can use the name `Key` for the `KeyId` again.

Before:

```rust
pub struct ExpiringKey {
    pub id: KeyId,
    pub valid_until: Option<DurationSinceUnixEpoch>,
}
```

After:

```rust
pub struct ExpiringKey {
    pub key: Key,
    pub valid_until: DurationSinceUnixEpoch,
}
```

After this refactoring, you can read the code like this:

"An `ExpiringKey` is a `Key` valid until a date expressed in a duration from the Unix epoch (timestamp)".