### PR TITLE
Refactor: tracker core service only needs the core config

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -445,7 +445,8 @@ use derive_more::Constructor;
 use log::debug;
 use tokio::sync::mpsc::error::SendError;
 use torrust_tracker_clock::clock::Time;
-use torrust_tracker_configuration::{AnnouncePolicy, Configuration, TrackerPolicy, TORRENT_PEERS_LIMIT};
+use torrust_tracker_configuration::v1::core::Core;
+use torrust_tracker_configuration::{AnnouncePolicy, TrackerPolicy, TORRENT_PEERS_LIMIT};
 use torrust_tracker_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
 use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
@@ -540,17 +541,17 @@ impl Tracker {
     ///
     /// Will return a `databases::error::Error` if unable to connect to database. The `Tracker` is responsible for the persistence.
     pub fn new(
-        config: &Configuration,
+        config: &Core,
         stats_event_sender: Option<Box<dyn statistics::EventSender>>,
         stats_repository: statistics::Repo,
     ) -> Result<Tracker, databases::error::Error> {
-        let database = Arc::new(databases::driver::build(&config.core.db_driver, &config.core.db_path)?);
+        let database = Arc::new(databases::driver::build(&config.db_driver, &config.db_path)?);
 
-        let mode = config.core.mode;
+        let mode = config.mode;
 
         Ok(Tracker {
             //config,
-            announce_policy: AnnouncePolicy::new(config.core.announce_interval, config.core.min_announce_interval),
+            announce_policy: AnnouncePolicy::new(config.announce_interval, config.min_announce_interval),
             mode,
             keys: tokio::sync::RwLock::new(std::collections::HashMap::new()),
             whitelist: tokio::sync::RwLock::new(std::collections::HashSet::new()),
@@ -558,13 +559,13 @@ impl Tracker {
             stats_event_sender,
             stats_repository,
             database,
-            external_ip: config.get_ext_ip(),
+            external_ip: config.external_ip,
             policy: TrackerPolicy::new(
-                config.core.remove_peerless_torrents,
-                config.core.max_peer_timeout,
-                config.core.persistent_torrent_completed_stat,
+                config.remove_peerless_torrents,
+                config.max_peer_timeout,
+                config.persistent_torrent_completed_stat,
             ),
-            on_reverse_proxy: config.core.on_reverse_proxy,
+            on_reverse_proxy: config.on_reverse_proxy,
         })
     }
 

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -24,7 +24,7 @@ pub fn tracker_factory(config: &Configuration) -> Tracker {
     let (stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
     // Initialize Torrust tracker
-    match Tracker::new(&Arc::new(config), stats_event_sender, stats_repository) {
+    match Tracker::new(&Arc::new(config).core, stats_event_sender, stats_repository) {
         Ok(tracker) => tracker,
         Err(error) => {
             panic!("{}", error)

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -135,8 +135,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let mut peer = sample_peer_using_ipv4();
 
@@ -149,7 +155,7 @@ mod tests {
                 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
             )));
 
-            Tracker::new(&configuration, Some(stats_event_sender), statistics::Repo::new()).unwrap()
+            Tracker::new(&configuration.core, Some(stats_event_sender), statistics::Repo::new()).unwrap()
         }
 
         fn peer_with_the_ipv4_loopback_ip() -> peer::Peer {
@@ -194,8 +200,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let mut peer = sample_peer_using_ipv6();
 

--- a/src/servers/http/v1/services/scrape.rs
+++ b/src/servers/http/v1/services/scrape.rs
@@ -146,8 +146,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let peer_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1));
 
@@ -164,8 +170,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let peer_ip = IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969));
 
@@ -217,8 +229,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let peer_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1));
 
@@ -235,8 +253,14 @@ mod tests {
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
-            let tracker =
-                Arc::new(Tracker::new(&configuration::ephemeral(), Some(stats_event_sender), statistics::Repo::new()).unwrap());
+            let tracker = Arc::new(
+                Tracker::new(
+                    &configuration::ephemeral().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
+            );
 
             let peer_ip = IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969));
 

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -506,7 +506,12 @@ mod tests {
             let client_socket_address = sample_ipv4_socket_address();
 
             let torrent_tracker = Arc::new(
-                core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                core::Tracker::new(
+                    &tracker_configuration().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
             );
             handle_connect(client_socket_address, &sample_connect_request(), &torrent_tracker)
                 .await
@@ -524,7 +529,12 @@ mod tests {
             let stats_event_sender = Box::new(stats_event_sender_mock);
 
             let torrent_tracker = Arc::new(
-                core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                core::Tracker::new(
+                    &tracker_configuration().core,
+                    Some(stats_event_sender),
+                    statistics::Repo::new(),
+                )
+                .unwrap(),
             );
             handle_connect(sample_ipv6_remote_addr(), &sample_connect_request(), &torrent_tracker)
                 .await
@@ -768,7 +778,12 @@ mod tests {
                 let stats_event_sender = Box::new(stats_event_sender_mock);
 
                 let tracker = Arc::new(
-                    core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                    core::Tracker::new(
+                        &tracker_configuration().core,
+                        Some(stats_event_sender),
+                        statistics::Repo::new(),
+                    )
+                    .unwrap(),
                 );
 
                 handle_announce(
@@ -997,7 +1012,12 @@ mod tests {
                 let stats_event_sender = Box::new(stats_event_sender_mock);
 
                 let tracker = Arc::new(
-                    core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                    core::Tracker::new(
+                        &tracker_configuration().core,
+                        Some(stats_event_sender),
+                        statistics::Repo::new(),
+                    )
+                    .unwrap(),
                 );
 
                 let remote_addr = sample_ipv6_remote_addr();
@@ -1027,7 +1047,7 @@ mod tests {
                     let configuration = Arc::new(TrackerConfigurationBuilder::default().with_external_ip("::126.0.0.1").into());
                     let (stats_event_sender, stats_repository) = Keeper::new_active_instance();
                     let tracker =
-                        Arc::new(core::Tracker::new(&configuration, Some(stats_event_sender), stats_repository).unwrap());
+                        Arc::new(core::Tracker::new(&configuration.core, Some(stats_event_sender), stats_repository).unwrap());
 
                     let loopback_ipv4 = Ipv4Addr::new(127, 0, 0, 1);
                     let loopback_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);
@@ -1305,7 +1325,12 @@ mod tests {
 
                 let remote_addr = sample_ipv4_remote_addr();
                 let tracker = Arc::new(
-                    core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                    core::Tracker::new(
+                        &tracker_configuration().core,
+                        Some(stats_event_sender),
+                        statistics::Repo::new(),
+                    )
+                    .unwrap(),
                 );
 
                 handle_scrape(remote_addr, &sample_scrape_request(&remote_addr), &tracker)
@@ -1337,7 +1362,12 @@ mod tests {
 
                 let remote_addr = sample_ipv6_remote_addr();
                 let tracker = Arc::new(
-                    core::Tracker::new(&tracker_configuration(), Some(stats_event_sender), statistics::Repo::new()).unwrap(),
+                    core::Tracker::new(
+                        &tracker_configuration().core,
+                        Some(stats_event_sender),
+                        statistics::Repo::new(),
+                    )
+                    .unwrap(),
                 );
 
                 handle_scrape(remote_addr, &sample_scrape_request(&remote_addr), &tracker)


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/issues/401

After [extracting the `Core` config type](https://github.com/torrust/torrust-tracker/pull/854/commits/b545b33c17b3f71591a98dba9aeab84294cd1a62), we don't need to pass the whole configuration to the tracker core service. We can pass only its config.