### PR TITLE
New torrent repository: HashMap for Peer List

### DIFF
--- a/cSpell.json
+++ b/cSpell.json
@@ -106,6 +106,7 @@
         "Pando",
         "peekable",
         "peerlist",
+        "prefixfree",
         "proot",
         "proto",
         "Quickstart",

--- a/packages/torrent-repository/src/entry/mod.rs
+++ b/packages/torrent-repository/src/entry/mod.rs
@@ -79,11 +79,23 @@ pub trait EntryAsync {
 /// This is the tracker entry for a given torrent and contains the swarm data,
 /// that's the list of all the peers trying to download the same torrent.
 /// The tracker keeps one entry like this for every torrent.
-#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Torrent {
     /// The swarm: a network of peers that are all trying to download the torrent associated to this entry
     // #[serde(skip)]
-    pub(crate) peers: std::collections::BTreeMap<peer::Id, Arc<peer::Peer>>,
+    pub(crate) peers: std::collections::HashMap<peer::Id, Arc<peer::Peer>>,
     /// The number of peers that have ever completed downloading the torrent associated to this entry
     pub(crate) downloaded: u32,
+}
+
+impl std::hash::Hash for Torrent {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write_length_prefix(self.peers.len());
+
+        for peer in &self.peers {
+            peer.hash(state);
+        }
+
+        self.downloaded.hash(state);
+    }
 }

--- a/packages/torrent-repository/src/lib.rs
+++ b/packages/torrent-repository/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(hasher_prefixfree_extras)]
+
 use std::sync::Arc;
 
 use repository::dash_map_mutex_std::XacrimonDashMap;

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -82,7 +82,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use torrust_tracker_configuration::TrackerPolicy;
 use torrust_tracker_primitives::info_hash::InfoHash;
@@ -13,7 +13,7 @@ use crate::{EntrySingle, TorrentsRwLockStd};
 
 #[derive(Default, Debug)]
 pub struct RwLockStd<T> {
-    pub(crate) torrents: std::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
+    pub(crate) torrents: std::sync::RwLock<std::collections::HashMap<InfoHash, T>>,
 }
 
 impl<T> RwLockStd<T> {
@@ -22,22 +22,22 @@ impl<T> RwLockStd<T> {
     /// Panics if unable to get a lock.
     pub fn write(
         &self,
-    ) -> std::sync::RwLockWriteGuard<'_, std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>> {
+    ) -> std::sync::RwLockWriteGuard<'_, std::collections::HashMap<torrust_tracker_primitives::info_hash::InfoHash, T>> {
         self.torrents.write().expect("it should get lock")
     }
 }
 
 impl TorrentsRwLockStd {
-    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
+    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntrySingle>>
     where
-        std::collections::BTreeMap<InfoHash, EntrySingle>: 'a,
+        std::collections::HashMap<InfoHash, EntrySingle>: 'a,
     {
         self.torrents.read().expect("it should get the read lock")
     }
 
-    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
+    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntrySingle>>
     where
-        std::collections::BTreeMap<InfoHash, EntrySingle>: 'a,
+        std::collections::HashMap<InfoHash, EntrySingle>: 'a,
     {
         self.torrents.write().expect("it should get the write lock")
     }
@@ -102,7 +102,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: BTreeMap::default(),
+                peers: HashMap::default(),
                 downloaded: *downloaded,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -13,16 +13,16 @@ use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockStdMutexStd};
 
 impl TorrentsRwLockStdMutexStd {
-    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexStd>>
+    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntryMutexStd>>
     where
-        std::collections::BTreeMap<InfoHash, crate::EntryMutexStd>: 'a,
+        std::collections::HashMap<InfoHash, crate::EntryMutexStd>: 'a,
     {
         self.torrents.read().expect("unable to get torrent list")
     }
 
-    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexStd>>
+    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntryMutexStd>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexStd>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexStd>: 'a,
     {
         self.torrents.write().expect("unable to get writable torrent list")
     }
@@ -97,7 +97,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::iter::zip;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -17,16 +17,16 @@ use crate::entry::{Entry, EntryAsync};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockStdMutexTokio};
 
 impl TorrentsRwLockStdMutexTokio {
-    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexTokio>>
+    fn get_torrents<'a>(&'a self) -> std::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntryMutexTokio>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexTokio>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexTokio>: 'a,
     {
         self.torrents.read().expect("unable to get torrent list")
     }
 
-    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexTokio>>
+    fn get_torrents_mut<'a>(&'a self) -> std::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntryMutexTokio>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexTokio>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexTokio>: 'a,
     {
         self.torrents.write().expect("unable to get writable torrent list")
     }
@@ -106,7 +106,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 
 use torrust_tracker_configuration::TrackerPolicy;
 use torrust_tracker_primitives::info_hash::InfoHash;
@@ -13,7 +13,7 @@ use crate::{EntrySingle, TorrentsRwLockTokio};
 
 #[derive(Default, Debug)]
 pub struct RwLockTokio<T> {
-    pub(crate) torrents: tokio::sync::RwLock<std::collections::BTreeMap<InfoHash, T>>,
+    pub(crate) torrents: tokio::sync::RwLock<std::collections::HashMap<InfoHash, T>>,
 }
 
 impl<T> RwLockTokio<T> {
@@ -22,7 +22,7 @@ impl<T> RwLockTokio<T> {
     ) -> impl std::future::Future<
         Output = tokio::sync::RwLockWriteGuard<
             '_,
-            std::collections::BTreeMap<torrust_tracker_primitives::info_hash::InfoHash, T>,
+            std::collections::HashMap<torrust_tracker_primitives::info_hash::InfoHash, T>,
         >,
     > {
         self.torrents.write()
@@ -30,18 +30,18 @@ impl<T> RwLockTokio<T> {
 }
 
 impl TorrentsRwLockTokio {
-    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
+    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntrySingle>>
     where
-        std::collections::BTreeMap<InfoHash, EntrySingle>: 'a,
+        std::collections::HashMap<InfoHash, EntrySingle>: 'a,
     {
         self.torrents.read().await
     }
 
     async fn get_torrents_mut<'a>(
         &'a self,
-    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntrySingle>>
+    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntrySingle>>
     where
-        std::collections::BTreeMap<InfoHash, EntrySingle>: 'a,
+        std::collections::HashMap<InfoHash, EntrySingle>: 'a,
     {
         self.torrents.write().await
     }
@@ -106,7 +106,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: BTreeMap::default(),
+                peers: HashMap::default(),
                 downloaded: *completed,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -13,18 +13,18 @@ use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockTokioMutexStd};
 
 impl TorrentsRwLockTokioMutexStd {
-    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexStd>>
+    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntryMutexStd>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexStd>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexStd>: 'a,
     {
         self.torrents.read().await
     }
 
     async fn get_torrents_mut<'a>(
         &'a self,
-    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexStd>>
+    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntryMutexStd>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexStd>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexStd>: 'a,
     {
         self.torrents.write().await
     }
@@ -97,7 +97,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -13,18 +13,18 @@ use crate::entry::{Entry, EntryAsync};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockTokioMutexTokio};
 
 impl TorrentsRwLockTokioMutexTokio {
-    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexTokio>>
+    async fn get_torrents<'a>(&'a self) -> tokio::sync::RwLockReadGuard<'a, std::collections::HashMap<InfoHash, EntryMutexTokio>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexTokio>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexTokio>: 'a,
     {
         self.torrents.read().await
     }
 
     async fn get_torrents_mut<'a>(
         &'a self,
-    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::BTreeMap<InfoHash, EntryMutexTokio>>
+    ) -> tokio::sync::RwLockWriteGuard<'a, std::collections::HashMap<InfoHash, EntryMutexTokio>>
     where
-        std::collections::BTreeMap<InfoHash, EntryMutexTokio>: 'a,
+        std::collections::HashMap<InfoHash, EntryMutexTokio>: 'a,
     {
         self.torrents.write().await
     }
@@ -100,7 +100,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crossbeam_skiplist::SkipMap;
@@ -76,7 +76,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: HashMap::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/tests/repository/mod.rs
+++ b/packages/torrent-repository/tests/repository/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::hash::{DefaultHasher, Hash, Hasher};
 
 use rstest::{fixture, rstest};
@@ -140,7 +140,7 @@ fn many_out_of_order() -> Entries {
 
 #[fixture]
 fn many_hashed_in_order() -> Entries {
-    let mut entries: BTreeMap<InfoHash, EntrySingle> = BTreeMap::default();
+    let mut entries: HashMap<InfoHash, EntrySingle> = HashMap::default();
 
     for i in 0..408 {
         let mut entry = EntrySingle::default();


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/discussions/774

New torrent repository using a HashMap for the peer list instead of a BTreeMap.

**WIP:** Some tests fail because it does not keep the order. This PR is only intended to check the performance. The performance is similar to the BTreeMap, so replacing it does not make sense if we lose the order. The order makes results deterministic.

BTreeMap:

```output
Requests out: 400847.83/second
Responses in: 361008.64/second
  - Connect responses:  178712.68
  - Announce responses: 178730.98
  - Scrape responses:   3564.99
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 105
  - p99.9: 293
  - p100: 363
```

HashMap:

```output
Requests out: 410866.90/second
Responses in: 368759.97/second
  - Connect responses:  182729.63
  - Announce responses: 182390.37
  - Scrape responses:   3639.97
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 105
  - p99.9: 297
  - p100: 365
```

I won't merge it:

- It's not finished. Test related to order are failing.
- It does not make sense to lose the "order" if the performance is not much better.