### PR TITLE
New API endpoint to upload pre-existing keys

### DIFF
--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -152,7 +152,7 @@ pub struct Key(String);
 /// ```
 ///
 /// If the string does not contains a valid key, the parser function will return this error.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Display)]
 pub struct ParseKeyError;
 
 impl FromStr for Key {

--- a/src/servers/apis/v1/context/auth_key/forms.rs
+++ b/src/servers/apis/v1/context/auth_key/forms.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AddKeyForm {
+    #[serde(rename = "key")]
+    pub opt_key: Option<String>,
+    pub seconds_valid: u64,
+}

--- a/src/servers/apis/v1/context/auth_key/handlers.rs
+++ b/src/servers/apis/v1/context/auth_key/handlers.rs
@@ -75,6 +75,8 @@ pub async fn add_auth_key_handler(
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::auth_key#generate-a-new-authentication-key)
 /// for more information about this endpoint.
+///
+/// This endpoint has been deprecated. Use [`add_auth_key_handler`].
 pub async fn generate_auth_key_handler(State(tracker): State<Arc<Tracker>>, Path(seconds_valid_or_key): Path<u64>) -> Response {
     let seconds_valid = seconds_valid_or_key;
     match tracker.generate_auth_key(Duration::from_secs(seconds_valid)).await {

--- a/src/servers/apis/v1/context/auth_key/mod.rs
+++ b/src/servers/apis/v1/context/auth_key/mod.rs
@@ -3,8 +3,8 @@
 //! Authentication keys are used to authenticate HTTP tracker `announce` and
 //! `scrape` requests.
 //!
-//! When the tracker is running in `private` or `private_listed` mode, the
-//! authentication keys are required to announce and scrape torrents.
+//! When the tracker is running in `private` mode, the authentication keys are
+//! required to announce and scrape torrents.
 //!
 //! A sample `announce` request **without** authentication key:
 //!
@@ -22,22 +22,31 @@
 //!
 //! # Generate a new authentication key
 //!
-//! `POST /key/:seconds_valid`
+//! `POST /keys`
 //!
-//! It generates a new authentication key.
+//! It generates a new authentication key or upload a pre-generated key.
 //!
 //! > **NOTICE**: keys expire after a certain amount of time.
 //!
-//! **Path parameters**
+//! **POST parameters**
 //!
 //! Name | Type | Description | Required | Example
 //! ---|---|---|---|---
+//! `key` | 32-char string (0-9, a-z, A-Z) | The optional pre-generated key. | No | `Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z7`
 //! `seconds_valid` | positive integer | The number of seconds the key will be valid. | Yes | `3600`
+//!
+//! > **NOTICE**: the `key` field is optional. If is not provided the tracker
+//! > will generated a random one.
 //!
 //! **Example request**
 //!
 //! ```bash
-//! curl -X POST "http://127.0.0.1:1212/api/v1/key/120?token=MyAccessToken"
+//! curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
+//!      -H "Content-Type: application/json" \
+//!      -d '{
+//!            "key": "xqD6NWH9TcKrOCwDmqcdH5hF5RrbL0A6",
+//!            "seconds_valid": 7200
+//!          }'
 //! ```
 //!
 //! **Example response** `200`

--- a/src/servers/apis/v1/context/auth_key/mod.rs
+++ b/src/servers/apis/v1/context/auth_key/mod.rs
@@ -119,6 +119,7 @@
 //!     "status": "ok"
 //! }
 //! ```
+pub mod forms;
 pub mod handlers;
 pub mod resources;
 pub mod responses;

--- a/src/servers/apis/v1/context/auth_key/responses.rs
+++ b/src/servers/apis/v1/context/auth_key/responses.rs
@@ -4,8 +4,9 @@ use std::error::Error;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 
+use crate::core::auth::ParseKeyError;
 use crate::servers::apis::v1::context::auth_key::resources::AuthKey;
-use crate::servers::apis::v1::responses::unhandled_rejection_response;
+use crate::servers::apis::v1::responses::{bad_request_response, unhandled_rejection_response};
 
 /// `200` response that contains the `AuthKey` resource as json.
 ///
@@ -22,10 +23,18 @@ pub fn auth_key_response(auth_key: &AuthKey) -> Response {
         .into_response()
 }
 
+// Error responses
+
 /// `500` error response when a new authentication key cannot be generated.
 #[must_use]
 pub fn failed_to_generate_key_response<E: Error>(e: E) -> Response {
     unhandled_rejection_response(format!("failed to generate key: {e}"))
+}
+
+/// `500` error response when the provide key cannot be added.
+#[must_use]
+pub fn failed_to_add_key_response<E: Error>(e: E) -> Response {
+    unhandled_rejection_response(format!("failed to add key: {e}"))
 }
 
 /// `500` error response when an authentication key cannot be deleted.
@@ -39,4 +48,14 @@ pub fn failed_to_delete_key_response<E: Error>(e: E) -> Response {
 #[must_use]
 pub fn failed_to_reload_keys_response<E: Error>(e: E) -> Response {
     unhandled_rejection_response(format!("failed to reload keys: {e}"))
+}
+
+#[must_use]
+pub fn invalid_auth_key_response(auth_key: &str, error: &ParseKeyError) -> Response {
+    bad_request_response(&format!("Invalid URL: invalid auth key: string \"{auth_key}\", {error}"))
+}
+
+#[must_use]
+pub fn invalid_auth_key_duration_response(duration: u64) -> Response {
+    bad_request_response(&format!("Invalid URL: invalid auth key duration: \"{duration}\""))
 }

--- a/src/servers/apis/v1/context/auth_key/routes.rs
+++ b/src/servers/apis/v1/context/auth_key/routes.rs
@@ -21,8 +21,12 @@ pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
         .route(
             // code-review: Axum does not allow two routes with the same path but different path variable name.
             // In the new major API version, `seconds_valid` should be a POST form field so that we will have two paths:
-            // POST /key
-            // DELETE /key/:key
+            //
+            // POST /keys
+            // DELETE /keys/:key
+            //
+            // The POST /key/:seconds_valid has been deprecated and it will removed in the future.
+            // Use POST /keys
             &format!("{prefix}/key/:seconds_valid_or_key"),
             post(generate_auth_key_handler)
                 .with_state(tracker.clone())

--- a/src/servers/apis/v1/context/auth_key/routes.rs
+++ b/src/servers/apis/v1/context/auth_key/routes.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use axum::routing::{get, post};
 use axum::Router;
 
-use super::handlers::{delete_auth_key_handler, generate_auth_key_handler, reload_keys_handler};
+use super::handlers::{add_auth_key_handler, delete_auth_key_handler, generate_auth_key_handler, reload_keys_handler};
 use crate::core::Tracker;
 
 /// It adds the routes to the router for the [`auth_key`](crate::servers::apis::v1::context::auth_key) API context.
@@ -30,5 +30,9 @@ pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
                 .with_state(tracker.clone()),
         )
         // Keys command
-        .route(&format!("{prefix}/keys/reload"), get(reload_keys_handler).with_state(tracker))
+        .route(
+            &format!("{prefix}/keys/reload"),
+            get(reload_keys_handler).with_state(tracker.clone()),
+        )
+        .route(&format!("{prefix}/keys"), post(add_auth_key_handler).with_state(tracker))
 }

--- a/src/servers/apis/v1/responses.rs
+++ b/src/servers/apis/v1/responses.rs
@@ -61,7 +61,8 @@ pub fn invalid_auth_key_param_response(invalid_key: &str) -> Response {
     bad_request_response(&format!("Invalid auth key id param \"{invalid_key}\""))
 }
 
-fn bad_request_response(body: &str) -> Response {
+#[must_use]
+pub fn bad_request_response(body: &str) -> Response {
     (
         StatusCode::BAD_REQUEST,
         [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],

--- a/tests/servers/api/v1/asserts.rs
+++ b/tests/servers/api/v1/asserts.rs
@@ -61,6 +61,12 @@ pub async fn assert_bad_request(response: Response, body: &str) {
     assert_eq!(response.text().await.unwrap(), body);
 }
 
+pub async fn assert_unprocessable_content(response: Response, text: &str) {
+    assert_eq!(response.status(), 422);
+    assert_eq!(response.headers().get("content-type").unwrap(), "text/plain; charset=utf-8");
+    assert!(response.text().await.unwrap().contains(text));
+}
+
 pub async fn assert_not_found(response: Response) {
     assert_eq!(response.status(), 404);
     // todo: missing header in the response
@@ -82,8 +88,35 @@ pub async fn assert_invalid_infohash_param(response: Response, invalid_infohash:
     .await;
 }
 
-pub async fn assert_invalid_auth_key_param(response: Response, invalid_auth_key: &str) {
+pub async fn assert_invalid_auth_key_get_param(response: Response, invalid_auth_key: &str) {
     assert_bad_request(response, &format!("Invalid auth key id param \"{}\"", &invalid_auth_key)).await;
+}
+
+pub async fn assert_invalid_auth_key_post_param(response: Response, invalid_auth_key: &str) {
+    assert_bad_request(
+        response,
+        &format!(
+            "Invalid URL: invalid auth key: string \"{}\", ParseKeyError",
+            &invalid_auth_key
+        ),
+    )
+    .await;
+}
+
+pub async fn _assert_unprocessable_auth_key_param(response: Response, _invalid_value: &str) {
+    assert_unprocessable_content(
+        response,
+        "Failed to deserialize the JSON body into the target type: seconds_valid: invalid type",
+    )
+    .await;
+}
+
+pub async fn assert_unprocessable_auth_key_duration_param(response: Response, _invalid_value: &str) {
+    assert_unprocessable_content(
+        response,
+        "Failed to deserialize the JSON body into the target type: seconds_valid: invalid type",
+    )
+    .await;
 }
 
 pub async fn assert_invalid_key_duration_param(response: Response, invalid_key_duration: &str) {

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -1,23 +1,51 @@
 use std::time::Duration;
 
+use serde::Serialize;
 use torrust_tracker::core::auth::Key;
 use torrust_tracker_test_helpers::configuration;
 
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{
     assert_auth_key_utf8, assert_failed_to_delete_key, assert_failed_to_generate_key, assert_failed_to_reload_keys,
-    assert_invalid_auth_key_param, assert_invalid_key_duration_param, assert_ok, assert_token_not_valid, assert_unauthorized,
+    assert_invalid_auth_key_get_param, assert_invalid_auth_key_post_param, assert_ok, assert_token_not_valid,
+    assert_unauthorized, assert_unprocessable_auth_key_duration_param,
 };
-use crate::servers::api::v1::client::Client;
+use crate::servers::api::v1::client::{AddKeyForm, Client};
 use crate::servers::api::{force_database_error, Started};
 
 #[tokio::test]
-async fn should_allow_generating_a_new_auth_key() {
+async fn should_allow_generating_a_new_random_auth_key() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let seconds_valid = 60;
+    let response = Client::new(env.get_connection_info())
+        .add_auth_key(AddKeyForm {
+            opt_key: None,
+            seconds_valid: 60,
+        })
+        .await;
 
-    let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+    let auth_key_resource = assert_auth_key_utf8(response).await;
+
+    // Verify the key with the tracker
+    assert!(env
+        .tracker
+        .verify_auth_key(&auth_key_resource.key.parse::<Key>().unwrap())
+        .await
+        .is_ok());
+
+    env.stop().await;
+}
+
+#[tokio::test]
+async fn should_allow_uploading_a_preexisting_auth_key() {
+    let env = Started::new(&configuration::ephemeral().into()).await;
+
+    let response = Client::new(env.get_connection_info())
+        .add_auth_key(AddKeyForm {
+            opt_key: Some("Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z5".to_string()),
+            seconds_valid: 60,
+        })
+        .await;
 
     let auth_key_resource = assert_auth_key_utf8(response).await;
 
@@ -35,40 +63,23 @@ async fn should_allow_generating_a_new_auth_key() {
 async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let seconds_valid = 60;
-
     let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
-        .generate_auth_key(seconds_valid)
+        .add_auth_key(AddKeyForm {
+            opt_key: None,
+            seconds_valid: 60,
+        })
         .await;
 
     assert_token_not_valid(response).await;
 
     let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
-        .generate_auth_key(seconds_valid)
+        .add_auth_key(AddKeyForm {
+            opt_key: None,
+            seconds_valid: 60,
+        })
         .await;
 
     assert_unauthorized(response).await;
-
-    env.stop().await;
-}
-
-#[tokio::test]
-async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid() {
-    let env = Started::new(&configuration::ephemeral().into()).await;
-
-    let invalid_key_durations = [
-        // "", it returns 404
-        // " ", it returns 404
-        "-1", "text",
-    ];
-
-    for invalid_key_duration in invalid_key_durations {
-        let response = Client::new(env.get_connection_info())
-            .post(&format!("key/{invalid_key_duration}"))
-            .await;
-
-        assert_invalid_key_duration_param(response, invalid_key_duration).await;
-    }
 
     env.stop().await;
 }
@@ -79,8 +90,12 @@ async fn should_fail_when_the_auth_key_cannot_be_generated() {
 
     force_database_error(&env.tracker);
 
-    let seconds_valid = 60;
-    let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+    let response = Client::new(env.get_connection_info())
+        .add_auth_key(AddKeyForm {
+            opt_key: None,
+            seconds_valid: 60,
+        })
+        .await;
 
     assert_failed_to_generate_key(response).await;
 
@@ -108,6 +123,77 @@ async fn should_allow_deleting_an_auth_key() {
 }
 
 #[tokio::test]
+async fn should_fail_generating_a_new_auth_key_when_the_provided_key_is_invalid() {
+    #[derive(Serialize, Debug)]
+    pub struct InvalidAddKeyForm {
+        #[serde(rename = "key")]
+        pub opt_key: Option<String>,
+        pub seconds_valid: u64,
+    }
+
+    let env = Started::new(&configuration::ephemeral().into()).await;
+
+    let invalid_keys = [
+        // "", it returns 404
+        // " ", it returns 404
+        "-1",      // Not a string
+        "invalid", // Invalid string
+        "GQEs2ZNcCm9cwEV9dBpcPB5OwNFWFiR", // Not a 32-char string
+                   // "%QEs2ZNcCm9cwEV9dBpcPB5OwNFWFiRd", // Invalid char. todo: this doesn't fail
+    ];
+
+    for invalid_key in invalid_keys {
+        let response = Client::new(env.get_connection_info())
+            .post_form(
+                "keys",
+                &InvalidAddKeyForm {
+                    opt_key: Some(invalid_key.to_string()),
+                    seconds_valid: 60,
+                },
+            )
+            .await;
+
+        assert_invalid_auth_key_post_param(response, invalid_key).await;
+    }
+
+    env.stop().await;
+}
+
+#[tokio::test]
+async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid() {
+    #[derive(Serialize, Debug)]
+    pub struct InvalidAddKeyForm {
+        #[serde(rename = "key")]
+        pub opt_key: Option<String>,
+        pub seconds_valid: String,
+    }
+
+    let env = Started::new(&configuration::ephemeral().into()).await;
+
+    let invalid_key_durations = [
+        // "", it returns 404
+        // " ", it returns 404
+        "-1", "text",
+    ];
+
+    for invalid_key_duration in invalid_key_durations {
+        let response = Client::new(env.get_connection_info())
+            .post_form(
+                "keys",
+                &InvalidAddKeyForm {
+                    opt_key: None,
+                    seconds_valid: invalid_key_duration.to_string(),
+                },
+            )
+            .await;
+
+        assert_unprocessable_auth_key_duration_param(response, invalid_key_duration).await;
+    }
+
+    env.stop().await;
+}
+
+#[tokio::test]
 async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -124,7 +210,7 @@ async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
     for invalid_auth_key in &invalid_auth_keys {
         let response = Client::new(env.get_connection_info()).delete_auth_key(invalid_auth_key).await;
 
-        assert_invalid_auth_key_param(response, invalid_auth_key).await;
+        assert_invalid_auth_key_get_param(response, invalid_auth_key).await;
     }
 
     env.stop().await;
@@ -246,4 +332,94 @@ async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
     assert_unauthorized(response).await;
 
     env.stop().await;
+}
+
+mod deprecated_generate_key_endpoint {
+
+    use torrust_tracker::core::auth::Key;
+    use torrust_tracker_test_helpers::configuration;
+
+    use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
+    use crate::servers::api::v1::asserts::{
+        assert_auth_key_utf8, assert_failed_to_generate_key, assert_invalid_key_duration_param, assert_token_not_valid,
+        assert_unauthorized,
+    };
+    use crate::servers::api::v1::client::Client;
+    use crate::servers::api::{force_database_error, Started};
+
+    #[tokio::test]
+    async fn should_allow_generating_a_new_auth_key() {
+        let env = Started::new(&configuration::ephemeral().into()).await;
+
+        let seconds_valid = 60;
+
+        let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+
+        let auth_key_resource = assert_auth_key_utf8(response).await;
+
+        // Verify the key with the tracker
+        assert!(env
+            .tracker
+            .verify_auth_key(&auth_key_resource.key.parse::<Key>().unwrap())
+            .await
+            .is_ok());
+
+        env.stop().await;
+    }
+
+    #[tokio::test]
+    async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() {
+        let env = Started::new(&configuration::ephemeral().into()).await;
+
+        let seconds_valid = 60;
+
+        let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
+            .generate_auth_key(seconds_valid)
+            .await;
+
+        assert_token_not_valid(response).await;
+
+        let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
+            .generate_auth_key(seconds_valid)
+            .await;
+
+        assert_unauthorized(response).await;
+
+        env.stop().await;
+    }
+
+    #[tokio::test]
+    async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid() {
+        let env = Started::new(&configuration::ephemeral().into()).await;
+
+        let invalid_key_durations = [
+            // "", it returns 404
+            // " ", it returns 404
+            "-1", "text",
+        ];
+
+        for invalid_key_duration in invalid_key_durations {
+            let response = Client::new(env.get_connection_info())
+                .post_empty(&format!("key/{invalid_key_duration}"))
+                .await;
+
+            assert_invalid_key_duration_param(response, invalid_key_duration).await;
+        }
+
+        env.stop().await;
+    }
+
+    #[tokio::test]
+    async fn should_fail_when_the_auth_key_cannot_be_generated() {
+        let env = Started::new(&configuration::ephemeral().into()).await;
+
+        force_database_error(&env.tracker);
+
+        let seconds_valid = 60;
+        let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+
+        assert_failed_to_generate_key(response).await;
+
+        env.stop().await;
+    }
 }


### PR DESCRIPTION
You can test it with:

```console
curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
     -H "Content-Type: application/json" \
     -d '{
           "key": "Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z7",
           "seconds_valid": 7200
         }'
```

The `key` field is optional. If it's not provided, a random key will be generated.

### Subtasks

- [x] New endpoint to upload a pre-existing key.
- [x] Add E2E test.
- [x] Add new endpoint to rustdoc.
- [x] Mark the current endpoint to generate random keys as deprecated.