### PR TITLE
Add privacy methods to the `TrackerMode` enum

### DIFF
--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -67,7 +67,7 @@ pub type PersistentTorrents = BTreeMap<InfoHash, u32>;
 ///
 /// Refer to [Torrust Tracker Configuration](https://docs.rs/torrust-tracker-configuration)
 /// to know how to configure the tracker to run in each mode.
-#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub enum TrackerMode {
     /// Will track every new info hash and serve every peer.
     #[serde(rename = "public")]

--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -85,3 +85,21 @@ pub enum TrackerMode {
     #[serde(rename = "private_listed")]
     PrivateListed,
 }
+
+impl Default for TrackerMode {
+    fn default() -> Self {
+        Self::Public
+    }
+}
+
+impl TrackerMode {
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        matches!(self, TrackerMode::Public | TrackerMode::Listed)
+    }
+
+    #[must_use]
+    pub fn is_close(&self) -> bool {
+        !self.is_open()
+    }
+}

--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -5,6 +5,8 @@
 //! by the tracker server crate, but also by other crates in the Torrust
 //! ecosystem.
 use std::collections::BTreeMap;
+use std::fmt;
+use std::str::FromStr;
 use std::time::Duration;
 
 use info_hash::InfoHash;
@@ -89,6 +91,32 @@ pub enum TrackerMode {
 impl Default for TrackerMode {
     fn default() -> Self {
         Self::Public
+    }
+}
+
+impl fmt::Display for TrackerMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let display_str = match self {
+            TrackerMode::Public => "public",
+            TrackerMode::Listed => "listed",
+            TrackerMode::Private => "private",
+            TrackerMode::PrivateListed => "private_listed",
+        };
+        write!(f, "{display_str}")
+    }
+}
+
+impl FromStr for TrackerMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "public" => Ok(TrackerMode::Public),
+            "listed" => Ok(TrackerMode::Listed),
+            "private" => Ok(TrackerMode::Private),
+            "private_listed" => Ok(TrackerMode::PrivateListed),
+            _ => Err(format!("Unknown tracker mode: {s}")),
+        }
     }
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -547,7 +547,7 @@ impl Tracker {
     ) -> Result<Tracker, databases::error::Error> {
         let database = Arc::new(databases::driver::build(&config.db_driver, &config.db_path)?);
 
-        let mode = config.mode;
+        let mode = config.mode.clone();
 
         Ok(Tracker {
             //config,


### PR DESCRIPTION
The tracker mode can be:

- Public (Non-whitelisted)
- Listed (Whitelisted)
- Private (Non-whitelisted)
- PrivateListed (Whitelisted)

There should have been two different flags (in my opinion):

- Visibility: public or private
- Whitelisted: true or false

So we would have the same four combinations:

- Not whitelisted:
  - Public
  - Private
- Whitelisted
  - Public
  - Private

That's a pending refactor. For this PR, the goal is just to align this enum with what we added to the Index so we can use it in the Index via the primitive crate.

See https://github.com/torrust/torrust-index/blob/develop/src/config.rs#L140-L171