### PR TITLE
Fix broken grateful shutdown for tracker API

### DIFF
--- a/src/bin/http_health_check.rs
+++ b/src/bin/http_health_check.rs
@@ -11,7 +11,7 @@ async fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() != 2 {
         eprintln!("Usage:   cargo run --bin http_health_check <HEALTH_URL>");
-        eprintln!("Example: cargo run --bin http_health_check http://127.0.0.1:1212/api/health_check");
+        eprintln!("Example: cargo run --bin http_health_check http://127.0.0.1:1313/health_check");
         std::process::exit(1);
     }
 

--- a/src/bootstrap/jobs/health_check_api.rs
+++ b/src/bootstrap/jobs/health_check_api.rs
@@ -55,7 +55,7 @@ pub async fn start_job(config: Arc<Configuration>) -> JoinHandle<()> {
 
     // Wait until the API server job is running
     match rx_start.await {
-        Ok(msg) => info!("Torrust Health Check API server started on socket: {}", msg.address),
+        Ok(msg) => info!("Torrust Health Check API server started on: http://{}", msg.address),
         Err(e) => panic!("the Health Check API server was dropped: {e}"),
     }
 

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -22,7 +22,7 @@ pub struct Started {
 
 pub async fn make_rust_tls(enabled: bool, cert: &Option<String>, key: &Option<String>) -> Option<Result<RustlsConfig, Error>> {
     if !enabled {
-        info!("tls not enabled");
+        info!("TLS not enabled");
         return None;
     }
 

--- a/src/bootstrap/jobs/tracker_apis.rs
+++ b/src/bootstrap/jobs/tracker_apis.rs
@@ -80,6 +80,7 @@ async fn start_v1(socket: SocketAddr, tls: Option<RustlsConfig>, tracker: Arc<co
         .expect("it should be able to start to the tracker api");
 
     tokio::spawn(async move {
+        assert!(!server.state.halt_task.is_closed(), "Halt channel should be open");
         server.state.task.await.expect("failed to close service");
     })
 }

--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -170,7 +170,7 @@ impl Launcher {
         tokio::task::spawn(graceful_shutdown(
             handle.clone(),
             rx_halt,
-            format!("shutting down http server on socket address: {address}"),
+            format!("Shutting down http server on socket address: {address}"),
         ));
 
         let tls = self.tls.clone();

--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -30,7 +30,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use derive_more::Constructor;
 use futures::future::BoxFuture;
-use log::error;
+use log::{error, info};
 use tokio::sync::oneshot::{Receiver, Sender};
 
 use super::routes::router;
@@ -102,7 +102,6 @@ impl ApiServer<Stopped> {
             launcher
         });
 
-        //let address = rx_start.await.expect("unable to start service").address;
         let api_server = match rx_start.await {
             Ok(started) => ApiServer {
                 state: Running {
@@ -112,7 +111,7 @@ impl ApiServer<Stopped> {
                 },
             },
             Err(err) => {
-                let msg = format!("unable to start API server: {err}");
+                let msg = format!("Unable to start API server: {err}");
                 error!("{}", msg);
                 panic!("{}", msg);
             }
@@ -170,10 +169,11 @@ impl Launcher {
         tokio::task::spawn(graceful_shutdown(
             handle.clone(),
             rx_halt,
-            format!("Shutting down http server on socket address: {address}"),
+            format!("Shutting down tracker API server on socket address: {address}"),
         ));
 
         let tls = self.tls.clone();
+        let protocol = if tls.is_some() { "https" } else { "http" };
 
         let running = Box::pin(async {
             match tls {
@@ -181,18 +181,20 @@ impl Launcher {
                     .handle(handle)
                     .serve(router.into_make_service_with_connect_info::<std::net::SocketAddr>())
                     .await
-                    .expect("Axum server crashed."),
+                    .expect("Axum server for tracker API crashed."),
                 None => axum_server::from_tcp(socket)
                     .handle(handle)
                     .serve(router.into_make_service_with_connect_info::<std::net::SocketAddr>())
                     .await
-                    .expect("Axum server crashed."),
+                    .expect("Axum server for tracker API crashed."),
             }
         });
 
+        info!(target: "API", "API server started on {protocol}://{}", address);
+
         tx_start
             .send(Started { address })
-            .expect("the HTTP(s) Tracker service should not be dropped");
+            .expect("the HTTP(s) Tracker API service should not be dropped");
 
         running
     }

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -47,7 +47,7 @@ impl Launcher {
         tokio::task::spawn(graceful_shutdown(
             handle.clone(),
             rx_halt,
-            format!("shutting down http server on socket address: {address}"),
+            format!("Shutting down http server on socket address: {address}"),
         ));
 
         let tls = self.tls.clone();

--- a/src/servers/signals.rs
+++ b/src/servers/signals.rs
@@ -69,7 +69,7 @@ pub async fn shutdown_signal_with_message(rx_halt: tokio::sync::oneshot::Receive
 pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync::oneshot::Receiver<Halted>, message: String) {
     shutdown_signal_with_message(rx_halt, message).await;
 
-    info!("sending graceful shutdown signal");
+    info!("Sending graceful shutdown signal");
     handle.graceful_shutdown(Some(Duration::from_secs(90)));
 
     println!("!! shuting down in 90 seconds !!");


### PR DESCRIPTION
The internal halt channel was not working because the sender was being dropped just after starting the server.

That also made the `shutdown_signal` fail.

```rust
pub async fn shutdown_signal(rx_halt: tokio::sync::oneshot::Receiver<Halted>) {
    let halt = async {
        match rx_halt.await {
            Ok(signal) => signal,
            Err(err) => panic!("Failed to install stop signal: {err}"),
        }
    };

    tokio::select! {
        signal = halt => { info!("Halt signal processed: {}", signal) },
        () = global_shutdown_signal() => { info!("Global shutdown signal processed") }
    }
}
```

Since the signal branch in the `tokio::select!` was finishing the global_shutdown_signal did not work either. So you had to kill the process manually to stop the tracker.

It seems Rust partially dropped the `Running::halt_taks` attribute and that closed the channel.

The issue was introduced in this commit: https://github.com/torrust/torrust-tracker/commit/13140f60dbd461fafb2ce234c6c968d7f23052ec