### PR TITLE
Performance optimization: create a new torrent repository using `DashMap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,6 +3929,7 @@ dependencies = [
  "colored",
  "config",
  "crossbeam-skiplist",
+ "dashmap",
  "derive_more",
  "fern",
  "futures",
@@ -4022,6 +4036,7 @@ dependencies = [
  "async-std",
  "criterion",
  "crossbeam-skiplist",
+ "dashmap",
  "futures",
  "rstest",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [package.metadata.cargo-machete]
-ignored = ["serde_bytes", "crossbeam-skiplist"]
+ignored = ["serde_bytes", "crossbeam-skiplist", "dashmap"]
 
 [dev-dependencies]
 local-ip-address = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ clap = { version = "4", features = ["derive", "env"] }
 colored = "2"
 config = "0"
 crossbeam-skiplist = "0.1"
+dashmap = "5.5.3"
 derive_more = "0"
 fern = "0"
 futures = "0"

--- a/cSpell.json
+++ b/cSpell.json
@@ -163,6 +163,7 @@
         "Weidendorfer",
         "Werror",
         "whitespaces",
+        "Xacrimon",
         "XBTT",
         "Xdebug",
         "Xeon",

--- a/packages/torrent-repository/Cargo.toml
+++ b/packages/torrent-repository/Cargo.toml
@@ -17,6 +17,7 @@ version.workspace = true
 
 [dependencies]
 crossbeam-skiplist = "0.1"
+dashmap = "5.5.3"
 futures = "0.3.29"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 torrust-tracker-clock = { version = "3.0.0-alpha.12-develop", path = "../clock" }

--- a/packages/torrent-repository/benches/repository_benchmark.rs
+++ b/packages/torrent-repository/benches/repository_benchmark.rs
@@ -4,8 +4,8 @@ mod helpers;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use torrust_tracker_torrent_repository::{
-    TorrentsRwLockStd, TorrentsRwLockStdMutexStd, TorrentsRwLockStdMutexTokio, TorrentsRwLockTokio, TorrentsRwLockTokioMutexStd,
-    TorrentsRwLockTokioMutexTokio, TorrentsSkipMapMutexStd,
+    TorrentsDashMapMutexStd, TorrentsRwLockStd, TorrentsRwLockStdMutexStd, TorrentsRwLockStdMutexTokio, TorrentsRwLockTokio,
+    TorrentsRwLockTokioMutexStd, TorrentsRwLockTokioMutexTokio, TorrentsSkipMapMutexStd,
 };
 
 use crate::helpers::{asyn, sync};
@@ -47,6 +47,10 @@ fn add_one_torrent(c: &mut Criterion) {
 
     group.bench_function("SkipMapMutexStd", |b| {
         b.iter_custom(sync::add_one_torrent::<TorrentsSkipMapMutexStd, _>);
+    });
+
+    group.bench_function("DashMapMutexStd", |b| {
+        b.iter_custom(sync::add_one_torrent::<TorrentsDashMapMutexStd, _>);
     });
 
     group.finish();
@@ -98,6 +102,11 @@ fn add_multiple_torrents_in_parallel(c: &mut Criterion) {
             .iter_custom(|iters| sync::add_multiple_torrents_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
     });
 
+    group.bench_function("DashMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::add_multiple_torrents_in_parallel::<TorrentsDashMapMutexStd, _>(&rt, iters, None));
+    });
+
     group.finish();
 }
 
@@ -145,6 +154,11 @@ fn update_one_torrent_in_parallel(c: &mut Criterion) {
     group.bench_function("SkipMapMutexStd", |b| {
         b.to_async(&rt)
             .iter_custom(|iters| sync::update_one_torrent_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
+    });
+
+    group.bench_function("DashMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::update_one_torrent_in_parallel::<TorrentsDashMapMutexStd, _>(&rt, iters, None));
     });
 
     group.finish();
@@ -195,6 +209,11 @@ fn update_multiple_torrents_in_parallel(c: &mut Criterion) {
     group.bench_function("SkipMapMutexStd", |b| {
         b.to_async(&rt)
             .iter_custom(|iters| sync::update_multiple_torrents_in_parallel::<TorrentsSkipMapMutexStd, _>(&rt, iters, None));
+    });
+
+    group.bench_function("DashMapMutexStd", |b| {
+        b.to_async(&rt)
+            .iter_custom(|iters| sync::update_multiple_torrents_in_parallel::<TorrentsDashMapMutexStd, _>(&rt, iters, None));
     });
 
     group.finish();

--- a/packages/torrent-repository/src/lib.rs
+++ b/packages/torrent-repository/src/lib.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use repository::dash_map_mutex_std::XacrimonDashMap;
 use repository::rw_lock_std::RwLockStd;
 use repository::rw_lock_tokio::RwLockTokio;
 use repository::skip_map_mutex_std::CrossbeamSkipList;
@@ -20,6 +21,7 @@ pub type TorrentsRwLockTokioMutexStd = RwLockTokio<EntryMutexStd>;
 pub type TorrentsRwLockTokioMutexTokio = RwLockTokio<EntryMutexTokio>;
 
 pub type TorrentsSkipMapMutexStd = CrossbeamSkipList<EntryMutexStd>;
+pub type TorrentsDashMapMutexStd = XacrimonDashMap<EntryMutexStd>;
 
 /// This code needs to be copied into each crate.
 /// Working version, for production.

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use torrust_tracker_configuration::TrackerPolicy;
+use torrust_tracker_primitives::info_hash::InfoHash;
+use torrust_tracker_primitives::pagination::Pagination;
+use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
+use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
+
+use super::Repository;
+use crate::entry::{Entry, EntrySync};
+use crate::{EntryMutexStd, EntrySingle};
+
+#[derive(Default, Debug)]
+pub struct XacrimonDashMap<T> {
+    pub torrents: DashMap<InfoHash, T>,
+}
+
+impl Repository<EntryMutexStd> for XacrimonDashMap<EntryMutexStd>
+where
+    EntryMutexStd: EntrySync,
+    EntrySingle: Entry,
+{
+    fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata) {
+        if let Some(entry) = self.torrents.get(info_hash) {
+            entry.insert_or_update_peer_and_get_stats(peer)
+        } else {
+            let _unused = self.torrents.insert(*info_hash, Arc::default());
+
+            match self.torrents.get(info_hash) {
+                Some(entry) => entry.insert_or_update_peer_and_get_stats(peer),
+                None => (false, SwarmMetadata::zeroed()),
+            }
+        }
+    }
+
+    fn get(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        let maybe_entry = self.torrents.get(key);
+        maybe_entry.map(|entry| entry.clone())
+    }
+
+    fn get_metrics(&self) -> TorrentsMetrics {
+        let mut metrics = TorrentsMetrics::default();
+
+        for entry in &self.torrents {
+            let stats = entry.value().lock().expect("it should get a lock").get_stats();
+            metrics.complete += u64::from(stats.complete);
+            metrics.downloaded += u64::from(stats.downloaded);
+            metrics.incomplete += u64::from(stats.incomplete);
+            metrics.torrents += 1;
+        }
+
+        metrics
+    }
+
+    fn get_paginated(&self, pagination: Option<&Pagination>) -> Vec<(InfoHash, EntryMutexStd)> {
+        match pagination {
+            Some(pagination) => self
+                .torrents
+                .iter()
+                .skip(pagination.offset as usize)
+                .take(pagination.limit as usize)
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .collect(),
+            None => self
+                .torrents
+                .iter()
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .collect(),
+        }
+    }
+
+    fn import_persistent(&self, persistent_torrents: &PersistentTorrents) {
+        for (info_hash, completed) in persistent_torrents {
+            if self.torrents.contains_key(info_hash) {
+                continue;
+            }
+
+            let entry = EntryMutexStd::new(
+                EntrySingle {
+                    peers: BTreeMap::default(),
+                    downloaded: *completed,
+                }
+                .into(),
+            );
+
+            self.torrents.insert(*info_hash, entry);
+        }
+    }
+
+    fn remove(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        self.torrents.remove(key).map(|(_key, value)| value.clone())
+    }
+
+    fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch) {
+        for entry in &self.torrents {
+            entry.value().remove_inactive_peers(current_cutoff);
+        }
+    }
+
+    fn remove_peerless_torrents(&self, policy: &TrackerPolicy) {
+        self.torrents.retain(|_, entry| entry.is_good(policy));
+    }
+}

--- a/packages/torrent-repository/src/repository/mod.rs
+++ b/packages/torrent-repository/src/repository/mod.rs
@@ -5,6 +5,7 @@ use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
 use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
+pub mod dash_map_mutex_std;
 pub mod rw_lock_std;
 pub mod rw_lock_std_mutex_std;
 pub mod rw_lock_std_mutex_tokio;

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -278,8 +278,7 @@ async fn it_should_get_paginated_entries_in_a_stable_or_sorted_order(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std(),
-        dash_map_std()
+        skip_list_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -321,8 +320,7 @@ async fn it_should_get_paginated(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std(),
-        dash_map_std()
+        skip_list_std()
     )]
     repo: Repo,
     #[case] entries: Entries,

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -8,6 +8,7 @@ use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
 use torrust_tracker_primitives::{NumberOfBytes, PersistentTorrents};
 use torrust_tracker_torrent_repository::entry::Entry as _;
+use torrust_tracker_torrent_repository::repository::dash_map_mutex_std::XacrimonDashMap;
 use torrust_tracker_torrent_repository::repository::rw_lock_std::RwLockStd;
 use torrust_tracker_torrent_repository::repository::rw_lock_tokio::RwLockTokio;
 use torrust_tracker_torrent_repository::repository::skip_map_mutex_std::CrossbeamSkipList;
@@ -49,6 +50,11 @@ fn tokio_tokio() -> Repo {
 #[fixture]
 fn skip_list_std() -> Repo {
     Repo::SkipMapMutexStd(CrossbeamSkipList::default())
+}
+
+#[fixture]
+fn dash_map_std() -> Repo {
+    Repo::DashMapMutexStd(XacrimonDashMap::default())
 }
 
 type Entries = Vec<(InfoHash, EntrySingle)>;
@@ -239,7 +245,8 @@ async fn it_should_get_a_torrent_entry(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -271,7 +278,8 @@ async fn it_should_get_paginated_entries_in_a_stable_or_sorted_order(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -313,7 +321,8 @@ async fn it_should_get_paginated(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -370,7 +379,8 @@ async fn it_should_get_metrics(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -411,7 +421,8 @@ async fn it_should_import_persistent_torrents(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -449,7 +460,8 @@ async fn it_should_remove_an_entry(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -485,7 +497,8 @@ async fn it_should_remove_inactive_peers(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,
@@ -567,7 +580,8 @@ async fn it_should_remove_peerless_torrents(
         tokio_std(),
         tokio_mutex(),
         tokio_tokio(),
-        skip_list_std()
+        skip_list_std(),
+        dash_map_std()
     )]
     repo: Repo,
     #[case] entries: Entries,


### PR DESCRIPTION
Relates to: 

- https://github.com/torrust/torrust-tracker/pull/778
- https://github.com/torrust/torrust-tracker/issues/567#issuecomment-2018926623

This PR adds a new torrent repository implementation where the outer collection for torrents uses a [DashMap](https://docs.rs/dashmap/latest/dashmap/).

This is something @mickvandijke was working on this [PR](https://github.com/torrust/torrust-tracker/pull/645).

There have been many changes. @da2ce7 has extracted a [package for the repositories](https://github.com/torrust/torrust-tracker/tree/develop/packages/torrent-repository).

This PR adds a new repo using DashMap to the new package. However, it does not implement some of the extra features @mickvandijke added to the other [PR](https://github.com/torrust/torrust-tracker/pull/645). For example, it does not limit memory consumption. None of the other repos have that feature, so I suggest merging this PR and implementing that feature in the future for all repos.

### Why

The current repository used in production is the one using a [SkipMap](https://docs.rs/crossbeam-skiplist/latest/crossbeam_skiplist/struct.SkipMap.html) data structure. DashMap was the first type we considered to allow adding new torrents in parallels.

The implementation with DashMap has not been merged because it does not guarantee the order when you iterate over the torrents. The tracker API returns torrents ordered by InfoHash. To avoid breaking the API that PR would need to add a new data structure (kind of Index) to keep the torrent list ordered.

This implementation helps us run performance tests with this option without spending much time fixing its limitations. It looks like the performance is similar to the SkiMap, so we don't need to use it in production now. We only need to keep it for benchmarking in the future if other versions are better.

### Benchmarking

Running the Aquatic UDP load test, the DashMap looks slightly better.

SkipMap:

```output
Requests out: 396788.68/second
Responses in: 357105.27/second
  - Connect responses:  176662.91
  - Announce responses: 176863.44
  - Scrape responses:   3578.91
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 105
  - p99.9: 287
  - p100: 351  
```
  
DashMap with initial capacity 0 (best result. On average is lower, similar to SkipMap):

```output
Requests out: 410658.38/second
Responses in: 365892.86/second
  - Connect responses:  181258.91
  - Announce responses: 181005.95
  - Scrape responses:   3628.00
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 104
  - p99.9: 295
  - p100: 363
```

With Criterion:

![image](https://github.com/torrust/torrust-tracker/assets/58816/1e1fca2d-821d-4e2c-adf8-49e055758bd0)

![image](https://github.com/torrust/torrust-tracker/assets/58816/fcb9a32f-c4f1-4ffd-9797-4a74fc000336)

![image](https://github.com/torrust/torrust-tracker/assets/58816/efe2d788-31ac-4997-82f6-d022aa8f79a0)

![image](https://github.com/torrust/torrust-tracker/assets/58816/f64a4e5a-a363-48cd-87d9-78162cda11d4)

### Conclusion

From my point of view, other [performance optimisations](https://github.com/torrust/torrust-tracker/discussions/774) have more potential than this, considering this implementation is not finished. The changes needed to finish this implementation will probably decrease the performance obtained in this benchmarking. In the future, we can review this option if we change the [tracker API behaviour to getting all torrents](https://github.com/torrust/torrust-tracker/discussions/775).