### PR TITLE
Add DashMap implementation for torrent repository and set as used one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3420,6 +3433,7 @@ dependencies = [
  "chrono",
  "config",
  "criterion",
+ "dashmap",
  "derive_more",
  "fern",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ axum-server = { version = "0", features = ["tls-rustls"] }
 binascii = "0"
 chrono = { version = "0", default-features = false, features = ["clock"] }
 config = "0"
+dashmap = "5.5.3"
 derive_more = "0"
 fern = "0"
 futures = "0"

--- a/packages/torrent-repository-benchmarks/src/main.rs
+++ b/packages/torrent-repository-benchmarks/src/main.rs
@@ -7,7 +7,9 @@ use torrust_torrent_repository_benchmarks::benches::asyn::{
 use torrust_torrent_repository_benchmarks::benches::sync::{
     add_multiple_torrents_in_parallel, add_one_torrent, update_multiple_torrents_in_parallel, update_one_torrent_in_parallel,
 };
-use torrust_tracker::core::torrent::repository::{AsyncSync, RepositoryAsync, RepositoryAsyncSingle, Sync, SyncSingle};
+use torrust_tracker::core::torrent::repository::{
+    AsyncSync, RepositoryAsync, RepositoryAsyncSingle, RepositoryDashmap, Sync, SyncSingle,
+};
 
 #[allow(clippy::too_many_lines)]
 #[allow(clippy::print_literal)]
@@ -134,6 +136,30 @@ fn main() {
             "{}: Avg/AdjAvg: {:?}",
             "update_multiple_torrents_in_parallel",
             rt.block_on(async_update_multiple_torrents_in_parallel::<RepositoryAsync>(&rt, 10))
+        );
+
+        println!();
+
+        println!("DashMap<InfoHash, Entry>");
+        println!(
+            "{}: Avg/AdjAvg: {:?}",
+            "add_one_torrent",
+            add_one_torrent::<RepositoryDashmap>(1_000_000)
+        );
+        println!(
+            "{}: Avg/AdjAvg: {:?}",
+            "update_one_torrent_in_parallel",
+            rt.block_on(update_one_torrent_in_parallel::<RepositoryDashmap>(&rt, 10))
+        );
+        println!(
+            "{}: Avg/AdjAvg: {:?}",
+            "add_multiple_torrents_in_parallel",
+            rt.block_on(add_multiple_torrents_in_parallel::<RepositoryDashmap>(&rt, 10))
+        );
+        println!(
+            "{}: Avg/AdjAvg: {:?}",
+            "update_multiple_torrents_in_parallel",
+            rt.block_on(update_multiple_torrents_in_parallel::<RepositoryDashmap>(&rt, 10))
         );
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -453,8 +453,8 @@ use torrust_tracker_primitives::TrackerMode;
 use self::auth::Key;
 use self::error::Error;
 use self::peer::Peer;
-use self::torrent::repository::{RepositoryAsyncSingle, TRepositoryAsync};
 use crate::core::databases::Database;
+use crate::core::torrent::repository::{Repository, RepositoryDashmap};
 use crate::core::torrent::{SwarmMetadata, SwarmStats};
 use crate::shared::bit_torrent::info_hash::InfoHash;
 
@@ -479,7 +479,7 @@ pub struct Tracker {
     mode: TrackerMode,
     keys: tokio::sync::RwLock<std::collections::HashMap<Key, auth::ExpiringKey>>,
     whitelist: tokio::sync::RwLock<std::collections::HashSet<InfoHash>>,
-    pub torrents: Arc<RepositoryAsyncSingle>,
+    pub torrent_repository: Arc<RepositoryDashmap>,
     stats_event_sender: Option<Box<dyn statistics::EventSender>>,
     stats_repository: statistics::Repo,
 }
@@ -574,7 +574,7 @@ impl Tracker {
             mode,
             keys: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             whitelist: tokio::sync::RwLock::new(std::collections::HashSet::new()),
-            torrents: Arc::new(RepositoryAsyncSingle::new()),
+            torrent_repository: Arc::new(RepositoryDashmap::new()),
             stats_event_sender,
             stats_repository,
             database,
@@ -657,9 +657,7 @@ impl Tracker {
 
     /// It returns the data for a `scrape` response.
     async fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
-        let torrents = self.torrents.get_torrents().await;
-
-        match torrents.get(info_hash) {
+        match &self.torrent_repository.torrents.get(info_hash) {
             Some(torrent_entry) => torrent_entry.get_swarm_metadata(),
             None => SwarmMetadata::default(),
         }
@@ -676,11 +674,9 @@ impl Tracker {
     pub async fn load_torrents_from_database(&self) -> Result<(), databases::error::Error> {
         let persistent_torrents = self.database.load_persistent_torrents().await?;
 
-        let mut torrents = self.torrents.get_torrents_mut().await;
-
         for (info_hash, completed) in persistent_torrents {
             // Skip if torrent entry already exists
-            if torrents.contains_key(&info_hash) {
+            if self.torrent_repository.torrents.contains_key(&info_hash) {
                 continue;
             }
 
@@ -689,16 +685,14 @@ impl Tracker {
                 completed,
             };
 
-            torrents.insert(info_hash, torrent_entry);
+            self.torrent_repository.torrents.insert(info_hash, torrent_entry);
         }
 
         Ok(())
     }
 
     async fn get_torrent_peers_for_peer(&self, info_hash: &InfoHash, peer: &Peer) -> Vec<peer::Peer> {
-        let read_lock = self.torrents.get_torrents().await;
-
-        match read_lock.get(info_hash) {
+        match &self.torrent_repository.torrents.get(info_hash) {
             None => vec![],
             Some(entry) => entry
                 .get_peers_for_peer(peer, TORRENT_PEERS_LIMIT)
@@ -712,9 +706,7 @@ impl Tracker {
     ///
     /// Get all torrent peers for a given torrent
     pub async fn get_torrent_peers(&self, info_hash: &InfoHash) -> Vec<peer::Peer> {
-        let read_lock = self.torrents.get_torrents().await;
-
-        match read_lock.get(info_hash) {
+        match &self.torrent_repository.torrents.get(info_hash) {
             None => vec![],
             Some(entry) => entry.get_peers(TORRENT_PEERS_LIMIT).into_iter().copied().collect(),
         }
@@ -729,7 +721,9 @@ impl Tracker {
         // code-review: consider splitting the function in two (command and query segregation).
         // `update_torrent_with_peer` and `get_stats`
 
-        let (stats, stats_updated) = self.torrents.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
+        let (stats, stats_updated) = self
+            .torrent_repository
+            .update_torrent_with_peer_and_get_stats(info_hash, peer);
 
         if self.config.persistent_torrent_completed_stat && stats_updated {
             let completed = stats.completed;
@@ -756,12 +750,12 @@ impl Tracker {
             torrents: 0,
         }));
 
-        let db = self.torrents.get_torrents().await.clone();
+        let torrents = &self.torrent_repository.torrents;
 
-        let futures = db
-            .values()
-            .map(|torrent_entry| {
-                let torrent_entry = torrent_entry.clone();
+        let futures = torrents
+            .iter()
+            .map(|rm| {
+                let torrent_entry = rm.value().clone();
                 let torrents_metrics = arc_torrents_metrics.clone();
 
                 async move {
@@ -789,32 +783,19 @@ impl Tracker {
     ///
     /// # Context: Tracker
     pub async fn cleanup_torrents(&self) {
-        let mut torrents_lock = self.torrents.get_torrents_mut().await;
+        self.remove_all_inactive_peers_for_torrents();
 
-        // If we don't need to remove torrents we will use the faster iter
         if self.config.remove_peerless_torrents {
-            let mut cleaned_torrents_map: BTreeMap<InfoHash, torrent::Entry> = BTreeMap::new();
-
-            for (info_hash, torrent_entry) in &mut *torrents_lock {
-                torrent_entry.remove_inactive_peers(self.config.max_peer_timeout);
-
-                if torrent_entry.peers.is_empty() {
-                    continue;
-                }
-
-                if self.config.persistent_torrent_completed_stat && torrent_entry.completed == 0 {
-                    continue;
-                }
-
-                cleaned_torrents_map.insert(*info_hash, torrent_entry.clone());
-            }
-
-            *torrents_lock = cleaned_torrents_map;
-        } else {
-            for torrent_entry in (*torrents_lock).values_mut() {
-                torrent_entry.remove_inactive_peers(self.config.max_peer_timeout);
-            }
+            self.torrent_repository
+                .torrents
+                .retain(|_, torrent_entry| !torrent_entry.peers.is_empty());
         }
+    }
+
+    pub fn remove_all_inactive_peers_for_torrents(&self) {
+        self.torrent_repository.torrents.iter_mut().for_each(|mut rm| {
+            rm.value_mut().remove_inactive_peers(self.config.max_peer_timeout);
+        })
     }
 
     /// It authenticates the peer `key` against the `Tracker` authentication
@@ -1746,11 +1727,11 @@ mod tests {
                 assert_eq!(swarm_stats.completed, 1);
 
                 // Remove the newly updated torrent from memory
-                tracker.torrents.get_torrents_mut().await.remove(&info_hash);
+                tracker.torrent_repository.torrents.remove(&info_hash);
 
                 tracker.load_torrents_from_database().await.unwrap();
 
-                let torrents = tracker.torrents.get_torrents().await;
+                let torrents = &tracker.torrent_repository.torrents;
                 assert!(torrents.contains_key(&info_hash));
 
                 let torrent_entry = torrents.get(&info_hash).unwrap();


### PR DESCRIPTION
DashMap does not support ordering of keys that we use right now for our scrape responses, since DashMap works using multiple inner HashMaps (sharded). 

When I implement the torrent repository limit, I plan on adding a new HashMap that keeps track of the storage priority of torrents. We could also use the ordering of that HashMap for our torrents and scrape responses.