### PR TITLE
Change log for UDP tracker

### DIFF
--- a/contrib/bencode/src/reference/decode_opt.rs
+++ b/contrib/bencode/src/reference/decode_opt.rs
@@ -41,7 +41,7 @@ impl BDecodeOpt {
     ///
     /// It may be useful to disable this if for example, the input bencode is prepended to
     /// some payload and you would like to disassociate it. In this case, to find where the
-    /// rest of the payload starts that wasn't decoded, get the bencode buffer, and call len().
+    /// rest of the payload starts that wasn't decoded, get the bencode buffer, and call `len()`.
     #[must_use]
     pub fn enforce_full_decode(&self) -> bool {
         self.enforce_full_decode

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -7,7 +7,7 @@ use aquatic_udp_protocol::{
     AnnounceInterval, AnnounceRequest, AnnounceResponse, ConnectRequest, ConnectResponse, ErrorResponse, NumberOfDownloads,
     NumberOfPeers, Port, Request, Response, ResponsePeer, ScrapeRequest, ScrapeResponse, TorrentScrapeStatistics, TransactionId,
 };
-use log::debug;
+use log::{debug, info};
 
 use super::connection_cookie::{check, from_connection_id, into_connection_id, make};
 use crate::core::{statistics, Tracker};
@@ -73,6 +73,7 @@ pub async fn handle_request(request: Request, remote_addr: SocketAddr, tracker: 
 ///
 /// This function does not ever return an error.
 pub async fn handle_connect(remote_addr: SocketAddr, request: &ConnectRequest, tracker: &Tracker) -> Result<Response, Error> {
+    info!(target: "UDP", "\"CONNECT TxID {}\"", request.transaction_id.0);
     debug!("udp connect request: {:#?}", request);
 
     let connection_cookie = make(&remote_addr);
@@ -135,6 +136,8 @@ pub async fn handle_announce(
     let remote_client_ip = remote_addr.ip();
 
     authenticate(&info_hash, tracker).await?;
+
+    info!(target: "UDP", "\"ANNOUNCE TxID {} IH {}\"", announce_request.transaction_id.0, info_hash.to_hex_string());
 
     let mut peer = peer_builder::from_request(&wrapped_announce_request, &remote_client_ip);
 
@@ -210,6 +213,7 @@ pub async fn handle_announce(
 ///
 /// This function does not ever return an error.
 pub async fn handle_scrape(remote_addr: SocketAddr, request: &ScrapeRequest, tracker: &Tracker) -> Result<Response, Error> {
+    info!(target: "UDP", "\"SCRAPE TxID {}\"", request.transaction_id.0);
     debug!("udp scrape request: {:#?}", request);
 
     // Convert from aquatic infohashes

--- a/src/servers/udp/server.rs
+++ b/src/servers/udp/server.rs
@@ -191,7 +191,7 @@ impl Udp {
                 Ok((valid_bytes, remote_addr)) = socket.recv_from(&mut data) => {
                     let payload = data[..valid_bytes].to_vec();
 
-                    info!("Received {} bytes", payload.len());
+                    debug!("Received {} bytes", payload.len());
                     debug!("From: {}", &remote_addr);
                     debug!("Payload: {:?}", payload);
 
@@ -227,7 +227,7 @@ impl Udp {
                 Ok((valid_bytes, remote_addr)) = socket.recv_from(&mut data) => {
                     let payload = data[..valid_bytes].to_vec();
 
-                    info!("Received {} bytes", payload.len());
+                    debug!("Received {} bytes", payload.len());
                     debug!("From: {}", &remote_addr);
                     debug!("Payload: {:?}", payload);
 
@@ -249,13 +249,13 @@ impl Udp {
                 let position = cursor.position() as usize;
                 let inner = cursor.get_ref();
 
-                info!("Sending {} bytes ...", &inner[..position].len());
+                debug!("Sending {} bytes ...", &inner[..position].len());
                 debug!("To: {:?}", &remote_addr);
                 debug!("Payload: {:?}", &inner[..position]);
 
                 Udp::send_packet(socket, &remote_addr, &inner[..position]).await;
 
-                info!("{} bytes sent", &inner[..position].len());
+                debug!("{} bytes sent", &inner[..position].len());
             }
             Err(_) => {
                 error!("could not write response to bytes.");


### PR DESCRIPTION
Changed log lines format for the UDP tracker:

From:

```s
2023-12-22T12:32:53.016911160+00:00 [torrust_tracker::servers::udp::server][INFO] Received 109 bytes
2023-12-22T12:32:53.016953899+00:00 [torrust_tracker::servers::udp::server][INFO] Sending 43 bytes ...
2023-12-22T12:32:53.017038257+00:00 [torrust_tracker::servers::udp::server][INFO] 43 bytes sent
```

To:

```s
2023-12-22T12:35:51.320114322+00:00 [UDP][INFO] "CONNECT TxID 1583189312"
2023-12-22T12:35:51.345003905+00:00 [UDP][INFO] "ANNOUNCE TxID 1583189313 IH 443c7602b4fde83d1154d6d9da48808418b181b6"
2023-12-22T12:35:51.320114322+00:00 [UDP][INFO] "SCRAPE TxID 1583189312"
````

- The target is more generic "UDP" and it will be always the same even if we rearrange the packages.
- The info is more useful. It includes the request type, the transaction ID to identify the client, and the info-hash. That would allow us to extract statistics from the logs.

NOTE:

In the long term maybe this should be configurable.