### PR TITLE
chore(deps): bump `rustc-demangle` from `v0.1.23` to `v0.1.24`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3212,9 +3212,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"


### PR DESCRIPTION
```output
cargo update
    Updating crates.io index
     Locking 1 package to latest compatible version
    Updating rustc-demangle v0.1.23 -> v0.1.24
```