### PR TITLE
refactor: [#680] http return errors instead of panicking

### DIFF
--- a/src/console/clients/http/app.rs
+++ b/src/console/clients/http/app.rs
@@ -64,11 +64,11 @@ async fn announce_command(tracker_url: String, info_hash: String) -> anyhow::Res
     let info_hash =
         InfoHash::from_str(&info_hash).expect("Invalid infohash. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`");
 
-    let response = Client::new(base_url)
+    let response = Client::new(base_url)?
         .announce(&QueryBuilder::with_default_values().with_info_hash(&info_hash).query())
-        .await;
+        .await?;
 
-    let body = response.bytes().await.unwrap();
+    let body = response.bytes().await?;
 
     let announce_response: Announce = serde_bencode::from_bytes(&body)
         .unwrap_or_else(|_| panic!("response body should be a valid announce response, got: \"{:#?}\"", &body));
@@ -85,9 +85,9 @@ async fn scrape_command(tracker_url: &str, info_hashes: &[String]) -> anyhow::Re
 
     let query = requests::scrape::Query::try_from(info_hashes).context("failed to parse infohashes")?;
 
-    let response = Client::new(base_url).scrape(&query).await;
+    let response = Client::new(base_url)?.scrape(&query).await?;
 
-    let body = response.bytes().await.unwrap();
+    let body = response.bytes().await?;
 
     let scrape_response = scrape::Response::try_from_bencoded(&body)
         .unwrap_or_else(|_| panic!("response body should be a valid scrape response, got: \"{:#?}\"", &body));


### PR DESCRIPTION
Refactor: HTTP tracker client returns errors instead of panicking.