### PR TITLE
Disable `TimeoutAcceptor` when TSL is enabled

### DIFF
--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -239,7 +239,9 @@ impl Launcher {
             match tls {
                 Some(tls) => custom_axum_server::from_tcp_rustls_with_timeouts(socket, tls)
                     .handle(handle)
-                    .acceptor(TimeoutAcceptor)
+                    // The TimeoutAcceptor is commented because TSL does not work with it.
+                    // See: https://github.com/torrust/torrust-index/issues/204#issuecomment-2115529214
+                    //.acceptor(TimeoutAcceptor)
                     .serve(router.into_make_service_with_connect_info::<std::net::SocketAddr>())
                     .await
                     .expect("Axum server for tracker API crashed."),

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -65,7 +65,9 @@ impl Launcher {
             match tls {
                 Some(tls) => custom_axum_server::from_tcp_rustls_with_timeouts(socket, tls)
                     .handle(handle)
-                    .acceptor(TimeoutAcceptor)
+                    // The TimeoutAcceptor is commented because TSL does not work with it.
+                    // See: https://github.com/torrust/torrust-index/issues/204#issuecomment-2115529214
+                    //.acceptor(TimeoutAcceptor)
                     .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
                     .await
                     .expect("Axum server crashed."),


### PR DESCRIPTION
The TimeoutAcceptor es a custom acceptor for Axum that sets a timeput for making a request after openning a connection.

It does not work when TSL is enabled.

This commit disables it, therefore the app does not have any way to avoid a DDos attacks where clients just open connections without making any request.