### PR TITLE
WIP: try to fix halt channel closed after starting UDP tracker

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -32,6 +32,7 @@
         "Containerfile",
         "curr",
         "Cyberneering",
+        "datagram",
         "datetime",
         "Dijke",
         "distroless",
@@ -79,6 +80,7 @@
         "nonroot",
         "Norberg",
         "numwant",
+        "nvCFlJCq7fz7Qx6KoKTDiMZvns8l5Kw7",
         "oneshot",
         "ostr",
         "Pando",
@@ -129,8 +131,7 @@
         "Xtorrent",
         "Xunlei",
         "xxxxxxxxxxxxxxxxxxxxd",
-        "yyyyyyyyyyyyyyyyyyyyd",
-        "nvCFlJCq7fz7Qx6KoKTDiMZvns8l5Kw7"
+        "yyyyyyyyyyyyyyyyyyyyd"
     ],
     "enableFiletypes": [
         "dockerfile",

--- a/src/bootstrap/jobs/udp_tracker.rs
+++ b/src/bootstrap/jobs/udp_tracker.rs
@@ -8,6 +8,7 @@
 //! for the configuration options.
 use std::sync::Arc;
 
+use log::debug;
 use tokio::task::JoinHandle;
 use torrust_tracker_configuration::UdpTracker;
 
@@ -36,6 +37,13 @@ pub async fn start_job(config: &UdpTracker, tracker: Arc<core::Tracker>) -> Join
         .expect("it should be able to start the udp tracker");
 
     tokio::spawn(async move {
+        debug!(target: "UDP Tracker", "Wait for launcher (UDP service) to finish ...");
+
+        assert!(
+            !server.state.halt_task.is_closed(),
+            "Halt channel for UDP tracker should be open"
+        );
+
         server
             .state
             .task

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -48,7 +48,7 @@ impl Launcher {
         tokio::task::spawn(graceful_shutdown(
             handle.clone(),
             rx_halt,
-            format!("Shutting down http server on socket address: {address}"),
+            format!("Shutting down HTTP server on socket address: {address}"),
         ));
 
         let tls = self.tls.clone();

--- a/src/servers/udp/server.rs
+++ b/src/servers/udp/server.rs
@@ -120,10 +120,19 @@ impl UdpServer<Stopped> {
         let (tx_start, rx_start) = tokio::sync::oneshot::channel::<Started>();
         let (tx_halt, rx_halt) = tokio::sync::oneshot::channel::<Halted>();
 
+        assert!(!tx_halt.is_closed(), "Halt channel for UDP tracker should be open");
+
         let launcher = self.state.launcher;
 
         let task = tokio::spawn(async move {
-            launcher.start(tracker, tx_start, rx_halt).await;
+            debug!(target: "UDP Tracker", "Launcher starting ...");
+
+            let server = launcher.start(tracker, tx_start, rx_halt);
+
+            server.await;
+
+            debug!(target: "UDP Tracker", "Launcher finished ...");
+
             launcher
         });
 
@@ -134,8 +143,6 @@ impl UdpServer<Stopped> {
                 task,
             },
         };
-
-        info!("Running UDP Tracker on Socket: {}", running_udp_server.state.binding);
 
         Ok(running_udp_server)
     }
@@ -202,37 +209,58 @@ impl Udp {
         tx_start: Sender<Started>,
         rx_halt: Receiver<Halted>,
     ) -> JoinHandle<()> {
-        let binding = Arc::new(UdpSocket::bind(bind_to).await.expect("Could not bind to {self.socket}."));
-        let address = binding.local_addr().expect("Could not get local_addr from {binding}.");
+        let socket = Arc::new(UdpSocket::bind(bind_to).await.expect("Could not bind to {self.socket}."));
+        let address = socket.local_addr().expect("Could not get local_addr from {binding}.");
+
+        let halt = tokio::task::spawn(async move {
+            debug!(target: "UDP Tracker", "Server on socket address: udp://{address} waiting for halt signal ...");
+
+            shutdown_signal_with_message(
+                rx_halt,
+                format!("Shutting down UDP server on socket address: udp://{address}"),
+            )
+            .await;
+        });
+
+        info!(target: "UDP Tracker", "Starting on: udp://{}", address);
 
         let running = tokio::task::spawn(async move {
-            let halt = async move {
-                shutdown_signal_with_message(rx_halt, format!("Halting Http Service Bound to Socket: {address}")).await;
+            let listen = async move {
+                debug!(target: "UDP Tracker", "Waiting for packets ...");
+
+                loop {
+                    let mut data = [0; MAX_PACKET_SIZE];
+                    let socket_clone = socket.clone();
+
+                    match socket_clone.recv_from(&mut data).await {
+                        Ok((valid_bytes, remote_addr)) => {
+                            let payload = data[..valid_bytes].to_vec();
+
+                            debug!(target: "UDP Tracker", "Received {} bytes", payload.len());
+                            debug!(target: "UDP Tracker", "From: {}", &remote_addr);
+                            debug!(target: "UDP Tracker", "Payload: {:?}", payload);
+
+                            let response = handle_packet(remote_addr, payload, &tracker).await;
+
+                            Udp::send_response(socket_clone, remote_addr, response).await;
+                        }
+                        Err(err) => {
+                            error!("Error reading UDP datagram from socket. Error: {:?}", err);
+                        }
+                    }
+                }
             };
 
             pin_mut!(halt);
+            pin_mut!(listen);
 
-            loop {
-                let mut data = [0; MAX_PACKET_SIZE];
-                let binding = binding.clone();
-
-                tokio::select! {
-                    () = & mut halt => {},
-
-                    Ok((valid_bytes, remote_addr)) = binding.recv_from(&mut data) => {
-                        let payload = data[..valid_bytes].to_vec();
-
-                        debug!("Received {} bytes", payload.len());
-                        debug!("From: {}", &remote_addr);
-                        debug!("Payload: {:?}", payload);
-
-                        let response = handle_packet(remote_addr, payload, &tracker).await;
-
-                        Udp::send_response(binding, remote_addr, response).await;
-                    }
-                }
+            tokio::select! {
+                _ = & mut halt => { debug!(target: "UDP Tracker", "Halt signal spawned task stopped on address: udp://{address}"); },
+                () = & mut listen => { debug!(target: "UDP Tracker", "Socket listener stopped on address: udp://{address}"); },
             }
         });
+
+        info!(target: "UDP Tracker", "Started on: udp://{}", address);
 
         tx_start
             .send(Started { address })


### PR DESCRIPTION
Hi @da2ce7 @WarmBeer I'm been debugging this error some hours but I can't find the problem.

It seems that the "halt" channel is immediately closed after starting the UDP tracker. So the app panics with:

```console
thread 'tokio-runtime-worker' panicked at src/servers/signals.rs:52:25:
Failed to install stop signal: channel closed
```

The UDP is started but it's not possible to shut it down gracefully.

I've added a lot of debug lines in this PR:

```rust
$ cargo run
   Compiling torrust-tracker v3.0.0-alpha.12-develop (/home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker)
    Finished dev [optimized + debuginfo] target(s) in 7.05s
     Running `target/debug/torrust-tracker`
Loading default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
2024-01-10T17:46:40.348930411+00:00 [torrust_tracker::bootstrap::logging][INFO] logging initialized.
2024-01-10T17:46:40.349651636+00:00 [UDP Tracker][DEBUG] Launcher starting ...
2024-01-10T17:46:40.349677556+00:00 [UDP Tracker][INFO] Starting on: udp://0.0.0.0:6969
2024-01-10T17:46:40.349682046+00:00 [UDP Tracker][INFO] Started on: udp://0.0.0.0:6969
2024-01-10T17:46:40.349684556+00:00 [UDP Tracker][DEBUG] Launcher finished ...
2024-01-10T17:46:40.349687856+00:00 [UDP Tracker][DEBUG] Waiting for packets ...
2024-01-10T17:46:40.349687736+00:00 [torrust_tracker::bootstrap::jobs::http_tracker][INFO] Note: Not loading Http Tracker Service, Not Enabled in Configuration.
2024-01-10T17:46:40.349691306+00:00 [UDP Tracker][DEBUG] Wait for launcher (UDP service) to finish ...
2024-01-10T17:46:40.349689536+00:00 [UDP Tracker][DEBUG] Server on socket address: udp://0.0.0.0:6969 waiting for halt signal ...
2024-01-10T17:46:40.349700506+00:00 [torrust_tracker::bootstrap::jobs::health_check_api][INFO] Starting Health Check API server: http://127.0.0.1:1313
thread 'tokio-runtime-worker' panicked at src/servers/signals.rs:52:25:
Failed to install stop signal: channel closed
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2024-01-10T17:46:40.349793665+00:00 [torrust_tracker::bootstrap::jobs::health_check_api][INFO] Torrust Health Check API server started on: http://127.0.0.1:1313
2024-01-10T17:46:40.349793225+00:00 [UDP Tracker][DEBUG] Halt signal spawned task stopped on address: udp://0.0.0.0:6969

```

The function panicking is:

```rust
pub async fn shutdown_signal(rx_halt: tokio::sync::oneshot::Receiver<Halted>) {
    let halt = async {
        match rx_halt.await {
            Ok(signal) => signal,
            Err(err) => panic!("Failed to install stop signal: {err}"),
        }
    };

    tokio::select! {
        signal = halt => { info!("Halt signal processed: {}", signal) },
        () = global_shutdown_signal() => { info!("Global shutdown signal processed") }
    }
}
```

When the thread starts waiting for the signal it receives the error "channel closed".

I fixed a similar problem for the Tracker API and the HTTP Tracker:

- https://github.com/torrust/torrust-tracker/pull/593
- https://github.com/torrust/torrust-tracker/pull/589

Apparently the problem was the sender in the channel was dropped (I don't know why, it looks like a compiler optimization)

Are we using this feature (sending a halt signal to the services to stop them). I think we are not using it yet and we do not have tests. Maybe I should just remove it. It's an interesting topic but it might take long to solve it.

Could you take a look? Maybe I'm missing something obvious.

The only problem with this bug it's the UDP is forced to close when we close the app and we don't see anything in the logs. But maybe it does not make sense to use the signal if we do nothing with it.
