### PR TITLE
Refactor: enrich field types in configuration structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,6 +721,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,6 +3889,7 @@ dependencies = [
  "axum-client-ip",
  "axum-extra",
  "axum-server",
+ "camino",
  "chrono",
  "clap",
  "crossbeam-skiplist",
@@ -3938,6 +3948,7 @@ dependencies = [
 name = "torrust-tracker-configuration"
 version = "3.0.0-alpha.12-develop"
 dependencies = [
+ "camino",
  "derive_more",
  "figment",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ axum = { version = "0", features = ["macros"] }
 axum-client-ip = "0"
 axum-extra = { version = "0", features = ["query"] }
 axum-server = { version = "0", features = ["tls-rustls"] }
+camino = { version = "1.1.6", features = ["serde"] }
 chrono = { version = "0", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 crossbeam-skiplist = "0.1"

--- a/cSpell.json
+++ b/cSpell.json
@@ -25,6 +25,7 @@
         "Buildx",
         "byteorder",
         "callgrind",
+        "camino",
         "canonicalize",
         "canonicalized",
         "certbot",

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+camino = { version = "1.1.6", features = ["serde"] }
 derive_more = "0"
 figment = { version = "0.10.18", features = ["env", "test", "toml"] }
 serde = { version = "1", features = ["derive"] }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -171,3 +171,20 @@ pub struct TslConfig {
     #[serde_as(as = "NoneAsEmptyString")]
     pub ssl_key_path: Option<Utf8PathBuf>,
 }
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    /// A level lower than all log levels.
+    Off,
+    /// Corresponds to the `Error` log level.
+    Error,
+    /// Corresponds to the `Warn` log level.
+    Warn,
+    /// Corresponds to the `Info` log level.
+    Info,
+    /// Corresponds to the `Debug` log level.
+    Debug,
+    /// Corresponds to the `Trace` log level.
+    Trace,
+}

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -3,7 +3,7 @@
 //! This module contains the configuration data structures for the
 //! Torrust Tracker, which is a `BitTorrent` tracker server.
 //!
-//! The current version for configuration is [`v1`](crate::v1).
+//! The current version for configuration is [`v1`].
 pub mod v1;
 
 use std::collections::HashMap;
@@ -172,7 +172,7 @@ pub struct TslConfig {
     pub ssl_key_path: Option<Utf8PathBuf>,
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
 #[serde(rename_all = "lowercase")]
 pub enum LogLevel {
     /// A level lower than all log levels.

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use derive_more::Constructor;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, NoneAsEmptyString};
 use thiserror::Error;
 use torrust_tracker_located_error::{DynError, LocatedError};
 
@@ -156,4 +158,15 @@ impl From<figment::Error> for Error {
             source: (Arc::new(err) as DynError).into(),
         }
     }
+}
+
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct TslConfig {
+    /// Path to the SSL certificate file.
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub ssl_cert_path: Option<String>,
+    /// Path to the SSL key file.
+    #[serde_as(as = "NoneAsEmptyString")]
+    pub ssl_key_path: Option<String>,
 }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::{env, fs};
 
+use camino::Utf8PathBuf;
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, NoneAsEmptyString};
@@ -165,8 +166,8 @@ impl From<figment::Error> for Error {
 pub struct TslConfig {
     /// Path to the SSL certificate file.
     #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_cert_path: Option<String>,
+    pub ssl_cert_path: Option<Utf8PathBuf>,
     /// Path to the SSL key file.
     #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_key_path: Option<String>,
+    pub ssl_key_path: Option<Utf8PathBuf>,
 }

--- a/packages/configuration/src/v1/core.rs
+++ b/packages/configuration/src/v1/core.rs
@@ -1,0 +1,88 @@
+use std::net::{IpAddr, Ipv4Addr};
+
+use serde::{Deserialize, Serialize};
+use torrust_tracker_primitives::{DatabaseDriver, TrackerMode};
+
+use crate::{AnnouncePolicy, LogLevel};
+
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct Core {
+    /// Logging level. Possible values are: `Off`, `Error`, `Warn`, `Info`,
+    /// `Debug` and `Trace`. Default is `Info`.
+    pub log_level: Option<LogLevel>,
+    /// Tracker mode. See [`TrackerMode`] for more information.
+    pub mode: TrackerMode,
+
+    // Database configuration
+    /// Database driver. Possible values are: `Sqlite3`, and `MySQL`.
+    pub db_driver: DatabaseDriver,
+    /// Database connection string. The format depends on the database driver.
+    /// For `Sqlite3`, the format is `path/to/database.db`, for example:
+    /// `./storage/tracker/lib/database/sqlite3.db`.
+    /// For `Mysql`, the format is `mysql://db_user:db_user_password:port/db_name`, for
+    /// example: `root:password@localhost:3306/torrust`.
+    pub db_path: String,
+
+    /// See [`AnnouncePolicy::interval`]
+    pub announce_interval: u32,
+
+    /// See [`AnnouncePolicy::interval_min`]
+    pub min_announce_interval: u32,
+    /// Weather the tracker is behind a reverse proxy or not.
+    /// If the tracker is behind a reverse proxy, the `X-Forwarded-For` header
+    /// sent from the proxy will be used to get the client's IP address.
+    pub on_reverse_proxy: bool,
+    /// The external IP address of the tracker. If the client is using a
+    /// loopback IP address, this IP address will be used instead. If the peer
+    /// is using a loopback IP address, the tracker assumes that the peer is
+    /// in the same network as the tracker and will use the tracker's IP
+    /// address instead.
+    pub external_ip: Option<IpAddr>,
+    /// Weather the tracker should collect statistics about tracker usage.
+    /// If enabled, the tracker will collect statistics like the number of
+    /// connections handled, the number of announce requests handled, etc.
+    /// Refer to the [`Tracker`](https://docs.rs/torrust-tracker) for more
+    /// information about the collected metrics.
+    pub tracker_usage_statistics: bool,
+    /// If enabled the tracker will persist the number of completed downloads.
+    /// That's how many times a torrent has been downloaded completely.
+    pub persistent_torrent_completed_stat: bool,
+
+    // Cleanup job configuration
+    /// Maximum time in seconds that a peer can be inactive before being
+    /// considered an inactive peer. If a peer is inactive for more than this
+    /// time, it will be removed from the torrent peer list.
+    pub max_peer_timeout: u32,
+    /// Interval in seconds that the cleanup job will run to remove inactive
+    /// peers from the torrent peer list.
+    pub inactive_peer_cleanup_interval: u64,
+    /// If enabled, the tracker will remove torrents that have no peers.
+    /// The clean up torrent job runs every `inactive_peer_cleanup_interval`
+    /// seconds and it removes inactive peers. Eventually, the peer list of a
+    /// torrent could be empty and the torrent will be removed if this option is
+    /// enabled.
+    pub remove_peerless_torrents: bool,
+}
+
+impl Default for Core {
+    fn default() -> Self {
+        let announce_policy = AnnouncePolicy::default();
+
+        Self {
+            log_level: Some(LogLevel::Info),
+            mode: TrackerMode::Public,
+            db_driver: DatabaseDriver::Sqlite3,
+            db_path: String::from("./storage/tracker/lib/database/sqlite3.db"),
+            announce_interval: announce_policy.interval,
+            min_announce_interval: announce_policy.interval_min,
+            max_peer_timeout: 900,
+            on_reverse_proxy: false,
+            external_ip: Some(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))),
+            tracker_usage_statistics: true,
+            persistent_torrent_completed_stat: false,
+            inactive_peer_cleanup_interval: 600,
+            remove_peerless_torrents: true,
+        }
+    }
+}

--- a/packages/configuration/src/v1/health_check_api.rs
+++ b/packages/configuration/src/v1/health_check_api.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -9,13 +11,13 @@ pub struct HealthCheckApi {
     /// The format is `ip:port`, for example `127.0.0.1:1313`. If you want to
     /// listen to all interfaces, use `0.0.0.0`. If you want the operating
     /// system to choose a random port, use port `0`.
-    pub bind_address: String,
+    pub bind_address: SocketAddr,
 }
 
 impl Default for HealthCheckApi {
     fn default() -> Self {
         Self {
-            bind_address: String::from("127.0.0.1:1313"),
+            bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1313),
         }
     }
 }

--- a/packages/configuration/src/v1/http_tracker.rs
+++ b/packages/configuration/src/v1/http_tracker.rs
@@ -1,5 +1,9 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, NoneAsEmptyString};
+use serde_with::serde_as;
+
+use crate::TslConfig;
 
 /// Configuration for each HTTP tracker.
 #[serde_as]
@@ -11,25 +15,21 @@ pub struct HttpTracker {
     /// The format is `ip:port`, for example `0.0.0.0:6969`. If you want to
     /// listen to all interfaces, use `0.0.0.0`. If you want the operating
     /// system to choose a random port, use port `0`.
-    pub bind_address: String,
+    pub bind_address: SocketAddr,
     /// Weather the HTTP tracker will use SSL or not.
     pub ssl_enabled: bool,
-    /// Path to the SSL certificate file. Only used if `ssl_enabled` is `true`.
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_cert_path: Option<String>,
-    /// Path to the SSL key file. Only used if `ssl_enabled` is `true`.
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_key_path: Option<String>,
+    /// TSL config. Only used if `ssl_enabled` is true.
+    #[serde(flatten)]
+    pub tsl_config: TslConfig,
 }
 
 impl Default for HttpTracker {
     fn default() -> Self {
         Self {
             enabled: false,
-            bind_address: String::from("0.0.0.0:7070"),
+            bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 7070),
             ssl_enabled: false,
-            ssl_cert_path: None,
-            ssl_key_path: None,
+            tsl_config: TslConfig::default(),
         }
     }
 }

--- a/packages/configuration/src/v1/tracker_api.rs
+++ b/packages/configuration/src/v1/tracker_api.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, NoneAsEmptyString};
+use serde_with::serde_as;
+
+use crate::TslConfig;
 
 pub type AccessTokens = HashMap<String, String>;
 
@@ -15,19 +18,16 @@ pub struct HttpApi {
     /// The format is `ip:port`, for example `0.0.0.0:6969`. If you want to
     /// listen to all interfaces, use `0.0.0.0`. If you want the operating
     /// system to choose a random port, use port `0`.
-    pub bind_address: String,
+    pub bind_address: SocketAddr,
     /// Weather the HTTP API will use SSL or not.
     pub ssl_enabled: bool,
-    /// Path to the SSL certificate file. Only used if `ssl_enabled` is `true`.
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_cert_path: Option<String>,
-    /// Path to the SSL key file. Only used if `ssl_enabled` is `true`.
-    #[serde_as(as = "NoneAsEmptyString")]
-    pub ssl_key_path: Option<String>,
+    /// TSL config. Only used if `ssl_enabled` is true.
+    #[serde(flatten)]
+    pub tsl_config: TslConfig,
     /// Access tokens for the HTTP API. The key is a label identifying the
     /// token and the value is the token itself. The token is used to
     /// authenticate the user. All tokens are valid for all endpoints and have
-    /// the all permissions.
+    /// all permissions.
     pub access_tokens: AccessTokens,
 }
 
@@ -35,10 +35,9 @@ impl Default for HttpApi {
     fn default() -> Self {
         Self {
             enabled: true,
-            bind_address: String::from("127.0.0.1:1212"),
+            bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1212),
             ssl_enabled: false,
-            ssl_cert_path: None,
-            ssl_key_path: None,
+            tsl_config: TslConfig::default(),
             access_tokens: [(String::from("admin"), String::from("MyAccessToken"))]
                 .iter()
                 .cloned()

--- a/packages/configuration/src/v1/udp_tracker.rs
+++ b/packages/configuration/src/v1/udp_tracker.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -8,13 +10,13 @@ pub struct UdpTracker {
     /// The format is `ip:port`, for example `0.0.0.0:6969`. If you want to
     /// listen to all interfaces, use `0.0.0.0`. If you want the operating
     /// system to choose a random port, use port `0`.
-    pub bind_address: String,
+    pub bind_address: SocketAddr,
 }
 impl Default for UdpTracker {
     fn default() -> Self {
         Self {
             enabled: false,
-            bind_address: String::from("0.0.0.0:6969"),
+            bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6969),
         }
     }
 }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use torrust_tracker_configuration::Configuration;
+use torrust_tracker_configuration::{Configuration, LogLevel};
 use torrust_tracker_primitives::TrackerMode;
 
 use crate::random;
@@ -28,7 +28,7 @@ pub fn ephemeral() -> Configuration {
     // For example: a test for the UDP tracker should disable the API and HTTP tracker.
 
     let mut config = Configuration {
-        log_level: Some("off".to_owned()), // Change to `debug` for tests debugging
+        log_level: Some(LogLevel::Off), // Change to `debug` for tests debugging
         ..Default::default()
     };
 
@@ -125,7 +125,7 @@ pub fn ephemeral_mode_private_whitelisted() -> Configuration {
 pub fn ephemeral_with_external_ip(ip: IpAddr) -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.external_ip = Some(ip.to_string());
+    cfg.external_ip = Some(ip);
 
     cfg
 }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -49,7 +49,7 @@ pub fn ephemeral() -> Configuration {
     // Ephemeral socket address for HTTP tracker
     let http_port = 0u16;
     config.http_trackers[0].enabled = true;
-    config.http_trackers[0].bind_address = format!("127.0.0.1:{}", &http_port);
+    config.http_trackers[0].bind_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), http_port);
 
     // Ephemeral sqlite database
     let temp_directory = env::temp_dir();
@@ -139,7 +139,7 @@ pub fn ephemeral_ipv6() -> Configuration {
     let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 0);
 
     cfg.http_api.bind_address.clone_from(&ipv6.to_string());
-    cfg.http_trackers[0].bind_address.clone_from(&ipv6.to_string());
+    cfg.http_trackers[0].bind_address.clone_from(&ipv6);
     cfg.udp_trackers[0].bind_address = ipv6;
 
     cfg

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -27,10 +27,9 @@ pub fn ephemeral() -> Configuration {
     // todo: disable services that are not needed.
     // For example: a test for the UDP tracker should disable the API and HTTP tracker.
 
-    let mut config = Configuration {
-        log_level: Some(LogLevel::Off), // Change to `debug` for tests debugging
-        ..Default::default()
-    };
+    let mut config = Configuration::default();
+
+    config.core.log_level = Some(LogLevel::Off); // Change to `debug` for tests debugging
 
     // Ephemeral socket address for API
     let api_port = 0u16;
@@ -55,7 +54,7 @@ pub fn ephemeral() -> Configuration {
     let temp_directory = env::temp_dir();
     let random_db_id = random::string(16);
     let temp_file = temp_directory.join(format!("data_{random_db_id}.db"));
-    temp_file.to_str().unwrap().clone_into(&mut config.db_path);
+    temp_file.to_str().unwrap().clone_into(&mut config.core.db_path);
 
     config
 }
@@ -65,7 +64,7 @@ pub fn ephemeral() -> Configuration {
 pub fn ephemeral_with_reverse_proxy() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.on_reverse_proxy = true;
+    cfg.core.on_reverse_proxy = true;
 
     cfg
 }
@@ -75,7 +74,7 @@ pub fn ephemeral_with_reverse_proxy() -> Configuration {
 pub fn ephemeral_without_reverse_proxy() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.on_reverse_proxy = false;
+    cfg.core.on_reverse_proxy = false;
 
     cfg
 }
@@ -85,7 +84,7 @@ pub fn ephemeral_without_reverse_proxy() -> Configuration {
 pub fn ephemeral_mode_public() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.mode = TrackerMode::Public;
+    cfg.core.mode = TrackerMode::Public;
 
     cfg
 }
@@ -95,7 +94,7 @@ pub fn ephemeral_mode_public() -> Configuration {
 pub fn ephemeral_mode_private() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.mode = TrackerMode::Private;
+    cfg.core.mode = TrackerMode::Private;
 
     cfg
 }
@@ -105,7 +104,7 @@ pub fn ephemeral_mode_private() -> Configuration {
 pub fn ephemeral_mode_whitelisted() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.mode = TrackerMode::Listed;
+    cfg.core.mode = TrackerMode::Listed;
 
     cfg
 }
@@ -115,7 +114,7 @@ pub fn ephemeral_mode_whitelisted() -> Configuration {
 pub fn ephemeral_mode_private_whitelisted() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.mode = TrackerMode::PrivateListed;
+    cfg.core.mode = TrackerMode::PrivateListed;
 
     cfg
 }
@@ -125,7 +124,7 @@ pub fn ephemeral_mode_private_whitelisted() -> Configuration {
 pub fn ephemeral_with_external_ip(ip: IpAddr) -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.external_ip = Some(ip);
+    cfg.core.external_ip = Some(ip);
 
     cfg
 }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -35,7 +35,7 @@ pub fn ephemeral() -> Configuration {
     // Ephemeral socket address for API
     let api_port = 0u16;
     config.http_api.enabled = true;
-    config.http_api.bind_address = format!("127.0.0.1:{}", &api_port);
+    config.http_api.bind_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), api_port);
 
     // Ephemeral socket address for Health Check API
     let health_check_api_port = 0u16;
@@ -138,7 +138,7 @@ pub fn ephemeral_ipv6() -> Configuration {
 
     let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 0);
 
-    cfg.http_api.bind_address.clone_from(&ipv6.to_string());
+    cfg.http_api.bind_address.clone_from(&ipv6);
     cfg.http_trackers[0].bind_address.clone_from(&ipv6);
     cfg.udp_trackers[0].bind_address = ipv6;
 

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -1,6 +1,6 @@
 //! Tracker configuration factories for testing.
 use std::env;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use torrust_tracker_configuration::Configuration;
 use torrust_tracker_primitives::TrackerMode;
@@ -44,7 +44,7 @@ pub fn ephemeral() -> Configuration {
     // Ephemeral socket address for UDP tracker
     let udp_port = 0u16;
     config.udp_trackers[0].enabled = true;
-    config.udp_trackers[0].bind_address = format!("127.0.0.1:{}", &udp_port);
+    config.udp_trackers[0].bind_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), udp_port);
 
     // Ephemeral socket address for HTTP tracker
     let http_port = 0u16;
@@ -136,10 +136,10 @@ pub fn ephemeral_with_external_ip(ip: IpAddr) -> Configuration {
 pub fn ephemeral_ipv6() -> Configuration {
     let mut cfg = ephemeral();
 
-    let ipv6 = format!("[::]:{}", 0);
+    let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0)), 0);
 
-    cfg.http_api.bind_address.clone_from(&ipv6);
-    cfg.http_trackers[0].bind_address.clone_from(&ipv6);
+    cfg.http_api.bind_address.clone_from(&ipv6.to_string());
+    cfg.http_trackers[0].bind_address.clone_from(&ipv6.to_string());
     cfg.udp_trackers[0].bind_address = ipv6;
 
     cfg

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -1,6 +1,6 @@
 //! Tracker configuration factories for testing.
 use std::env;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use torrust_tracker_configuration::Configuration;
 use torrust_tracker_primitives::TrackerMode;
@@ -39,7 +39,7 @@ pub fn ephemeral() -> Configuration {
 
     // Ephemeral socket address for Health Check API
     let health_check_api_port = 0u16;
-    config.health_check_api.bind_address = format!("127.0.0.1:{}", &health_check_api_port);
+    config.health_check_api.bind_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), health_check_api_port);
 
     // Ephemeral socket address for UDP tracker
     let udp_port = 0u16;

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,7 +67,7 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
         if tracker.is_private() {
             warn!(
                 "Could not start UDP tracker on: {} while in {:?}. UDP is not safe for private trackers!",
-                udp_tracker_config.bind_address, config.mode
+                udp_tracker_config.bind_address, config.core.mode
             );
         } else {
             jobs.push(udp_tracker::start_job(udp_tracker_config, tracker.clone(), registar.give_form()).await);
@@ -107,8 +107,8 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
     }
 
     // Start runners to remove torrents without peers, every interval
-    if config.inactive_peer_cleanup_interval > 0 {
-        jobs.push(torrent_cleanup::start_job(config, &tracker));
+    if config.core.inactive_peer_cleanup_interval > 0 {
+        jobs.push(torrent_cleanup::start_job(&config.core, &tracker));
     }
 
     // Start Health Check API

--- a/src/bootstrap/jobs/health_check_api.rs
+++ b/src/bootstrap/jobs/health_check_api.rs
@@ -35,10 +35,7 @@ use crate::servers::signals::Halted;
 ///
 /// It would panic if unable to send the  `ApiServerJobStarted` notice.
 pub async fn start_job(config: &HealthCheckApi, register: ServiceRegistry) -> JoinHandle<()> {
-    let bind_addr = config
-        .bind_address
-        .parse::<std::net::SocketAddr>()
-        .expect("it should have a valid health check bind address");
+    let bind_addr = config.bind_address;
 
     let (tx_start, rx_start) = oneshot::channel::<Started>();
     let (tx_halt, rx_halt) = tokio::sync::oneshot::channel::<Halted>();

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -18,7 +18,7 @@ use log::info;
 use tokio::task::JoinHandle;
 use torrust_tracker_configuration::HttpTracker;
 
-use super::make_rust_tls;
+use super::make_rust_tls_from_path_buf;
 use crate::core;
 use crate::servers::http::server::{HttpServer, Launcher};
 use crate::servers::http::Version;
@@ -42,7 +42,7 @@ pub async fn start_job(
     if config.enabled {
         let socket = config.bind_address;
 
-        let tls = make_rust_tls(
+        let tls = make_rust_tls_from_path_buf(
             config.ssl_enabled,
             &config.tsl_config.ssl_cert_path,
             &config.tsl_config.ssl_key_path,

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -40,14 +40,15 @@ pub async fn start_job(
     version: Version,
 ) -> Option<JoinHandle<()>> {
     if config.enabled {
-        let socket = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("it should have a valid http tracker bind address");
+        let socket = config.bind_address;
 
-        let tls = make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path)
-            .await
-            .map(|tls| tls.expect("it should have a valid http tracker tls configuration"));
+        let tls = make_rust_tls(
+            config.ssl_enabled,
+            &config.tsl_config.ssl_cert_path,
+            &config.tsl_config.ssl_key_path,
+        )
+        .await
+        .map(|tls| tls.expect("it should have a valid http tracker tls configuration"));
 
         match version {
             Version::V1 => Some(start_v1(socket, tls, tracker.clone(), form).await),

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -18,7 +18,7 @@ use log::info;
 use tokio::task::JoinHandle;
 use torrust_tracker_configuration::HttpTracker;
 
-use super::make_rust_tls_from_path_buf;
+use super::make_rust_tls;
 use crate::core;
 use crate::servers::http::server::{HttpServer, Launcher};
 use crate::servers::http::Version;
@@ -42,13 +42,9 @@ pub async fn start_job(
     if config.enabled {
         let socket = config.bind_address;
 
-        let tls = make_rust_tls_from_path_buf(
-            config.ssl_enabled,
-            &config.tsl_config.ssl_cert_path,
-            &config.tsl_config.ssl_key_path,
-        )
-        .await
-        .map(|tls| tls.expect("it should have a valid http tracker tls configuration"));
+        let tls = make_rust_tls(config.ssl_enabled, &config.tsl_config)
+            .await
+            .map(|tls| tls.expect("it should have a valid http tracker tls configuration"));
 
         match version {
             Version::V1 => Some(start_v1(socket, tls, tracker.clone(), form).await),

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -28,7 +28,35 @@ pub async fn make_rust_tls(enabled: bool, cert: &Option<String>, key: &Option<St
 
     if let (Some(cert), Some(key)) = (cert, key) {
         info!("Using https: cert path: {cert}.");
-        info!("Using https: key path: {cert}.");
+        info!("Using https: key path: {key}.");
+
+        Some(
+            RustlsConfig::from_pem_file(cert, key)
+                .await
+                .map_err(|err| Error::BadTlsConfig {
+                    source: (Arc::new(err) as DynError).into(),
+                }),
+        )
+    } else {
+        Some(Err(Error::MissingTlsConfig {
+            location: Location::caller(),
+        }))
+    }
+}
+
+pub async fn make_rust_tls_from_path_buf(
+    enabled: bool,
+    cert: &Option<Utf8PathBuf>,
+    key: &Option<Utf8PathBuf>,
+) -> Option<Result<RustlsConfig, Error>> {
+    if !enabled {
+        info!("TLS not enabled");
+        return None;
+    }
+
+    if let (Some(cert), Some(key)) = (cert, key) {
+        info!("Using https: cert path: {cert}.");
+        info!("Using https: key path: {key}.");
 
         Some(
             RustlsConfig::from_pem_file(cert, key)
@@ -77,6 +105,7 @@ use std::panic::Location;
 use std::sync::Arc;
 
 use axum_server::tls_rustls::RustlsConfig;
+use camino::Utf8PathBuf;
 use log::info;
 use thiserror::Error;
 use torrust_tracker_located_error::{DynError, LocatedError};

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -20,41 +20,13 @@ pub struct Started {
     pub address: std::net::SocketAddr,
 }
 
-pub async fn make_rust_tls(enabled: bool, cert: &Option<String>, key: &Option<String>) -> Option<Result<RustlsConfig, Error>> {
+pub async fn make_rust_tls(enabled: bool, tsl_config: &TslConfig) -> Option<Result<RustlsConfig, Error>> {
     if !enabled {
         info!("TLS not enabled");
         return None;
     }
 
-    if let (Some(cert), Some(key)) = (cert, key) {
-        info!("Using https: cert path: {cert}.");
-        info!("Using https: key path: {key}.");
-
-        Some(
-            RustlsConfig::from_pem_file(cert, key)
-                .await
-                .map_err(|err| Error::BadTlsConfig {
-                    source: (Arc::new(err) as DynError).into(),
-                }),
-        )
-    } else {
-        Some(Err(Error::MissingTlsConfig {
-            location: Location::caller(),
-        }))
-    }
-}
-
-pub async fn make_rust_tls_from_path_buf(
-    enabled: bool,
-    cert: &Option<Utf8PathBuf>,
-    key: &Option<Utf8PathBuf>,
-) -> Option<Result<RustlsConfig, Error>> {
-    if !enabled {
-        info!("TLS not enabled");
-        return None;
-    }
-
-    if let (Some(cert), Some(key)) = (cert, key) {
+    if let (Some(cert), Some(key)) = (tsl_config.ssl_cert_path.clone(), tsl_config.ssl_key_path.clone()) {
         info!("Using https: cert path: {cert}.");
         info!("Using https: key path: {key}.");
 
@@ -75,15 +47,23 @@ pub async fn make_rust_tls_from_path_buf(
 #[cfg(test)]
 mod tests {
 
+    use camino::Utf8PathBuf;
+    use torrust_tracker_configuration::TslConfig;
+
     use super::make_rust_tls;
 
     #[tokio::test]
     async fn it_should_error_on_bad_tls_config() {
-        let (bad_cert_path, bad_key_path) = (Some("bad cert path".to_string()), Some("bad key path".to_string()));
-        let err = make_rust_tls(true, &bad_cert_path, &bad_key_path)
-            .await
-            .expect("tls_was_enabled")
-            .expect_err("bad_cert_and_key_files");
+        let err = make_rust_tls(
+            true,
+            &TslConfig {
+                ssl_cert_path: Some(Utf8PathBuf::from("bad cert path")),
+                ssl_key_path: Some(Utf8PathBuf::from("bad key path")),
+            },
+        )
+        .await
+        .expect("tls_was_enabled")
+        .expect_err("bad_cert_and_key_files");
 
         assert!(err
             .to_string()
@@ -91,11 +71,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_error_on_missing_tls_config() {
-        let err = make_rust_tls(true, &None, &None)
-            .await
-            .expect("tls_was_enabled")
-            .expect_err("missing_config");
+    async fn it_should_error_on_missing_cert_or_key_paths() {
+        let err = make_rust_tls(
+            true,
+            &TslConfig {
+                ssl_cert_path: None,
+                ssl_key_path: None,
+            },
+        )
+        .await
+        .expect("tls_was_enabled")
+        .expect_err("missing_config");
 
         assert_eq!(err.to_string(), "tls config missing");
     }
@@ -105,9 +91,9 @@ use std::panic::Location;
 use std::sync::Arc;
 
 use axum_server::tls_rustls::RustlsConfig;
-use camino::Utf8PathBuf;
 use log::info;
 use thiserror::Error;
+use torrust_tracker_configuration::TslConfig;
 use torrust_tracker_located_error::{DynError, LocatedError};
 
 /// Error returned by the Bootstrap Process.

--- a/src/bootstrap/jobs/torrent_cleanup.rs
+++ b/src/bootstrap/jobs/torrent_cleanup.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use log::info;
 use tokio::task::JoinHandle;
-use torrust_tracker_configuration::Configuration;
+use torrust_tracker_configuration::v1::core::Core;
 
 use crate::core;
 
@@ -25,7 +25,7 @@ use crate::core;
 ///
 /// Refer to [`torrust-tracker-configuration documentation`](https://docs.rs/torrust-tracker-configuration) for more info about that option.
 #[must_use]
-pub fn start_job(config: &Configuration, tracker: &Arc<core::Tracker>) -> JoinHandle<()> {
+pub fn start_job(config: &Core, tracker: &Arc<core::Tracker>) -> JoinHandle<()> {
     let weak_tracker = std::sync::Arc::downgrade(tracker);
     let interval = config.inactive_peer_cleanup_interval;
 

--- a/src/bootstrap/jobs/tracker_apis.rs
+++ b/src/bootstrap/jobs/tracker_apis.rs
@@ -61,12 +61,9 @@ pub async fn start_job(
     version: Version,
 ) -> Option<JoinHandle<()>> {
     if config.enabled {
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("it should have a valid tracker api bind address");
+        let bind_to = config.bind_address;
 
-        let tls = make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path)
+        let tls = make_rust_tls(config.ssl_enabled, &config.tsl_config)
             .await
             .map(|tls| tls.expect("it should have a valid tracker api tls configuration"));
 

--- a/src/bootstrap/jobs/udp_tracker.rs
+++ b/src/bootstrap/jobs/udp_tracker.rs
@@ -27,10 +27,7 @@ use crate::servers::udp::server::{Launcher, UdpServer};
 /// It will panic if the task did not finish successfully.
 #[must_use]
 pub async fn start_job(config: &UdpTracker, tracker: Arc<core::Tracker>, form: ServiceRegistrationForm) -> JoinHandle<()> {
-    let bind_to = config
-        .bind_address
-        .parse::<std::net::SocketAddr>()
-        .expect("it should have a valid udp tracker bind address");
+    let bind_to = config.bind_address;
 
     let server = UdpServer::new(Launcher::new(bind_to))
         .start(tracker, form)

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -10,11 +10,10 @@
 //! - `Trace`
 //!
 //! Refer to the [configuration crate documentation](https://docs.rs/torrust-tracker-configuration) to know how to change log settings.
-use std::str::FromStr;
 use std::sync::Once;
 
 use log::{info, LevelFilter};
-use torrust_tracker_configuration::Configuration;
+use torrust_tracker_configuration::{Configuration, LogLevel};
 
 static INIT: Once = Once::new();
 
@@ -31,10 +30,17 @@ pub fn setup(cfg: &Configuration) {
     });
 }
 
-fn config_level_or_default(log_level: &Option<String>) -> LevelFilter {
+fn config_level_or_default(log_level: &Option<LogLevel>) -> LevelFilter {
     match log_level {
         None => log::LevelFilter::Info,
-        Some(level) => LevelFilter::from_str(level).unwrap(),
+        Some(level) => match level {
+            LogLevel::Off => LevelFilter::Off,
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Info => LevelFilter::Info,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+        },
     }
 }
 

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -19,7 +19,7 @@ static INIT: Once = Once::new();
 
 /// It redirects the log info to the standard output with the log level defined in the configuration
 pub fn setup(cfg: &Configuration) {
-    let level = config_level_or_default(&cfg.log_level);
+    let level = config_level_or_default(&cfg.core.log_level);
 
     if level == log::LevelFilter::Off {
         return;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -544,13 +544,13 @@ impl Tracker {
         stats_event_sender: Option<Box<dyn statistics::EventSender>>,
         stats_repository: statistics::Repo,
     ) -> Result<Tracker, databases::error::Error> {
-        let database = Arc::new(databases::driver::build(&config.db_driver, &config.db_path)?);
+        let database = Arc::new(databases::driver::build(&config.core.db_driver, &config.core.db_path)?);
 
-        let mode = config.mode;
+        let mode = config.core.mode;
 
         Ok(Tracker {
             //config,
-            announce_policy: AnnouncePolicy::new(config.announce_interval, config.min_announce_interval),
+            announce_policy: AnnouncePolicy::new(config.core.announce_interval, config.core.min_announce_interval),
             mode,
             keys: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             whitelist: tokio::sync::RwLock::new(std::collections::HashSet::new()),
@@ -560,11 +560,11 @@ impl Tracker {
             database,
             external_ip: config.get_ext_ip(),
             policy: TrackerPolicy::new(
-                config.remove_peerless_torrents,
-                config.max_peer_timeout,
-                config.persistent_torrent_completed_stat,
+                config.core.remove_peerless_torrents,
+                config.core.max_peer_timeout,
+                config.core.persistent_torrent_completed_stat,
             ),
-            on_reverse_proxy: config.on_reverse_proxy,
+            on_reverse_proxy: config.core.on_reverse_proxy,
         })
     }
 
@@ -1033,7 +1033,7 @@ mod tests {
 
         pub fn tracker_persisting_torrents_in_database() -> Tracker {
             let mut configuration = configuration::ephemeral();
-            configuration.persistent_torrent_completed_stat = true;
+            configuration.core.persistent_torrent_completed_stat = true;
             tracker_factory(&configuration)
         }
 

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -21,7 +21,7 @@ use crate::core::Tracker;
 #[must_use]
 pub fn tracker_factory(config: &Configuration) -> Tracker {
     // Initialize statistics
-    let (stats_event_sender, stats_repository) = statistics::setup::factory(config.tracker_usage_statistics);
+    let (stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
     // Initialize Torrust tracker
     match Tracker::new(&Arc::new(config), stats_event_sender, stats_repository) {

--- a/src/servers/apis/mod.rs
+++ b/src/servers/apis/mod.rs
@@ -130,8 +130,8 @@
 //! > **NOTICE**: You can generate a self-signed certificate for localhost using
 //! OpenSSL. See [Let's Encrypt](https://letsencrypt.org/docs/certificates-for-localhost/).
 //! That's particularly useful for testing purposes. Once you have the certificate
-//! you need to set the [`ssl_cert_path`](torrust_tracker_configuration::HttpApi::ssl_cert_path)
-//! and [`ssl_key_path`](torrust_tracker_configuration::HttpApi::ssl_key_path)
+//! you need to set the [`ssl_cert_path`](torrust_tracker_configuration::HttpApi::tsl_config.ssl_cert_path)
+//! and [`ssl_key_path`](torrust_tracker_configuration::HttpApi::tsl_config.ssl_key_path)
 //! options in the configuration file with the paths to the certificate
 //! (`localhost.crt`) and key (`localhost.key`) files.
 //!

--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -275,12 +275,9 @@ mod tests {
 
         let tracker = initialize_with_configuration(&cfg);
 
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
-        let tls = make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path)
+        let tls = make_rust_tls(config.ssl_enabled, &config.tsl_config)
             .await
             .map(|tls| tls.expect("tls config failed"));
 

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -224,7 +224,7 @@ mod tests {
     use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
-    use crate::bootstrap::jobs::make_rust_tls_from_path_buf;
+    use crate::bootstrap::jobs::make_rust_tls;
     use crate::servers::http::server::{HttpServer, Launcher};
     use crate::servers::registar::Registar;
 
@@ -236,13 +236,9 @@ mod tests {
 
         let bind_to = config.bind_address;
 
-        let tls = make_rust_tls_from_path_buf(
-            config.ssl_enabled,
-            &config.tsl_config.ssl_cert_path,
-            &config.tsl_config.ssl_key_path,
-        )
-        .await
-        .map(|tls| tls.expect("tls config failed"));
+        let tls = make_rust_tls(config.ssl_enabled, &config.tsl_config)
+            .await
+            .map(|tls| tls.expect("tls config failed"));
 
         let register = &Registar::default();
 

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -234,14 +234,15 @@ mod tests {
         let tracker = initialize_with_configuration(&cfg);
         let config = &cfg.http_trackers[0];
 
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
-        let tls = make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path)
-            .await
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = make_rust_tls(
+            config.ssl_enabled,
+            &config.tsl_config.ssl_cert_path,
+            &config.tsl_config.ssl_key_path,
+        )
+        .await
+        .map(|tls| tls.expect("tls config failed"));
 
         let register = &Registar::default();
 

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -224,7 +224,7 @@ mod tests {
     use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
-    use crate::bootstrap::jobs::make_rust_tls;
+    use crate::bootstrap::jobs::make_rust_tls_from_path_buf;
     use crate::servers::http::server::{HttpServer, Launcher};
     use crate::servers::registar::Registar;
 
@@ -236,7 +236,7 @@ mod tests {
 
         let bind_to = config.bind_address;
 
-        let tls = make_rust_tls(
+        let tls = make_rust_tls_from_path_buf(
             config.ssl_enabled,
             &config.tsl_config.ssl_cert_path,
             &config.tsl_config.ssl_key_path,

--- a/src/servers/http/v1/extractors/client_ip_sources.rs
+++ b/src/servers/http/v1/extractors/client_ip_sources.rs
@@ -16,7 +16,7 @@
 //! the tracker will use the `X-Forwarded-For` header to get the client IP
 //! address.
 //!
-//! See [`torrust_tracker_configuration::Configuration::on_reverse_proxy`].
+//! See [`torrust_tracker_configuration::Configuration::core.on_reverse_proxy`].
 //!
 //! The tracker can also be configured to run without a reverse proxy. In this
 //! case, the tracker will use the IP address from the connection info.

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -145,7 +145,7 @@ mod tests {
 
         fn tracker_with_an_ipv6_external_ip(stats_event_sender: Box<dyn statistics::EventSender>) -> Tracker {
             let mut configuration = configuration::ephemeral();
-            configuration.external_ip = Some(IpAddr::V6(Ipv6Addr::new(
+            configuration.core.external_ip = Some(IpAddr::V6(Ipv6Addr::new(
                 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
             )));
 

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -145,8 +145,9 @@ mod tests {
 
         fn tracker_with_an_ipv6_external_ip(stats_event_sender: Box<dyn statistics::EventSender>) -> Tracker {
             let mut configuration = configuration::ephemeral();
-            configuration.external_ip =
-                Some(IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)).to_string());
+            configuration.external_ip = Some(IpAddr::V6(Ipv6Addr::new(
+                0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
+            )));
 
             Tracker::new(&configuration, Some(stats_event_sender), statistics::Repo::new()).unwrap()
         }

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -426,7 +426,7 @@ mod tests {
         }
 
         pub fn with_external_ip(mut self, external_ip: &str) -> Self {
-            self.configuration.external_ip = Some(external_ip.to_owned().parse().expect("valid IP address"));
+            self.configuration.core.external_ip = Some(external_ip.to_owned().parse().expect("valid IP address"));
             self
         }
 

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -426,7 +426,7 @@ mod tests {
         }
 
         pub fn with_external_ip(mut self, external_ip: &str) -> Self {
-            self.configuration.external_ip = Some(external_ip.to_owned());
+            self.configuration.external_ip = Some(external_ip.to_owned().parse().expect("valid IP address"));
             self
         }
 

--- a/src/servers/udp/server.rs
+++ b/src/servers/udp/server.rs
@@ -463,19 +463,16 @@ mod tests {
         let cfg = Arc::new(ephemeral_mode_public());
         let tracker = initialize_with_configuration(&cfg);
         let config = &cfg.udp_trackers[0];
-
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
-
+        let bind_to = config.bind_address;
         let register = &Registar::default();
 
         let stopped = UdpServer::new(Launcher::new(bind_to));
+
         let started = stopped
             .start(tracker, register.give_form())
             .await
             .expect("it should start the server");
+
         let stopped = started.stop().await.expect("it should stop the server");
 
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -33,13 +33,9 @@ impl Environment<Stopped> {
 
         let config = Arc::new(configuration.http_api.clone());
 
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
-        let tls = block_on(make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path))
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = block_on(make_rust_tls(config.ssl_enabled, &config.tsl_config)).map(|tls| tls.expect("tls config failed"));
 
         let server = ApiServer::new(Launcher::new(bind_to, tls));
 

--- a/tests/servers/health_check_api/environment.rs
+++ b/tests/servers/health_check_api/environment.rs
@@ -33,10 +33,7 @@ pub struct Environment<S> {
 
 impl Environment<Stopped> {
     pub fn new(config: &Arc<HealthCheckApi>, registar: Registar) -> Self {
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
         Self {
             registar,

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -31,13 +31,14 @@ impl Environment<Stopped> {
 
         let config = Arc::new(configuration.http_trackers[0].clone());
 
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
-        let tls = block_on(make_rust_tls(config.ssl_enabled, &config.ssl_cert_path, &config.ssl_key_path))
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = block_on(make_rust_tls(
+            config.ssl_enabled,
+            &config.tsl_config.ssl_cert_path,
+            &config.tsl_config.ssl_key_path,
+        ))
+        .map(|tls| tls.expect("tls config failed"));
 
         let server = HttpServer::new(Launcher::new(bind_to, tls));
 

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::executor::block_on;
 use torrust_tracker::bootstrap::app::initialize_with_configuration;
-use torrust_tracker::bootstrap::jobs::make_rust_tls_from_path_buf;
+use torrust_tracker::bootstrap::jobs::make_rust_tls;
 use torrust_tracker::core::Tracker;
 use torrust_tracker::servers::http::server::{HttpServer, Launcher, Running, Stopped};
 use torrust_tracker::servers::registar::Registar;
@@ -33,12 +33,7 @@ impl Environment<Stopped> {
 
         let bind_to = config.bind_address;
 
-        let tls = block_on(make_rust_tls_from_path_buf(
-            config.ssl_enabled,
-            &config.tsl_config.ssl_cert_path,
-            &config.tsl_config.ssl_key_path,
-        ))
-        .map(|tls| tls.expect("tls config failed"));
+        let tls = block_on(make_rust_tls(config.ssl_enabled, &config.tsl_config)).map(|tls| tls.expect("tls config failed"));
 
         let server = HttpServer::new(Launcher::new(bind_to, tls));
 

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::executor::block_on;
 use torrust_tracker::bootstrap::app::initialize_with_configuration;
-use torrust_tracker::bootstrap::jobs::make_rust_tls;
+use torrust_tracker::bootstrap::jobs::make_rust_tls_from_path_buf;
 use torrust_tracker::core::Tracker;
 use torrust_tracker::servers::http::server::{HttpServer, Launcher, Running, Stopped};
 use torrust_tracker::servers::registar::Registar;
@@ -33,7 +33,7 @@ impl Environment<Stopped> {
 
         let bind_to = config.bind_address;
 
-        let tls = block_on(make_rust_tls(
+        let tls = block_on(make_rust_tls_from_path_buf(
             config.ssl_enabled,
             &config.tsl_config.ssl_cert_path,
             &config.tsl_config.ssl_key_path,

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -31,10 +31,7 @@ impl Environment<Stopped> {
 
         let config = Arc::new(configuration.udp_trackers[0].clone());
 
-        let bind_to = config
-            .bind_address
-            .parse::<std::net::SocketAddr>()
-            .expect("Tracker API bind_address invalid.");
+        let bind_to = config.bind_address;
 
         let server = UdpServer::new(Launcher::new(bind_to));
 


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/pull/790

Refactor: enrich field types in configuration structs.

This will cause the app to fail earlier while loading invalid configurations and simplify the code by reducing conversions to get the rich type from the primitive when it's used.

- [x] `HealthCheckApi`
- [x] `UdpTracker`
- [x] `HttpTracker`
- [x] `HttpApi`
- [x] `Configuration`

Output example when you provide an invalid socket address:

```output
$ cargo run
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.10s
     Running `target/debug/torrust-tracker`
Loading default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
thread 'main' panicked at src/bootstrap/config.rs:45:32:
called `Result::unwrap()` on an `Err` value: ConfigError { source: LocatedError { source: Error { tag: Tag(Default, 2), profile: Some(Profile(Uncased { string: "default" })), metadata: Some(Metadata { name: "TOML source string", source: None, provide_location: Some(Location { file: "packages/configuration/src/v1/mod.rs", line: 397, col: 14 }), interpolater:  }), path: ["health_check_api", "bind_address"], kind: Message("invalid socket address syntax"), prev: None }, location: Location { file: "packages/configuration/src/v1/mod.rs", line: 400, col: 41 } } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

You get that error proving this config option:

```toml
[health_check_api]
bind_address = "127.0.0.1-1313"
```

The error contains all the information needed, although it could be more user-friendly. Maybe we can map that error to a simpler explanation like this:

```
Configuration error: invalid socket address provided in toml file PATH in section `health_check_api` option `bind_address`.
```
