### PR TITLE
Reproduce bug for zombie health check threads

### DIFF
--- a/share/default/config/tracker.development.sqlite3.toml
+++ b/share/default/config/tracker.development.sqlite3.toml
@@ -3,7 +3,7 @@ db_driver = "Sqlite3"
 db_path = "./storage/tracker/lib/database/sqlite3.db"
 external_ip = "0.0.0.0"
 inactive_peer_cleanup_interval = 600
-log_level = "info"
+log_level = "debug"
 max_peer_timeout = 900
 min_announce_interval = 120
 mode = "public"
@@ -14,7 +14,7 @@ tracker_usage_statistics = true
 
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"
-enabled = false
+enabled = true
 
 [[http_trackers]]
 bind_address = "0.0.0.0:7070"
@@ -25,7 +25,7 @@ ssl_key_path = ""
 
 [http_api]
 bind_address = "127.0.0.1:1212"
-enabled = true
+enabled = false
 ssl_cert_path = ""
 ssl_enabled = false
 ssl_key_path = ""

--- a/src/servers/udp/server.rs
+++ b/src/servers/udp/server.rs
@@ -20,6 +20,7 @@
 use std::io::Cursor;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::thread;
 
 use aquatic_udp_protocol::Response;
 use derive_more::Constructor;
@@ -28,6 +29,7 @@ use log::{debug, error, info};
 use tokio::net::UdpSocket;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::task::JoinHandle;
+use tokio::time;
 
 use crate::bootstrap::jobs::Started;
 use crate::core::Tracker;
@@ -241,6 +243,8 @@ impl Udp {
                             debug!(target: "UDP Tracker", "Payload: {:?}", payload);
 
                             let response = handle_packet(remote_addr, payload, &tracker).await;
+
+                            thread::sleep(time::Duration::from_secs(20));
 
                             Udp::send_response(socket_clone, remote_addr, response).await;
                         }


### PR DESCRIPTION
**This should not be merged**. The intention is only to document the bug.

When the UDP tracker socket is bound to an address but the service is not responding, there is no timeout for both the healthcheck request. So the thread waits forever consuming resources.

I've just add a 20-second delay for the UDP response to confirm that the healthcheck wait 20 seconds.

Tracker output:

```console
$ cargo run
    Finished dev [optimized + debuginfo] target(s) in 0.07s
     Running `target/debug/torrust-tracker`
Loading default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
2024-01-12T13:51:46.331659385+00:00 [torrust_tracker::bootstrap::logging][INFO] logging initialized.
2024-01-12T13:51:46.332365591+00:00 [UDP Tracker][DEBUG] Launcher starting ...
2024-01-12T13:51:46.332414740+00:00 [UDP Tracker][INFO] Starting on: udp://0.0.0.0:6969
2024-01-12T13:51:46.332423320+00:00 [UDP Tracker][INFO] Started on: udp://0.0.0.0:6969
2024-01-12T13:51:46.332437360+00:00 [UDP Tracker][DEBUG] Waiting for packets on socket address: udp://0.0.0.0:6969 ...
2024-01-12T13:51:46.332441610+00:00 [torrust_tracker::bootstrap::jobs::http_tracker][INFO] Note: Not loading Http Tracker Service, Not Enabled in Configuration.
2024-01-12T13:51:46.332442630+00:00 [UDP Tracker][DEBUG] Waiting for halt signal for socket address: udp://0.0.0.0:6969  ...
2024-01-12T13:51:46.332445400+00:00 [UDP Tracker][DEBUG] Wait for launcher (UDP service) to finish ...
2024-01-12T13:51:46.332459980+00:00 [UDP Tracker][DEBUG] Is halt channel closed before waiting?: false
2024-01-12T13:51:46.332470650+00:00 [Health Check API][INFO] Starting on: http://127.0.0.1:1313
2024-01-12T13:51:46.332573259+00:00 [Health Check API][INFO] Started on: http://127.0.0.1:1313
2024-01-12T13:51:54.994614604+00:00 [UDP Tracker][DEBUG] Received 16 bytes
2024-01-12T13:51:54.994646494+00:00 [UDP Tracker][DEBUG] From: 127.0.0.1:44239
2024-01-12T13:51:54.994649174+00:00 [UDP Tracker][DEBUG] Payload: [0, 0, 4, 23, 39, 16, 25, 128, 0, 0, 0, 0, 0, 0, 0, 123]
2024-01-12T13:51:54.994654304+00:00 [UDP][INFO] "CONNECT TxID 123"
2024-01-12T13:51:54.994656934+00:00 [torrust_tracker::servers::udp::handlers][DEBUG] udp connect request: ConnectRequest {
    transaction_id: TransactionId(
        123,
    ),
}
2024-01-12T13:51:54.994670494+00:00 [torrust_tracker::servers::udp::handlers][DEBUG] udp connect response: ConnectResponse {
    connection_id: ConnectionId(
        586323190029847869,
    ),
    transaction_id: TransactionId(
        123,
    ),
}
2024-01-12T13:52:14.994761282+00:00 [torrust_tracker::servers::udp::server][DEBUG] Sending 16 bytes ...
2024-01-12T13:52:14.994786951+00:00 [torrust_tracker::servers::udp::server][DEBUG] To: 127.0.0.1:44239
2024-01-12T13:52:14.994796541+00:00 [torrust_tracker::servers::udp::server][DEBUG] Payload: [0, 0, 0, 0, 0, 0, 0, 123, 8, 35, 9, 213, 185, 77, 141, 61]
2024-01-12T13:52:14.994827791+00:00 [torrust_tracker::servers::udp::server][DEBUG] 16 bytes sent
2024-01-12T13:52:14.994841221+00:00 [torrust_tracker::core::statistics][DEBUG] stats: Metrics { tcp4_connections_handled: 0, tcp4_announces_handled: 0, tcp4_scrapes_handled: 0, tcp6_connections_handled: 0, tcp6_announces_handled: 0, tcp6_scrapes_handled: 0, udp4_connections_handled: 1, udp4_announces_handled: 0, udp4_scrapes_handled: 0, udp6_connections_handled: 0, udp6_announces_handled: 0, udp6_scrapes_handled: 0 }
```

Healthcheck executed manually:

```console
$ time cargo run --bin http_health_check http://127.0.0.1:1313/health_check
    Finished dev [optimized + debuginfo] target(s) in 0.07s
     Running `target/debug/http_health_check 'http://127.0.0.1:1313/health_check'`
Health check ...
STATUS: 200 OK

real    0m20.110s
user    0m0.076s
sys     0m0.037s
```


