### PR TITLE
Performance optimization: create a new torrent repository using a `SkipMap` instead of a `BTreeMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +3918,7 @@ dependencies = [
  "clap",
  "colored",
  "config",
+ "crossbeam-skiplist",
  "derive_more",
  "fern",
  "futures",
@@ -4013,6 +4024,7 @@ version = "3.0.0-alpha.12-develop"
 dependencies = [
  "async-std",
  "criterion",
+ "crossbeam-skiplist",
  "futures",
  "rstest",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ chrono = { version = "0", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 colored = "2"
 config = "0"
+crossbeam-skiplist = "0.1"
 derive_more = "0"
 fern = "0"
 futures = "0"
@@ -63,8 +64,8 @@ serde_json = "1"
 serde_repr = "0"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "packages/configuration" }
 torrust-tracker-clock = { version = "3.0.0-alpha.12-develop", path = "packages/clock" }
+torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "packages/configuration" }
 torrust-tracker-contrib-bencode = { version = "3.0.0-alpha.12-develop", path = "contrib/bencode" }
 torrust-tracker-located-error = { version = "3.0.0-alpha.12-develop", path = "packages/located-error" }
 torrust-tracker-primitives = { version = "3.0.0-alpha.12-develop", path = "packages/primitives" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [package.metadata.cargo-machete]
-ignored = ["serde_bytes"]
+ignored = ["serde_bytes", "crossbeam-skiplist"]
 
 [dev-dependencies]
 local-ip-address = "0"

--- a/cSpell.json
+++ b/cSpell.json
@@ -135,6 +135,7 @@
         "Shareaza",
         "sharktorrent",
         "SHLVL",
+        "skiplist",
         "socketaddr",
         "sqllite",
         "subsec",

--- a/packages/torrent-repository/Cargo.toml
+++ b/packages/torrent-repository/Cargo.toml
@@ -16,11 +16,12 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+crossbeam-skiplist = "0.1"
 futures = "0.3.29"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-primitives = { version = "3.0.0-alpha.12-develop", path = "../primitives" }
-torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "../configuration" }
 torrust-tracker-clock = { version = "3.0.0-alpha.12-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "../configuration" }
+torrust-tracker-primitives = { version = "3.0.0-alpha.12-develop", path = "../primitives" }
 
 [dev-dependencies]
 criterion = { version = "0", features = ["async_tokio"] }

--- a/packages/torrent-repository/benches/repository_benchmark.rs
+++ b/packages/torrent-repository/benches/repository_benchmark.rs
@@ -5,7 +5,7 @@ mod helpers;
 use criterion::{criterion_group, criterion_main, Criterion};
 use torrust_tracker_torrent_repository::{
     TorrentsRwLockStd, TorrentsRwLockStdMutexStd, TorrentsRwLockStdMutexTokio, TorrentsRwLockTokio, TorrentsRwLockTokioMutexStd,
-    TorrentsRwLockTokioMutexTokio,
+    TorrentsRwLockTokioMutexTokio, TorrentsSkipMapMutexStd,
 };
 
 use crate::helpers::{asyn, sync};
@@ -43,6 +43,10 @@ fn add_one_torrent(c: &mut Criterion) {
     group.bench_function("RwLockTokioMutexTokio", |b| {
         b.to_async(&rt)
             .iter_custom(asyn::add_one_torrent::<TorrentsRwLockTokioMutexTokio, _>);
+    });
+
+    group.bench_function("SkipMapMutexStd", |b| {
+        b.iter_custom(sync::add_one_torrent::<TorrentsSkipMapMutexStd, _>);
     });
 
     group.finish();
@@ -89,6 +93,11 @@ fn add_multiple_torrents_in_parallel(c: &mut Criterion) {
             .iter_custom(|iters| asyn::add_multiple_torrents_in_parallel::<TorrentsRwLockTokioMutexTokio, _>(&rt, iters, None));
     });
 
+    group.bench_function("SkipMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::add_multiple_torrents_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
+    });
+
     group.finish();
 }
 
@@ -131,6 +140,11 @@ fn update_one_torrent_in_parallel(c: &mut Criterion) {
     group.bench_function("RwLockTokioMutexTokio", |b| {
         b.to_async(&rt)
             .iter_custom(|iters| asyn::update_one_torrent_in_parallel::<TorrentsRwLockTokioMutexTokio, _>(&rt, iters, None));
+    });
+
+    group.bench_function("SkipMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::update_one_torrent_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
     });
 
     group.finish();
@@ -176,6 +190,11 @@ fn update_multiple_torrents_in_parallel(c: &mut Criterion) {
         b.to_async(&rt).iter_custom(|iters| {
             asyn::update_multiple_torrents_in_parallel::<TorrentsRwLockTokioMutexTokio, _>(&rt, iters, None)
         });
+    });
+
+    group.bench_function("SkipMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::update_multiple_torrents_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
     });
 
     group.finish();

--- a/packages/torrent-repository/src/lib.rs
+++ b/packages/torrent-repository/src/lib.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use repository::rw_lock_std::RwLockStd;
+use repository::rw_lock_tokio::RwLockTokio;
 use repository::skip_map_mutex_std::CrossbeamSkipList;
 use torrust_tracker_clock::clock;
 
@@ -10,12 +12,12 @@ pub type EntrySingle = entry::Torrent;
 pub type EntryMutexStd = Arc<std::sync::Mutex<entry::Torrent>>;
 pub type EntryMutexTokio = Arc<tokio::sync::Mutex<entry::Torrent>>;
 
-pub type TorrentsRwLockStd = repository::RwLockStd<EntrySingle>;
-pub type TorrentsRwLockStdMutexStd = repository::RwLockStd<EntryMutexStd>;
-pub type TorrentsRwLockStdMutexTokio = repository::RwLockStd<EntryMutexTokio>;
-pub type TorrentsRwLockTokio = repository::RwLockTokio<EntrySingle>;
-pub type TorrentsRwLockTokioMutexStd = repository::RwLockTokio<EntryMutexStd>;
-pub type TorrentsRwLockTokioMutexTokio = repository::RwLockTokio<EntryMutexTokio>;
+pub type TorrentsRwLockStd = RwLockStd<EntrySingle>;
+pub type TorrentsRwLockStdMutexStd = RwLockStd<EntryMutexStd>;
+pub type TorrentsRwLockStdMutexTokio = RwLockStd<EntryMutexTokio>;
+pub type TorrentsRwLockTokio = RwLockTokio<EntrySingle>;
+pub type TorrentsRwLockTokioMutexStd = RwLockTokio<EntryMutexStd>;
+pub type TorrentsRwLockTokioMutexTokio = RwLockTokio<EntryMutexTokio>;
 
 pub type TorrentsSkipMapMutexStd = CrossbeamSkipList<EntryMutexStd>;
 

--- a/packages/torrent-repository/src/lib.rs
+++ b/packages/torrent-repository/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use repository::skip_map_mutex_std::CrossbeamSkipList;
 use torrust_tracker_clock::clock;
 
 pub mod entry;
@@ -15,6 +16,8 @@ pub type TorrentsRwLockStdMutexTokio = repository::RwLockStd<EntryMutexTokio>;
 pub type TorrentsRwLockTokio = repository::RwLockTokio<EntrySingle>;
 pub type TorrentsRwLockTokioMutexStd = repository::RwLockTokio<EntryMutexStd>;
 pub type TorrentsRwLockTokioMutexTokio = repository::RwLockTokio<EntryMutexTokio>;
+
+pub type TorrentsSkipMapMutexStd = CrossbeamSkipList<EntryMutexStd>;
 
 /// This code needs to be copied into each crate.
 /// Working version, for production.

--- a/packages/torrent-repository/src/repository/mod.rs
+++ b/packages/torrent-repository/src/repository/mod.rs
@@ -41,37 +41,3 @@ pub trait RepositoryAsync<T>: Debug + Default + Sized + 'static {
         peer: &peer::Peer,
     ) -> impl std::future::Future<Output = (bool, SwarmMetadata)> + Send;
 }
-
-#[derive(Default, Debug)]
-pub struct RwLockStd<T> {
-    torrents: std::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
-}
-
-#[derive(Default, Debug)]
-pub struct RwLockTokio<T> {
-    torrents: tokio::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
-}
-
-impl<T> RwLockStd<T> {
-    /// # Panics
-    ///
-    /// Panics if unable to get a lock.
-    pub fn write(
-        &self,
-    ) -> std::sync::RwLockWriteGuard<'_, std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>> {
-        self.torrents.write().expect("it should get lock")
-    }
-}
-
-impl<T> RwLockTokio<T> {
-    pub fn write(
-        &self,
-    ) -> impl std::future::Future<
-        Output = tokio::sync::RwLockWriteGuard<
-            '_,
-            std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>,
-        >,
-    > {
-        self.torrents.write()
-    }
-}

--- a/packages/torrent-repository/src/repository/mod.rs
+++ b/packages/torrent-repository/src/repository/mod.rs
@@ -11,6 +11,7 @@ pub mod rw_lock_std_mutex_tokio;
 pub mod rw_lock_tokio;
 pub mod rw_lock_tokio_mutex_std;
 pub mod rw_lock_tokio_mutex_tokio;
+pub mod skip_map_mutex_std;
 
 use std::fmt::Debug;
 

--- a/packages/torrent-repository/src/repository/rw_lock_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std.rs
@@ -11,6 +11,22 @@ use super::Repository;
 use crate::entry::Entry;
 use crate::{EntrySingle, TorrentsRwLockStd};
 
+#[derive(Default, Debug)]
+pub struct RwLockStd<T> {
+    pub(crate) torrents: std::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
+}
+
+impl<T> RwLockStd<T> {
+    /// # Panics
+    ///
+    /// Panics if unable to get a lock.
+    pub fn write(
+        &self,
+    ) -> std::sync::RwLockWriteGuard<'_, std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>> {
+        self.torrents.write().expect("it should get lock")
+    }
+}
+
 impl TorrentsRwLockStd {
     fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
     where

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -11,6 +11,24 @@ use super::RepositoryAsync;
 use crate::entry::Entry;
 use crate::{EntrySingle, TorrentsRwLockTokio};
 
+#[derive(Default, Debug)]
+pub struct RwLockTokio<T> {
+    pub(crate) torrents: tokio::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
+}
+
+impl<T> RwLockTokio<T> {
+    pub fn write(
+        &self,
+    ) -> impl std::future::Future<
+        Output = tokio::sync::RwLockWriteGuard<
+            '_,
+            std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>,
+        >,
+    > {
+        self.torrents.write()
+    }
+}
+
 impl TorrentsRwLockTokio {
     async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
     where

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crossbeam_skiplist::SkipMap;
+use torrust_tracker_configuration::TrackerPolicy;
+use torrust_tracker_primitives::info_hash::InfoHash;
+use torrust_tracker_primitives::pagination::Pagination;
+use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
+use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
+
+use super::Repository;
+use crate::entry::{Entry, EntrySync};
+use crate::{EntryMutexStd, EntrySingle};
+
+#[derive(Default, Debug)]
+pub struct CrossbeamSkipList<T> {
+    torrents: SkipMap<InfoHash, T>,
+}
+
+impl Repository<EntryMutexStd> for CrossbeamSkipList<EntryMutexStd>
+where
+    EntryMutexStd: EntrySync,
+    EntrySingle: Entry,
+{
+    fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata) {
+        let entry = self.torrents.get_or_insert(*info_hash, Arc::default());
+        entry.value().insert_or_update_peer_and_get_stats(peer)
+    }
+
+    fn get(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        let maybe_entry = self.torrents.get(key);
+        maybe_entry.map(|entry| entry.value().clone())
+    }
+
+    fn get_metrics(&self) -> TorrentsMetrics {
+        let mut metrics = TorrentsMetrics::default();
+
+        for entry in &self.torrents {
+            let stats = entry.value().lock().expect("it should get a lock").get_stats();
+            metrics.complete += u64::from(stats.complete);
+            metrics.downloaded += u64::from(stats.downloaded);
+            metrics.incomplete += u64::from(stats.incomplete);
+            metrics.torrents += 1;
+        }
+
+        metrics
+    }
+
+    fn get_paginated(&self, pagination: Option<&Pagination>) -> Vec<(InfoHash, EntryMutexStd)> {
+        match pagination {
+            Some(pagination) => self
+                .torrents
+                .iter()
+                .skip(pagination.offset as usize)
+                .take(pagination.limit as usize)
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .collect(),
+            None => self
+                .torrents
+                .iter()
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .collect(),
+        }
+    }
+
+    fn import_persistent(&self, persistent_torrents: &PersistentTorrents) {
+        for (info_hash, completed) in persistent_torrents {
+            if self.torrents.contains_key(info_hash) {
+                continue;
+            }
+
+            let entry = EntryMutexStd::new(
+                EntrySingle {
+                    peers: BTreeMap::default(),
+                    downloaded: *completed,
+                }
+                .into(),
+            );
+
+            // Since SkipMap is lock-free the torrent could have been inserted
+            // after checking if it exists.
+            self.torrents.get_or_insert(*info_hash, entry);
+        }
+    }
+
+    fn remove(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        self.torrents.remove(key).map(|entry| entry.value().clone())
+    }
+
+    fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch) {
+        for entry in &self.torrents {
+            entry.value().remove_inactive_peers(current_cutoff);
+        }
+    }
+
+    fn remove_peerless_torrents(&self, policy: &TrackerPolicy) {
+        for entry in &self.torrents {
+            if entry.value().is_good(policy) {
+                continue;
+            }
+
+            entry.remove();
+        }
+    }
+}

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -15,7 +15,7 @@ use crate::{EntryMutexStd, EntrySingle};
 
 #[derive(Default, Debug)]
 pub struct CrossbeamSkipList<T> {
-    torrents: SkipMap<InfoHash, T>,
+    pub torrents: SkipMap<InfoHash, T>,
 }
 
 impl Repository<EntryMutexStd> for CrossbeamSkipList<EntryMutexStd>

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -10,6 +10,7 @@ use torrust_tracker_primitives::{NumberOfBytes, PersistentTorrents};
 use torrust_tracker_torrent_repository::entry::Entry as _;
 use torrust_tracker_torrent_repository::repository::rw_lock_std::RwLockStd;
 use torrust_tracker_torrent_repository::repository::rw_lock_tokio::RwLockTokio;
+use torrust_tracker_torrent_repository::repository::skip_map_mutex_std::CrossbeamSkipList;
 use torrust_tracker_torrent_repository::EntrySingle;
 
 use crate::common::repo::Repo;
@@ -17,30 +18,37 @@ use crate::common::torrent_peer_builder::{a_completed_peer, a_started_peer};
 
 #[fixture]
 fn standard() -> Repo {
-    Repo::Std(RwLockStd::default())
+    Repo::RwLockStd(RwLockStd::default())
 }
+
 #[fixture]
 fn standard_mutex() -> Repo {
-    Repo::StdMutexStd(RwLockStd::default())
+    Repo::RwLockStdMutexStd(RwLockStd::default())
 }
 
 #[fixture]
 fn standard_tokio() -> Repo {
-    Repo::StdMutexTokio(RwLockStd::default())
+    Repo::RwLockStdMutexTokio(RwLockStd::default())
 }
 
 #[fixture]
 fn tokio_std() -> Repo {
-    Repo::Tokio(RwLockTokio::default())
+    Repo::RwLockTokio(RwLockTokio::default())
 }
+
 #[fixture]
 fn tokio_mutex() -> Repo {
-    Repo::TokioMutexStd(RwLockTokio::default())
+    Repo::RwLockTokioMutexStd(RwLockTokio::default())
 }
 
 #[fixture]
 fn tokio_tokio() -> Repo {
-    Repo::TokioMutexTokio(RwLockTokio::default())
+    Repo::RwLockTokioMutexTokio(RwLockTokio::default())
+}
+
+#[fixture]
+fn skip_list_std() -> Repo {
+    Repo::SkipMapMutexStd(CrossbeamSkipList::default())
 }
 
 type Entries = Vec<(InfoHash, EntrySingle)>;
@@ -224,7 +232,16 @@ fn policy_remove_persist() -> TrackerPolicy {
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_get_a_torrent_entry(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
 ) {
     make(&repo, &entries).await;
@@ -247,7 +264,16 @@ async fn it_should_get_a_torrent_entry(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_get_paginated_entries_in_a_stable_or_sorted_order(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
     many_out_of_order: Entries,
 ) {
@@ -280,7 +306,16 @@ async fn it_should_get_paginated_entries_in_a_stable_or_sorted_order(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_get_paginated(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
     #[values(paginated_limit_zero(), paginated_limit_one(), paginated_limit_one_offset_one())] paginated: Pagination,
 ) {
@@ -328,7 +363,16 @@ async fn it_should_get_paginated(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_get_metrics(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
 ) {
     use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
@@ -360,7 +404,16 @@ async fn it_should_get_metrics(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_import_persistent_torrents(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
     #[values(persistent_empty(), persistent_single(), persistent_three())] persistent_torrents: PersistentTorrents,
 ) {
@@ -389,7 +442,16 @@ async fn it_should_import_persistent_torrents(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_remove_an_entry(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
 ) {
     make(&repo, &entries).await;
@@ -416,7 +478,16 @@ async fn it_should_remove_an_entry(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_remove_inactive_peers(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
 ) {
     use std::ops::Sub as _;
@@ -489,7 +560,16 @@ async fn it_should_remove_inactive_peers(
 #[case::in_order(many_hashed_in_order())]
 #[tokio::test]
 async fn it_should_remove_peerless_torrents(
-    #[values(standard(), standard_mutex(), standard_tokio(), tokio_std(), tokio_mutex(), tokio_tokio())] repo: Repo,
+    #[values(
+        standard(),
+        standard_mutex(),
+        standard_tokio(),
+        tokio_std(),
+        tokio_mutex(),
+        tokio_tokio(),
+        skip_list_std()
+    )]
+    repo: Repo,
     #[case] entries: Entries,
     #[values(policy_none(), policy_persist(), policy_remove(), policy_remove_persist())] policy: TrackerPolicy,
 ) {

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -8,7 +8,8 @@ use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
 use torrust_tracker_primitives::{NumberOfBytes, PersistentTorrents};
 use torrust_tracker_torrent_repository::entry::Entry as _;
-use torrust_tracker_torrent_repository::repository::{RwLockStd, RwLockTokio};
+use torrust_tracker_torrent_repository::repository::rw_lock_std::RwLockStd;
+use torrust_tracker_torrent_repository::repository::rw_lock_tokio::RwLockTokio;
 use torrust_tracker_torrent_repository::EntrySingle;
 
 use crate::common::repo::Repo;

--- a/src/core/torrent/mod.rs
+++ b/src/core/torrent/mod.rs
@@ -26,6 +26,7 @@
 //! Peer that don not have a full copy of the torrent data are called "leechers".
 //!
 
-use torrust_tracker_torrent_repository::TorrentsRwLockStdMutexStd;
+use torrust_tracker_torrent_repository::TorrentsSkipMapMutexStd;
 
-pub type Torrents = TorrentsRwLockStdMutexStd; // Currently Used
+//pub type Torrents = TorrentsRwLockStdMutexStd; // Currently Used
+pub type Torrents = TorrentsSkipMapMutexStd; // Currently Used

--- a/src/core/torrent/mod.rs
+++ b/src/core/torrent/mod.rs
@@ -25,8 +25,6 @@
 //! - The number of peers that have NOT completed downloading the torrent and are still active, that means they are actively participating in the network.
 //! Peer that don not have a full copy of the torrent data are called "leechers".
 //!
-
 use torrust_tracker_torrent_repository::TorrentsSkipMapMutexStd;
 
-//pub type Torrents = TorrentsRwLockStdMutexStd; // Currently Used
 pub type Torrents = TorrentsSkipMapMutexStd; // Currently Used


### PR DESCRIPTION
This PR implements a new Torrent Repository replacing the outer BTreeMap for torrents with a [SkipMap](https://docs.rs/crossbeam-skiplist/latest/crossbeam_skiplist/).

### Why

- It is straightforward to implement because the API is very similar. In fact, SkipMap is a replacement for BTreeMap that allows concurrency in adding new torrents.
- One problem with BTreeMap is that you have to lock the entire structure to add a new torrent. SkipMap is a lock-free structure.
- It is a lock-free structure that uses Atomics internally, which is more lightweight than locks.
- Unlike the DashMap implementation, it does not use unsafe code. However:

> NOTICE: Race conditions could be introduced if the implementation was incorrect. See https://docs.rs/crossbeam-skiplist/latest/crossbeam_skiplist/#concurrent-access

### Benchmarking

Running the Aquatic UDP load test gives the same results:

Current best implementation:

```output
  
Requests out: 397287.37/second
Responses in: 357549.15/second
  - Connect responses:  177073.94
  - Announce responses: 176905.36
  - Scrape responses:   3569.85
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 104
  - p99.9: 287
  - p100: 371  
```

SkipMap:

```output
Requests out: 396788.68/second
Responses in: 357105.27/second
  - Connect responses:  176662.91
  - Announce responses: 176863.44
  - Scrape responses:   3578.91
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 105
  - p99.9: 287
  - p100: 351  
```

However, benchmarking the repositories using Criterion shows better results in adding and updating multiple torrents in parallel.

![image](https://github.com/torrust/torrust-tracker/assets/58816/4f0736f1-3e70-4a55-8084-3265e9cd087d)

![image](https://github.com/torrust/torrust-tracker/assets/58816/a9c7a034-dbd3-40a0-85d5-c884f1286964)

![image](https://github.com/torrust/torrust-tracker/assets/58816/a3a8f37c-4230-4cfb-9adb-2c4d72ab9fd7)

![image](https://github.com/torrust/torrust-tracker/assets/58816/43a2d9cb-ccbc-496c-9d57-a98887f1575c)

### Conclusion

I think we car merge it but I would also continue with the DashMap implementation to compare.
