### PR TITLE
Enable colour in console output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4067,6 +4067,7 @@ dependencies = [
  "r2d2_mysql",
  "r2d2_sqlite",
  "rand",
+ "regex",
  "reqwest",
  "ringbuf",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ r2d2 = "0"
 r2d2_mysql = "24"
 r2d2_sqlite = { version = "0", features = ["bundled"] }
 rand = "0"
+regex = "1.10.5"
 reqwest = { version = "0", features = ["json"] }
 ringbuf = "0"
 serde = { version = "1", features = ["derive"] }

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -46,7 +46,7 @@ fn config_level_or_default(log_level: &Option<LogLevel>) -> LevelFilter {
 }
 
 fn tracing_stdout_init(filter: LevelFilter, style: &TraceStyle) {
-    let builder = tracing_subscriber::fmt().with_max_level(filter).with_ansi(false);
+    let builder = tracing_subscriber::fmt().with_max_level(filter).with_ansi(true);
 
     let () = match style {
         TraceStyle::Default => builder.init(),

--- a/src/console/ci/e2e/runner.rs
+++ b/src/console/ci/e2e/runner.rs
@@ -116,7 +116,7 @@ pub fn run() -> anyhow::Result<()> {
 }
 
 fn tracing_stdout_init(filter: LevelFilter) {
-    tracing_subscriber::fmt().with_max_level(filter).with_ansi(false).init();
+    tracing_subscriber::fmt().with_max_level(filter).init();
     info!("Logging initialized.");
 }
 

--- a/src/console/clients/checker/app.rs
+++ b/src/console/clients/checker/app.rs
@@ -58,7 +58,7 @@ pub async fn run() -> Result<Vec<CheckResult>> {
 }
 
 fn tracing_stdout_init(filter: LevelFilter) {
-    tracing_subscriber::fmt().with_max_level(filter).with_ansi(false).init();
+    tracing_subscriber::fmt().with_max_level(filter).init();
     info!("logging initialized.");
 }
 

--- a/src/console/clients/udp/app.rs
+++ b/src/console/clients/udp/app.rs
@@ -127,7 +127,7 @@ pub async fn run() -> anyhow::Result<()> {
 }
 
 fn tracing_stdout_init(filter: LevelFilter) {
-    tracing_subscriber::fmt().with_max_level(filter).with_ansi(false).init();
+    tracing_subscriber::fmt().with_max_level(filter).init();
     info!("logging initialized.");
 }
 


### PR DESCRIPTION
Enable colour in console output.

We were using the `logging` crate for logging. [We move to `tracing`](https://github.com/torrust/torrust-tracker/issues/884) but keeping the same format for logs. The only difference was the colour introduced by the `tracing` crate. This is just a patch to allow using color with tracing. We parse the logs to extract the running services for example from these lines:

```
2024-06-10T16:07:39.989540Z  INFO torrust_tracker::bootstrap::logging: logging initialized.
2024-06-10T16:07:39.990205Z  INFO UDP TRACKER: Starting on: udp://0.0.0.0:6868
2024-06-10T16:07:39.990215Z  INFO UDP TRACKER: Started on: udp://0.0.0.0:6868
2024-06-10T16:07:39.990244Z  INFO UDP TRACKER: Starting on: udp://0.0.0.0:6969
2024-06-10T16:07:39.990255Z  INFO UDP TRACKER: Started on: udp://0.0.0.0:6969
2024-06-10T16:07:39.990261Z  INFO torrust_tracker::bootstrap::jobs: TLS not enabled
2024-06-10T16:07:39.990303Z  INFO HTTP TRACKER: Starting on: http://0.0.0.0:7070
2024-06-10T16:07:39.990439Z  INFO HTTP TRACKER: Started on: http://0.0.0.0:7070
2024-06-10T16:07:39.990448Z  INFO torrust_tracker::bootstrap::jobs: TLS not enabled
2024-06-10T16:07:39.990563Z  INFO API: Starting on http://127.0.0.1:1212
2024-06-10T16:07:39.990565Z  INFO API: Started on http://127.0.0.1:1212
2024-06-10T16:07:39.990577Z  INFO HEALTH CHECK API: Starting on: http://127.0.0.1:1313
2024-06-10T16:07:39.990638Z  INFO HEALTH CHECK API: Started on: http://127.0.0.1:1313
```

We extract these running services:

```json
{
  "udp_trackers": [
    "127.0.0.1:6969"
  ],
  "http_trackers": [
    "http://127.0.0.1:7070"
  ],
  "health_checks": [
    "http://127.0.0.1:1313/health_check"
  ]
}
```

We should refactor the output format to take advantage of the new `tracing` crate. [`tracing` supports structured fields on spans and events](https://docs.rs/tracing/latest/tracing/#recording-fields), so it would be easier to parse those services.