### PR TITLE
feat: replace peer ID recognition with tdyne-peer-id-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,6 +2067,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +3008,23 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tdyne-peer-id"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dde285ba6f835045648f9d4f4703f778aaafb47421d9c5dff47be1534370c3e"
+
+[[package]]
+name = "tdyne-peer-id-registry"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1923b2d356e080e8bee847c39b58de293309df2fe0bc9ecd859ae3210e868c25"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "tdyne-peer-id",
+]
 
 [[package]]
 name = "tempfile"
@@ -3219,6 +3280,8 @@ dependencies = [
  "serde_repr",
  "serde_urlencoded",
  "serde_with",
+ "tdyne-peer-id",
+ "tdyne-peer-id-registry",
  "thiserror",
  "tokio",
  "torrust-tracker-configuration",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,8 @@ serde = { version = "1", features = ["derive"] }
 serde_bencode = "0"
 serde_json = "1"
 serde_with = "3"
+tdyne-peer-id = "1"
+tdyne-peer-id-registry = "0.1"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "packages/configuration" }

--- a/src/servers/apis/v1/context/torrent/resources/peer.rs
+++ b/src/servers/apis/v1/context/torrent/resources/peer.rs
@@ -39,7 +39,7 @@ impl From<tracker::peer::Id> for Id {
     fn from(peer_id: tracker::peer::Id) -> Self {
         Id {
             id: peer_id.to_hex_string(),
-            client: peer_id.get_client_name().map(std::string::ToString::to_string),
+            client: peer_id.get_client_name(),
         }
     }
 }

--- a/src/tracker/peer.rs
+++ b/src/tracker/peer.rs
@@ -252,81 +252,9 @@ impl Id {
     }
 
     #[must_use]
-    pub fn get_client_name(&self) -> Option<&'static str> {
-        if self.0[0] == b'M' {
-            return Some("BitTorrent");
-        }
-        if self.0[0] == b'-' {
-            let name = match &self.0[1..3] {
-                b"AG" | b"A~" => "Ares",
-                b"AR" => "Arctic",
-                b"AV" => "Avicora",
-                b"AX" => "BitPump",
-                b"AZ" => "Azureus",
-                b"BB" => "BitBuddy",
-                b"BC" => "BitComet",
-                b"BF" => "Bitflu",
-                b"BG" => "BTG (uses Rasterbar libtorrent)",
-                b"BR" => "BitRocket",
-                b"BS" => "BTSlave",
-                b"BX" => "~Bittorrent X",
-                b"CD" => "Enhanced CTorrent",
-                b"CT" => "CTorrent",
-                b"DE" => "DelugeTorrent",
-                b"DP" => "Propagate Data Client",
-                b"EB" => "EBit",
-                b"ES" => "electric sheep",
-                b"FT" => "FoxTorrent",
-                b"FW" => "FrostWire",
-                b"FX" => "Freebox BitTorrent",
-                b"GS" => "GSTorrent",
-                b"HL" => "Halite",
-                b"HN" => "Hydranode",
-                b"KG" => "KGet",
-                b"KT" => "KTorrent",
-                b"LH" => "LH-ABC",
-                b"LP" => "Lphant",
-                b"LT" => "libtorrent",
-                b"lt" => "libTorrent",
-                b"LW" => "LimeWire",
-                b"MO" => "MonoTorrent",
-                b"MP" => "MooPolice",
-                b"MR" => "Miro",
-                b"MT" => "MoonlightTorrent",
-                b"NX" => "Net Transport",
-                b"PD" => "Pando",
-                b"qB" => "qBittorrent",
-                b"QD" => "QQDownload",
-                b"QT" => "Qt 4 Torrent example",
-                b"RT" => "Retriever",
-                b"S~" => "Shareaza alpha/beta",
-                b"SB" => "~Swiftbit",
-                b"SS" => "SwarmScope",
-                b"ST" => "SymTorrent",
-                b"st" => "sharktorrent",
-                b"SZ" => "Shareaza",
-                b"TN" => "TorrentDotNET",
-                b"TR" => "Transmission",
-                b"TS" => "Torrentstorm",
-                b"TT" => "TuoTu",
-                b"UL" => "uLeecher!",
-                b"UT" => "µTorrent",
-                b"UW" => "µTorrent Web",
-                b"VG" => "Vagaa",
-                b"WD" => "WebTorrent Desktop",
-                b"WT" => "BitLet",
-                b"WW" => "WebTorrent",
-                b"WY" => "FireTorrent",
-                b"XL" => "Xunlei",
-                b"XT" => "XanTorrent",
-                b"XX" => "Xtorrent",
-                b"ZT" => "ZipTorrent",
-                _ => return None,
-            };
-            Some(name)
-        } else {
-            None
-        }
+    pub fn get_client_name(&self) -> Option<String> {
+        let peer_id = tdyne_peer_id::PeerId::from(self.0);
+        tdyne_peer_id_registry::parse(peer_id).ok().map(|parsed| parsed.client)
     }
 }
 
@@ -336,9 +264,9 @@ impl Serialize for Id {
         S: serde::Serializer,
     {
         #[derive(Serialize)]
-        struct PeerIdInfo<'a> {
+        struct PeerIdInfo {
             id: Option<String>,
-            client: Option<&'a str>,
+            client: Option<String>,
         }
 
         let obj = PeerIdInfo {
@@ -476,7 +404,7 @@ mod test {
         #[test]
         fn it_should_be_serializable() {
             let torrent_peer = Peer {
-                peer_id: peer::Id(*b"-qB00000000000000000"),
+                peer_id: peer::Id(*b"-qB0000-000000000000"),
                 peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),
                 updated: Current::now(),
                 uploaded: NumberOfBytes(0),
@@ -490,7 +418,7 @@ mod test {
             let expected_raw_json = r#"
                 {
                     "peer_id": {
-                        "id": "0x2d71423030303030303030303030303030303030",
+                        "id": "0x2d7142303030302d303030303030303030303030",
                         "client": "qBittorrent"
                     },
                     "peer_addr":"126.0.0.1:8080",


### PR DESCRIPTION
See also: #475

I made this PR as small as possible. I had to change the test, as `-qB00000000000000000` is not a valid qBittorent peer ID (it has to have another dash), so I amended it.

Do you want me to append the detected version to the string `.get_client_name()` returns? It can become `qBittorrent 2.3.4` instead, which is on the one hand more convenient for people, but on the other might interfere with grouping somewhere.

If you're open to it, I'll experiment with extracting more logic from `Id` into [`tdyne-peer-id`](https://crates.io/crates/tdyne-peer-id) (and maybe `InfoHash`, see #360, although it's trickier to design because of v2) to make it possible to share types directly and make a separate PR.