### PR TITLE
Refactor: segregate command and query for announce request

### DIFF
--- a/packages/torrent-repository/benches/helpers/asyn.rs
+++ b/packages/torrent-repository/benches/helpers/asyn.rs
@@ -18,9 +18,9 @@ where
 
         let info_hash = InfoHash([0; 20]);
 
-        torrent_repository
-            .update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER)
-            .await;
+        torrent_repository.upsert_peer(&info_hash, &DEFAULT_PEER).await;
+
+        torrent_repository.get_swarm_metadata(&info_hash).await;
     }
 
     start.elapsed()
@@ -37,9 +37,9 @@ where
     let handles = FuturesUnordered::new();
 
     // Add the torrent/peer to the torrent repository
-    torrent_repository
-        .update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER)
-        .await;
+    torrent_repository.upsert_peer(info_hash, &DEFAULT_PEER).await;
+
+    torrent_repository.get_swarm_metadata(info_hash).await;
 
     let start = Instant::now();
 
@@ -47,9 +47,9 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone
-                .update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER)
-                .await;
+            torrent_repository_clone.upsert_peer(info_hash, &DEFAULT_PEER).await;
+
+            torrent_repository_clone.get_swarm_metadata(info_hash).await;
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();
@@ -87,9 +87,9 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone
-                .update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER)
-                .await;
+            torrent_repository_clone.upsert_peer(&info_hash, &DEFAULT_PEER).await;
+
+            torrent_repository_clone.get_swarm_metadata(&info_hash).await;
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();
@@ -123,9 +123,8 @@ where
 
     // Add the torrents/peers to the torrent repository
     for info_hash in &info_hashes {
-        torrent_repository
-            .update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER)
-            .await;
+        torrent_repository.upsert_peer(info_hash, &DEFAULT_PEER).await;
+        torrent_repository.get_swarm_metadata(info_hash).await;
     }
 
     let start = Instant::now();
@@ -134,9 +133,8 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone
-                .update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER)
-                .await;
+            torrent_repository_clone.upsert_peer(&info_hash, &DEFAULT_PEER).await;
+            torrent_repository_clone.get_swarm_metadata(&info_hash).await;
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();

--- a/packages/torrent-repository/benches/helpers/sync.rs
+++ b/packages/torrent-repository/benches/helpers/sync.rs
@@ -20,7 +20,9 @@ where
 
         let info_hash = InfoHash([0; 20]);
 
-        torrent_repository.update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER);
+        torrent_repository.upsert_peer(&info_hash, &DEFAULT_PEER);
+
+        torrent_repository.get_swarm_metadata(&info_hash);
     }
 
     start.elapsed()
@@ -37,7 +39,9 @@ where
     let handles = FuturesUnordered::new();
 
     // Add the torrent/peer to the torrent repository
-    torrent_repository.update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER);
+    torrent_repository.upsert_peer(info_hash, &DEFAULT_PEER);
+
+    torrent_repository.get_swarm_metadata(info_hash);
 
     let start = Instant::now();
 
@@ -45,7 +49,9 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone.update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER);
+            torrent_repository_clone.upsert_peer(info_hash, &DEFAULT_PEER);
+
+            torrent_repository_clone.get_swarm_metadata(info_hash);
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();
@@ -83,7 +89,9 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone.update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER);
+            torrent_repository_clone.upsert_peer(&info_hash, &DEFAULT_PEER);
+
+            torrent_repository_clone.get_swarm_metadata(&info_hash);
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();
@@ -117,7 +125,8 @@ where
 
     // Add the torrents/peers to the torrent repository
     for info_hash in &info_hashes {
-        torrent_repository.update_torrent_with_peer_and_get_stats(info_hash, &DEFAULT_PEER);
+        torrent_repository.upsert_peer(info_hash, &DEFAULT_PEER);
+        torrent_repository.get_swarm_metadata(info_hash);
     }
 
     let start = Instant::now();
@@ -126,7 +135,8 @@ where
         let torrent_repository_clone = torrent_repository.clone();
 
         let handle = runtime.spawn(async move {
-            torrent_repository_clone.update_torrent_with_peer_and_get_stats(&info_hash, &DEFAULT_PEER);
+            torrent_repository_clone.upsert_peer(&info_hash, &DEFAULT_PEER);
+            torrent_repository_clone.get_swarm_metadata(&info_hash);
 
             if let Some(sleep_time) = sleep {
                 let start_time = std::time::Instant::now();

--- a/packages/torrent-repository/src/entry/mod.rs
+++ b/packages/torrent-repository/src/entry/mod.rs
@@ -15,7 +15,7 @@ pub trait Entry {
     /// It returns the swarm metadata (statistics) as a struct:
     ///
     /// `(seeders, completed, leechers)`
-    fn get_stats(&self) -> SwarmMetadata;
+    fn get_swarm_metadata(&self) -> SwarmMetadata;
 
     /// Returns True if Still a Valid Entry according to the Tracker Policy
     fn is_good(&self, policy: &TrackerPolicy) -> bool;
@@ -40,10 +40,7 @@ pub trait Entry {
     ///
     /// The number of peers that have complete downloading is synchronously updated when peers are updated.
     /// That's the total torrent downloads counter.
-    fn insert_or_update_peer(&mut self, peer: &peer::Peer) -> bool;
-
-    // It preforms a combined operation of `insert_or_update_peer` and `get_stats`.
-    fn insert_or_update_peer_and_get_stats(&mut self, peer: &peer::Peer) -> (bool, SwarmMetadata);
+    fn upsert_peer(&mut self, peer: &peer::Peer) -> bool;
 
     /// It removes peer from the swarm that have not been updated for more than `current_cutoff` seconds
     fn remove_inactive_peers(&mut self, current_cutoff: DurationSinceUnixEpoch);
@@ -51,20 +48,19 @@ pub trait Entry {
 
 #[allow(clippy::module_name_repetitions)]
 pub trait EntrySync {
-    fn get_stats(&self) -> SwarmMetadata;
+    fn get_swarm_metadata(&self) -> SwarmMetadata;
     fn is_good(&self, policy: &TrackerPolicy) -> bool;
     fn peers_is_empty(&self) -> bool;
     fn get_peers_len(&self) -> usize;
     fn get_peers(&self, limit: Option<usize>) -> Vec<Arc<peer::Peer>>;
     fn get_peers_for_client(&self, client: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>>;
-    fn insert_or_update_peer(&self, peer: &peer::Peer) -> bool;
-    fn insert_or_update_peer_and_get_stats(&self, peer: &peer::Peer) -> (bool, SwarmMetadata);
+    fn upsert_peer(&self, peer: &peer::Peer) -> bool;
     fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch);
 }
 
 #[allow(clippy::module_name_repetitions)]
 pub trait EntryAsync {
-    fn get_stats(&self) -> impl std::future::Future<Output = SwarmMetadata> + Send;
+    fn get_swarm_metadata(&self) -> impl std::future::Future<Output = SwarmMetadata> + Send;
     fn check_good(self, policy: &TrackerPolicy) -> impl std::future::Future<Output = bool> + Send;
     fn peers_is_empty(&self) -> impl std::future::Future<Output = bool> + Send;
     fn get_peers_len(&self) -> impl std::future::Future<Output = usize> + Send;
@@ -74,11 +70,7 @@ pub trait EntryAsync {
         client: &SocketAddr,
         limit: Option<usize>,
     ) -> impl std::future::Future<Output = Vec<Arc<peer::Peer>>> + Send;
-    fn insert_or_update_peer(self, peer: &peer::Peer) -> impl std::future::Future<Output = bool> + Send;
-    fn insert_or_update_peer_and_get_stats(
-        self,
-        peer: &peer::Peer,
-    ) -> impl std::future::Future<Output = (bool, SwarmMetadata)> + std::marker::Send;
+    fn upsert_peer(self, peer: &peer::Peer) -> impl std::future::Future<Output = bool> + Send;
     fn remove_inactive_peers(self, current_cutoff: DurationSinceUnixEpoch) -> impl std::future::Future<Output = ()> + Send;
 }
 

--- a/packages/torrent-repository/src/entry/mutex_std.rs
+++ b/packages/torrent-repository/src/entry/mutex_std.rs
@@ -9,8 +9,8 @@ use super::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle};
 
 impl EntrySync for EntryMutexStd {
-    fn get_stats(&self) -> SwarmMetadata {
-        self.lock().expect("it should get a lock").get_stats()
+    fn get_swarm_metadata(&self) -> SwarmMetadata {
+        self.lock().expect("it should get a lock").get_swarm_metadata()
     }
 
     fn is_good(&self, policy: &TrackerPolicy) -> bool {
@@ -33,14 +33,8 @@ impl EntrySync for EntryMutexStd {
         self.lock().expect("it should get lock").get_peers_for_client(client, limit)
     }
 
-    fn insert_or_update_peer(&self, peer: &peer::Peer) -> bool {
-        self.lock().expect("it should lock the entry").insert_or_update_peer(peer)
-    }
-
-    fn insert_or_update_peer_and_get_stats(&self, peer: &peer::Peer) -> (bool, SwarmMetadata) {
-        self.lock()
-            .expect("it should lock the entry")
-            .insert_or_update_peer_and_get_stats(peer)
+    fn upsert_peer(&self, peer: &peer::Peer) -> bool {
+        self.lock().expect("it should lock the entry").upsert_peer(peer)
     }
 
     fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch) {

--- a/packages/torrent-repository/src/entry/mutex_tokio.rs
+++ b/packages/torrent-repository/src/entry/mutex_tokio.rs
@@ -9,8 +9,8 @@ use super::{Entry, EntryAsync};
 use crate::{EntryMutexTokio, EntrySingle};
 
 impl EntryAsync for EntryMutexTokio {
-    async fn get_stats(&self) -> SwarmMetadata {
-        self.lock().await.get_stats()
+    async fn get_swarm_metadata(&self) -> SwarmMetadata {
+        self.lock().await.get_swarm_metadata()
     }
 
     async fn check_good(self, policy: &TrackerPolicy) -> bool {
@@ -33,12 +33,8 @@ impl EntryAsync for EntryMutexTokio {
         self.lock().await.get_peers_for_client(client, limit)
     }
 
-    async fn insert_or_update_peer(self, peer: &peer::Peer) -> bool {
-        self.lock().await.insert_or_update_peer(peer)
-    }
-
-    async fn insert_or_update_peer_and_get_stats(self, peer: &peer::Peer) -> (bool, SwarmMetadata) {
-        self.lock().await.insert_or_update_peer_and_get_stats(peer)
+    async fn upsert_peer(self, peer: &peer::Peer) -> bool {
+        self.lock().await.upsert_peer(peer)
     }
 
     async fn remove_inactive_peers(self, current_cutoff: DurationSinceUnixEpoch) {

--- a/packages/torrent-repository/src/entry/single.rs
+++ b/packages/torrent-repository/src/entry/single.rs
@@ -12,7 +12,7 @@ use crate::EntrySingle;
 
 impl Entry for EntrySingle {
     #[allow(clippy::cast_possible_truncation)]
-    fn get_stats(&self) -> SwarmMetadata {
+    fn get_swarm_metadata(&self) -> SwarmMetadata {
         let complete: u32 = self.peers.values().filter(|peer| peer.is_seeder()).count() as u32;
         let incomplete: u32 = self.peers.len() as u32 - complete;
 
@@ -70,7 +70,7 @@ impl Entry for EntrySingle {
         }
     }
 
-    fn insert_or_update_peer(&mut self, peer: &peer::Peer) -> bool {
+    fn upsert_peer(&mut self, peer: &peer::Peer) -> bool {
         let mut downloaded_stats_updated: bool = false;
 
         match peer::ReadInfo::get_event(peer) {
@@ -91,12 +91,6 @@ impl Entry for EntrySingle {
         }
 
         downloaded_stats_updated
-    }
-
-    fn insert_or_update_peer_and_get_stats(&mut self, peer: &peer::Peer) -> (bool, SwarmMetadata) {
-        let changed = self.insert_or_update_peer(peer);
-        let stats = self.get_stats();
-        (changed, stats)
     }
 
     fn remove_inactive_peers(&mut self, current_cutoff: DurationSinceUnixEpoch) {

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -23,17 +23,19 @@ where
     EntryMutexStd: EntrySync,
     EntrySingle: Entry,
 {
-    fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata) {
+    fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
         if let Some(entry) = self.torrents.get(info_hash) {
-            entry.insert_or_update_peer_and_get_stats(peer)
+            entry.upsert_peer(peer);
         } else {
             let _unused = self.torrents.insert(*info_hash, Arc::default());
-
-            match self.torrents.get(info_hash) {
-                Some(entry) => entry.insert_or_update_peer_and_get_stats(peer),
-                None => (false, SwarmMetadata::zeroed()),
+            if let Some(entry) = self.torrents.get(info_hash) {
+                entry.upsert_peer(peer);
             }
         }
+    }
+
+    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
+        self.torrents.get(info_hash).map(|entry| entry.value().get_swarm_metadata())
     }
 
     fn get(&self, key: &InfoHash) -> Option<EntryMutexStd> {
@@ -45,7 +47,7 @@ where
         let mut metrics = TorrentsMetrics::default();
 
         for entry in &self.torrents {
-            let stats = entry.value().lock().expect("it should get a lock").get_stats();
+            let stats = entry.value().lock().expect("it should get a lock").get_swarm_metadata();
             metrics.complete += u64::from(stats.complete);
             metrics.downloaded += u64::from(stats.downloaded);
             metrics.incomplete += u64::from(stats.incomplete);

--- a/packages/torrent-repository/src/repository/mod.rs
+++ b/packages/torrent-repository/src/repository/mod.rs
@@ -24,7 +24,8 @@ pub trait Repository<T>: Debug + Default + Sized + 'static {
     fn remove(&self, key: &InfoHash) -> Option<T>;
     fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch);
     fn remove_peerless_torrents(&self, policy: &TrackerPolicy);
-    fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata);
+    fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer);
+    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata>;
 }
 
 #[allow(clippy::module_name_repetitions)]
@@ -36,9 +37,6 @@ pub trait RepositoryAsync<T>: Debug + Default + Sized + 'static {
     fn remove(&self, key: &InfoHash) -> impl std::future::Future<Output = Option<T>> + Send;
     fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch) -> impl std::future::Future<Output = ()> + Send;
     fn remove_peerless_torrents(&self, policy: &TrackerPolicy) -> impl std::future::Future<Output = ()> + Send;
-    fn update_torrent_with_peer_and_get_stats(
-        &self,
-        info_hash: &InfoHash,
-        peer: &peer::Peer,
-    ) -> impl std::future::Future<Output = (bool, SwarmMetadata)> + Send;
+    fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) -> impl std::future::Future<Output = ()> + Send;
+    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> impl std::future::Future<Output = Option<SwarmMetadata>> + Send;
 }

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -51,13 +51,18 @@ impl RepositoryAsync<EntrySingle> for TorrentsRwLockTokio
 where
     EntrySingle: Entry,
 {
-    async fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata) {
+    async fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
         let mut db = self.get_torrents_mut().await;
 
         let entry = db.entry(*info_hash).or_insert(EntrySingle::default());
 
-        entry.insert_or_update_peer_and_get_stats(peer)
+        entry.upsert_peer(peer);
     }
+
+    async fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
+        self.get(info_hash).await.map(|entry| entry.get_swarm_metadata())
+    }
+
     async fn get(&self, key: &InfoHash) -> Option<EntrySingle> {
         let db = self.get_torrents().await;
         db.get(key).cloned()
@@ -81,7 +86,7 @@ where
         let mut metrics = TorrentsMetrics::default();
 
         for entry in self.get_torrents().await.values() {
-            let stats = entry.get_stats();
+            let stats = entry.get_swarm_metadata();
             metrics.complete += u64::from(stats.complete);
             metrics.downloaded += u64::from(stats.downloaded);
             metrics.incomplete += u64::from(stats.incomplete);

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -23,9 +23,13 @@ where
     EntryMutexStd: EntrySync,
     EntrySingle: Entry,
 {
-    fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata) {
+    fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
         let entry = self.torrents.get_or_insert(*info_hash, Arc::default());
-        entry.value().insert_or_update_peer_and_get_stats(peer)
+        entry.value().upsert_peer(peer);
+    }
+
+    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
+        self.torrents.get(info_hash).map(|entry| entry.value().get_swarm_metadata())
     }
 
     fn get(&self, key: &InfoHash) -> Option<EntryMutexStd> {
@@ -37,7 +41,7 @@ where
         let mut metrics = TorrentsMetrics::default();
 
         for entry in &self.torrents {
-            let stats = entry.value().lock().expect("it should get a lock").get_stats();
+            let stats = entry.value().lock().expect("it should get a lock").get_swarm_metadata();
             metrics.complete += u64::from(stats.complete);
             metrics.downloaded += u64::from(stats.downloaded);
             metrics.incomplete += u64::from(stats.incomplete);

--- a/packages/torrent-repository/tests/common/repo.rs
+++ b/packages/torrent-repository/tests/common/repo.rs
@@ -23,6 +23,32 @@ pub(crate) enum Repo {
 }
 
 impl Repo {
+    pub(crate) async fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
+        match self {
+            Repo::RwLockStd(repo) => repo.upsert_peer(info_hash, peer),
+            Repo::RwLockStdMutexStd(repo) => repo.upsert_peer(info_hash, peer),
+            Repo::RwLockStdMutexTokio(repo) => repo.upsert_peer(info_hash, peer).await,
+            Repo::RwLockTokio(repo) => repo.upsert_peer(info_hash, peer).await,
+            Repo::RwLockTokioMutexStd(repo) => repo.upsert_peer(info_hash, peer).await,
+            Repo::RwLockTokioMutexTokio(repo) => repo.upsert_peer(info_hash, peer).await,
+            Repo::SkipMapMutexStd(repo) => repo.upsert_peer(info_hash, peer),
+            Repo::DashMapMutexStd(repo) => repo.upsert_peer(info_hash, peer),
+        }
+    }
+
+    pub(crate) async fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
+        match self {
+            Repo::RwLockStd(repo) => repo.get_swarm_metadata(info_hash),
+            Repo::RwLockStdMutexStd(repo) => repo.get_swarm_metadata(info_hash),
+            Repo::RwLockStdMutexTokio(repo) => repo.get_swarm_metadata(info_hash).await,
+            Repo::RwLockTokio(repo) => repo.get_swarm_metadata(info_hash).await,
+            Repo::RwLockTokioMutexStd(repo) => repo.get_swarm_metadata(info_hash).await,
+            Repo::RwLockTokioMutexTokio(repo) => repo.get_swarm_metadata(info_hash).await,
+            Repo::SkipMapMutexStd(repo) => repo.get_swarm_metadata(info_hash),
+            Repo::DashMapMutexStd(repo) => repo.get_swarm_metadata(info_hash),
+        }
+    }
+
     pub(crate) async fn get(&self, key: &InfoHash) -> Option<EntrySingle> {
         match self {
             Repo::RwLockStd(repo) => repo.get(key),
@@ -142,23 +168,6 @@ impl Repo {
             Repo::RwLockTokioMutexTokio(repo) => repo.remove_peerless_torrents(policy).await,
             Repo::SkipMapMutexStd(repo) => repo.remove_peerless_torrents(policy),
             Repo::DashMapMutexStd(repo) => repo.remove_peerless_torrents(policy),
-        }
-    }
-
-    pub(crate) async fn update_torrent_with_peer_and_get_stats(
-        &self,
-        info_hash: &InfoHash,
-        peer: &peer::Peer,
-    ) -> (bool, SwarmMetadata) {
-        match self {
-            Repo::RwLockStd(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer),
-            Repo::RwLockStdMutexStd(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer),
-            Repo::RwLockStdMutexTokio(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer).await,
-            Repo::RwLockTokio(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer).await,
-            Repo::RwLockTokioMutexStd(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer).await,
-            Repo::RwLockTokioMutexTokio(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer).await,
-            Repo::SkipMapMutexStd(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer),
-            Repo::DashMapMutexStd(repo) => repo.update_torrent_with_peer_and_get_stats(info_hash, peer),
         }
     }
 

--- a/packages/torrent-repository/tests/common/torrent.rs
+++ b/packages/torrent-repository/tests/common/torrent.rs
@@ -17,9 +17,9 @@ pub(crate) enum Torrent {
 impl Torrent {
     pub(crate) async fn get_stats(&self) -> SwarmMetadata {
         match self {
-            Torrent::Single(entry) => entry.get_stats(),
-            Torrent::MutexStd(entry) => entry.get_stats(),
-            Torrent::MutexTokio(entry) => entry.clone().get_stats().await,
+            Torrent::Single(entry) => entry.get_swarm_metadata(),
+            Torrent::MutexStd(entry) => entry.get_swarm_metadata(),
+            Torrent::MutexTokio(entry) => entry.clone().get_swarm_metadata().await,
         }
     }
 
@@ -63,19 +63,11 @@ impl Torrent {
         }
     }
 
-    pub(crate) async fn insert_or_update_peer(&mut self, peer: &peer::Peer) -> bool {
+    pub(crate) async fn upsert_peer(&mut self, peer: &peer::Peer) -> bool {
         match self {
-            Torrent::Single(entry) => entry.insert_or_update_peer(peer),
-            Torrent::MutexStd(entry) => entry.insert_or_update_peer(peer),
-            Torrent::MutexTokio(entry) => entry.clone().insert_or_update_peer(peer).await,
-        }
-    }
-
-    pub(crate) async fn insert_or_update_peer_and_get_stats(&mut self, peer: &peer::Peer) -> (bool, SwarmMetadata) {
-        match self {
-            Torrent::Single(entry) => entry.insert_or_update_peer_and_get_stats(peer),
-            Torrent::MutexStd(entry) => entry.insert_or_update_peer_and_get_stats(peer),
-            Torrent::MutexTokio(entry) => entry.clone().insert_or_update_peer_and_get_stats(peer).await,
+            Torrent::Single(entry) => entry.upsert_peer(peer),
+            Torrent::MutexStd(entry) => entry.upsert_peer(peer),
+            Torrent::MutexTokio(entry) => entry.clone().upsert_peer(peer).await,
         }
     }
 

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -6,6 +6,7 @@ use torrust_tracker_configuration::TrackerPolicy;
 use torrust_tracker_primitives::announce_event::AnnounceEvent;
 use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
+use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
 use torrust_tracker_primitives::{NumberOfBytes, PersistentTorrents};
 use torrust_tracker_torrent_repository::entry::Entry as _;
 use torrust_tracker_torrent_repository::repository::dash_map_mutex_std::XacrimonDashMap;
@@ -72,14 +73,14 @@ fn default() -> Entries {
 #[fixture]
 fn started() -> Entries {
     let mut torrent = EntrySingle::default();
-    torrent.insert_or_update_peer(&a_started_peer(1));
+    torrent.upsert_peer(&a_started_peer(1));
     vec![(InfoHash::default(), torrent)]
 }
 
 #[fixture]
 fn completed() -> Entries {
     let mut torrent = EntrySingle::default();
-    torrent.insert_or_update_peer(&a_completed_peer(2));
+    torrent.upsert_peer(&a_completed_peer(2));
     vec![(InfoHash::default(), torrent)]
 }
 
@@ -87,10 +88,10 @@ fn completed() -> Entries {
 fn downloaded() -> Entries {
     let mut torrent = EntrySingle::default();
     let mut peer = a_started_peer(3);
-    torrent.insert_or_update_peer(&peer);
+    torrent.upsert_peer(&peer);
     peer.event = AnnounceEvent::Completed;
     peer.left = NumberOfBytes(0);
-    torrent.insert_or_update_peer(&peer);
+    torrent.upsert_peer(&peer);
     vec![(InfoHash::default(), torrent)]
 }
 
@@ -98,21 +99,21 @@ fn downloaded() -> Entries {
 fn three() -> Entries {
     let mut started = EntrySingle::default();
     let started_h = &mut DefaultHasher::default();
-    started.insert_or_update_peer(&a_started_peer(1));
+    started.upsert_peer(&a_started_peer(1));
     started.hash(started_h);
 
     let mut completed = EntrySingle::default();
     let completed_h = &mut DefaultHasher::default();
-    completed.insert_or_update_peer(&a_completed_peer(2));
+    completed.upsert_peer(&a_completed_peer(2));
     completed.hash(completed_h);
 
     let mut downloaded = EntrySingle::default();
     let downloaded_h = &mut DefaultHasher::default();
     let mut downloaded_peer = a_started_peer(3);
-    downloaded.insert_or_update_peer(&downloaded_peer);
+    downloaded.upsert_peer(&downloaded_peer);
     downloaded_peer.event = AnnounceEvent::Completed;
     downloaded_peer.left = NumberOfBytes(0);
-    downloaded.insert_or_update_peer(&downloaded_peer);
+    downloaded.upsert_peer(&downloaded_peer);
     downloaded.hash(downloaded_h);
 
     vec![
@@ -128,7 +129,7 @@ fn many_out_of_order() -> Entries {
 
     for i in 0..408 {
         let mut entry = EntrySingle::default();
-        entry.insert_or_update_peer(&a_started_peer(i));
+        entry.upsert_peer(&a_started_peer(i));
 
         entries.insert((InfoHash::from(&i), entry));
     }
@@ -143,7 +144,7 @@ fn many_hashed_in_order() -> Entries {
 
     for i in 0..408 {
         let mut entry = EntrySingle::default();
-        entry.insert_or_update_peer(&a_started_peer(i));
+        entry.upsert_peer(&a_started_peer(i));
 
         let hash: &mut DefaultHasher = &mut DefaultHasher::default();
         hash.write_i32(i);
@@ -390,7 +391,7 @@ async fn it_should_get_metrics(
     let mut metrics = TorrentsMetrics::default();
 
     for (_, torrent) in entries {
-        let stats = torrent.get_stats();
+        let stats = torrent.get_swarm_metadata();
 
         metrics.torrents += 1;
         metrics.incomplete += u64::from(stats.incomplete);
@@ -537,8 +538,23 @@ async fn it_should_remove_inactive_peers(
     // Insert the infohash and peer into the repository
     // and verify there is an extra torrent entry.
     {
-        repo.update_torrent_with_peer_and_get_stats(&info_hash, &peer).await;
+        repo.upsert_peer(&info_hash, &peer).await;
         assert_eq!(repo.get_metrics().await.torrents, entries.len() as u64 + 1);
+    }
+
+    // Insert the infohash and peer into the repository
+    // and verify the swarm metadata was updated.
+    {
+        repo.upsert_peer(&info_hash, &peer).await;
+        let stats = repo.get_swarm_metadata(&info_hash).await;
+        assert_eq!(
+            stats,
+            Some(SwarmMetadata {
+                downloaded: 0,
+                complete: 1,
+                incomplete: 0
+            })
+        );
     }
 
     // Verify that this new peer was inserted into the repository.

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -626,10 +626,9 @@ impl Tracker {
         peer.change_ip(&assign_ip_address_to_peer(remote_client_ip, self.external_ip));
         debug!("After: {peer:?}");
 
-        // we should update the torrent and get the stats before we get the peer list.
-        let stats = self.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
+        let stats = self.upsert_peer_and_get_stats(info_hash, peer).await;
 
-        let peers = self.get_torrent_peers_for_peer(info_hash, peer);
+        let peers = self.get_peers_for(info_hash, peer);
 
         AnnounceData {
             peers,
@@ -660,7 +659,7 @@ impl Tracker {
     /// It returns the data for a `scrape` response.
     fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
         match self.torrents.get(info_hash) {
-            Some(torrent_entry) => torrent_entry.get_stats(),
+            Some(torrent_entry) => torrent_entry.get_swarm_metadata(),
             None => SwarmMetadata::default(),
         }
     }
@@ -681,7 +680,7 @@ impl Tracker {
         Ok(())
     }
 
-    fn get_torrent_peers_for_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) -> Vec<Arc<peer::Peer>> {
+    fn get_peers_for(&self, info_hash: &InfoHash, peer: &peer::Peer) -> Vec<Arc<peer::Peer>> {
         match self.torrents.get(info_hash) {
             None => vec![],
             Some(entry) => entry.get_peers_for_client(&peer.peer_addr, Some(TORRENT_PEERS_LIMIT)),
@@ -703,20 +702,36 @@ impl Tracker {
     /// needed for a `announce` request response.
     ///
     /// # Context: Tracker
-    pub async fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> SwarmMetadata {
-        // code-review: consider splitting the function in two (command and query segregation).
-        // `update_torrent_with_peer` and `get_stats`
+    pub async fn upsert_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> SwarmMetadata {
+        let swarm_metadata_before = match self.torrents.get_swarm_metadata(info_hash) {
+            Some(swarm_metadata) => swarm_metadata,
+            None => SwarmMetadata::zeroed(),
+        };
 
-        let (stats_updated, stats) = self.torrents.update_torrent_with_peer_and_get_stats(info_hash, peer);
+        self.torrents.upsert_peer(info_hash, peer);
 
-        if self.policy.persistent_torrent_completed_stat && stats_updated {
-            let completed = stats.downloaded;
+        let swarm_metadata_after = match self.torrents.get_swarm_metadata(info_hash) {
+            Some(swarm_metadata) => swarm_metadata,
+            None => SwarmMetadata::zeroed(),
+        };
+
+        if swarm_metadata_before != swarm_metadata_after {
+            self.persist_stats(info_hash, &swarm_metadata_after).await;
+        }
+
+        swarm_metadata_after
+    }
+
+    /// It stores the torrents stats into the database (if persistency is enabled).
+    ///
+    /// # Context: Tracker
+    async fn persist_stats(&self, info_hash: &InfoHash, swarm_metadata: &SwarmMetadata) {
+        if self.policy.persistent_torrent_completed_stat {
+            let completed = swarm_metadata.downloaded;
             let info_hash = *info_hash;
 
             drop(self.database.save_persistent_torrent(&info_hash, completed).await);
         }
-
-        stats
     }
 
     /// It calculates and returns the general `Tracker`
@@ -1130,7 +1145,7 @@ mod tests {
             let info_hash = sample_info_hash();
             let peer = sample_peer();
 
-            tracker.update_torrent_with_peer_and_get_stats(&info_hash, &peer).await;
+            tracker.upsert_peer_and_get_stats(&info_hash, &peer).await;
 
             let peers = tracker.get_torrent_peers(&info_hash);
 
@@ -1144,9 +1159,9 @@ mod tests {
             let info_hash = sample_info_hash();
             let peer = sample_peer();
 
-            tracker.update_torrent_with_peer_and_get_stats(&info_hash, &peer).await;
+            tracker.upsert_peer_and_get_stats(&info_hash, &peer).await;
 
-            let peers = tracker.get_torrent_peers_for_peer(&info_hash, &peer);
+            let peers = tracker.get_peers_for(&info_hash, &peer);
 
             assert_eq!(peers, vec![]);
         }
@@ -1155,9 +1170,7 @@ mod tests {
         async fn it_should_return_the_torrent_metrics() {
             let tracker = public_tracker();
 
-            tracker
-                .update_torrent_with_peer_and_get_stats(&sample_info_hash(), &leecher())
-                .await;
+            tracker.upsert_peer_and_get_stats(&sample_info_hash(), &leecher()).await;
 
             let torrent_metrics = tracker.get_torrents_metrics();
 
@@ -1178,9 +1191,7 @@ mod tests {
 
             let start_time = std::time::Instant::now();
             for i in 0..1_000_000 {
-                tracker
-                    .update_torrent_with_peer_and_get_stats(&gen_seeded_infohash(&i), &leecher())
-                    .await;
+                tracker.upsert_peer_and_get_stats(&gen_seeded_infohash(&i), &leecher()).await;
             }
             let result_a = start_time.elapsed();
 
@@ -1704,11 +1715,11 @@ mod tests {
                 let mut peer = sample_peer();
 
                 peer.event = AnnounceEvent::Started;
-                let swarm_stats = tracker.update_torrent_with_peer_and_get_stats(&info_hash, &peer).await;
+                let swarm_stats = tracker.upsert_peer_and_get_stats(&info_hash, &peer).await;
                 assert_eq!(swarm_stats.downloaded, 0);
 
                 peer.event = AnnounceEvent::Completed;
-                let swarm_stats = tracker.update_torrent_with_peer_and_get_stats(&info_hash, &peer).await;
+                let swarm_stats = tracker.upsert_peer_and_get_stats(&info_hash, &peer).await;
                 assert_eq!(swarm_stats.downloaded, 1);
 
                 // Remove the newly updated torrent from memory
@@ -1719,7 +1730,7 @@ mod tests {
                 let torrent_entry = tracker.torrents.get(&info_hash).expect("it should be able to get entry");
 
                 // It persists the number of completed peers.
-                assert_eq!(torrent_entry.get_stats().downloaded, 1);
+                assert_eq!(torrent_entry.get_swarm_metadata().downloaded, 1);
 
                 // It does not persist the peers
                 assert!(torrent_entry.peers_is_empty());

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -50,7 +50,7 @@ pub async fn get_torrent_info(tracker: Arc<Tracker>, info_hash: &InfoHash) -> Op
 
     let torrent_entry = torrent_entry_option?;
 
-    let stats = torrent_entry.get_stats();
+    let stats = torrent_entry.get_swarm_metadata();
 
     let peers = torrent_entry.get_peers(None);
 
@@ -70,7 +70,7 @@ pub async fn get_torrents_page(tracker: Arc<Tracker>, pagination: Option<&Pagina
     let mut basic_infos: Vec<BasicInfo> = vec![];
 
     for (info_hash, torrent_entry) in tracker.torrents.get_paginated(pagination) {
-        let stats = torrent_entry.get_stats();
+        let stats = torrent_entry.get_swarm_metadata();
 
         basic_infos.push(BasicInfo {
             info_hash,
@@ -88,7 +88,7 @@ pub async fn get_torrents(tracker: Arc<Tracker>, info_hashes: &[InfoHash]) -> Ve
     let mut basic_infos: Vec<BasicInfo> = vec![];
 
     for info_hash in info_hashes {
-        if let Some(stats) = tracker.torrents.get(info_hash).map(|t| t.get_stats()) {
+        if let Some(stats) = tracker.torrents.get(info_hash).map(|t| t.get_swarm_metadata()) {
             basic_infos.push(BasicInfo {
                 info_hash: *info_hash,
                 seeders: u64::from(stats.complete),
@@ -156,9 +156,7 @@ mod tests {
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash, &sample_peer()).await;
 
             let torrent_info = get_torrent_info(tracker.clone(), &info_hash).await.unwrap();
 
@@ -208,9 +206,7 @@ mod tests {
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
 
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash, &sample_peer()).await;
 
             let torrents = get_torrents_page(tracker.clone(), Some(&Pagination::default())).await;
 
@@ -234,12 +230,8 @@ mod tests {
             let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
 
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash1, &sample_peer())
-                .await;
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash2, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash1, &sample_peer()).await;
+            tracker.upsert_peer_and_get_stats(&info_hash2, &sample_peer()).await;
 
             let offset = 0;
             let limit = 1;
@@ -258,12 +250,8 @@ mod tests {
             let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
 
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash1, &sample_peer())
-                .await;
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash2, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash1, &sample_peer()).await;
+            tracker.upsert_peer_and_get_stats(&info_hash2, &sample_peer()).await;
 
             let offset = 1;
             let limit = 4000;
@@ -288,15 +276,11 @@ mod tests {
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash1, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash1, &sample_peer()).await;
 
             let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash2, &sample_peer())
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash2, &sample_peer()).await;
 
             let torrents = get_torrents_page(tracker.clone(), Some(&Pagination::default())).await;
 

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -718,9 +718,7 @@ mod tests {
                     .with_peer_address(SocketAddr::new(IpAddr::V6(client_ip_v6), client_port))
                     .into();
 
-                tracker
-                    .update_torrent_with_peer_and_get_stats(&info_hash.0.into(), &peer_using_ipv6)
-                    .await;
+                tracker.upsert_peer_and_get_stats(&info_hash.0.into(), &peer_using_ipv6).await;
             }
 
             async fn announce_a_new_peer_using_ipv4(tracker: Arc<core::Tracker>) -> Response {
@@ -944,9 +942,7 @@ mod tests {
                     .with_peer_address(SocketAddr::new(IpAddr::V4(client_ip_v4), client_port))
                     .into();
 
-                tracker
-                    .update_torrent_with_peer_and_get_stats(&info_hash.0.into(), &peer_using_ipv4)
-                    .await;
+                tracker.upsert_peer_and_get_stats(&info_hash.0.into(), &peer_using_ipv4).await;
             }
 
             async fn announce_a_new_peer_using_ipv6(tracker: Arc<core::Tracker>) -> Response {
@@ -1119,9 +1115,7 @@ mod tests {
                 .with_number_of_bytes_left(0)
                 .into();
 
-            tracker
-                .update_torrent_with_peer_and_get_stats(&info_hash.0.into(), &peer)
-                .await;
+            tracker.upsert_peer_and_get_stats(&info_hash.0.into(), &peer).await;
         }
 
         fn build_scrape_request(remote_addr: &SocketAddr, info_hash: &InfoHash) -> ScrapeRequest {

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -23,7 +23,7 @@ pub struct Environment<S> {
 impl<S> Environment<S> {
     /// Add a torrent to the tracker
     pub async fn add_torrent_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
-        self.tracker.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
+        self.tracker.upsert_peer_and_get_stats(info_hash, peer).await;
     }
 }
 

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -20,7 +20,7 @@ pub struct Environment<S> {
 impl<S> Environment<S> {
     /// Add a torrent to the tracker
     pub async fn add_torrent_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
-        self.tracker.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
+        self.tracker.upsert_peer_and_get_stats(info_hash, peer).await;
     }
 }
 

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -20,7 +20,7 @@ impl<S> Environment<S> {
     /// Add a torrent to the tracker
     #[allow(dead_code)]
     pub async fn add_torrent(&self, info_hash: &InfoHash, peer: &peer::Peer) {
-        self.tracker.update_torrent_with_peer_and_get_stats(info_hash, peer).await;
+        self.tracker.upsert_peer_and_get_stats(info_hash, peer).await;
     }
 }
 


### PR DESCRIPTION
This changes the API of the torrent repository.

The method:

```rust
fn update_torrent_with_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> (bool, SwarmMetadata);
```

is replaced with two methods (command and query):

```rust
fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer);
fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata>;
```

The performance is not affected. Bechmarking is still using both methods in order to simulate `announce` requests.

The **interface is simpler** (command/query segregation).