### PR TITLE
Remove always-empty peer list in torrent list item

### DIFF
--- a/src/servers/apis/v1/context/torrent/resources/torrent.rs
+++ b/src/servers/apis/v1/context/torrent/resources/torrent.rs
@@ -44,9 +44,6 @@ pub struct ListItem {
     /// The torrent's leechers counter. Active peers that are downloading the
     /// torrent.
     pub leechers: u64,
-    /// The torrent's peers. It's always `None` in the struct and `null` in the
-    /// JSON response.
-    pub peers: Option<Vec<super::peer::Peer>>, // todo: this is always None. Remove field from endpoint?
 }
 
 impl ListItem {
@@ -90,7 +87,6 @@ impl From<BasicInfo> for ListItem {
             seeders: basic_info.seeders,
             completed: basic_info.completed,
             leechers: basic_info.leechers,
-            peers: None,
         }
     }
 }
@@ -156,7 +152,6 @@ mod tests {
                 seeders: 1,
                 completed: 2,
                 leechers: 3,
-                peers: None,
             }
         );
     }

--- a/tests/servers/api/v1/contract/context/torrent.rs
+++ b/tests/servers/api/v1/contract/context/torrent.rs
@@ -35,7 +35,6 @@ async fn should_allow_getting_torrents() {
             seeders: 1,
             completed: 0,
             leechers: 0,
-            peers: None, // Torrent list does not include the peer list for each torrent
         }],
     )
     .await;
@@ -65,7 +64,6 @@ async fn should_allow_limiting_the_torrents_in_the_result() {
             seeders: 1,
             completed: 0,
             leechers: 0,
-            peers: None, // Torrent list does not include the peer list for each torrent
         }],
     )
     .await;
@@ -95,7 +93,6 @@ async fn should_allow_the_torrents_result_pagination() {
             seeders: 1,
             completed: 0,
             leechers: 0,
-            peers: None, // Torrent list does not include the peer list for each torrent
         }],
     )
     .await;


### PR DESCRIPTION
The endpoint to get the list of torrents returns a list of items like this:

```json
[
  {
    "info_hash": "0031ad8520ddfebd856d70776063e477eaf07ada",
    "seeders": 0,
    "completed": 0,
    "leechers": 1,
    "peers": null
    }
]
```

The `peers` list is always `null` even if there are peers. That's very confusing especially if you enable the config option `remove_peerless_torrents`.

This PR removes that unused attribute.