### PR TITLE
chore: bump alpha version to 3.0.0-alpha.7-develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "async-trait",
@@ -3215,7 +3215,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-configuration"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "config",
  "log",
@@ -3230,7 +3230,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-contrib-bencode"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "criterion",
  "error-chain",
@@ -3238,7 +3238,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-located-error"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "log",
  "thiserror",
@@ -3246,7 +3246,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-primitives"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "derive_more",
  "serde",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-test-helpers"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 dependencies = [
  "lazy_static",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ license-file = "COPYRIGHT"
 publish = true
 repository = "https://github.com/torrust/torrust-tracker"
 rust-version = "1.72"
-version = "3.0.0-alpha.6"
+version = "3.0.0-alpha.7-develop"
 
 [dependencies]
 aquatic_udp_protocol = "0.8"
@@ -56,10 +56,10 @@ serde_json = "1.0"
 serde_with = "3.2"
 thiserror = "1.0"
 tokio = { version = "1.29", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-configuration = { version = "3.0.0-alpha.6", path = "packages/configuration" }
-torrust-tracker-contrib-bencode = { version = "3.0.0-alpha.6", path = "contrib/bencode" }
-torrust-tracker-located-error = { version = "3.0.0-alpha.6", path = "packages/located-error" }
-torrust-tracker-primitives = { version = "3.0.0-alpha.6", path = "packages/primitives" }
+torrust-tracker-configuration = { version = "3.0.0-alpha.7-develop", path = "packages/configuration" }
+torrust-tracker-contrib-bencode = { version = "3.0.0-alpha.7-develop", path = "contrib/bencode" }
+torrust-tracker-located-error = { version = "3.0.0-alpha.7-develop", path = "packages/located-error" }
+torrust-tracker-primitives = { version = "3.0.0-alpha.7-develop", path = "packages/primitives" }
 tower-http = { version = "0.4", features = ["compression-full"] }
 uuid = { version = "1", features = ["v4"] }
 
@@ -70,7 +70,7 @@ reqwest = { version = "0.11.18", features = ["json"] }
 serde_bytes = "0.11"
 serde_repr = "0.1"
 serde_urlencoded = "0.7"
-torrust-tracker-test-helpers = { version = "3.0.0-alpha.6", path = "packages/test-helpers" }
+torrust-tracker-test-helpers = { version = "3.0.0-alpha.7-develop", path = "packages/test-helpers" }
 
 [workspace]
 members = ["contrib/bencode", "packages/configuration", "packages/located-error", "packages/primitives", "packages/test-helpers"]

--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ This project was a joint effort by [Nautilus Cyberneering GmbH][nautilus] and [D
 
 [containers.md]: ./docs/containers.md
 
-[api]: https://docs.rs/torrust-tracker/3.0.0-alpha.6/torrust_tracker/servers/apis/v1
-[http]: https://docs.rs/torrust-tracker/3.0.0-alpha.6/torrust_tracker/servers/http
-[udp]: https://docs.rs/torrust-tracker/3.0.0-alpha.6/torrust_tracker/servers/udp
+[api]: https://docs.rs/torrust-tracker/3.0.0-alpha.7-develop/torrust_tracker/servers/apis/v1
+[http]: https://docs.rs/torrust-tracker/3.0.0-alpha.7-develop/torrust_tracker/servers/http
+[udp]: https://docs.rs/torrust-tracker/3.0.0-alpha.7-develop/torrust_tracker/servers/udp
 
 [good first issues]: https://github.com/torrust/torrust-tracker/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
 [documentation]: https://docs.rs/torrust-tracker/
-[API documentation]: https://docs.rs/torrust-tracker/3.0.0-alpha.6/torrust_tracker/servers/apis/v1
+[API documentation]: https://docs.rs/torrust-tracker/3.0.0-alpha.7-develop/torrust_tracker/servers/apis/v1
 [discussions]: https://github.com/torrust/torrust-tracker/discussions
 
 [COPYRIGHT]: ./COPYRIGHT

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_with = "3.2"
 thiserror = "1.0"
 toml = "0.8"
-torrust-tracker-located-error = { version = "3.0.0-alpha.6", path = "../located-error" }
-torrust-tracker-primitives = { version = "3.0.0-alpha.6", path = "../primitives" }
+torrust-tracker-located-error = { version = "3.0.0-alpha.7-develop", path = "../located-error" }
+torrust-tracker-primitives = { version = "3.0.0-alpha.7-develop", path = "../primitives" }
 
 [dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/packages/test-helpers/Cargo.toml
+++ b/packages/test-helpers/Cargo.toml
@@ -17,5 +17,5 @@ version.workspace = true
 [dependencies]
 lazy_static = "1.4"
 rand = "0.8.5"
-torrust-tracker-configuration = { version = "3.0.0-alpha.6", path = "../configuration" }
-torrust-tracker-primitives = { version = "3.0.0-alpha.6", path = "../primitives" }
+torrust-tracker-configuration = { version = "3.0.0-alpha.7-develop", path = "../configuration" }
+torrust-tracker-primitives = { version = "3.0.0-alpha.7-develop", path = "../primitives" }


### PR DESCRIPTION
add version suffix to match release process expectations