### PR TITLE
Config overhaul: remove secrets when final config is printed to console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4018,6 +4018,7 @@ dependencies = [
  "toml",
  "torrust-tracker-located-error",
  "torrust-tracker-primitives",
+ "url",
  "uuid",
 ]
 

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 toml = "0"
 torrust-tracker-located-error = { version = "3.0.0-alpha.12-develop", path = "../located-error" }
 torrust-tracker-primitives = { version = "3.0.0-alpha.12-develop", path = "../primitives" }
+url = "2.5.2"
 
 [dev-dependencies]
 uuid = { version = "1", features = ["v4"] }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -48,7 +48,7 @@ pub type AccessTokens = HashMap<String, String>;
 pub const LATEST_VERSION: &str = "2";
 
 /// Info about the configuration specification.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Display)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Display, Clone)]
 pub struct Metadata {
     #[serde(default = "Metadata::default_version")]
     #[serde(flatten)]
@@ -70,7 +70,7 @@ impl Metadata {
 }
 
 /// The configuration version.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Display)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Display, Clone)]
 pub struct Version {
     #[serde(default = "Version::default_semver")]
     version: String,

--- a/packages/configuration/src/v2/database.rs
+++ b/packages/configuration/src/v2/database.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use torrust_tracker_primitives::DatabaseDriver;
+use url::Url;
 
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
@@ -13,7 +14,7 @@ pub struct Database {
     /// For `Sqlite3`, the format is `path/to/database.db`, for example:
     /// `./storage/tracker/lib/database/sqlite3.db`.
     /// For `Mysql`, the format is `mysql://db_user:db_user_password:port/db_name`, for
-    /// example: `root:password@localhost:3306/torrust`.
+    /// example: `mysql://root:password@localhost:3306/torrust`.
     #[serde(default = "Database::default_path")]
     pub path: String,
 }
@@ -34,5 +35,43 @@ impl Database {
 
     fn default_path() -> String {
         String::from("./storage/tracker/lib/database/sqlite3.db")
+    }
+
+    /// Masks secrets in the configuration.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the database path for `MySQL` is not a valid URL.
+    pub fn mask_secrets(&mut self) {
+        match self.driver {
+            DatabaseDriver::Sqlite3 => {
+                // Nothing to mask
+            }
+            DatabaseDriver::MySQL => {
+                let mut url = Url::parse(&self.path).expect("path for MySQL driver should be a valid URL");
+                url.set_password(Some("***")).expect("url password should be changed");
+                self.path = url.to_string();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use torrust_tracker_primitives::DatabaseDriver;
+
+    use super::Database;
+
+    #[test]
+    fn it_should_allow_masking_the_mysql_user_password() {
+        let mut database = Database {
+            driver: DatabaseDriver::MySQL,
+            path: "mysql://root:password@localhost:3306/torrust".to_string(),
+        };
+
+        database.mask_secrets();
+
+        assert_eq!(database.path, "mysql://root:***@localhost:3306/torrust".to_string());
     }
 }

--- a/packages/configuration/src/v2/mod.rs
+++ b/packages/configuration/src/v2/mod.rs
@@ -263,7 +263,7 @@ const CONFIG_OVERRIDE_PREFIX: &str = "TORRUST_TRACKER_CONFIG_OVERRIDE_";
 const CONFIG_OVERRIDE_SEPARATOR: &str = "__";
 
 /// Core configuration for the tracker.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Default, Clone)]
 pub struct Configuration {
     /// Configuration metadata.
     #[serde(flatten)]
@@ -379,6 +379,18 @@ impl Configuration {
     pub fn to_json(&self) -> String {
         // code-review: do we need to use Figment also to serialize into json?
         serde_json::to_string_pretty(self).expect("Could not encode JSON value")
+    }
+
+    /// Masks secrets in the configuration.
+    #[must_use]
+    pub fn mask_secrets(mut self) -> Self {
+        self.core.database.mask_secrets();
+
+        if let Some(ref mut api) = self.http_api {
+            api.mask_secrets();
+        }
+
+        self
     }
 }
 

--- a/packages/configuration/src/v2/tracker_api.rs
+++ b/packages/configuration/src/v2/tracker_api.rs
@@ -61,6 +61,12 @@ impl HttpApi {
     pub fn override_admin_token(&mut self, api_admin_token: &str) {
         self.access_tokens.insert("admin".to_string(), api_admin_token.to_string());
     }
+
+    pub fn mask_secrets(&mut self) {
+        for token in self.access_tokens.values_mut() {
+            *token = "***".to_string();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -30,7 +30,7 @@ pub fn setup() -> (Configuration, Arc<Tracker>) {
 
     let tracker = initialize_with_configuration(&configuration);
 
-    info!("Configuration:\n{}", configuration.to_json());
+    info!("Configuration:\n{}", configuration.clone().mask_secrets().to_json());
 
     (configuration, tracker)
 }


### PR DESCRIPTION
When the tracker is started, the final configuration is printed out. This feature was added in https://github.com/torrust/torrust-tracker/issues/935. This PR masks the secrets with asterics.