### PR TITLE
Remove coverage report generation from testing workflow

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -110,7 +110,3 @@ jobs:
       - id: test
         name: Run Unit Tests
         run: cargo test --tests --benches --examples --workspace --all-targets --all-features
-
-      - id: coverage
-        name: Generate Coverage Report
-        run: cargo llvm-cov nextest --tests --benches --examples --workspace --all-targets --all-features


### PR DESCRIPTION
The coverage report is also generated in the `coverage` workflow. And it takes long.