### PR TITLE
Refactor: extract peer list in torrent repository entry

### DIFF
--- a/packages/primitives/src/peer.rs
+++ b/packages/primitives/src/peer.rs
@@ -364,6 +364,38 @@ pub mod fixture {
     impl PeerBuilder {
         #[allow(dead_code)]
         #[must_use]
+        pub fn seeder() -> Self {
+            let peer = Peer {
+                peer_id: Id(*b"-qB00000000000000001"),
+                peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080),
+                updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+                uploaded: NumberOfBytes(0),
+                downloaded: NumberOfBytes(0),
+                left: NumberOfBytes(0),
+                event: AnnounceEvent::Completed,
+            };
+
+            Self { peer }
+        }
+
+        #[allow(dead_code)]
+        #[must_use]
+        pub fn leecher() -> Self {
+            let peer = Peer {
+                peer_id: Id(*b"-qB00000000000000002"),
+                peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080),
+                updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+                uploaded: NumberOfBytes(0),
+                downloaded: NumberOfBytes(0),
+                left: NumberOfBytes(10),
+                event: AnnounceEvent::Started,
+            };
+
+            Self { peer }
+        }
+
+        #[allow(dead_code)]
+        #[must_use]
         pub fn with_peer_id(mut self, peer_id: &Id) -> Self {
             self.peer.peer_id = *peer_id;
             self
@@ -387,6 +419,13 @@ pub mod fixture {
         #[must_use]
         pub fn with_no_bytes_pending_to_download(mut self) -> Self {
             self.peer.left = NumberOfBytes(0);
+            self
+        }
+
+        #[allow(dead_code)]
+        #[must_use]
+        pub fn last_updated_on(mut self, updated: DurationSinceUnixEpoch) -> Self {
+            self.peer.updated = updated;
             self
         }
 

--- a/packages/torrent-repository/src/entry/mod.rs
+++ b/packages/torrent-repository/src/entry/mod.rs
@@ -81,8 +81,8 @@ pub trait EntryAsync {
 /// The tracker keeps one entry like this for every torrent.
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Torrent {
-    /// The swarm: a network of peers that are all trying to download the torrent associated to this entry
-    pub(crate) peers: PeerList,
+    /// A network of peers that are all trying to download the torrent associated to this entry
+    pub(crate) swarm: PeerList,
     /// The number of peers that have ever completed downloading the torrent associated to this entry
     pub(crate) downloaded: u32,
 }

--- a/packages/torrent-repository/src/entry/mod.rs
+++ b/packages/torrent-repository/src/entry/mod.rs
@@ -82,8 +82,72 @@ pub trait EntryAsync {
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Torrent {
     /// The swarm: a network of peers that are all trying to download the torrent associated to this entry
-    // #[serde(skip)]
-    pub(crate) peers: std::collections::BTreeMap<peer::Id, Arc<peer::Peer>>,
+    pub(crate) peers: PeerList,
     /// The number of peers that have ever completed downloading the torrent associated to this entry
     pub(crate) downloaded: u32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeerList {
+    peers: std::collections::BTreeMap<peer::Id, Arc<peer::Peer>>,
+}
+
+impl PeerList {
+    fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    fn insert(&mut self, key: peer::Id, value: Arc<peer::Peer>) -> Option<Arc<peer::Peer>> {
+        self.peers.insert(key, value)
+    }
+
+    fn remove(&mut self, key: &peer::Id) -> Option<Arc<peer::Peer>> {
+        self.peers.remove(key)
+    }
+
+    fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&peer::Id, &mut Arc<peer::Peer>) -> bool,
+    {
+        self.peers.retain(f);
+    }
+
+    fn seeders_and_leechers(&self) -> (usize, usize) {
+        let seeders = self.peers.values().filter(|peer| peer.is_seeder()).count();
+        let leechers = self.len() - seeders;
+
+        (seeders, leechers)
+    }
+
+    fn get_peers(&self, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+        match limit {
+            Some(limit) => self.peers.values().take(limit).cloned().collect(),
+            None => self.peers.values().cloned().collect(),
+        }
+    }
+
+    fn get_peers_for_client(&self, client: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+        match limit {
+            Some(limit) => self
+                .peers
+                .values()
+                // Take peers which are not the client peer
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                // Limit the number of peers on the result
+                .take(limit)
+                .cloned()
+                .collect(),
+            None => self
+                .peers
+                .values()
+                // Take peers which are not the client peer
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                .cloned()
+                .collect(),
+        }
+    }
 }

--- a/packages/torrent-repository/src/entry/peer_list.rs
+++ b/packages/torrent-repository/src/entry/peer_list.rs
@@ -1,7 +1,13 @@
+//! A peer list.
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use torrust_tracker_primitives::peer;
+use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
+
+// code-review: the current implementation uses the peer Id as the ``BTreeMap``
+// key. That would allow adding two identical peers except for the Id.
+// For example, two peers with the same socket address but a different peer Id
+// would be allowed. That would lead to duplicated peers in the tracker responses.
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PeerList {
@@ -19,19 +25,30 @@ impl PeerList {
         self.peers.is_empty()
     }
 
-    pub fn insert(&mut self, key: peer::Id, value: Arc<peer::Peer>) -> Option<Arc<peer::Peer>> {
-        self.peers.insert(key, value)
+    pub fn upsert(&mut self, value: Arc<peer::Peer>) -> Option<Arc<peer::Peer>> {
+        self.peers.insert(value.peer_id, value)
     }
 
     pub fn remove(&mut self, key: &peer::Id) -> Option<Arc<peer::Peer>> {
         self.peers.remove(key)
     }
 
-    pub fn retain<F>(&mut self, f: F)
-    where
-        F: FnMut(&peer::Id, &mut Arc<peer::Peer>) -> bool,
-    {
-        self.peers.retain(f);
+    pub fn remove_inactive_peers(&mut self, current_cutoff: DurationSinceUnixEpoch) {
+        self.peers
+            .retain(|_, peer| peer::ReadInfo::get_updated(peer) > current_cutoff);
+    }
+
+    #[must_use]
+    pub fn get(&self, peer_id: &peer::Id) -> Option<&Arc<peer::Peer>> {
+        self.peers.get(peer_id)
+    }
+
+    #[must_use]
+    pub fn get_all(&self, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+        match limit {
+            Some(limit) => self.peers.values().take(limit).cloned().collect(),
+            None => self.peers.values().cloned().collect(),
+        }
     }
 
     #[must_use]
@@ -43,21 +60,13 @@ impl PeerList {
     }
 
     #[must_use]
-    pub fn get_peers(&self, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
-        match limit {
-            Some(limit) => self.peers.values().take(limit).cloned().collect(),
-            None => self.peers.values().cloned().collect(),
-        }
-    }
-
-    #[must_use]
-    pub fn get_peers_for_client(&self, client: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+    pub fn get_peers_excluding_addr(&self, peer_addr: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
         match limit {
             Some(limit) => self
                 .peers
                 .values()
                 // Take peers which are not the client peer
-                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
                 // Limit the number of peers on the result
                 .take(limit)
                 .cloned()
@@ -66,9 +75,215 @@ impl PeerList {
                 .peers
                 .values()
                 // Take peers which are not the client peer
-                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
                 .cloned()
                 .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod it_should {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+        use std::sync::Arc;
+
+        use torrust_tracker_primitives::peer::fixture::PeerBuilder;
+        use torrust_tracker_primitives::peer::{self};
+        use torrust_tracker_primitives::DurationSinceUnixEpoch;
+
+        use crate::entry::peer_list::PeerList;
+
+        #[test]
+        fn be_empty_when_no_peers_have_been_inserted() {
+            let peer_list = PeerList::default();
+
+            assert!(peer_list.is_empty());
+        }
+
+        #[test]
+        fn have_zero_length_when_no_peers_have_been_inserted() {
+            let peer_list = PeerList::default();
+
+            assert_eq!(peer_list.len(), 0);
+        }
+
+        #[test]
+        fn allow_inserting_a_new_peer() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            assert_eq!(peer_list.upsert(peer.into()), None);
+        }
+
+        #[test]
+        fn allow_updating_a_preexisting_peer() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            assert_eq!(peer_list.upsert(peer.into()), Some(Arc::new(peer)));
+        }
+
+        #[test]
+        fn allow_getting_all_peers() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            assert_eq!(peer_list.get_all(None), [Arc::new(peer)]);
+        }
+
+        #[test]
+        fn allow_getting_one_peer_by_id() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            assert_eq!(peer_list.get(&peer.peer_id), Some(Arc::new(peer)).as_ref());
+        }
+
+        #[test]
+        fn increase_the_number_of_peers_after_inserting_a_new_one() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            assert_eq!(peer_list.len(), 1);
+        }
+
+        #[test]
+        fn decrease_the_number_of_peers_after_removing_one() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            peer_list.remove(&peer.peer_id);
+
+            assert!(peer_list.is_empty());
+        }
+
+        #[test]
+        fn allow_removing_an_existing_peer() {
+            let mut peer_list = PeerList::default();
+
+            let peer = PeerBuilder::default().build();
+
+            peer_list.upsert(peer.into());
+
+            peer_list.remove(&peer.peer_id);
+
+            assert_eq!(peer_list.get(&peer.peer_id), None);
+        }
+
+        #[test]
+        fn allow_getting_all_peers_excluding_peers_with_a_given_address() {
+            let mut peer_list = PeerList::default();
+
+            let peer1 = PeerBuilder::default()
+                .with_peer_id(&peer::Id(*b"-qB00000000000000001"))
+                .with_peer_addr(&SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 6969))
+                .build();
+            peer_list.upsert(peer1.into());
+
+            let peer2 = PeerBuilder::default()
+                .with_peer_id(&peer::Id(*b"-qB00000000000000002"))
+                .with_peer_addr(&SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 6969))
+                .build();
+            peer_list.upsert(peer2.into());
+
+            assert_eq!(peer_list.get_peers_excluding_addr(&peer2.peer_addr, None), [Arc::new(peer1)]);
+        }
+
+        #[test]
+        fn return_the_number_of_seeders_in_the_list() {
+            let mut peer_list = PeerList::default();
+
+            let seeder = PeerBuilder::seeder().build();
+            let leecher = PeerBuilder::leecher().build();
+
+            peer_list.upsert(seeder.into());
+            peer_list.upsert(leecher.into());
+
+            let (seeders, _leechers) = peer_list.seeders_and_leechers();
+
+            assert_eq!(seeders, 1);
+        }
+
+        #[test]
+        fn return_the_number_of_leechers_in_the_list() {
+            let mut peer_list = PeerList::default();
+
+            let seeder = PeerBuilder::seeder().build();
+            let leecher = PeerBuilder::leecher().build();
+
+            peer_list.upsert(seeder.into());
+            peer_list.upsert(leecher.into());
+
+            let (_seeders, leechers) = peer_list.seeders_and_leechers();
+
+            assert_eq!(leechers, 1);
+        }
+
+        #[test]
+        fn remove_inactive_peers() {
+            let mut peer_list = PeerList::default();
+            let one_second = DurationSinceUnixEpoch::new(1, 0);
+
+            // Insert the peer
+            let last_update_time = DurationSinceUnixEpoch::new(1_669_397_478_934, 0);
+            let peer = PeerBuilder::default().last_updated_on(last_update_time).build();
+            peer_list.upsert(peer.into());
+
+            // Remove peers not updated since one second after inserting the peer
+            peer_list.remove_inactive_peers(last_update_time + one_second);
+
+            assert_eq!(peer_list.len(), 0);
+        }
+
+        #[test]
+        fn not_remove_active_peers() {
+            let mut peer_list = PeerList::default();
+            let one_second = DurationSinceUnixEpoch::new(1, 0);
+
+            // Insert the peer
+            let last_update_time = DurationSinceUnixEpoch::new(1_669_397_478_934, 0);
+            let peer = PeerBuilder::default().last_updated_on(last_update_time).build();
+            peer_list.upsert(peer.into());
+
+            // Remove peers not updated since one second before inserting the peer.
+            peer_list.remove_inactive_peers(last_update_time - one_second);
+
+            assert_eq!(peer_list.len(), 1);
+        }
+
+        #[test]
+        fn allow_inserting_two_identical_peers_except_for_the_id() {
+            let mut peer_list = PeerList::default();
+
+            let peer1 = PeerBuilder::default()
+                .with_peer_id(&peer::Id(*b"-qB00000000000000001"))
+                .build();
+            peer_list.upsert(peer1.into());
+
+            let peer2 = PeerBuilder::default()
+                .with_peer_id(&peer::Id(*b"-qB00000000000000002"))
+                .build();
+            peer_list.upsert(peer2.into());
+
+            assert_eq!(peer_list.len(), 2);
         }
     }
 }

--- a/packages/torrent-repository/src/entry/peer_list.rs
+++ b/packages/torrent-repository/src/entry/peer_list.rs
@@ -1,0 +1,74 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use torrust_tracker_primitives::peer;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PeerList {
+    peers: std::collections::BTreeMap<peer::Id, Arc<peer::Peer>>,
+}
+
+impl PeerList {
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.peers.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.peers.is_empty()
+    }
+
+    pub fn insert(&mut self, key: peer::Id, value: Arc<peer::Peer>) -> Option<Arc<peer::Peer>> {
+        self.peers.insert(key, value)
+    }
+
+    pub fn remove(&mut self, key: &peer::Id) -> Option<Arc<peer::Peer>> {
+        self.peers.remove(key)
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&peer::Id, &mut Arc<peer::Peer>) -> bool,
+    {
+        self.peers.retain(f);
+    }
+
+    #[must_use]
+    pub fn seeders_and_leechers(&self) -> (usize, usize) {
+        let seeders = self.peers.values().filter(|peer| peer.is_seeder()).count();
+        let leechers = self.len() - seeders;
+
+        (seeders, leechers)
+    }
+
+    #[must_use]
+    pub fn get_peers(&self, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+        match limit {
+            Some(limit) => self.peers.values().take(limit).cloned().collect(),
+            None => self.peers.values().cloned().collect(),
+        }
+    }
+
+    #[must_use]
+    pub fn get_peers_for_client(&self, client: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
+        match limit {
+            Some(limit) => self
+                .peers
+                .values()
+                // Take peers which are not the client peer
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                // Limit the number of peers on the result
+                .take(limit)
+                .cloned()
+                .collect(),
+            None => self
+                .peers
+                .values()
+                // Take peers which are not the client peer
+                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *client)
+                .cloned()
+                .collect(),
+        }
+    }
+}

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -10,7 +9,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync};
+use crate::entry::{Entry, EntrySync, PeerList};
 use crate::{EntryMutexStd, EntrySingle};
 
 #[derive(Default, Debug)]
@@ -82,7 +81,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -9,7 +9,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle};
 
 #[derive(Default, Debug)]

--- a/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/dash_map_mutex_std.rs
@@ -81,7 +81,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use torrust_tracker_configuration::TrackerPolicy;
 use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
@@ -8,7 +6,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::Entry;
+use crate::entry::{Entry, PeerList};
 use crate::{EntrySingle, TorrentsRwLockStd};
 
 #[derive(Default, Debug)]
@@ -102,7 +100,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: BTreeMap::default(),
+                peers: PeerList::default(),
                 downloaded: *downloaded,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std.rs
@@ -100,7 +100,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: PeerList::default(),
+                swarm: PeerList::default(),
                 downloaded: *downloaded,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std.rs
@@ -6,7 +6,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::Entry;
 use crate::{EntrySingle, TorrentsRwLockStd};
 
 #[derive(Default, Debug)]

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
@@ -96,7 +96,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -9,7 +8,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync};
+use crate::entry::{Entry, EntrySync, PeerList};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockStdMutexStd};
 
 impl TorrentsRwLockStdMutexStd {
@@ -97,7 +96,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_std.rs
@@ -8,7 +8,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockStdMutexStd};
 
 impl TorrentsRwLockStdMutexStd {

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
@@ -105,7 +105,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::iter::zip;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -13,7 +12,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntryAsync};
+use crate::entry::{Entry, EntryAsync, PeerList};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockStdMutexTokio};
 
 impl TorrentsRwLockStdMutexTokio {
@@ -106,7 +105,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_std_mutex_tokio.rs
@@ -12,7 +12,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntryAsync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntryAsync};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockStdMutexTokio};
 
 impl TorrentsRwLockStdMutexTokio {

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -6,7 +6,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::Entry;
 use crate::{EntrySingle, TorrentsRwLockTokio};
 
 #[derive(Default, Debug)]

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use torrust_tracker_configuration::TrackerPolicy;
 use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
@@ -8,7 +6,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::Entry;
+use crate::entry::{Entry, PeerList};
 use crate::{EntrySingle, TorrentsRwLockTokio};
 
 #[derive(Default, Debug)]
@@ -106,7 +104,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: BTreeMap::default(),
+                peers: PeerList::default(),
                 downloaded: *completed,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio.rs
@@ -104,7 +104,7 @@ where
             }
 
             let entry = EntrySingle {
-                peers: PeerList::default(),
+                swarm: PeerList::default(),
                 downloaded: *completed,
             };
 

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
@@ -96,7 +96,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
@@ -8,7 +8,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntrySync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockTokioMutexStd};
 
 impl TorrentsRwLockTokioMutexStd {

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_std.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -9,7 +8,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntrySync};
+use crate::entry::{Entry, EntrySync, PeerList};
 use crate::{EntryMutexStd, EntrySingle, TorrentsRwLockTokioMutexStd};
 
 impl TorrentsRwLockTokioMutexStd {
@@ -97,7 +96,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use torrust_tracker_configuration::TrackerPolicy;
@@ -9,7 +8,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntryAsync};
+use crate::entry::{Entry, EntryAsync, PeerList};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockTokioMutexTokio};
 
 impl TorrentsRwLockTokioMutexTokio {
@@ -100,7 +99,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
@@ -99,7 +99,7 @@ where
 
             let entry = EntryMutexTokio::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
+++ b/packages/torrent-repository/src/repository/rw_lock_tokio_mutex_tokio.rs
@@ -8,7 +8,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::RepositoryAsync;
-use crate::entry::{Entry, EntryAsync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntryAsync};
 use crate::{EntryMutexTokio, EntrySingle, TorrentsRwLockTokioMutexTokio};
 
 impl TorrentsRwLockTokioMutexTokio {

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -9,7 +9,8 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync, PeerList};
+use crate::entry::peer_list::PeerList;
+use crate::entry::{Entry, EntrySync};
 use crate::{EntryMutexStd, EntrySingle};
 
 #[derive(Default, Debug)]

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use crossbeam_skiplist::SkipMap;
@@ -10,7 +9,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
 
 use super::Repository;
-use crate::entry::{Entry, EntrySync};
+use crate::entry::{Entry, EntrySync, PeerList};
 use crate::{EntryMutexStd, EntrySingle};
 
 #[derive(Default, Debug)]
@@ -76,7 +75,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: BTreeMap::default(),
+                    peers: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),

--- a/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
+++ b/packages/torrent-repository/src/repository/skip_map_mutex_std.rs
@@ -75,7 +75,7 @@ where
 
             let entry = EntryMutexStd::new(
                 EntrySingle {
-                    peers: PeerList::default(),
+                    swarm: PeerList::default(),
                     downloaded: *completed,
                 }
                 .into(),


### PR DESCRIPTION
This PR extracts a new type, "PeerList", used in the torrent repository entry.

### Why

- It can be tested independently (unit tests and benchmarking).
- Other implementations could be added in the future. This abstraction hides implementation details (the collection used).

### Performance

It looks like it does not affect the performance.

```output
Requests out: 406025.97/second
Responses in: 365423.41/second
  - Connect responses:  180950.24
  - Announce responses: 180818.87
  - Scrape responses:   3654.30
  - Error responses:    0.00
Peers per announce response: 0.00
Announce responses per info hash:
  - p10: 1
  - p25: 1
  - p50: 1
  - p75: 1
  - p90: 2
  - p95: 3
  - p99: 104
  - p99.9: 295
  - p100: 367
```