### PR TITLE
Move API healthcheck endpoint from `/health_check` to `/api/health_check`

### DIFF
--- a/src/bin/http_health_check.rs
+++ b/src/bin/http_health_check.rs
@@ -11,7 +11,7 @@ async fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         eprintln!("Usage:   cargo run --bin http_health_check <HEALTH_URL>");
-        eprintln!("Example: cargo run --bin http_health_check http://127.0.0.1:1212/health_check");
+        eprintln!("Example: cargo run --bin http_health_check http://127.0.0.1:1212/api/health_check");
         std::process::exit(1);
     }
 

--- a/src/servers/apis/routes.rs
+++ b/src/servers/apis/routes.rs
@@ -29,6 +29,6 @@ pub fn router(tracker: Arc<Tracker>) -> Router {
             tracker.config.clone(),
             v1::middlewares::auth::auth,
         ))
-        .route("/health_check", get(health_check_handler))
+        .route(&format!("{api_url_prefix}/health_check"), get(health_check_handler))
         .layer(CompressionLayer::new())
 }

--- a/src/servers/apis/v1/context/health_check/mod.rs
+++ b/src/servers/apis/v1/context/health_check/mod.rs
@@ -8,14 +8,14 @@
 //!
 //! # Health Check
 //!
-//! `GET /health_check`
+//! `GET /api/health_check`
 //!
 //! Returns the API status.
 //!
 //! **Example request**
 //!
 //! ```bash
-//! curl "http://127.0.0.1:1212/health_check"
+//! curl "http://127.0.0.1:1212/api/health_check"
 //! ```
 //!
 //! **Example response** `200`

--- a/src/servers/apis/v1/routes.rs
+++ b/src/servers/apis/v1/routes.rs
@@ -9,8 +9,10 @@ use crate::core::Tracker;
 /// Add the routes for the v1 API.
 pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
     let v1_prefix = format!("{prefix}/v1");
+
     let router = auth_key::routes::add(&v1_prefix, router, tracker.clone());
     let router = stats::routes::add(&v1_prefix, router, tracker.clone());
     let router = whitelist::routes::add(&v1_prefix, router, tracker.clone());
+
     torrent::routes::add(&v1_prefix, router, tracker)
 }

--- a/src/servers/health_check_api/handlers.rs
+++ b/src/servers/health_check_api/handlers.rs
@@ -45,7 +45,7 @@ async fn api_health_check(config: &HttpApi) -> Option<Json<Report>> {
         let addr: SocketAddr = config.bind_address.parse().expect("invalid socket address for API");
 
         if addr.port() != UNKNOWN_PORT {
-            let health_check_url = format!("http://{addr}/health_check");
+            let health_check_url = format!("http://{addr}/api/health_check");
 
             if !get_req_is_ok(&health_check_url).await {
                 return Some(responses::error(format!(

--- a/tests/servers/api/v1/contract/context/health_check.rs
+++ b/tests/servers/api/v1/contract/context/health_check.rs
@@ -8,7 +8,7 @@ use crate::servers::api::v1::client::get;
 async fn health_check_endpoint_should_return_status_ok_if_api_is_running() {
     let test_env = running_test_environment(configuration::ephemeral()).await;
 
-    let url = format!("http://{}/health_check", test_env.get_connection_info().bind_address);
+    let url = format!("http://{}/api/health_check", test_env.get_connection_info().bind_address);
 
     let response = get(&url, None).await;
 


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-compose/issues/2

From: `GET /health_check`
To:   `GET /api/health_check`

To avoid collission with HTTP Tracker health check enpoint when the API and the HTTP Tracker are using the same domain+port. For example:

- API:          https://tracker.com:443/api/
- HTTP tracker: https://tracker.com:443/

Old health check endpoints:

- API:          https://tracker.com:443/health_check
- HTTP tracker: https://tracker.com:443/health_check

New API health check endpoint:

- API:          https://tracker.com:443/api/health_check
- HTTP tracker: https://tracker.com:443/health_check