### PR TITLE
Use `clap` and `anyhow`crates in E2E test runner

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -152,4 +152,4 @@ jobs:
 
       - id: test
         name: Run E2E Tests
-        run: cargo run --bin e2e_tests_runner ./share/default/config/tracker.e2e.container.sqlite3.toml
+        run: cargo run --bin e2e_tests_runner -- --config-toml-path "./share/default/config/tracker.e2e.container.sqlite3.toml"

--- a/src/bin/e2e_tests_runner.rs
+++ b/src/bin/e2e_tests_runner.rs
@@ -1,6 +1,6 @@
 //! Program to run E2E tests.
 use torrust_tracker::console::ci::e2e;
 
-fn main() {
-    e2e::runner::run();
+fn main() -> anyhow::Result<()> {
+    e2e::runner::run()
 }


### PR DESCRIPTION
You can execute the E2E runner with:

```bash
cargo run --bin e2e_tests_runner -- --config-toml-path "./share/default/config/tracker.e2e.container.sqlite3.toml"
```

Or:

```bash
TORRUST_TRACKER_CONFIG_TOML_PATH="./share/default/config/tracker.e2e.container.sqlite3.toml" cargo run --bin e2e_tests_runner
```

Or:

```bash
TORRUST_TRACKER_CONFIG_TOML=$(cat "./share/default/config/tracker.e2e.container.sqlite3.toml") cargo run --bin e2e_tests_runner
```