### PR TITLE
Fix: clients output in JSON should not include logging

### DIFF
--- a/src/console/clients/checker/app.rs
+++ b/src/console/clients/checker/app.rs
@@ -12,12 +12,56 @@
 //! ```text
 //! TORRUST_CHECKER_CONFIG=$(cat "./share/default/config/tracker_checker.json") cargo run --bin tracker_checker
 //! ```
+//!
+//! Another real example to test the Torrust demo tracker:
+//!
+//! ```text
+//! TORRUST_CHECKER_CONFIG='{
+//!     "udp_trackers": ["144.126.245.19:6969"],
+//!     "http_trackers": ["https://tracker.torrust-demo.com"],
+//!     "health_checks": ["https://tracker.torrust-demo.com/api/health_check"]
+//! }' cargo run --bin tracker_checker
+//! ```
+//!
+//! The output should be something like the following:
+//!
+//! ```json
+//! {
+//!   "udp_trackers": [
+//!     {
+//!       "url": "144.126.245.19:6969",
+//!       "status": {
+//!         "code": "ok",
+//!         "message": ""
+//!       }
+//!     }
+//!   ],
+//!   "http_trackers": [
+//!     {
+//!       "url": "https://tracker.torrust-demo.com/",
+//!       "status": {
+//!         "code": "ok",
+//!         "message": ""
+//!       }
+//!     }
+//!   ],
+//!   "health_checks": [
+//!     {
+//!       "url": "https://tracker.torrust-demo.com/api/health_check",
+//!       "status": {
+//!         "code": "ok",
+//!         "message": ""
+//!       }
+//!     }
+//!   ]
+//! }
+//! ```
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use tracing::info;
+use tracing::debug;
 use tracing::level_filters::LevelFilter;
 
 use super::config::Configuration;
@@ -59,7 +103,7 @@ pub async fn run() -> Result<Vec<CheckResult>> {
 
 fn tracing_stdout_init(filter: LevelFilter) {
     tracing_subscriber::fmt().with_max_level(filter).init();
-    info!("logging initialized.");
+    debug!("logging initialized.");
 }
 
 fn setup_config(args: Args) -> Result<Configuration> {

--- a/src/console/clients/udp/app.rs
+++ b/src/console/clients/udp/app.rs
@@ -63,8 +63,8 @@ use anyhow::Context;
 use aquatic_udp_protocol::{Port, Response, TransactionId};
 use clap::{Parser, Subcommand};
 use torrust_tracker_primitives::info_hash::InfoHash as TorrustInfoHash;
+use tracing::debug;
 use tracing::level_filters::LevelFilter;
-use tracing::{debug, info};
 use url::Url;
 
 use crate::console::clients::udp::checker;
@@ -128,7 +128,7 @@ pub async fn run() -> anyhow::Result<()> {
 
 fn tracing_stdout_init(filter: LevelFilter) {
     tracing_subscriber::fmt().with_max_level(filter).init();
-    info!("logging initialized.");
+    debug!("logging initialized.");
 }
 
 async fn handle_announce(tracker_socket_addr: &SocketAddr, info_hash: &TorrustInfoHash) -> anyhow::Result<Response> {


### PR DESCRIPTION
The console clients' output should not include logging info when the output is JSON. IT fixes this behavior:

Command:

```s
$ cargo run --bin udp_tracker_client announce 144.126.245.19:6969 9c38422213e30bff212b30c360d26f9a02136422 
    Finished `dev` profile [optimized + debuginfo] target(s) in 0.09s
     Running `target/debug/udp_tracker_client announce '144.126.245.19:6969' 9c38422213e30bff212b30c360d26f9a02136422`

Output:

```s
2024-06-26T07:46:10.051490Z  INFO torrust_tracker::console::clients::udp::app: logging initialized.
{
  "AnnounceIpv4": {
    "transaction_id": -888840697,
    "announce_interval": 300,
    "leechers": 0,
    "seeders": 1,
    "peers": []
  }
}
```

The line `2024-06-26T07:46:10.051490Z  INFO torrust_tracker::console::clients::udp::app: logging initialized.` or any other lines should not be included. I will open a discussion about how to deal with logging in console clients.