### PR TITLE
Config overhaul: improve admin experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,6 +4012,7 @@ dependencies = [
  "derive_more",
  "figment",
  "serde",
+ "serde_json",
  "serde_with",
  "thiserror",
  "toml",

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -19,6 +19,7 @@ camino = { version = "1.1.6", features = ["serde", "serde1"] }
 derive_more = "0"
 figment = { version = "0.10.18", features = ["env", "test", "toml"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = "3"
 thiserror = "1"
 toml = "0"

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -111,17 +111,17 @@ impl Info {
         let env_var_config_toml_path = ENV_VAR_CONFIG_TOML_PATH.to_string();
 
         let config_toml = if let Ok(config_toml) = env::var(env_var_config_toml) {
-            println!("Loading configuration from environment variable:\n {config_toml}");
+            println!("Loading extra configuration from environment variable:\n {config_toml}");
             Some(config_toml)
         } else {
             None
         };
 
         let config_toml_path = if let Ok(config_toml_path) = env::var(env_var_config_toml_path) {
-            println!("Loading configuration from file: `{config_toml_path}` ...");
+            println!("Loading extra configuration from file: `{config_toml_path}` ...");
             config_toml_path
         } else {
-            println!("Loading configuration from default configuration file: `{default_config_toml_path}` ...");
+            println!("Loading extra configuration from default configuration file: `{default_config_toml_path}` ...");
             default_config_toml_path
         };
 

--- a/packages/configuration/src/v2/mod.rs
+++ b/packages/configuration/src/v2/mod.rs
@@ -346,9 +346,25 @@ impl Configuration {
     }
 
     /// Encodes the configuration to TOML.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if it can't be converted to TOML.
+    #[must_use]
     fn to_toml(&self) -> String {
         // code-review: do we need to use Figment also to serialize into toml?
         toml::to_string(self).expect("Could not encode TOML value")
+    }
+
+    /// Encodes the configuration to JSON.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if it can't be converted to JSON.
+    #[must_use]
+    pub fn to_json(&self) -> String {
+        // code-review: do we need to use Figment also to serialize into json?
+        serde_json::to_string_pretty(self).expect("Could not encode JSON value")
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,13 @@ use crate::{core, servers};
 /// - Can't retrieve tracker keys from database.
 /// - Can't load whitelist from database.
 pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<JoinHandle<()>> {
+    if config.http_api.is_none()
+        && (config.udp_trackers.is_none() || config.udp_trackers.as_ref().map_or(true, std::vec::Vec::is_empty))
+        && (config.http_trackers.is_none() || config.http_trackers.as_ref().map_or(true, std::vec::Vec::is_empty))
+    {
+        warn!("No services enabled in configuration");
+    }
+
     let mut jobs: Vec<JoinHandle<()>> = Vec::new();
 
     let registar = Registar::default();

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use torrust_tracker_clock::static_time;
 use torrust_tracker_configuration::Configuration;
+use tracing::info;
 
 use super::config::initialize_configuration;
 use crate::bootstrap;
@@ -26,7 +27,10 @@ use crate::shared::crypto::ephemeral_instance_keys;
 #[must_use]
 pub fn setup() -> (Configuration, Arc<Tracker>) {
     let configuration = initialize_configuration();
+
     let tracker = initialize_with_configuration(&configuration);
+
+    info!("Configuration:\n{}", configuration.to_json());
 
     (configuration, tracker)
 }

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -52,7 +52,7 @@ fn tracing_stdout_init(filter: LevelFilter, style: &TraceStyle) {
         TraceStyle::Json => builder.json().init(),
     };
 
-    info!("logging initialized.");
+    info!("Logging initialized");
 }
 
 #[derive(Debug)]

--- a/src/console/ci/e2e/logs_parser.rs
+++ b/src/console/ci/e2e/logs_parser.rs
@@ -23,7 +23,7 @@ impl RunningServices {
     ///
     /// ```text
     /// Loading configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
-    /// 2024-06-10T16:07:39.989540Z  INFO torrust_tracker::bootstrap::logging: logging initialized.
+    /// 2024-06-10T16:07:39.989540Z  INFO torrust_tracker::bootstrap::logging: Logging initialized
     /// 2024-06-10T16:07:39.990205Z  INFO UDP TRACKER: Starting on: udp://0.0.0.0:6868
     /// 2024-06-10T16:07:39.990215Z  INFO UDP TRACKER: Started on: udp://0.0.0.0:6868
     /// 2024-06-10T16:07:39.990244Z  INFO UDP TRACKER: Starting on: udp://0.0.0.0:6969
@@ -116,7 +116,7 @@ mod tests {
     fn it_should_parse_from_logs_with_valid_logs() {
         let logs = r"
             Loading configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
-            2024-06-10T16:07:39.989540Z  INFO torrust_tracker::bootstrap::logging: logging initialized.
+            2024-06-10T16:07:39.989540Z  INFO torrust_tracker::bootstrap::logging: Logging initialized
             2024-06-10T16:07:39.990244Z  INFO UDP TRACKER: Starting on: udp://0.0.0.0:6969
             2024-06-10T16:07:39.990255Z  INFO UDP TRACKER: Started on: udp://0.0.0.0:6969
             2024-06-10T16:07:39.990261Z  INFO torrust_tracker::bootstrap::jobs: TLS not enabled

--- a/src/console/ci/e2e/runner.rs
+++ b/src/console/ci/e2e/runner.rs
@@ -117,7 +117,7 @@ pub fn run() -> anyhow::Result<()> {
 
 fn tracing_stdout_init(filter: LevelFilter) {
     tracing_subscriber::fmt().with_max_level(filter).init();
-    info!("Logging initialized.");
+    info!("Logging initialized");
 }
 
 fn load_tracker_configuration(args: &Args) -> anyhow::Result<String> {

--- a/src/console/clients/checker/app.rs
+++ b/src/console/clients/checker/app.rs
@@ -103,7 +103,7 @@ pub async fn run() -> Result<Vec<CheckResult>> {
 
 fn tracing_stdout_init(filter: LevelFilter) {
     tracing_subscriber::fmt().with_max_level(filter).init();
-    debug!("logging initialized.");
+    debug!("Logging initialized");
 }
 
 fn setup_config(args: Args) -> Result<Configuration> {

--- a/src/console/clients/udp/app.rs
+++ b/src/console/clients/udp/app.rs
@@ -129,7 +129,7 @@ pub async fn run() -> anyhow::Result<()> {
 
 fn tracing_stdout_init(filter: LevelFilter) {
     tracing_subscriber::fmt().with_max_level(filter).init();
-    debug!("logging initialized.");
+    debug!("Logging initialized");
 }
 
 async fn handle_announce(remote_addr: SocketAddr, info_hash: &TorrustInfoHash) -> Result<Response, Error> {

--- a/src/console/profiling.rs
+++ b/src/console/profiling.rs
@@ -192,7 +192,7 @@ pub async fn run() {
             info!("Torrust timed shutdown..");
         },
         _ = tokio::signal::ctrl_c() => {
-            info!("Torrust shutting down via Ctrl+C..");
+            info!("Torrust shutting down via Ctrl+C ...");
             // Await for all jobs to shutdown
             futures::future::join_all(jobs).await;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ async fn main() {
     // handle the signals
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
-            info!("Torrust shutting down..");
+            info!("Torrust shutting down ...");
 
             // Await for all jobs to shutdown
             futures::future::join_all(jobs).await;

--- a/src/servers/apis/mod.rs
+++ b/src/servers/apis/mod.rs
@@ -42,7 +42,7 @@
 //!
 //! ```text
 //! Loading configuration from config file ./tracker.toml
-//! 023-03-28T12:19:24.963054069+01:00 [torrust_tracker::bootstrap::logging][INFO] logging initialized.
+//! 023-03-28T12:19:24.963054069+01:00 [torrust_tracker::bootstrap::logging][INFO] Logging initialized
 //! ...
 //! 023-03-28T12:19:24.964138723+01:00 [torrust_tracker::bootstrap::jobs::tracker_apis][INFO] Starting Torrust APIs server on: http://0.0.0.0:1212
 //! ```


### PR DESCRIPTION
- Add a warning when the configuration does not enable any service (UDP tracker, HTTP tracker, or tracker API). It does not make sense to run the app without services enabled.
- Write the final used config to the logs when the tracker starts. We are only writing the config values when the source is an env var. We should do it always and print out the final configuration after merging sources (defaults -> TOML file -> env vars).