### PR TITLE
Refactor: split global consts for limits

### DIFF
--- a/src/core/torrent/repository.rs
+++ b/src/core/torrent/repository.rs
@@ -69,7 +69,7 @@ impl Repository for Sync {
 
         let (stats, stats_updated) = {
             let mut torrent_entry_lock = torrent_entry.lock().unwrap();
-            let stats_updated = torrent_entry_lock.update_peer(peer);
+            let stats_updated = torrent_entry_lock.insert_or_update_peer(peer);
             let stats = torrent_entry_lock.get_stats();
 
             (stats, stats_updated)
@@ -126,7 +126,7 @@ impl Repository for SyncSingle {
             std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
         };
 
-        let stats_updated = torrent_entry.update_peer(peer);
+        let stats_updated = torrent_entry.insert_or_update_peer(peer);
         let stats = torrent_entry.get_stats();
 
         (
@@ -168,7 +168,7 @@ impl TRepositoryAsync for RepositoryAsync {
 
         let (stats, stats_updated) = {
             let mut torrent_entry_lock = torrent_entry.lock().await;
-            let stats_updated = torrent_entry_lock.update_peer(peer);
+            let stats_updated = torrent_entry_lock.insert_or_update_peer(peer);
             let stats = torrent_entry_lock.get_stats();
 
             (stats, stats_updated)
@@ -226,7 +226,7 @@ impl TRepositoryAsync for AsyncSync {
 
         let (stats, stats_updated) = {
             let mut torrent_entry_lock = torrent_entry.lock().unwrap();
-            let stats_updated = torrent_entry_lock.update_peer(peer);
+            let stats_updated = torrent_entry_lock.insert_or_update_peer(peer);
             let stats = torrent_entry_lock.get_stats();
 
             (stats, stats_updated)
@@ -273,7 +273,7 @@ impl TRepositoryAsync for RepositoryAsyncSingle {
         let (stats, stats_updated) = {
             let mut torrents_lock = self.torrents.write().await;
             let torrent_entry = torrents_lock.entry(*info_hash).or_insert(Entry::new());
-            let stats_updated = torrent_entry.update_peer(peer);
+            let stats_updated = torrent_entry.insert_or_update_peer(peer);
             let stats = torrent_entry.get_stats();
 
             (stats, stats_updated)

--- a/src/servers/http/mod.rs
+++ b/src/servers/http/mod.rs
@@ -71,7 +71,7 @@
 //! is behind a reverse proxy.
 //!
 //! > **NOTICE**: the maximum number of peers that the tracker can return is
-//! `74`. Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](crate::shared::bit_torrent::common::MAX_SCRAPE_TORRENTS).
+//! `74`. Defined with a hardcoded const [`TORRENT_PEERS_LIMIT`](crate::core::TORRENT_PEERS_LIMIT).
 //! Refer to [issue 262](https://github.com/torrust/torrust-tracker/issues/262)
 //! for more information about this limitation.
 //!
@@ -237,7 +237,7 @@
 //! In order to scrape multiple torrents at the same time you can pass multiple
 //! `info_hash` parameters: `info_hash=%81%00%0...00%00%00&info_hash=%82%00%0...00%00%00`
 //!
-//! > **NOTICE**: the maximum number of torrent you can scrape at the same time
+//! > **NOTICE**: the maximum number of torrents you can scrape at the same time
 //! is `74`. Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](crate::shared::bit_torrent::common::MAX_SCRAPE_TORRENTS).
 //!
 //! **Sample response**

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -598,7 +598,7 @@ mod tests {
 
                 handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                 let expected_peer = TorrentPeerBuilder::default()
                     .with_peer_id(peer::Id(peer_id.0))
@@ -659,7 +659,7 @@ mod tests {
 
                 handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V4(remote_client_ip), client_port));
             }
@@ -763,7 +763,7 @@ mod tests {
 
                     handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                    let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                    let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                     let external_ip_in_tracker_configuration =
                         tracker.config.external_ip.clone().unwrap().parse::<Ipv4Addr>().unwrap();
@@ -820,7 +820,7 @@ mod tests {
 
                 handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                 let expected_peer = TorrentPeerBuilder::default()
                     .with_peer_id(peer::Id(peer_id.0))
@@ -884,7 +884,7 @@ mod tests {
 
                 handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                 // When using IPv6 the tracker converts the remote client ip into a IPv4 address
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V6(remote_client_ip), client_port));
@@ -1001,7 +1001,7 @@ mod tests {
 
                     handle_announce(remote_addr, &request, &tracker).await.unwrap();
 
-                    let peers = tracker.get_all_torrent_peers(&info_hash.0.into()).await;
+                    let peers = tracker.get_torrent_peers(&info_hash.0.into()).await;
 
                     let _external_ip_in_tracker_configuration =
                         tracker.config.external_ip.clone().unwrap().parse::<Ipv6Addr>().unwrap();

--- a/src/shared/bit_torrent/common.rs
+++ b/src/shared/bit_torrent/common.rs
@@ -5,7 +5,6 @@ use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
 use serde::{Deserialize, Serialize};
 
 /// The maximum number of torrents that can be returned in an `scrape` response.
-/// It's also the maximum number of peers returned in an `announce` response.
 ///
 /// The [BEP 15. UDP Tracker Protocol for `BitTorrent`](https://www.bittorrent.org/beps/bep_0015.html)
 /// defines this limit:

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -740,7 +740,7 @@ mod for_all_config_modes {
 
             client.announce(&announce_query).await;
 
-            let peers = test_env.tracker.get_all_torrent_peers(&info_hash).await;
+            let peers = test_env.tracker.get_torrent_peers(&info_hash).await;
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), client_ip);
@@ -776,7 +776,7 @@ mod for_all_config_modes {
 
             client.announce(&announce_query).await;
 
-            let peers = test_env.tracker.get_all_torrent_peers(&info_hash).await;
+            let peers = test_env.tracker.get_torrent_peers(&info_hash).await;
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), test_env.tracker.config.get_ext_ip().unwrap());
@@ -812,7 +812,7 @@ mod for_all_config_modes {
 
             client.announce(&announce_query).await;
 
-            let peers = test_env.tracker.get_all_torrent_peers(&info_hash).await;
+            let peers = test_env.tracker.get_torrent_peers(&info_hash).await;
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), test_env.tracker.config.get_ext_ip().unwrap());
@@ -846,7 +846,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let peers = test_env.tracker.get_all_torrent_peers(&info_hash).await;
+            let peers = test_env.tracker.get_torrent_peers(&info_hash).await;
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), IpAddr::from_str("150.172.238.178").unwrap());


### PR DESCRIPTION
Current const: `crate::shared::bit_torrent::common::MAX_SCRAPE_TORRENTS`

`MAX_SCRAPE_TORRENTS` is the limit only for the number of torrents in a `scrape`request.

New const: `crate::core::TORRENT_PEERS_LIMIT`

`TORRENT_PEERS_LIMIT` is now the limit for the number of peers in an announce request (UDP and HTTP tracker).

Besides, the endpoint to get the torrent details in the API does not limit the number of peers for the torrent. So the API returns all peers in the tracker. This could lead to performance issues and we might need to paginate results, but the API should either return all peers and paginate them in a new endpoint.