### PR TITLE
Fixes docker build error: `failed to load bitcode of module criterion ...`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ members = [
 
 [profile.dev]
 debug = 1
-lto = "thin"
+lto = "fat"
 opt-level = 1
 
 [profile.release]


### PR DESCRIPTION
Fixes docker build error: `failed to load bitcode of module criterion ...`

Command:

```
docker build --target release --tag torrust-tracker:release --file Containerfile .
```

Error:

```s
 => ERROR [build 3/3] RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-  56.8s
------
 > [build 3/3] RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/torrust-tracker.tar.zst --release:
0.674    Compiling torrust-tracker-located-error v3.0.0-alpha.12-develop (/build/src/packages/located-error)
0.675    Compiling torrust-tracker-primitives v3.0.0-alpha.12-develop (/build/src/packages/primitives)
0.679    Compiling torrust-tracker-contrib-bencode v3.0.0-alpha.12-develop (/build/src/contrib/bencode)
0.763    Compiling torrust-tracker-configuration v3.0.0-alpha.12-develop (/build/src/packages/configuration)
0.763    Compiling torrust-tracker-clock v3.0.0-alpha.12-develop (/build/src/packages/clock)
0.936    Compiling torrust-tracker-torrent-repository v3.0.0-alpha.12-develop (/build/src/packages/torrent-repository)
0.936    Compiling torrust-tracker-test-helpers v3.0.0-alpha.12-develop (/build/src/packages/test-helpers)
1.181    Compiling torrust-tracker v3.0.0-alpha.12-develop (/build/src)
1.891 warning: Invalid value (Producer: 'LLVM18.1.7-rust-1.79.0-stable' Reader: 'LLVM 18.1.7-rust-1.79.0-stable')
1.891
1.891 error: failed to load bitcode of module "criterion-af9a3f7183f1573d.criterion.b69900c842eb33fa-cgu.08.rcgu.o":
1.891
1.991 warning: `torrust-tracker-contrib-bencode` (bench "bencode_benchmark") generated 1 warning
1.991 error: could not compile `torrust-tracker-contrib-bencode` (bench "bencode_benchmark") due to 1 previous error; 1 warning emitted
1.991 warning: build failed, waiting for other jobs to finish...
3.936 warning: `torrust-tracker-torrent-repository` (bench "repository_benchmark") generated 1 warning (1 duplicate)
3.936 error: could not compile `torrust-tracker-torrent-repository` (bench "repository_benchmark") due to 1 previous error; 1 warning emitted
56.80 error: command `/usr/local/rustup/toolchains/1.79.0-x86_64-unknown-linux-gnu/bin/cargo test --no-run --message-format json-render-diagnostics --workspace --examples --tests --benches --all-targets --all-features --release` exited with code 101
------
Containerfile:61
--------------------
  59 |     WORKDIR /build/src
  60 |     COPY . /build/src
  61 | >>> RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/torrust-tracker.tar.zst --release
  62 |
  63 |
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/torrust-tracker.tar.zst --release" did not complete successfully: exit code: 101
```

- Docker: version 25.0.2, build 29cf629
- Rust: nightly-x86_64-unknown-linux-gnu (default). rustc 1.81.0-nightly (d7f6ebace 2024-06-16)