### PR TITLE
Config overhaul: rename `log_level` to `threshold`

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -26,11 +26,11 @@ cargo build --release -p aquatic_udp_load_test
 
 ### Run UDP load test
 
-Run the tracker with UDP service enabled and other services disabled and set log level to `error`.
+Run the tracker with UDP service enabled and other services disabled and set log threshold to `error`.
 
 ```toml
 [logging]
-log_level = "error"
+threshold = "error"
 
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"
@@ -97,7 +97,7 @@ Announce responses per info hash:
   - p100: 361
 ```
 
-> IMPORTANT: The performance of the Torrust UDP Tracker is drastically decreased with these log levels: `info`, `debug`, `trace`.
+> IMPORTANT: The performance of the Torrust UDP Tracker is drastically decreased with these log threshold: `info`, `debug`, `trace`.
 
 ```output
 Requests out: 40719.21/second
@@ -161,11 +161,11 @@ Announce responses per info hash:
 
 #### Torrust-Actix UDP Tracker
 
-Run the tracker with UDP service enabled and other services disabled and set log level to `error`.
+Run the tracker with UDP service enabled and other services disabled and set log threshold to `error`.
 
 ```toml
 [logging]
-log_level = "error"
+threshold = "error"
 
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -41,6 +41,7 @@ pub type HttpApi = v2::tracker_api::HttpApi;
 pub type HttpTracker = v2::http_tracker::HttpTracker;
 pub type UdpTracker = v2::udp_tracker::UdpTracker;
 pub type Database = v2::database::Database;
+pub type Threshold = v2::logging::Threshold;
 
 pub type AccessTokens = HashMap<String, String>;
 
@@ -240,21 +241,4 @@ impl TslConfig {
     fn default_ssl_key_path() -> Utf8PathBuf {
         Utf8PathBuf::new()
     }
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum LogLevel {
-    /// A level lower than all log levels.
-    Off,
-    /// Corresponds to the `Error` log level.
-    Error,
-    /// Corresponds to the `Warn` log level.
-    Warn,
-    /// Corresponds to the `Info` log level.
-    Info,
-    /// Corresponds to the `Debug` log level.
-    Debug,
-    /// Corresponds to the `Trace` log level.
-    Trace,
 }

--- a/packages/configuration/src/v2/logging.rs
+++ b/packages/configuration/src/v2/logging.rs
@@ -1,26 +1,41 @@
 use serde::{Deserialize, Serialize};
 
-use crate::LogLevel;
-
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Logging {
     /// Logging level. Possible values are: `Off`, `Error`, `Warn`, `Info`,
     /// `Debug` and `Trace`. Default is `Info`.
-    #[serde(default = "Logging::default_log_level")]
-    pub log_level: LogLevel,
+    #[serde(default = "Logging::default_threshold")]
+    pub threshold: Threshold,
 }
 
 impl Default for Logging {
     fn default() -> Self {
         Self {
-            log_level: Self::default_log_level(),
+            threshold: Self::default_threshold(),
         }
     }
 }
 
 impl Logging {
-    fn default_log_level() -> LogLevel {
-        LogLevel::Info
+    fn default_threshold() -> Threshold {
+        Threshold::Info
     }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum Threshold {
+    /// A threshold lower than all security levels.
+    Off,
+    /// Corresponds to the `Error` security level.
+    Error,
+    /// Corresponds to the `Warn` security level.
+    Warn,
+    /// Corresponds to the `Info` security level.
+    Info,
+    /// Corresponds to the `Debug` security level.
+    Debug,
+    /// Corresponds to the `Trace` security level.
+    Trace,
 }

--- a/packages/configuration/src/v2/mod.rs
+++ b/packages/configuration/src/v2/mod.rs
@@ -196,7 +196,7 @@
 //!
 //! ```toml
 //! [logging]
-//! log_level = "info"
+//! threshold = "info"
 //!
 //! [core]
 //! inactive_peer_cleanup_interval = 600
@@ -379,7 +379,7 @@ mod tests {
     #[cfg(test)]
     fn default_config_toml() -> String {
         let config = r#"[logging]
-                                log_level = "info"
+                                threshold = "info"
 
                                 [core]
                                 inactive_peer_cleanup_interval = 600

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
-use torrust_tracker_configuration::{Configuration, HttpApi, HttpTracker, LogLevel, UdpTracker};
+use torrust_tracker_configuration::{Configuration, HttpApi, HttpTracker, Threshold, UdpTracker};
 
 use crate::random;
 
@@ -14,7 +14,7 @@ use crate::random;
 /// > **NOTICE**: Port 0 is used for ephemeral ports, which means that the OS
 /// > will assign a random free port for the tracker to use.
 ///
-/// > **NOTICE**: You can change the log level to `debug` to see the logs of the
+/// > **NOTICE**: You can change the log threshold to `debug` to see the logs of the
 /// > tracker while running the tests. That can be particularly useful when
 /// > debugging tests.
 ///
@@ -28,7 +28,7 @@ pub fn ephemeral() -> Configuration {
 
     let mut config = Configuration::default();
 
-    config.logging.log_level = LogLevel::Off; // Change to `debug` for tests debugging
+    config.logging.threshold = Threshold::Off; // Change to `debug` for tests debugging
 
     // Ephemeral socket address for API
     let api_port = 0u16;

--- a/share/default/config/tracker.udp.benchmarking.toml
+++ b/share/default/config/tracker.udp.benchmarking.toml
@@ -1,5 +1,5 @@
 [logging]
-log_level = "error"
+threshold = "error"
 
 [core]
 remove_peerless_torrents = false

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -68,7 +68,7 @@ pub fn initialize_tracker(config: &Configuration) -> Tracker {
     tracker_factory(config)
 }
 
-/// It initializes the log level, format and channel.
+/// It initializes the log threshold, format and channel.
 ///
 /// See [the logging setup](crate::bootstrap::logging::setup) for more info about logging.
 pub fn initialize_logging(config: &Configuration) {

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -1,6 +1,7 @@
 //! Setup for the application logging.
 //!
-//! It redirects the log info to the standard output with the log level defined in the configuration.
+//! It redirects the log info to the standard output with the log threshold
+//! defined in the configuration.
 //!
 //! - `Off`
 //! - `Error`
@@ -12,15 +13,16 @@
 //! Refer to the [configuration crate documentation](https://docs.rs/torrust-tracker-configuration) to know how to change log settings.
 use std::sync::Once;
 
-use torrust_tracker_configuration::{Configuration, LogLevel};
+use torrust_tracker_configuration::{Configuration, Threshold};
 use tracing::info;
 use tracing::level_filters::LevelFilter;
 
 static INIT: Once = Once::new();
 
-/// It redirects the log info to the standard output with the log level defined in the configuration
+/// It redirects the log info to the standard output with the log threshold
+/// defined in the configuration.
 pub fn setup(cfg: &Configuration) {
-    let tracing_level = map_to_tracing_level_filter(&cfg.logging.log_level);
+    let tracing_level = map_to_tracing_level_filter(&cfg.logging.threshold);
 
     if tracing_level == LevelFilter::OFF {
         return;
@@ -31,14 +33,14 @@ pub fn setup(cfg: &Configuration) {
     });
 }
 
-fn map_to_tracing_level_filter(log_level: &LogLevel) -> LevelFilter {
-    match log_level {
-        LogLevel::Off => LevelFilter::OFF,
-        LogLevel::Error => LevelFilter::ERROR,
-        LogLevel::Warn => LevelFilter::WARN,
-        LogLevel::Info => LevelFilter::INFO,
-        LogLevel::Debug => LevelFilter::DEBUG,
-        LogLevel::Trace => LevelFilter::TRACE,
+fn map_to_tracing_level_filter(threshold: &Threshold) -> LevelFilter {
+    match threshold {
+        Threshold::Off => LevelFilter::OFF,
+        Threshold::Error => LevelFilter::ERROR,
+        Threshold::Warn => LevelFilter::WARN,
+        Threshold::Info => LevelFilter::INFO,
+        Threshold::Debug => LevelFilter::DEBUG,
+        Threshold::Trace => LevelFilter::TRACE,
     }
 }
 

--- a/src/console/ci/e2e/logs_parser.rs
+++ b/src/console/ci/e2e/logs_parser.rs
@@ -7,7 +7,7 @@ use crate::servers::http::HTTP_TRACKER_LOG_TARGET;
 use crate::servers::logging::STARTED_ON;
 use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 
-const INFO_LOG_LEVEL: &str = "INFO";
+const INFO_THRESHOLD: &str = "INFO";
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct RunningServices {
@@ -74,7 +74,7 @@ impl RunningServices {
         for line in logs.lines() {
             let clean_line = ansi_escape_re.replace_all(line, "");
 
-            if !line.contains(INFO_LOG_LEVEL) {
+            if !line.contains(INFO_THRESHOLD) {
                 continue;
             };
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -313,7 +313,7 @@
 //!
 //! ```toml
 //! [logging]
-//! log_level = "debug"
+//! threshold = "debug"
 //!
 //! [core]
 //! inactive_peer_cleanup_interval = 600

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@
 //!
 //! ```toml
 //! [logging]
-//! log_level = "info"
+//! threshold = "info"
 //!
 //! [core]
 //! inactive_peer_cleanup_interval = 600


### PR DESCRIPTION
Rename config option `log_level` to `threshold`.

From:

```toml
[logging]
log_level = "info"
```

To:

```toml
[logging]
threshold = "info"
```

Threshold representts better the concept since this value is the security level at which the app stops collecting logs, meaning it filters out logs with a lower security level.