### PR TITLE
Tracker Checker: check HTTP trackers

### DIFF
--- a/src/console/clients/checker/service.rs
+++ b/src/console/clients/checker/service.rs
@@ -12,7 +12,8 @@ use crate::console::clients::checker::printer::Printer;
 use crate::shared::bit_torrent::info_hash::InfoHash;
 use crate::shared::bit_torrent::tracker::http::client::requests::announce::QueryBuilder;
 use crate::shared::bit_torrent::tracker::http::client::responses::announce::Announce;
-use crate::shared::bit_torrent::tracker::http::client::Client;
+use crate::shared::bit_torrent::tracker::http::client::responses::scrape;
+use crate::shared::bit_torrent::tracker::http::client::{requests, Client};
 
 pub struct Service {
     pub(crate) config: Arc<Configuration>,
@@ -58,9 +59,32 @@ impl Service {
         self.console.println("HTTP trackers ...");
 
         for http_tracker in &self.config.http_trackers {
-            match self.check_http_tracker(http_tracker).await {
-                Ok(()) => check_results.push(Ok(())),
-                Err(err) => check_results.push(Err(err)),
+            let colored_tracker_url = http_tracker.to_string().yellow();
+
+            match self.check_http_announce(http_tracker).await {
+                Ok(()) => {
+                    check_results.push(Ok(()));
+                    self.console
+                        .println(&format!("{} - Announce at {} is OK", "✓".green(), colored_tracker_url));
+                }
+                Err(err) => {
+                    check_results.push(Err(err));
+                    self.console
+                        .println(&format!("{} - Announce at {} is failing", "✗".red(), colored_tracker_url));
+                }
+            }
+
+            match self.check_http_scrape(http_tracker).await {
+                Ok(()) => {
+                    check_results.push(Ok(()));
+                    self.console
+                        .println(&format!("{} - Scrape at {} is OK", "✓".green(), colored_tracker_url));
+                }
+                Err(err) => {
+                    check_results.push(Err(err));
+                    self.console
+                        .println(&format!("{} - Scrape at {} is failing", "✗".red(), colored_tracker_url));
+                }
             }
         }
     }
@@ -80,15 +104,20 @@ impl Service {
         // todo:
         // - Make announce request
         // - Make scrape request
-        self.console
-            .println(&format!("{} - UDP tracker at udp://{:?} is OK (TODO)", "✓".green(), address));
+
+        let colored_address = address.to_string().yellow();
+
+        self.console.println(&format!(
+            "{} - UDP tracker at udp://{} is OK ({})",
+            "✓".green(),
+            colored_address,
+            "TODO".red(),
+        ));
     }
 
-    async fn check_http_tracker(&self, url: &Url) -> Result<(), CheckError> {
+    async fn check_http_announce(&self, url: &Url) -> Result<(), CheckError> {
         let info_hash_str = "9c38422213e30bff212b30c360d26f9a02136422".to_string(); // # DevSkim: ignore DS173237
         let info_hash = InfoHash::from_str(&info_hash_str).expect("a valid info-hash is required");
-
-        // Announce request
 
         let response = Client::new(url.clone())
             .announce(&QueryBuilder::with_default_values().with_info_hash(&info_hash).query())
@@ -96,41 +125,60 @@ impl Service {
 
         if let Ok(body) = response.bytes().await {
             if let Ok(_announce_response) = serde_bencode::from_bytes::<Announce>(&body) {
-                self.console.println(&format!("{} - Announce at {} is OK", "✓".green(), url));
-
                 Ok(())
             } else {
-                self.console.println(&format!("{} - Announce at {} failing", "✗".red(), url));
                 Err(CheckError::HttpError { url: url.clone() })
             }
         } else {
-            self.console.println(&format!("{} - Announce at {} failing", "✗".red(), url));
             Err(CheckError::HttpError { url: url.clone() })
         }
+    }
 
-        // Scrape request
+    async fn check_http_scrape(&self, url: &Url) -> Result<(), CheckError> {
+        let info_hashes: Vec<String> = vec!["9c38422213e30bff212b30c360d26f9a02136422".to_string()]; // # DevSkim: ignore DS173237
+        let query = requests::scrape::Query::try_from(info_hashes).expect("a valid array of info-hashes is required");
 
-        // todo
+        let response = Client::new(url.clone()).scrape(&query).await;
+
+        if let Ok(body) = response.bytes().await {
+            if let Ok(_scrape_response) = scrape::Response::try_from_bencoded(&body) {
+                Ok(())
+            } else {
+                Err(CheckError::HttpError { url: url.clone() })
+            }
+        } else {
+            Err(CheckError::HttpError { url: url.clone() })
+        }
     }
 
     async fn run_health_check(&self, url: Url) -> Result<(), CheckError> {
         let client = HttpClient::builder().timeout(Duration::from_secs(5)).build().unwrap();
 
+        let colored_url = url.to_string().yellow();
+
         match client.get(url.clone()).send().await {
             Ok(response) => {
                 if response.status().is_success() {
                     self.console
-                        .println(&format!("{} - Health API at {} is OK", "✓".green(), url));
+                        .println(&format!("{} - Health API at {} is OK", "✓".green(), colored_url));
                     Ok(())
                 } else {
-                    self.console
-                        .eprintln(&format!("{} - Health API at {} failing: {:?}", "✗".red(), url, response));
+                    self.console.eprintln(&format!(
+                        "{} - Health API at {} is failing: {:?}",
+                        "✗".red(),
+                        colored_url,
+                        response
+                    ));
                     Err(CheckError::HealthCheckError { url })
                 }
             }
             Err(err) => {
-                self.console
-                    .eprintln(&format!("{} - Health API at {} failing: {:?}", "✗".red(), url, err));
+                self.console.eprintln(&format!(
+                    "{} - Health API at {} is failing: {:?}",
+                    "✗".red(),
+                    colored_url,
+                    err
+                ));
                 Err(CheckError::HealthCheckError { url })
             }
         }

--- a/src/console/clients/checker/service.rs
+++ b/src/console/clients/checker/service.rs
@@ -1,13 +1,18 @@
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
 use colored::Colorize;
-use reqwest::{Client, Url};
+use reqwest::{Client as HttpClient, Url};
 
 use super::config::Configuration;
 use super::console::Console;
 use crate::console::clients::checker::printer::Printer;
+use crate::shared::bit_torrent::info_hash::InfoHash;
+use crate::shared::bit_torrent::tracker::http::client::requests::announce::QueryBuilder;
+use crate::shared::bit_torrent::tracker::http::client::responses::announce::Announce;
+use crate::shared::bit_torrent::tracker::http::client::Client;
 
 pub struct Service {
     pub(crate) config: Arc<Configuration>,
@@ -19,7 +24,7 @@ pub type CheckResult = Result<(), CheckError>;
 #[derive(Debug)]
 pub enum CheckError {
     UdpError,
-    HttpError,
+    HttpError { url: Url },
     HealthCheckError { url: Url },
 }
 
@@ -30,10 +35,15 @@ impl Service {
     pub async fn run_checks(&self) -> Vec<CheckResult> {
         self.console.println("Running checks for trackers ...");
 
-        self.check_udp_trackers();
-        self.check_http_trackers();
+        let mut check_results = vec![];
 
-        self.run_health_checks().await
+        self.check_udp_trackers();
+
+        self.check_http_trackers(&mut check_results).await;
+
+        self.run_health_checks(&mut check_results).await;
+
+        check_results
     }
 
     fn check_udp_trackers(&self) {
@@ -44,18 +54,19 @@ impl Service {
         }
     }
 
-    fn check_http_trackers(&self) {
+    async fn check_http_trackers(&self, check_results: &mut Vec<CheckResult>) {
         self.console.println("HTTP trackers ...");
 
         for http_tracker in &self.config.http_trackers {
-            self.check_http_tracker(http_tracker);
+            match self.check_http_tracker(http_tracker).await {
+                Ok(()) => check_results.push(Ok(())),
+                Err(err) => check_results.push(Err(err)),
+            }
         }
     }
 
-    async fn run_health_checks(&self) -> Vec<CheckResult> {
+    async fn run_health_checks(&self, check_results: &mut Vec<CheckResult>) {
         self.console.println("Health checks ...");
-
-        let mut check_results = vec![];
 
         for health_check_url in &self.config.health_checks {
             match self.run_health_check(health_check_url.clone()).await {
@@ -63,8 +74,6 @@ impl Service {
                 Err(err) => check_results.push(Err(err)),
             }
         }
-
-        check_results
     }
 
     fn check_udp_tracker(&self, address: &SocketAddr) {
@@ -72,19 +81,40 @@ impl Service {
         // - Make announce request
         // - Make scrape request
         self.console
-            .println(&format!("{} - UDP tracker at {:?} is OK (TODO)", "✓".green(), address));
+            .println(&format!("{} - UDP tracker at udp://{:?} is OK (TODO)", "✓".green(), address));
     }
 
-    fn check_http_tracker(&self, url: &Url) {
-        // todo:
-        // - Make announce request
-        // - Make scrape request
-        self.console
-            .println(&format!("{} - HTTP tracker at {} is OK (TODO)", "✓".green(), url));
+    async fn check_http_tracker(&self, url: &Url) -> Result<(), CheckError> {
+        let info_hash_str = "9c38422213e30bff212b30c360d26f9a02136422".to_string(); // # DevSkim: ignore DS173237
+        let info_hash = InfoHash::from_str(&info_hash_str).expect("a valid info-hash is required");
+
+        // Announce request
+
+        let response = Client::new(url.clone())
+            .announce(&QueryBuilder::with_default_values().with_info_hash(&info_hash).query())
+            .await;
+
+        if let Ok(body) = response.bytes().await {
+            if let Ok(_announce_response) = serde_bencode::from_bytes::<Announce>(&body) {
+                self.console.println(&format!("{} - Announce at {} is OK", "✓".green(), url));
+
+                Ok(())
+            } else {
+                self.console.println(&format!("{} - Announce at {} failing", "✗".red(), url));
+                Err(CheckError::HttpError { url: url.clone() })
+            }
+        } else {
+            self.console.println(&format!("{} - Announce at {} failing", "✗".red(), url));
+            Err(CheckError::HttpError { url: url.clone() })
+        }
+
+        // Scrape request
+
+        // todo
     }
 
     async fn run_health_check(&self, url: Url) -> Result<(), CheckError> {
-        let client = Client::builder().timeout(Duration::from_secs(5)).build().unwrap();
+        let client = HttpClient::builder().timeout(Duration::from_secs(5)).build().unwrap();
 
         match client.get(url.clone()).send().await {
             Ok(response) => {

--- a/src/shared/bit_torrent/tracker/http/client/requests/scrape.rs
+++ b/src/shared/bit_torrent/tracker/http/client/requests/scrape.rs
@@ -45,6 +45,23 @@ impl TryFrom<&[String]> for Query {
     }
 }
 
+impl TryFrom<Vec<String>> for Query {
+    type Error = ConversionError;
+
+    fn try_from(info_hashes: Vec<String>) -> Result<Self, Self::Error> {
+        let mut validated_info_hashes: Vec<ByteArray20> = Vec::new();
+
+        for info_hash in info_hashes {
+            let validated_info_hash = InfoHash::from_str(&info_hash).map_err(|_| ConversionError(info_hash.clone()))?;
+            validated_info_hashes.push(validated_info_hash.0);
+        }
+
+        Ok(Self {
+            info_hash: validated_info_hashes,
+        })
+    }
+}
+
 /// HTTP Tracker Scrape Request:
 ///
 /// <https://www.bittorrent.org/beps/bep_0048.html>


### PR DESCRIPTION
Implement checks for HTTP Trackers in the Tracker Checker.

- [x] Add check for `announce` request.
- [x] Add check for `scrape` request.