### PR TITLE
Performace experiment: Hardcoded announce response

### DIFF
--- a/src/servers/udp/server/request_buffer.rs
+++ b/src/servers/udp/server/request_buffer.rs
@@ -4,10 +4,15 @@ use tokio::task::AbortHandle;
 
 use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 
-/// Ring-Buffer of Active Requests
+/// A ring buffer for managing active UDP request abort handles.
+///
+/// The `ActiveRequests` struct maintains a fixed-size ring buffer of abort
+/// handles for UDP request processor tasks. It ensures that at most 50 requests
+/// are handled concurrently, and provides mechanisms to handle buffer overflow
+/// by removing finished or oldest unfinished tasks.
 #[derive(Default)]
 pub struct ActiveRequests {
-    rb: StaticRb<AbortHandle, 50>, // the number of requests we handle at the same time.
+    rb: StaticRb<AbortHandle, 50>, // The number of requests handled simultaneously.
 }
 
 impl std::fmt::Debug for ActiveRequests {
@@ -29,67 +34,103 @@ impl Drop for ActiveRequests {
 }
 
 impl ActiveRequests {
-    /// It inserts the abort handle for the UDP request processor tasks.
+    /// Inserts an abort handle for a UDP request processor task.
     ///
-    /// If there is no room for the new task, it tries to make place:
+    /// If the buffer is full, this method attempts to make space by:
     ///
-    /// - Firstly, removing finished tasks.
-    /// - Secondly, removing the oldest unfinished tasks.
+    /// 1. Removing finished tasks.
+    /// 2. Removing the oldest unfinished task if no finished tasks are found.
     ///
     /// # Panics
     ///
-    /// Will panics if it can't make space for the new handle.
+    /// This method will panic if it cannot make space for adding a new handle.
+    ///
+    /// # Arguments
+    ///
+    /// * `abort_handle` - The `AbortHandle` for the UDP request processor task.
+    /// * `local_addr` - A string slice representing the local address for logging.
     pub async fn force_push(&mut self, abort_handle: AbortHandle, local_addr: &str) {
-        // fill buffer with requests
-        let Err(abort_handle) = self.rb.try_push(abort_handle) else {
-            return;
+        // Attempt to add the new handle to the buffer.
+        match self.rb.try_push(abort_handle) {
+            Ok(()) => {
+                // Successfully added the task, no further action needed.
+            }
+            Err(abort_handle) => {
+                // Buffer is full, attempt to make space.
+
+                let mut finished: u64 = 0;
+                let mut unfinished_task = None;
+
+                for removed_abort_handle in self.rb.pop_iter() {
+                    // We found a finished tasks ... increase the counter and
+                    // continue searching for more and ...
+                    if removed_abort_handle.is_finished() {
+                        finished += 1;
+                        continue;
+                    }
+
+                    // The current removed tasks is not finished.
+
+                    // Give it a second chance to finish.
+                    tokio::task::yield_now().await;
+
+                    // Recheck if it finished ... increase the counter and
+                    // continue searching for more and ...
+                    if removed_abort_handle.is_finished() {
+                        finished += 1;
+                        continue;
+                    }
+
+                    // At this point we found a "definitive" unfinished task.
+
+                    // Log unfinished task.
+                    tracing::debug!(
+                        target: UDP_TRACKER_LOG_TARGET,
+                        local_addr,
+                        removed_count = finished,
+                        "Udp::run_udp_server::loop (got unfinished task)"
+                    );
+
+                    // If no finished tasks were found, abort the current
+                    // unfinished task.
+                    if finished == 0 {
+                        // We make place aborting this task.
+                        removed_abort_handle.abort();
+
+                        tracing::warn!(
+                            target: UDP_TRACKER_LOG_TARGET,
+                            local_addr,
+                            "Udp::run_udp_server::loop aborting request: (no finished tasks)"
+                        );
+
+                        break;
+                    }
+
+                    // At this point we found at least one finished task, but the
+                    // current one is not finished and it was removed from the
+                    // buffer, so we need to re-insert in in the buffer.
+
+                    // Save the unfinished task for re-entry.
+                    unfinished_task = Some(removed_abort_handle);
+                }
+
+                // After this point there can't be a race condition because only
+                // one thread owns the active buffer. There is no way for the
+                // buffer to be full again. That means the "expects" should
+                // never happen.
+
+                // Reinsert the unfinished task if any.
+                if let Some(h) = unfinished_task {
+                    self.rb.try_push(h).expect("it was previously inserted");
+                }
+
+                // Insert the new task, ensuring there's space.
+                if !abort_handle.is_finished() {
+                    self.rb
+                        .try_push(abort_handle)
+                        .expect("it should remove at least one element.");
+                }
+            }
         };
-
-        let mut finished: u64 = 0;
-        let mut unfinished_task = None;
-
-        // buffer is full.. lets make some space.
-        for h in self.rb.pop_iter() {
-            // remove some finished tasks
-            if h.is_finished() {
-                finished += 1;
-                continue;
-            }
-
-            // task is unfinished.. give it another chance.
-            tokio::task::yield_now().await;
-
-            // if now finished, we continue.
-            if h.is_finished() {
-                finished += 1;
-                continue;
-            }
-
-            tracing::debug!(target: UDP_TRACKER_LOG_TARGET, local_addr, removed_count = finished, "Udp::run_udp_server::loop (got unfinished task)");
-
-            if finished == 0 {
-                // we have _no_ finished tasks.. will abort the unfinished task to make space...
-                h.abort();
-
-                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, local_addr, "Udp::run_udp_server::loop aborting request: (no finished tasks)");
-
-                break;
-            }
-
-            // we have space, return unfinished task for re-entry.
-            unfinished_task = Some(h);
-        }
-
-        // re-insert the previous unfinished task.
-        if let Some(h) = unfinished_task {
-            self.rb.try_push(h).expect("it was previously inserted");
-        }
-
-        // insert the new task.
-        if !abort_handle.is_finished() {
-            self.rb
-                .try_push(abort_handle)
-                .expect("it should remove at least one element.");
-        }
     }
 }


### PR DESCRIPTION
I wanted to see how many UDP requests we could handle by hardcoding the "announce" response, eliminating the use of the torrent repository and its locks. This approach allows us to focus solely on the UDP layer's performance.

Surprisingly, the number of requests remained almost unchanged, indicating that the bottleneck likely lies within the UDP layer.

Additionally, it appears that the aquatic UDP load test initiates a new connection for each UDP request, as the numbers of connect and announce requests are similar.

I think I will hardcode the "connect" request, too, to see what happens.