### PR TITLE
Enable ignored test

### DIFF
--- a/tests/servers/api/v1/contract/configuration.rs
+++ b/tests/servers/api/v1/contract/configuration.rs
@@ -3,7 +3,6 @@ use torrust_tracker_test_helpers::configuration;
 use crate::servers::api::test_environment::stopped_test_environment;
 
 #[tokio::test]
-#[ignore]
 #[should_panic = "Could not receive bind_address."]
 async fn should_fail_with_ssl_enabled_and_bad_ssl_config() {
     let mut test_env = stopped_test_environment(configuration::ephemeral());


### PR DESCRIPTION
Test `should_fail_with_ssl_enabled_and_bad_ssl_config` was ignored [here](https://github.com/torrust/torrust-tracker/commit/efd1c995becbbf7fccf730d9cfa02157ce0c022c). 

It was ignored but it's now passing. I don't know was it was ignored.