### PR TITLE
Update cargo aliases

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
 [alias]
-cov = "llvm-cov --lcov --output-path=./.coverage/lcov.info"
+cov = "llvm-cov"
+cov-lcov = "llvm-cov --lcov --output-path=./.coverage/lcov.info"
 cov-html = "llvm-cov --html"
+time = "build --timings --all-targets"


### PR DESCRIPTION
Cargo aliases:

- `cargo cov`: generate text coverage report.
- `cargo cov-lcov`: generate lcov coverage report on `./.coverage/lcov.info`. VSCode coverage plugins use it.
- `cargo cov-html`: generate html coverage report.
- `cargo time`: generate build timing HTML report.