### PR TITLE
Config overhaul: split tracker mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,7 +4054,6 @@ version = "3.0.0-alpha.12-develop"
 dependencies = [
  "rand",
  "torrust-tracker-configuration",
- "torrust-tracker-primitives",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ uuid = { version = "1", features = ["v4"] }
 zerocopy = "0.7.33"
 
 [package.metadata.cargo-machete]
-ignored = ["crossbeam-skiplist", "dashmap", "figment", "parking_lot", "serde_bytes", "torrust-tracker-primitives"]
+ignored = ["crossbeam-skiplist", "dashmap", "figment", "parking_lot", "serde_bytes"]
 
 [dev-dependencies]
 local-ip-address = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,12 +80,12 @@ tower-http = { version = "0", features = ["compression-full", "cors", "propagate
 trace = "0"
 tracing = "0"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
-url = {version = "2", features = ["serde"] }
+url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 zerocopy = "0.7.33"
 
 [package.metadata.cargo-machete]
-ignored = ["crossbeam-skiplist", "dashmap", "figment", "parking_lot", "serde_bytes"]
+ignored = ["crossbeam-skiplist", "dashmap", "figment", "parking_lot", "serde_bytes", "torrust-tracker-primitives"]
 
 [dev-dependencies]
 local-ip-address = "0"

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -35,10 +35,11 @@ const ENV_VAR_CONFIG_TOML: &str = "TORRUST_TRACKER_CONFIG_TOML";
 pub const ENV_VAR_CONFIG_TOML_PATH: &str = "TORRUST_TRACKER_CONFIG_TOML_PATH";
 
 pub type Configuration = v1::Configuration;
-pub type UdpTracker = v1::udp_tracker::UdpTracker;
-pub type HttpTracker = v1::http_tracker::HttpTracker;
-pub type HttpApi = v1::tracker_api::HttpApi;
+pub type Core = v1::core::Core;
 pub type HealthCheckApi = v1::health_check_api::HealthCheckApi;
+pub type HttpApi = v1::tracker_api::HttpApi;
+pub type HttpTracker = v1::http_tracker::HttpTracker;
+pub type UdpTracker = v1::udp_tracker::UdpTracker;
 
 pub type AccessTokens = HashMap<String, String>;
 

--- a/packages/configuration/src/v1/core.rs
+++ b/packages/configuration/src/v1/core.rs
@@ -21,6 +21,10 @@ pub struct Core {
     #[serde(default = "Core::default_inactive_peer_cleanup_interval")]
     pub inactive_peer_cleanup_interval: u64,
 
+    // Whe `true` only approved torrents can be announced in the tracker.
+    #[serde(default = "Core::default_listed")]
+    pub listed: bool,
+
     /// Tracker mode. See [`TrackerMode`] for more information.
     #[serde(default = "Core::default_mode")]
     pub mode: TrackerMode,
@@ -28,6 +32,10 @@ pub struct Core {
     // Network configuration.
     #[serde(default = "Core::default_network")]
     pub net: Network,
+
+    // Whe `true` clients require a key to connect and use the tracker.
+    #[serde(default = "Core::default_private")]
+    pub private: bool,
 
     // Tracker policy configuration.
     #[serde(default = "Core::default_tracker_policy")]
@@ -48,8 +56,10 @@ impl Default for Core {
             announce_policy: Self::default_announce_policy(),
             database: Self::default_database(),
             inactive_peer_cleanup_interval: Self::default_inactive_peer_cleanup_interval(),
+            listed: Self::default_listed(),
             mode: Self::default_mode(),
             net: Self::default_network(),
+            private: Self::default_private(),
             tracker_policy: Self::default_tracker_policy(),
             tracker_usage_statistics: Self::default_tracker_usage_statistics(),
         }
@@ -69,12 +79,20 @@ impl Core {
         600
     }
 
+    fn default_listed() -> bool {
+        false
+    }
+
     fn default_mode() -> TrackerMode {
         TrackerMode::Public
     }
 
     fn default_network() -> Network {
         Network::default()
+    }
+
+    fn default_private() -> bool {
+        false
     }
 
     fn default_tracker_policy() -> TrackerPolicy {

--- a/packages/configuration/src/v1/core.rs
+++ b/packages/configuration/src/v1/core.rs
@@ -8,27 +8,6 @@ use crate::{AnnouncePolicy, TrackerPolicy};
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Core {
-    /// Tracker mode. See [`TrackerMode`] for more information.
-    #[serde(default = "Core::default_mode")]
-    pub mode: TrackerMode,
-
-    /// Weather the tracker should collect statistics about tracker usage.
-    /// If enabled, the tracker will collect statistics like the number of
-    /// connections handled, the number of announce requests handled, etc.
-    /// Refer to the [`Tracker`](https://docs.rs/torrust-tracker) for more
-    /// information about the collected metrics.
-    #[serde(default = "Core::default_tracker_usage_statistics")]
-    pub tracker_usage_statistics: bool,
-
-    /// Interval in seconds that the cleanup job will run to remove inactive
-    /// peers from the torrent peer list.
-    #[serde(default = "Core::default_inactive_peer_cleanup_interval")]
-    pub inactive_peer_cleanup_interval: u64,
-
-    // Tracker policy configuration.
-    #[serde(default = "Core::default_tracker_policy")]
-    pub tracker_policy: TrackerPolicy,
-
     // Announce policy configuration.
     #[serde(default = "Core::default_announce_policy")]
     pub announce_policy: AnnouncePolicy,
@@ -37,42 +16,47 @@ pub struct Core {
     #[serde(default = "Core::default_database")]
     pub database: Database,
 
+    /// Interval in seconds that the cleanup job will run to remove inactive
+    /// peers from the torrent peer list.
+    #[serde(default = "Core::default_inactive_peer_cleanup_interval")]
+    pub inactive_peer_cleanup_interval: u64,
+
+    /// Tracker mode. See [`TrackerMode`] for more information.
+    #[serde(default = "Core::default_mode")]
+    pub mode: TrackerMode,
+
     // Network configuration.
     #[serde(default = "Core::default_network")]
     pub net: Network,
+
+    // Tracker policy configuration.
+    #[serde(default = "Core::default_tracker_policy")]
+    pub tracker_policy: TrackerPolicy,
+
+    /// Weather the tracker should collect statistics about tracker usage.
+    /// If enabled, the tracker will collect statistics like the number of
+    /// connections handled, the number of announce requests handled, etc.
+    /// Refer to the [`Tracker`](https://docs.rs/torrust-tracker) for more
+    /// information about the collected metrics.
+    #[serde(default = "Core::default_tracker_usage_statistics")]
+    pub tracker_usage_statistics: bool,
 }
 
 impl Default for Core {
     fn default() -> Self {
         Self {
-            mode: Self::default_mode(),
-            tracker_usage_statistics: Self::default_tracker_usage_statistics(),
-            inactive_peer_cleanup_interval: Self::default_inactive_peer_cleanup_interval(),
-            tracker_policy: Self::default_tracker_policy(),
             announce_policy: Self::default_announce_policy(),
             database: Self::default_database(),
+            inactive_peer_cleanup_interval: Self::default_inactive_peer_cleanup_interval(),
+            mode: Self::default_mode(),
             net: Self::default_network(),
+            tracker_policy: Self::default_tracker_policy(),
+            tracker_usage_statistics: Self::default_tracker_usage_statistics(),
         }
     }
 }
 
 impl Core {
-    fn default_mode() -> TrackerMode {
-        TrackerMode::Public
-    }
-
-    fn default_tracker_usage_statistics() -> bool {
-        true
-    }
-
-    fn default_inactive_peer_cleanup_interval() -> u64 {
-        600
-    }
-
-    fn default_tracker_policy() -> TrackerPolicy {
-        TrackerPolicy::default()
-    }
-
     fn default_announce_policy() -> AnnouncePolicy {
         AnnouncePolicy::default()
     }
@@ -81,7 +65,22 @@ impl Core {
         Database::default()
     }
 
+    fn default_inactive_peer_cleanup_interval() -> u64 {
+        600
+    }
+
+    fn default_mode() -> TrackerMode {
+        TrackerMode::Public
+    }
+
     fn default_network() -> Network {
         Network::default()
+    }
+
+    fn default_tracker_policy() -> TrackerPolicy {
+        TrackerPolicy::default()
+    }
+    fn default_tracker_usage_statistics() -> bool {
+        true
     }
 }

--- a/packages/configuration/src/v1/core.rs
+++ b/packages/configuration/src/v1/core.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use torrust_tracker_primitives::TrackerMode;
 
 use super::network::Network;
 use crate::v1::database::Database;
@@ -21,19 +20,15 @@ pub struct Core {
     #[serde(default = "Core::default_inactive_peer_cleanup_interval")]
     pub inactive_peer_cleanup_interval: u64,
 
-    // Whe `true` only approved torrents can be announced in the tracker.
+    // When `true` only approved torrents can be announced in the tracker.
     #[serde(default = "Core::default_listed")]
     pub listed: bool,
-
-    /// Tracker mode. See [`TrackerMode`] for more information.
-    #[serde(default = "Core::default_mode")]
-    pub mode: TrackerMode,
 
     // Network configuration.
     #[serde(default = "Core::default_network")]
     pub net: Network,
 
-    // Whe `true` clients require a key to connect and use the tracker.
+    // When `true` clients require a key to connect and use the tracker.
     #[serde(default = "Core::default_private")]
     pub private: bool,
 
@@ -57,7 +52,6 @@ impl Default for Core {
             database: Self::default_database(),
             inactive_peer_cleanup_interval: Self::default_inactive_peer_cleanup_interval(),
             listed: Self::default_listed(),
-            mode: Self::default_mode(),
             net: Self::default_network(),
             private: Self::default_private(),
             tracker_policy: Self::default_tracker_policy(),
@@ -81,10 +75,6 @@ impl Core {
 
     fn default_listed() -> bool {
         false
-    }
-
-    fn default_mode() -> TrackerMode {
-        TrackerMode::Public
     }
 
     fn default_network() -> Network {

--- a/packages/configuration/src/v1/mod.rs
+++ b/packages/configuration/src/v1/mod.rs
@@ -366,8 +366,10 @@ mod tests {
 
                                 [core]
                                 mode = "public"
-                                tracker_usage_statistics = true
                                 inactive_peer_cleanup_interval = 600
+                                listed = false
+                                private = false
+                                tracker_usage_statistics = true
 
                                 [core.tracker_policy]
                                 max_peer_timeout = 900

--- a/packages/configuration/src/v1/mod.rs
+++ b/packages/configuration/src/v1/mod.rs
@@ -199,14 +199,10 @@
 //! log_level = "info"
 //!
 //! [core]
-//! mode = "public"
-//! tracker_usage_statistics = true
 //! inactive_peer_cleanup_interval = 600
-//!
-//! [core.tracker_policy]
-//! max_peer_timeout = 900
-//! persistent_torrent_completed_stat = false
-//! remove_peerless_torrents = true
+//! listed = false
+//! private = false
+//! tracker_usage_statistics = true
 //!
 //! [core.announce_policy]
 //! interval = 120
@@ -219,6 +215,11 @@
 //! [core.net]
 //! external_ip = "0.0.0.0"
 //! on_reverse_proxy = false
+//!
+//! [core.tracker_policy]
+//! max_peer_timeout = 900
+//! persistent_torrent_completed_stat = false
+//! remove_peerless_torrents = true
 //!
 //! [http_api]
 //! bind_address = "127.0.0.1:1212"
@@ -365,16 +366,10 @@ mod tests {
                                 log_level = "info"
 
                                 [core]
-                                mode = "public"
                                 inactive_peer_cleanup_interval = 600
                                 listed = false
                                 private = false
                                 tracker_usage_statistics = true
-
-                                [core.tracker_policy]
-                                max_peer_timeout = 900
-                                persistent_torrent_completed_stat = false
-                                remove_peerless_torrents = true
 
                                 [core.announce_policy]
                                 interval = 120
@@ -387,6 +382,11 @@ mod tests {
                                 [core.net]
                                 external_ip = "0.0.0.0"
                                 on_reverse_proxy = false
+
+                                [core.tracker_policy]
+                                max_peer_timeout = 900
+                                persistent_torrent_completed_stat = false
+                                remove_peerless_torrents = true
 
                                 [health_check_api]
                                 bind_address = "127.0.0.1:1313"

--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -5,8 +5,6 @@
 //! by the tracker server crate, but also by other crates in the Torrust
 //! ecosystem.
 use std::collections::BTreeMap;
-use std::fmt;
-use std::str::FromStr;
 use std::time::Duration;
 
 use info_hash::InfoHash;
@@ -64,70 +62,3 @@ pub enum DatabaseDriver {
 }
 
 pub type PersistentTorrents = BTreeMap<InfoHash, u32>;
-
-/// The mode the tracker will run in.
-///
-/// Refer to [Torrust Tracker Configuration](https://docs.rs/torrust-tracker-configuration)
-/// to know how to configure the tracker to run in each mode.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub enum TrackerMode {
-    /// Will track every new info hash and serve every peer.
-    #[serde(rename = "public")]
-    Public,
-
-    /// Will only track whitelisted info hashes.
-    #[serde(rename = "listed")]
-    Listed,
-
-    /// Will only serve authenticated peers
-    #[serde(rename = "private")]
-    Private,
-
-    /// Will only track whitelisted info hashes and serve authenticated peers
-    #[serde(rename = "private_listed")]
-    PrivateListed,
-}
-
-impl Default for TrackerMode {
-    fn default() -> Self {
-        Self::Public
-    }
-}
-
-impl fmt::Display for TrackerMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let display_str = match self {
-            TrackerMode::Public => "public",
-            TrackerMode::Listed => "listed",
-            TrackerMode::Private => "private",
-            TrackerMode::PrivateListed => "private_listed",
-        };
-        write!(f, "{display_str}")
-    }
-}
-
-impl FromStr for TrackerMode {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "public" => Ok(TrackerMode::Public),
-            "listed" => Ok(TrackerMode::Listed),
-            "private" => Ok(TrackerMode::Private),
-            "private_listed" => Ok(TrackerMode::PrivateListed),
-            _ => Err(format!("Unknown tracker mode: {s}")),
-        }
-    }
-}
-
-impl TrackerMode {
-    #[must_use]
-    pub fn is_open(&self) -> bool {
-        matches!(self, TrackerMode::Public | TrackerMode::Listed)
-    }
-
-    #[must_use]
-    pub fn is_close(&self) -> bool {
-        !self.is_open()
-    }
-}

--- a/packages/test-helpers/Cargo.toml
+++ b/packages/test-helpers/Cargo.toml
@@ -17,4 +17,3 @@ version.workspace = true
 [dependencies]
 rand = "0"
 torrust-tracker-configuration = { version = "3.0.0-alpha.12-develop", path = "../configuration" }
-torrust-tracker-primitives = { version = "3.0.0-alpha.12-develop", path = "../primitives" }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -3,7 +3,6 @@ use std::env;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use torrust_tracker_configuration::{Configuration, HttpApi, HttpTracker, LogLevel, UdpTracker};
-use torrust_tracker_primitives::TrackerMode;
 
 use crate::random;
 
@@ -86,40 +85,41 @@ pub fn ephemeral_without_reverse_proxy() -> Configuration {
 
 /// Ephemeral configuration with `public` mode.
 #[must_use]
-pub fn ephemeral_mode_public() -> Configuration {
+pub fn ephemeral_public() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.core.mode = TrackerMode::Public;
+    cfg.core.private = false;
 
     cfg
 }
 
 /// Ephemeral configuration with `private` mode.
 #[must_use]
-pub fn ephemeral_mode_private() -> Configuration {
+pub fn ephemeral_private() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.core.mode = TrackerMode::Private;
+    cfg.core.private = true;
 
     cfg
 }
 
 /// Ephemeral configuration with `listed` mode.
 #[must_use]
-pub fn ephemeral_mode_whitelisted() -> Configuration {
+pub fn ephemeral_listed() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.core.mode = TrackerMode::Listed;
+    cfg.core.listed = true;
 
     cfg
 }
 
 /// Ephemeral configuration with `private_listed` mode.
 #[must_use]
-pub fn ephemeral_mode_private_whitelisted() -> Configuration {
+pub fn ephemeral_private_and_listed() -> Configuration {
     let mut cfg = ephemeral();
 
-    cfg.core.mode = TrackerMode::PrivateListed;
+    cfg.core.private = true;
+    cfg.core.listed = true;
 
     cfg
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -51,7 +51,7 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
     }
 
     // Load whitelisted torrents
-    if tracker.is_whitelisted() {
+    if tracker.is_listed() {
         tracker
             .load_whitelist_from_database()
             .await
@@ -64,8 +64,8 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
             for udp_tracker_config in udp_trackers {
                 if tracker.is_private() {
                     warn!(
-                        "Could not start UDP tracker on: {} while in {:?}. UDP is not safe for private trackers!",
-                        udp_tracker_config.bind_address, config.core.mode
+                        "Could not start UDP tracker on: {} while in private mode. UDP is not safe for private trackers!",
+                        udp_tracker_config.bind_address
                     );
                 } else {
                     jobs.push(udp_tracker::start_job(udp_tracker_config, tracker.clone(), registar.give_form()).await);

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -77,7 +77,7 @@ async fn start_v1(
 mod tests {
     use std::sync::Arc;
 
-    use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
+    use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
     use crate::bootstrap::jobs::http_tracker::start_job;
@@ -86,7 +86,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_start_http_tracker() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let http_tracker = cfg.http_trackers.clone().expect("missing HTTP tracker configuration");
         let config = &http_tracker[0];
         let tracker = initialize_with_configuration(&cfg);

--- a/src/bootstrap/jobs/tracker_apis.rs
+++ b/src/bootstrap/jobs/tracker_apis.rs
@@ -94,7 +94,7 @@ async fn start_v1(
 mod tests {
     use std::sync::Arc;
 
-    use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
+    use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
     use crate::bootstrap::jobs::tracker_apis::start_job;
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_start_http_tracker() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let config = &cfg.http_api.clone().unwrap();
         let tracker = initialize_with_configuration(&cfg);
         let version = Version::V1;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -481,15 +481,26 @@ use crate::CurrentClock;
 /// > Typically, the `Tracker` is used by a higher application service that handles
 /// > the network layer.
 pub struct Tracker {
-    // The tracker configuration.
+    /// The tracker configuration.
     config: Core,
+
     /// A database driver implementation: [`Sqlite3`](crate::core::databases::sqlite)
     /// or [`MySQL`](crate::core::databases::mysql)
     database: Arc<Box<dyn Database>>,
+
+    /// Tracker users' keys. Only for private trackers.
     keys: tokio::sync::RwLock<std::collections::HashMap<Key, auth::ExpiringKey>>,
+
+    /// The list of allowed torrents. Only for listed trackers.
     whitelist: tokio::sync::RwLock<std::collections::HashSet<InfoHash>>,
+
+    /// The in-memory torrents repository.
     torrents: Arc<Torrents>,
+
+    /// Service to send stats events.
     stats_event_sender: Option<Box<dyn statistics::EventSender>>,
+
+    /// The in-memory stats repo.
     stats_repository: statistics::Repo,
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -481,13 +481,14 @@ use crate::CurrentClock;
 /// > Typically, the `Tracker` is used by a higher application service that handles
 /// > the network layer.
 pub struct Tracker {
+    // The tracker configuration.
     config: Core,
     /// A database driver implementation: [`Sqlite3`](crate::core::databases::sqlite)
     /// or [`MySQL`](crate::core::databases::mysql)
-    pub database: Arc<Box<dyn Database>>,
+    database: Arc<Box<dyn Database>>,
     keys: tokio::sync::RwLock<std::collections::HashMap<Key, auth::ExpiringKey>>,
     whitelist: tokio::sync::RwLock<std::collections::HashSet<InfoHash>>,
-    pub torrents: Arc<Torrents>,
+    torrents: Arc<Torrents>,
     stats_event_sender: Option<Box<dyn statistics::EventSender>>,
     stats_repository: statistics::Repo,
 }
@@ -986,6 +987,17 @@ impl Tracker {
             None => None,
             Some(stats_event_sender) => stats_event_sender.send_event(event).await,
         }
+    }
+
+    /// It drops the database tables.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if unable to drop tables.
+    pub fn drop_database_tables(&self) -> Result<(), databases::error::Error> {
+        // todo: this is only used for testing. WE have to pass the database
+        // reference directly to the tests instead of via the tracker.
+        self.database.drop_database_tables()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,13 +172,9 @@
 //!
 //! [core]
 //! inactive_peer_cleanup_interval = 600
-//! mode = "public"
+//! listed = false
+//! private = false
 //! tracker_usage_statistics = true
-//!
-//! [core.tracker_policy]
-//! max_peer_timeout = 900
-//! persistent_torrent_completed_stat = false
-//! remove_peerless_torrents = true
 //!
 //! [core.announce_policy]
 //! interval = 120
@@ -191,6 +187,11 @@
 //! [core.net]
 //! external_ip = "0.0.0.0"
 //! on_reverse_proxy = false
+//!
+//! [core.tracker_policy]
+//! max_peer_timeout = 900
+//! persistent_torrent_completed_stat = false
+//! remove_peerless_torrents = true
 //!
 //! [health_check_api]
 //! bind_address = "127.0.0.1:1313"

--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -266,7 +266,7 @@ impl Launcher {
 mod tests {
     use std::sync::Arc;
 
-    use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
+    use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
     use crate::bootstrap::jobs::make_rust_tls;
@@ -275,7 +275,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_be_able_to_start_and_stop() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let config = &cfg.http_api.clone().unwrap();
 
         let tracker = initialize_with_configuration(&cfg);

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -226,7 +226,7 @@ pub fn check_fn(binding: &SocketAddr) -> ServiceHealthCheckJob {
 mod tests {
     use std::sync::Arc;
 
-    use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
+    use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use crate::bootstrap::app::initialize_with_configuration;
     use crate::bootstrap::jobs::make_rust_tls;
@@ -235,7 +235,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_be_able_to_start_and_stop() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let tracker = initialize_with_configuration(&cfg);
         let http_trackers = cfg.http_trackers.clone().expect("missing HTTP trackers configuration");
         let config = &http_trackers[0];

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -181,11 +181,11 @@ mod tests {
     use crate::servers::http::v1::services::peer_ip_resolver::ClientIpSources;
 
     fn private_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_private())
+        tracker_factory(&configuration::ephemeral_private())
     }
 
     fn whitelisted_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_whitelisted())
+        tracker_factory(&configuration::ephemeral_listed())
     }
 
     fn tracker_on_reverse_proxy() -> Tracker {

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -121,11 +121,11 @@ mod tests {
     use crate::servers::http::v1::services::peer_ip_resolver::ClientIpSources;
 
     fn private_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_private())
+        tracker_factory(&configuration::ephemeral_private())
     }
 
     fn whitelisted_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_whitelisted())
+        tracker_factory(&configuration::ephemeral_listed())
     }
 
     fn tracker_on_reverse_proxy() -> Tracker {

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -57,7 +57,7 @@ mod tests {
     use crate::core::Tracker;
 
     fn public_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_public())
+        tracker_factory(&configuration::ephemeral_public())
     }
 
     fn sample_info_hash() -> InfoHash {

--- a/src/servers/http/v1/services/scrape.rs
+++ b/src/servers/http/v1/services/scrape.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::core::Tracker;
 
     fn public_tracker() -> Tracker {
-        tracker_factory(&configuration::ephemeral_mode_public())
+        tracker_factory(&configuration::ephemeral_public())
     }
 
     fn sample_info_hashes() -> Vec<InfoHash> {

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -339,15 +339,15 @@ mod tests {
     }
 
     fn public_tracker() -> Arc<Tracker> {
-        initialized_tracker(&configuration::ephemeral_mode_public())
+        initialized_tracker(&configuration::ephemeral_public())
     }
 
     fn private_tracker() -> Arc<Tracker> {
-        initialized_tracker(&configuration::ephemeral_mode_private())
+        initialized_tracker(&configuration::ephemeral_private())
     }
 
     fn whitelisted_tracker() -> Arc<Tracker> {
-        initialized_tracker(&configuration::ephemeral_mode_whitelisted())
+        initialized_tracker(&configuration::ephemeral_listed())
     }
 
     fn initialized_tracker(configuration: &Configuration) -> Arc<Tracker> {

--- a/src/servers/udp/server/mod.rs
+++ b/src/servers/udp/server/mod.rs
@@ -47,7 +47,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use torrust_tracker_test_helpers::configuration::ephemeral_mode_public;
+    use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use super::spawner::Spawner;
     use super::Server;
@@ -56,7 +56,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_be_able_to_start_and_stop() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let tracker = initialize_with_configuration(&cfg);
         let udp_trackers = cfg.udp_trackers.clone().expect("missing UDP trackers configuration");
         let config = &udp_trackers[0];
@@ -79,7 +79,7 @@ mod tests {
 
     #[tokio::test]
     async fn it_should_be_able_to_start_and_stop_with_wait() {
-        let cfg = Arc::new(ephemeral_mode_public());
+        let cfg = Arc::new(ephemeral_public());
         let tracker = initialize_with_configuration(&cfg);
         let config = &cfg.udp_trackers.as_ref().unwrap().first().unwrap();
         let bind_to = config.bind_address;

--- a/tests/servers/api/mod.rs
+++ b/tests/servers/api/mod.rs
@@ -11,7 +11,10 @@ pub type Started = environment::Environment<server::Running>;
 
 /// It forces a database error by dropping all tables.
 /// That makes any query fail.
-/// code-review: alternatively we could inject a database mock in the future.
+/// code-review:
+/// Alternatively we could:
+/// - Inject a database mock in the future.
+/// - Inject directly the database reference passed to the Tracker type.
 pub fn force_database_error(tracker: &Arc<Tracker>) {
-    tracker.database.drop_database_tables().unwrap();
+    tracker.drop_database_tables().unwrap();
 }

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -107,7 +107,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn it_should_start_and_stop() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
             env.stop().await;
         }
 
@@ -376,7 +376,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_no_peers_if_the_announced_peer_is_the_first_one() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let response = Client::new(*env.bind_address())
                 .announce(
@@ -405,7 +405,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_list_of_previously_announced_peers() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -447,7 +447,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_list_of_previously_announced_peers_including_peers_using_ipv4_and_ipv6() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -499,7 +499,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_consider_two_peers_to_be_the_same_when_they_have_the_same_peer_id_even_if_the_ip_is_different() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
             let peer = PeerBuilder::default().build();
@@ -526,7 +526,7 @@ mod for_all_config_modes {
             // Tracker Returns Compact Peer Lists
             // https://www.bittorrent.org/beps/bep_0023.html
 
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -567,7 +567,7 @@ mod for_all_config_modes {
             // code-review: the HTTP tracker does not return the compact response by default if the "compact"
             // param is not provided in the announce URL. The BEP 23 suggest to do so.
 
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -605,7 +605,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp4_connections_handled_in_statistics() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             Client::new(*env.bind_address())
                 .announce(&QueryBuilder::default().query())
@@ -648,7 +648,7 @@ mod for_all_config_modes {
         async fn should_not_increase_the_number_of_tcp6_connections_handled_if_the_client_is_not_using_an_ipv6_ip() {
             // The tracker ignores the peer address in the request param. It uses the client remote ip address.
 
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             Client::new(*env.bind_address())
                 .announce(
@@ -669,7 +669,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp4_announce_requests_handled_in_statistics() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             Client::new(*env.bind_address())
                 .announce(&QueryBuilder::default().query())
@@ -712,7 +712,7 @@ mod for_all_config_modes {
         async fn should_not_increase_the_number_of_tcp6_announce_requests_handled_if_the_client_is_not_using_an_ipv6_ip() {
             // The tracker ignores the peer address in the request param. It uses the client remote ip address.
 
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             Client::new(*env.bind_address())
                 .announce(
@@ -733,7 +733,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_assign_to_the_peer_ip_the_remote_client_ip_instead_of_the_peer_address_in_the_request_param() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
             let client_ip = local_ip().unwrap();
@@ -905,7 +905,7 @@ mod for_all_config_modes {
         //#[tokio::test]
         #[allow(dead_code)]
         async fn should_fail_when_the_request_is_empty() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
             let response = Client::new(*env.bind_address()).get("scrape").await;
 
             assert_missing_query_params_for_scrape_request_error_response(response).await;
@@ -915,7 +915,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_info_hash_param_is_invalid() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -932,7 +932,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -971,7 +971,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_file_with_the_complete_peer_when_there_is_one_peer_with_no_bytes_pending_to_download() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1010,7 +1010,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_a_file_with_zeroed_values_when_there_are_no_peers() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1029,7 +1029,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_accept_multiple_infohashes() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash1 = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
             let info_hash2 = InfoHash::from_str("3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0").unwrap();
@@ -1055,7 +1055,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_ot_tcp4_scrape_requests_handled_in_statistics() {
-            let env = Started::new(&configuration::ephemeral_mode_public().into()).await;
+            let env = Started::new(&configuration::ephemeral_public().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1123,7 +1123,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_fail_if_the_torrent_is_not_in_the_whitelist() {
-            let env = Started::new(&configuration::ephemeral_mode_whitelisted().into()).await;
+            let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1138,7 +1138,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_allow_announcing_a_whitelisted_torrent() {
-            let env = Started::new(&configuration::ephemeral_mode_whitelisted().into()).await;
+            let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1172,7 +1172,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_return_the_zeroed_file_when_the_requested_file_is_not_whitelisted() {
-            let env = Started::new(&configuration::ephemeral_mode_whitelisted().into()).await;
+            let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1202,7 +1202,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_return_the_file_stats_when_the_requested_file_is_whitelisted() {
-            let env = Started::new(&configuration::ephemeral_mode_whitelisted().into()).await;
+            let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1263,7 +1263,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_respond_to_authenticated_peers() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let expiring_key = env.tracker.generate_auth_key(Duration::from_secs(60)).await.unwrap();
 
@@ -1278,7 +1278,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_peer_has_not_provided_the_authentication_key() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1293,7 +1293,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let invalid_key = "INVALID_KEY";
 
@@ -1308,7 +1308,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_peer_cannot_be_authenticated_with_the_provided_key() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             // The tracker does not have this key
             let unregistered_key = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
@@ -1341,7 +1341,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let invalid_key = "INVALID_KEY";
 
@@ -1356,7 +1356,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_return_the_zeroed_file_when_the_client_is_not_authenticated() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1386,7 +1386,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_return_the_real_file_stats_when_the_client_is_authenticated() {
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 
@@ -1430,7 +1430,7 @@ mod configured_as_private {
             // There is not authentication error
             // code-review: should this really be this way?
 
-            let env = Started::new(&configuration::ephemeral_mode_private().into()).await;
+            let env = Started::new(&configuration::ephemeral_private().into()).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap();
 


### PR DESCRIPTION
Replace `mode` core config option with `private` and `listed` flags:

From:

```toml
[core]
mode = "public"
tracker_usage_statistics = true
inactive_peer_cleanup_interval = 600
```

To:

```toml
[core]
inactive_peer_cleanup_interval = 600
listed = false
private = false
tracker_usage_statistics = true
```