### PR TITLE
Remove duplication in HTTP announce response

### DIFF
--- a/src/servers/http/mod.rs
+++ b/src/servers/http/mod.rs
@@ -152,7 +152,7 @@
 //! 000000f0: 65                                       e
 //! ```
 //!
-//! Refer to the [`NonCompact`](crate::servers::http::v1::responses::announce::NonCompact)
+//! Refer to the [`NonCompact`](crate::servers::http::v1::responses::announce::Normal)
 //! response for more information about the response.
 //!
 //! **Sample compact response**

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -120,10 +120,10 @@ fn build_response(announce_request: &Announce, announce_data: AnnounceData) -> R
     match &announce_request.compact {
         Some(compact) => match compact {
             Compact::Accepted => announce::Compact::from(announce_data).into_response(),
-            Compact::NotAccepted => announce::NonCompact::from(announce_data).into_response(),
+            Compact::NotAccepted => announce::Normal::from(announce_data).into_response(),
         },
         // Default response format non compact
-        None => announce::NonCompact::from(announce_data).into_response(),
+        None => announce::Normal::from(announce_data).into_response(),
     }
 }
 

--- a/src/servers/http/v1/requests/announce.rs
+++ b/src/servers/http/v1/requests/announce.rs
@@ -180,7 +180,7 @@ impl fmt::Display for Event {
 /// Depending on the value of this param, the tracker will return a different
 /// response:
 ///
-/// - [`NonCompact`](crate::servers::http::v1::responses::announce::NonCompact) response.
+/// - [`NonCompact`](crate::servers::http::v1::responses::announce::Normal) response.
 /// - [`Compact`](crate::servers::http::v1::responses::announce::Compact) response.
 ///
 /// Refer to [BEP 23. Tracker Returns Compact Peer Lists](https://www.bittorrent.org/beps/bep_0023.html)

--- a/src/servers/http/v1/responses/announce.rs
+++ b/src/servers/http/v1/responses/announce.rs
@@ -14,6 +14,21 @@ use torrust_tracker_contrib_bencode::{ben_bytes, ben_int, ben_list, ben_map, BMu
 use crate::core::{self, AnnounceData};
 use crate::servers::http::v1::responses;
 
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct Announce<PeerList> {
+    pub policy: Policy,
+    pub stats: SwarmStats,
+    pub peer_list: PeerList,
+}
+
+pub type NormalPeerList = PeerList<NormalPeer>;
+pub type CompactPeerList = PeerList<CompactPeer>;
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct PeerList<PeerType> {
+    pub peers: Vec<PeerType>,
+}
+
 /// Normal (non compact) `announce` response.
 ///
 /// It's a bencoded dictionary.
@@ -62,20 +77,7 @@ use crate::servers::http::v1::responses;
 ///
 /// Refer to [BEP 03: The `BitTorrent` Protocol Specification](https://www.bittorrent.org/beps/bep_0003.html)
 /// for more information.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Normal {
-    pub policy: Policy,
-    pub stats: SwarmStats,
-    pub peer_list: NormalPeerList,
-}
-
-pub type NormalPeerList = PeerList<NormalPeer>;
-pub type CompactPeerList = PeerList<CompactPeer>;
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct PeerList<PeerType> {
-    pub peers: Vec<PeerType>,
-}
+pub type Normal = Announce<NormalPeerList>;
 
 /// Peer information in the [`Normal`]
 /// response.
@@ -226,12 +228,7 @@ impl From<AnnounceData> for Normal {
 ///
 /// - [BEP 23: Tracker Returns Compact Peer Lists](https://www.bittorrent.org/beps/bep_0023.html)
 /// - [BEP 07: IPv6 Tracker Extension](https://www.bittorrent.org/beps/bep_0007.html)
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Compact {
-    pub policy: Policy,
-    pub stats: SwarmStats,
-    pub peer_list: CompactPeerList,
-}
+pub type Compact = Announce<CompactPeerList>;
 
 /// Compact peer. It's used in the [`Compact`]
 /// response.

--- a/src/servers/http/v1/responses/announce.rs
+++ b/src/servers/http/v1/responses/announce.rs
@@ -25,8 +25,8 @@ pub type NormalPeerList = PeerList<NormalPeer>;
 pub type CompactPeerList = PeerList<CompactPeer>;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct PeerList<PeerType> {
-    pub peers: Vec<PeerType>,
+pub struct PeerList<Peer> {
+    pub peers: Vec<Peer>,
 }
 
 /// Normal (non compact) `announce` response.


### PR DESCRIPTION
Hi @da2ce7, this is an [alternative for removing duplication from the HTTP announce response](https://github.com/torrust/torrust-tracker/pull/563).

