### PR TITLE
Feat: add a new info_hash URL query array to the torrent list endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895ff42f72016617773af68fb90da2a9677d89c62338ec09162d4909d86fdd8f"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "serde_html_form",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2982,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_html_form"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50437e6a58912eecc08865e35ea2e8d365fbb2db0debb1c8bb43bf1faf055f25"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.2.3",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3520,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-client-ip",
+ "axum-extra",
  "axum-server",
  "binascii",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ aquatic_udp_protocol = "0"
 async-trait = "0"
 axum = { version = "0", features = ["macros"] }
 axum-client-ip = "0"
+axum-extra = { version = "0.9.2", features = ["query"] }
 axum-server = { version = "0", features = ["tls-rustls"] }
 binascii = "0"
 chrono = { version = "0", default-features = false, features = ["clock"] }

--- a/src/servers/apis/v1/context/torrent/handlers.rs
+++ b/src/servers/apis/v1/context/torrent/handlers.rs
@@ -4,14 +4,15 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use axum::extract::{Path, Query, State};
-use axum::response::{IntoResponse, Json, Response};
+use axum::extract::{Path, State};
+use axum::response::{IntoResponse, Response};
+use axum_extra::extract::Query;
 use log::debug;
 use serde::{de, Deserialize, Deserializer};
+use thiserror::Error;
 
-use super::resources::torrent::ListItem;
 use super::responses::{torrent_info_response, torrent_list_response, torrent_not_known_response};
-use crate::core::services::torrent::{get_torrent_info, get_torrents, Pagination};
+use crate::core::services::torrent::{get_torrent_info, get_torrents, get_torrents_page, Pagination};
 use crate::core::Tracker;
 use crate::servers::apis::v1::responses::invalid_info_hash_param_response;
 use crate::servers::apis::InfoHashParam;
@@ -36,39 +37,87 @@ pub async fn get_torrent_handler(State(tracker): State<Arc<Tracker>>, Path(info_
     }
 }
 
-/// A container for the optional URL query pagination parameters:
-/// `offset` and `limit`.
+/// A container for the URL query parameters.
+///
+/// Pagination: `offset` and `limit`.
+/// Array of infohashes: `info_hash`.
+///
+/// You can either get all torrents with pagination or get a list of torrents
+/// providing a list of infohashes. For example:
+///
+/// First page of torrents:
+///
+/// <http://127.0.0.1:1212/api/v1/torrents?token=MyAccessToken>
+///
+///
+/// Only two torrents:
+///
+/// <http://127.0.0.1:1212/api/v1/torrents?token=MyAccessToken&info_hash=9c38422213e30bff212b30c360d26f9a02136422&info_hash=2b66980093bc11806fab50cb3cb41835b95a0362>
+///
+///
+/// NOTICE: Pagination is ignored if array of infohashes is provided.
 #[derive(Deserialize, Debug)]
-pub struct PaginationParams {
+pub struct QueryParams {
     /// The offset of the first page to return. Starts at 0.
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub offset: Option<u32>,
-    /// The maximum number of items to return per page
+    /// The maximum number of items to return per page.
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub limit: Option<u32>,
+    /// A list of infohashes to retrieve.
+    #[serde(default, rename = "info_hash")]
+    pub info_hashes: Vec<String>,
 }
 
 /// It handles the request to get a list of torrents.
 ///
-/// It returns a `200` response with a json array with
-/// [`ListItem`]
-/// resources.
+/// It returns a `200` response with a json array with [`crate::servers::apis::v1::context::torrent::resources::torrent::ListItem`] resources.
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::torrent#list-torrents)
 /// for more information about this endpoint.
-pub async fn get_torrents_handler(
-    State(tracker): State<Arc<Tracker>>,
-    pagination: Query<PaginationParams>,
-) -> Json<Vec<ListItem>> {
+pub async fn get_torrents_handler(State(tracker): State<Arc<Tracker>>, pagination: Query<QueryParams>) -> Response {
     debug!("pagination: {:?}", pagination);
 
-    torrent_list_response(
-        &get_torrents(
-            tracker.clone(),
-            &Pagination::new_with_options(pagination.0.offset, pagination.0.limit),
+    if pagination.0.info_hashes.is_empty() {
+        torrent_list_response(
+            &get_torrents_page(
+                tracker.clone(),
+                &Pagination::new_with_options(pagination.0.offset, pagination.0.limit),
+            )
+            .await,
         )
-        .await,
-    )
+        .into_response()
+    } else {
+        match parse_info_hashes(pagination.0.info_hashes) {
+            Ok(info_hashes) => torrent_list_response(&get_torrents(tracker.clone(), &info_hashes).await).into_response(),
+            Err(err) => match err {
+                QueryParamError::InvalidInfoHash { info_hash } => invalid_info_hash_param_response(&info_hash),
+            },
+        }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum QueryParamError {
+    #[error("invalid infohash {info_hash}")]
+    InvalidInfoHash { info_hash: String },
+}
+
+fn parse_info_hashes(info_hashes_str: Vec<String>) -> Result<Vec<InfoHash>, QueryParamError> {
+    let mut info_hashes: Vec<InfoHash> = Vec::new();
+
+    for info_hash_str in info_hashes_str {
+        match InfoHash::from_str(&info_hash_str) {
+            Ok(info_hash) => info_hashes.push(info_hash),
+            Err(_err) => {
+                return Err(QueryParamError::InvalidInfoHash {
+                    info_hash: info_hash_str,
+                })
+            }
+        }
+    }
+
+    Ok(info_hashes)
 }
 
 /// Serde deserialization decorator to map empty Strings to None,


### PR DESCRIPTION
API endpoint: http://127.0.0.1:1212/api/v1/torrents?token=MyAccessToken&info_hash=9c38422213e30bff212b30c360d26f9a02136422&info_hash=2b66980093bc11806fab50cb3cb41835b95a0362

Added a new query parameter `info_hash` which is an array. You can specify directly the list of torrents you want to get.

The JSON result is the same:

```json
[
  {
    "info_hash": "9c38422213e30bff212b30c360d26f9a02136422",
    "seeders": 1,
    "completed": 0,
    "leechers": 0
  },
  {
    "info_hash": "2b66980093bc11806fab50cb3cb41835b95a0362",
    "seeders": 1,
    "completed": 0,
    "leechers": 0
  }
]
```

It contains torrent's stats.



