### PR TITLE
Fix CVE-2020-26235 vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,12 +394,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.45",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1018,7 +1015,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1527,7 +1524,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.45.0",
 ]
 
@@ -1626,7 +1623,7 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
- "time 0.3.20",
+ "time",
  "uuid",
 ]
 
@@ -2523,7 +2520,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -2714,17 +2711,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.14",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -3114,12 +3100,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 config = "0.13"
 log = { version = "0.4", features = ["release_max_level_info"] }
 fern = "0.6"
-chrono = "0.4"
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 r2d2 = "0.8"
 r2d2_mysql = "23.0"
 r2d2_sqlite = { version = "0.21", features = ["bundled"] }


### PR DESCRIPTION
Fix [CVE-2020-26235](https://github.com/advisories/GHSA-wcg3-cvx6-7396) vulnerability by removing the `chrono` package feature that was using the `time` pacakage version with the vulnerability.