### PR TITLE
Show `toml` file location in Figment errors

### DIFF
--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -20,6 +20,19 @@ use torrust_tracker_located_error::{DynError, LocatedError};
 /// The maximum number of returned peers for a torrent.
 pub const TORRENT_PEERS_LIMIT: usize = 74;
 
+// Environment variables
+
+/// The whole `tracker.toml` file content. It has priority over the config file.
+/// Even if the file is not on the default path.
+const ENV_VAR_CONFIG: &str = "TORRUST_TRACKER_CONFIG";
+
+/// The `tracker.toml` file location.
+pub const ENV_VAR_PATH_CONFIG: &str = "TORRUST_TRACKER_PATH_CONFIG";
+
+/// Env var to overwrite API admin token.
+/// Deprecated: use `TORRUST_TRACKER_CONFIG_OVERRIDE_HTTP_API__ACCESS_TOKENS__ADMIN`.
+const ENV_VAR_API_ADMIN_TOKEN: &str = "TORRUST_TRACKER_API_ADMIN_TOKEN";
+
 pub type Configuration = v1::Configuration;
 pub type UdpTracker = v1::udp_tracker::UdpTracker;
 pub type HttpTracker = v1::http_tracker::HttpTracker;
@@ -51,12 +64,11 @@ impl Info {
     /// Will return `Err` if unable to obtain a configuration.
     ///
     #[allow(clippy::needless_pass_by_value)]
-    pub fn new(
-        env_var_config_toml: String,
-        env_var_config_toml_path: String,
-        default_config_toml_path: String,
-        env_var_api_admin_token: String,
-    ) -> Result<Self, Error> {
+    pub fn new(default_config_toml_path: String) -> Result<Self, Error> {
+        let env_var_config_toml = ENV_VAR_CONFIG.to_string();
+        let env_var_config_toml_path = ENV_VAR_PATH_CONFIG.to_string();
+        let env_var_api_admin_token = ENV_VAR_API_ADMIN_TOKEN.to_string();
+
         let config_toml = if let Ok(config_toml) = env::var(env_var_config_toml) {
             println!("Loading configuration from environment variable {config_toml} ...");
             Some(config_toml)

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -4,17 +4,6 @@
 
 use torrust_tracker_configuration::{Configuration, Info};
 
-// Environment variables
-
-/// The whole `tracker.toml` file content. It has priority over the config file.
-/// Even if the file is not on the default path.
-const ENV_VAR_CONFIG: &str = "TORRUST_TRACKER_CONFIG";
-const ENV_VAR_API_ADMIN_TOKEN: &str = "TORRUST_TRACKER_API_ADMIN_TOKEN";
-
-/// The `tracker.toml` file location.
-pub const ENV_VAR_PATH_CONFIG: &str = "TORRUST_TRACKER_PATH_CONFIG";
-
-// Default values
 pub const DEFAULT_PATH_CONFIG: &str = "./share/default/config/tracker.development.sqlite3.toml";
 
 /// It loads the application configuration from the environment.
@@ -34,15 +23,8 @@ pub const DEFAULT_PATH_CONFIG: &str = "./share/default/config/tracker.developmen
 /// `./tracker.toml` file or the env var `TORRUST_TRACKER_CONFIG`.
 #[must_use]
 pub fn initialize_configuration() -> Configuration {
-    let info = Info::new(
-        ENV_VAR_CONFIG.to_string(),
-        ENV_VAR_PATH_CONFIG.to_string(),
-        DEFAULT_PATH_CONFIG.to_string(),
-        ENV_VAR_API_ADMIN_TOKEN.to_string(),
-    )
-    .unwrap();
-
-    Configuration::load(&info).unwrap()
+    let info = Info::new(DEFAULT_PATH_CONFIG.to_string()).expect("info to load configuration is not valid");
+    Configuration::load(&info).expect("configuration should be loaded from provided info")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Before this PR, we loaded the configuration in Figment, always using a Toml string, even if the configuration came from a Toml file. When there is an error, Figment does not show the file location, and that's one of the main advantages of using Figment. All errors point to the primary source of the configuration option.

This commit fixes the problem of Figment not showing the file location when the user provides a file and there is an error.

Sample error:

```
Loading configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
thread 'main' panicked at src/bootstrap/config.rs:45:32:
called `Result::unwrap()` on an `Err` value: ConfigError { source: LocatedError { source: Error { tag: Tag(Default, 2), profile: Some(Profile(Uncased { string: "default" })), metadata: Some(Metadata { name: "TOML file", source: Some(File("/home/developer/torrust/torrust-tracker/./share/default/config/tracker.development.sqlite3.toml")), provide_location: Some(Location { file: "packages/configuration/src/v1/mod.rs", line: 330, col: 18 }), interpolater:  }), path: [], kind: Message("TOML parse error at line 2, column 15\n  |\n2 | enabled = truee\n  |               ^\nexpected newline, `#`\n"), prev: None }, location: Location { file: "packages/configuration/src/v1/mod.rs", line: 334, col: 41 } } }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Notice how the file path is included is the error: `/home/developer/torrust/torrust-tracker/./share/default/config/tracker.development.sqlite3.toml`