### PR TITLE
Config overhaul: add version and namespace to the configuration

### DIFF
--- a/share/default/config/tracker.container.mysql.toml
+++ b/share/default/config/tracker.container.mysql.toml
@@ -1,3 +1,5 @@
+version = "2"
+
 [core.database]
 driver = "MySQL"
 path = "mysql://db_user:db_user_secret_password@mysql:3306/torrust_tracker"

--- a/share/default/config/tracker.container.sqlite3.toml
+++ b/share/default/config/tracker.container.sqlite3.toml
@@ -1,3 +1,5 @@
+version = "2"
+
 [core.database]
 path = "/var/lib/torrust/tracker/database/sqlite3.db"
 

--- a/share/default/config/tracker.development.sqlite3.toml
+++ b/share/default/config/tracker.development.sqlite3.toml
@@ -1,3 +1,5 @@
+version = "2"
+
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"
 

--- a/share/default/config/tracker.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.e2e.container.sqlite3.toml
@@ -1,3 +1,5 @@
+version = "2"
+
 [core.database]
 path = "/var/lib/torrust/tracker/database/sqlite3.db"
 

--- a/share/default/config/tracker.udp.benchmarking.toml
+++ b/share/default/config/tracker.udp.benchmarking.toml
@@ -1,3 +1,5 @@
+version = "2"
+
 [logging]
 threshold = "error"
 


### PR DESCRIPTION
Add version to the configuration. It will fail if the provided version is not supported.

```toml
version = "2"
```

It only supports the exact match '2'.