### PR TITLE
Fix services bootstraping

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -76,6 +76,10 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
 
     // Start the HTTP blocks
     for http_tracker_config in &config.http_trackers {
+        if !http_tracker_config.enabled {
+            continue;
+        }
+
         if let Some(job) = http_tracker::start_job(
             http_tracker_config,
             tracker.clone(),

--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -30,7 +30,7 @@ use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 use derive_more::Constructor;
 use futures::future::BoxFuture;
-use log::{error, info};
+use log::{debug, error, info};
 use tokio::sync::oneshot::{Receiver, Sender};
 use torrust_tracker_configuration::AccessTokens;
 
@@ -120,7 +120,12 @@ impl ApiServer<Stopped> {
         let launcher = self.state.launcher;
 
         let task = tokio::spawn(async move {
-            launcher.start(tracker, access_tokens, tx_start, rx_halt).await;
+            debug!(target: "API", "Starting with launcher in spawned task ...");
+
+            let _task = launcher.start(tracker, access_tokens, tx_start, rx_halt).await;
+
+            debug!(target: "API", "Started with launcher in spawned task");
+
             launcher
         });
 
@@ -266,8 +271,9 @@ mod tests {
     #[tokio::test]
     async fn it_should_be_able_to_start_and_stop() {
         let cfg = Arc::new(ephemeral_mode_public());
-        let tracker = initialize_with_configuration(&cfg);
         let config = &cfg.http_api;
+
+        let tracker = initialize_with_configuration(&cfg);
 
         let bind_to = config
             .bind_address

--- a/src/servers/health_check_api/server.rs
+++ b/src/servers/health_check_api/server.rs
@@ -8,6 +8,7 @@ use axum::routing::get;
 use axum::{Json, Router};
 use axum_server::Handle;
 use futures::Future;
+use log::debug;
 use serde_json::json;
 use tokio::sync::oneshot::{Receiver, Sender};
 
@@ -37,10 +38,12 @@ pub fn start(
 
     let handle = Handle::new();
 
+    debug!(target: "Health Check API", "Starting service with graceful shutdown in a spawned task ...");
+
     tokio::task::spawn(graceful_shutdown(
         handle.clone(),
         rx_halt,
-        format!("shutting down http server on socket address: {address}"),
+        format!("Shutting down http server on socket address: {address}"),
     ));
 
     let running = axum_server::from_tcp(socket)

--- a/src/servers/registar.rs
+++ b/src/servers/registar.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use derive_more::Constructor;
+use log::debug;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 
@@ -81,10 +82,15 @@ impl Registar {
 
     /// Inserts a listing into the registry.
     async fn insert(&self, rx: tokio::sync::oneshot::Receiver<ServiceRegistration>) {
-        let listing = rx.await.expect("it should receive the listing");
+        debug!("Waiting for the started service to send registration data ...");
+
+        let service_registration = rx
+            .await
+            .expect("it should receive the service registration from the started service");
 
         let mut mutex = self.registry.lock().await;
-        mutex.insert(listing.binding, listing);
+
+        mutex.insert(service_registration.binding, service_registration);
     }
 
     /// Returns the [`ServiceRegistry`] of services

--- a/tests/servers/health_check_api/environment.rs
+++ b/tests/servers/health_check_api/environment.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use log::debug;
 use tokio::sync::oneshot::{self, Sender};
 use tokio::task::JoinHandle;
 use torrust_tracker::bootstrap::jobs::Started;
@@ -50,12 +51,21 @@ impl Environment<Stopped> {
 
         let register = self.registar.entries();
 
+        debug!(target: "Health Check API", "Spawning task to launch the service ...");
+
         let server = tokio::spawn(async move {
+            debug!(target: "Health Check API", "Starting the server in a spawned task ...");
+
             server::start(self.state.bind_to, tx_start, rx_halt, register)
                 .await
                 .expect("it should start the health check service");
+
+            debug!(target: "Health Check API", "Server started. Sending the binding {} ...", self.state.bind_to);
+
             self.state.bind_to
         });
+
+        debug!(target: "Health Check API", "Waiting for spawning task to send the binding ...");
 
         let binding = rx_start.await.expect("it should send service binding").address;
 


### PR DESCRIPTION
This fixes all errors introduced after merging [this PR](https://github.com/torrust/torrust-tracker/pull/623).

- [x] HTTP tracker should not be started if it's disabled

Error running the Health Check API server:

```console
thread 'tokio-runtime-worker' panicked at src/servers/signals.rs:52:25:
Failed to install stop signal: channel closed
```