### PR TITLE
Overhaul tracker keys: allow permanent keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,6 +3886,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_repr",
+ "serde_with",
  "thiserror",
  "tokio",
  "torrust-tracker-clock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ serde_bencode = "0"
 serde_bytes = "0"
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_repr = "0"
+serde_with = { version = "3.9.0", features = ["json"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 torrust-tracker-clock = { version = "3.0.0-alpha.12-develop", path = "packages/clock" }

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,5 @@
+# Database Migrations
+
+We don't support automatic migrations yet. The tracker creates all the needed tables when it starts. The SQL sentences are hardcoded in each database driver.
+
+The migrations in this folder were introduced to add some new changes (permanent keys) and to allow users to migrate to the new version. In the future, we will remove the hardcoded SQL and start using a Rust crate for database migrations. For the time being, if you are using the initial schema described in the migration `20240730183000_torrust_tracker_create_all_tables.sql` you will need to run all the subsequent migrations manually.

--- a/migrations/mysql/20240730183000_torrust_tracker_create_all_tables.sql
+++ b/migrations/mysql/20240730183000_torrust_tracker_create_all_tables.sql
@@ -1,0 +1,21 @@
+CREATE TABLE
+    IF NOT EXISTS whitelist (
+        id integer PRIMARY KEY AUTO_INCREMENT,
+        info_hash VARCHAR(40) NOT NULL UNIQUE
+    );
+
+CREATE TABLE
+    IF NOT EXISTS torrents (
+        id integer PRIMARY KEY AUTO_INCREMENT,
+        info_hash VARCHAR(40) NOT NULL UNIQUE,
+        completed INTEGER DEFAULT 0 NOT NULL
+    );
+
+CREATE TABLE
+    IF NOT EXISTS `keys` (
+        `id` INT NOT NULL AUTO_INCREMENT,
+        `key` VARCHAR(32) NOT NULL,
+        `valid_until` INT (10) NOT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE (`key`)
+    );

--- a/migrations/mysql/20240730183500_torrust_tracker_keys_valid_until_nullable.sql
+++ b/migrations/mysql/20240730183500_torrust_tracker_keys_valid_until_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `keys` CHANGE `valid_until` `valid_until` INT (10);

--- a/migrations/sqlite/20240730183000_torrust_tracker_create_all_tables.sql
+++ b/migrations/sqlite/20240730183000_torrust_tracker_create_all_tables.sql
@@ -1,0 +1,19 @@
+CREATE TABLE
+    IF NOT EXISTS whitelist (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        info_hash TEXT NOT NULL UNIQUE
+    );
+
+CREATE TABLE
+    IF NOT EXISTS torrents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        info_hash TEXT NOT NULL UNIQUE,
+        completed INTEGER DEFAULT 0 NOT NULL
+    );
+
+CREATE TABLE
+    IF NOT EXISTS keys (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT NOT NULL UNIQUE,
+        valid_until INTEGER NOT NULL
+    );

--- a/migrations/sqlite/20240730183500_torrust_tracker_keys_valid_until_nullable.sql
+++ b/migrations/sqlite/20240730183500_torrust_tracker_keys_valid_until_nullable.sql
@@ -1,0 +1,12 @@
+CREATE TABLE
+    IF NOT EXISTS keys_new (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        key TEXT NOT NULL UNIQUE,
+        valid_until INTEGER
+    );
+
+INSERT INTO keys_new SELECT * FROM `keys`;
+
+DROP TABLE `keys`;
+
+ALTER TABLE keys_new RENAME TO `keys`;

--- a/src/core/databases/mod.rs
+++ b/src/core/databases/mod.rs
@@ -195,11 +195,11 @@ pub trait Database: Sync + Send {
     /// # Errors
     ///
     /// Will return `Err` if unable to load.
-    fn load_keys(&self) -> Result<Vec<auth::ExpiringKey>, Error>;
+    fn load_keys(&self) -> Result<Vec<auth::PeerKey>, Error>;
 
     /// It gets an expiring authentication key from the database.
     ///
-    /// It returns `Some(ExpiringKey)` if a [`ExpiringKey`](crate::core::auth::ExpiringKey)
+    /// It returns `Some(PeerKey)` if a [`PeerKey`](crate::core::auth::PeerKey)
     /// with the input [`Key`] exists, `None` otherwise.
     ///
     /// # Context: Authentication Keys
@@ -207,7 +207,7 @@ pub trait Database: Sync + Send {
     /// # Errors
     ///
     /// Will return `Err` if unable to load.
-    fn get_key_from_keys(&self, key: &Key) -> Result<Option<auth::ExpiringKey>, Error>;
+    fn get_key_from_keys(&self, key: &Key) -> Result<Option<auth::PeerKey>, Error>;
 
     /// It adds an expiring authentication key to the database.
     ///
@@ -216,7 +216,7 @@ pub trait Database: Sync + Send {
     /// # Errors
     ///
     /// Will return `Err` if unable to save.
-    fn add_key_to_keys(&self, auth_key: &auth::ExpiringKey) -> Result<usize, Error>;
+    fn add_key_to_keys(&self, auth_key: &auth::PeerKey) -> Result<usize, Error>;
 
     /// It removes an expiring authentication key from the database.
     ///

--- a/src/servers/apis/v1/context/auth_key/forms.rs
+++ b/src/servers/apis/v1/context/auth_key/forms.rs
@@ -1,8 +1,22 @@
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnNull};
 
+/// This type contains the info needed to add a new tracker key.
+///
+/// You can upload a pre-generated key or let the app to generate a new one.
+/// You can also set an expiration date or leave it empty (`None`) if you want
+/// to create permanent key that does not expire.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AddKeyForm {
+    /// The pre-generated key. Use `None` (null in json) to generate a random key.
+    #[serde_as(deserialize_as = "DefaultOnNull")]
     #[serde(rename = "key")]
     pub opt_key: Option<String>,
-    pub seconds_valid: u64,
+
+    /// How long the key will be valid in seconds. Use `None` (null in json) for
+    /// permanent keys.
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    #[serde(rename = "seconds_valid")]
+    pub opt_seconds_valid: Option<u64>,
 }

--- a/src/servers/apis/v1/context/auth_key/mod.rs
+++ b/src/servers/apis/v1/context/auth_key/mod.rs
@@ -26,17 +26,15 @@
 //!
 //! It generates a new authentication key or upload a pre-generated key.
 //!
-//! > **NOTICE**: keys expire after a certain amount of time.
-//!
 //! **POST parameters**
 //!
 //! Name | Type | Description | Required | Example
 //! ---|---|---|---|---
-//! `key` | 32-char string (0-9, a-z, A-Z) | The optional pre-generated key. | No | `Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z7`
-//! `seconds_valid` | positive integer | The number of seconds the key will be valid. | Yes | `3600`
+//! `key` | 32-char string (0-9, a-z, A-Z) or `null` | The optional pre-generated key. | Yes | `Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z7` or `null`
+//! `seconds_valid` | positive integer or `null` | The number of seconds the key will be valid. | Yes | `3600` or `null`
 //!
-//! > **NOTICE**: the `key` field is optional. If is not provided the tracker
-//! > will generated a random one.
+//! > **NOTICE**: the `key` and `seconds_valid` fields are optional. If `key` is not provided the tracker
+//! > will generated a random one. If `seconds_valid` field is not provided the key will be permanent. You can use the `null` value.
 //!
 //! **Example request**
 //!

--- a/src/servers/apis/v1/context/auth_key/responses.rs
+++ b/src/servers/apis/v1/context/auth_key/responses.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 
-use crate::core::auth::ParseKeyError;
 use crate::servers::apis::v1::context::auth_key::resources::AuthKey;
 use crate::servers::apis::v1::responses::{bad_request_response, unhandled_rejection_response};
 
@@ -51,8 +50,8 @@ pub fn failed_to_reload_keys_response<E: Error>(e: E) -> Response {
 }
 
 #[must_use]
-pub fn invalid_auth_key_response(auth_key: &str, error: &ParseKeyError) -> Response {
-    bad_request_response(&format!("Invalid URL: invalid auth key: string \"{auth_key}\", {error}"))
+pub fn invalid_auth_key_response<E: Error>(auth_key: &str, e: E) -> Response {
+    bad_request_response(&format!("Invalid URL: invalid auth key: string \"{auth_key}\", {e}"))
 }
 
 #[must_use]

--- a/src/shared/bit_torrent/common.rs
+++ b/src/shared/bit_torrent/common.rs
@@ -17,6 +17,6 @@ pub const MAX_SCRAPE_TORRENTS: u8 = 74;
 
 /// HTTP tracker authentication key length.
 ///
-/// See function to [`generate`](crate::core::auth::generate) the
-/// [`ExpiringKeys`](crate::core::auth::ExpiringKey) for more information.
+/// For more information see function [`generate_key`](crate::core::auth::generate_key) to generate the
+/// [`PeerKey`](crate::core::auth::PeerKey).
 pub const AUTH_KEY_LENGTH: usize = 32;

--- a/tests/servers/api/v1/client.rs
+++ b/tests/servers/api/v1/client.rs
@@ -134,5 +134,5 @@ pub async fn get(path: &str, query: Option<Query>) -> Response {
 pub struct AddKeyForm {
     #[serde(rename = "key")]
     pub opt_key: Option<String>,
-    pub seconds_valid: u64,
+    pub seconds_valid: Option<u64>,
 }

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -20,7 +20,7 @@ async fn should_allow_generating_a_new_random_auth_key() {
     let response = Client::new(env.get_connection_info())
         .add_auth_key(AddKeyForm {
             opt_key: None,
-            seconds_valid: 60,
+            seconds_valid: Some(60),
         })
         .await;
 
@@ -43,7 +43,7 @@ async fn should_allow_uploading_a_preexisting_auth_key() {
     let response = Client::new(env.get_connection_info())
         .add_auth_key(AddKeyForm {
             opt_key: Some("Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z5".to_string()),
-            seconds_valid: 60,
+            seconds_valid: Some(60),
         })
         .await;
 
@@ -66,7 +66,7 @@ async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() 
     let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
         .add_auth_key(AddKeyForm {
             opt_key: None,
-            seconds_valid: 60,
+            seconds_valid: Some(60),
         })
         .await;
 
@@ -75,7 +75,7 @@ async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() 
     let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
         .add_auth_key(AddKeyForm {
             opt_key: None,
-            seconds_valid: 60,
+            seconds_valid: Some(60),
         })
         .await;
 
@@ -93,7 +93,7 @@ async fn should_fail_when_the_auth_key_cannot_be_generated() {
     let response = Client::new(env.get_connection_info())
         .add_auth_key(AddKeyForm {
             opt_key: None,
-            seconds_valid: 60,
+            seconds_valid: Some(60),
         })
         .await;
 
@@ -109,7 +109,7 @@ async fn should_allow_deleting_an_auth_key() {
     let seconds_valid = 60;
     let auth_key = env
         .tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -223,7 +223,7 @@ async fn should_fail_when_the_auth_key_cannot_be_deleted() {
     let seconds_valid = 60;
     let auth_key = env
         .tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -247,7 +247,7 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
     // Generate new auth key
     let auth_key = env
         .tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -260,7 +260,7 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
     // Generate new auth key
     let auth_key = env
         .tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -279,7 +279,7 @@ async fn should_allow_reloading_keys() {
 
     let seconds_valid = 60;
     env.tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -296,7 +296,7 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
 
     let seconds_valid = 60;
     env.tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 
@@ -315,7 +315,7 @@ async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
 
     let seconds_valid = 60;
     env.tracker
-        .generate_auth_key(Duration::from_secs(seconds_valid))
+        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
 

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -1261,7 +1261,7 @@ mod configured_as_private {
         async fn should_respond_to_authenticated_peers() {
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
-            let expiring_key = env.tracker.generate_auth_key(Duration::from_secs(60)).await.unwrap();
+            let expiring_key = env.tracker.generate_auth_key(Some(Duration::from_secs(60))).await.unwrap();
 
             let response = Client::authenticated(*env.bind_address(), expiring_key.key())
                 .announce(&QueryBuilder::default().query())
@@ -1393,7 +1393,7 @@ mod configured_as_private {
                     .build(),
             );
 
-            let expiring_key = env.tracker.generate_auth_key(Duration::from_secs(60)).await.unwrap();
+            let expiring_key = env.tracker.generate_auth_key(Some(Duration::from_secs(60))).await.unwrap();
 
             let response = Client::authenticated(*env.bind_address(), expiring_key.key())
                 .scrape(


### PR DESCRIPTION
This PR introduces a new feature. Tracker keys can be permanent.

### How to use the endpoint

#### Upload a pre-generated and expiring key

```
curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
     -H "Content-Type: application/json" \
     -d '{
     	   "key": "Xc1L4PbQJSFGlrgSRZl8wxSFAuMa2110",
           "seconds_valid": 7200
         }'        
```

#### Upload a pre-generated and permanent key

```
curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
     -H "Content-Type: application/json" \
     -d '{
     	   "key": "Xc1L4PbQJSFGlrgSRZl8wxSFAuMa2110",
           "seconds_valid": null
         }'        
```

#### Generate a random and expiring key

You can omit the key, and the tracker will generate a random one.

```
curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
     -H "Content-Type: application/json" \
     -d '{
     	   "key": null,
           "seconds_valid": 7200
         }'        
```

#### Generate a random and permanent key

```
curl -X POST http://localhost:1212/api/v1/keys?token=MyAccessToken \
     -H "Content-Type: application/json" \
     -d '{
     	   "key": null,
           "seconds_valid": null
         }'        
```

### NOTES

- Fields in the json object are mandatory. You cannot omit them. Instead of omitting the field, I've decided to use the `null` value to represent the case where the value is not needed. I prefer to use always the same structure and make it explicit. However, omitting the field could have other advantages, like requiring less maintenance. For example, if we rename a field (breaking change), that would not affect users who are not using that field.
- I've introduced manual database migrations. The `second_valid` column in the `keys` table is now nullable (for permanent keys).