### PR TITLE
Remove unused dependencies

### DIFF
--- a/.github/workflows/test_build_release.yml
+++ b/.github/workflows/test_build_release.yml
@@ -36,9 +36,11 @@ jobs:
         run: cargo clippy --all-targets -- -D clippy::pedantic
       - name: Test Documentation
         run: cargo test --doc
+      - name: Run Tests
+        run: cargo test --workspace        
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
-      - name: Run Tests
+      - name: Show coverage
         run: cargo llvm-cov nextest
 
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.5.11",
+ "toml",
  "yaml-rust",
 ]
 
@@ -1982,7 +1982,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -2490,15 +2490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,40 +2834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.19.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
-]
-
-[[package]]
 name = "torrust-tracker"
 version = "3.0.0-alpha.1"
 dependencies = [
@@ -2892,7 +2849,6 @@ dependencies = [
  "derive_more",
  "fern",
  "futures",
- "hex",
  "hyper",
  "lazy_static",
  "local-ip-address",
@@ -2915,7 +2871,6 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
- "toml 0.7.3",
  "torrust-tracker-configuration",
  "torrust-tracker-located-error",
  "torrust-tracker-primitives",
@@ -2932,7 +2887,7 @@ dependencies = [
  "serde",
  "serde_with",
  "thiserror",
- "toml 0.5.11",
+ "toml",
  "torrust-tracker-located-error",
  "torrust-tracker-primitives",
  "uuid",
@@ -2960,7 +2915,6 @@ version = "3.0.0-alpha.1"
 dependencies = [
  "lazy_static",
  "rand",
- "tokio",
  "torrust-tracker-configuration",
  "torrust-tracker-primitives",
 ]
@@ -3402,15 +3356,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "winnow"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bencode = "^0.2"
 serde_json = "1.0"
 serde_with = "2.0"
-hex = "0.4"
 percent-encoding = "2.2"
 binascii = "0.1"
 lazy_static = "1.4"
 openssl = { version = "0.10", features = ["vendored"] }
 config = "0.13"
-toml = "0.7"
 log = { version = "0.4", features = ["release_max_level_info"] }
 fern = "0.6"
 chrono = "0.4"

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -15,4 +15,6 @@ log = { version = "0.4", features = ["release_max_level_info"] }
 thiserror = "1.0"
 torrust-tracker-primitives = { version = "3.0.0-alpha.1", path = "../primitives" }
 torrust-tracker-located-error = { version = "3.0.0-alpha.1", path = "../located-error" }
+
+[dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -557,9 +557,13 @@ impl Configuration {
     /// permission to read it. Will also return `Err` if the configuration is
     /// not valid or cannot be encoded to TOML.
     pub fn save_to_file(&self, path: &str) -> Result<(), Error> {
-        let toml_string = toml::to_string(self).expect("Could not encode TOML value");
-        fs::write(path, toml_string).expect("Could not write to file!");
+        fs::write(path, self.to_toml()).expect("Could not write to file!");
         Ok(())
+    }
+
+    /// Encodes the configuration to TOML.
+    fn to_toml(&self) -> String {
+        toml::to_string(self).expect("Could not encode TOML value")
     }
 }
 
@@ -575,11 +579,11 @@ mod tests {
                                 db_path = "./storage/database/data.db"
                                 announce_interval = 120
                                 min_announce_interval = 120
-                                max_peer_timeout = 900
                                 on_reverse_proxy = false
                                 external_ip = "0.0.0.0"
                                 tracker_usage_statistics = true
                                 persistent_torrent_completed_stat = false
+                                max_peer_timeout = 900
                                 inactive_peer_cleanup_interval = 600
                                 remove_peerless_torrents = true
 

--- a/packages/located-error/Cargo.toml
+++ b/packages/located-error/Cargo.toml
@@ -8,4 +8,7 @@ edition.workspace = true
 
 [dependencies]
 log = { version = "0.4", features = ["release_max_level_info"] }
+
+[dev-dependencies]
 thiserror = "1.0"
+

--- a/packages/test-helpers/Cargo.toml
+++ b/packages/test-helpers/Cargo.toml
@@ -7,7 +7,6 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "net", "sync", "macros", "signal"] }
 lazy_static = "1.4"
 rand = "0.8.5"
 torrust-tracker-configuration = { version = "3.0.0-alpha.1", path = "../configuration"}


### PR DESCRIPTION
Remove unused dependencies detected by this command:

```
cargo +nightly udeps --all-targets
```

Some of them were false positives because they were used for testing. It was fixed by moving them from `[dependencies]` to `[dev-dependencies]` section in the `Cargo.toml` file.