### PR TITLE
Overhaul tracker keys: option to disable auth key expiration 

### DIFF
--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -5,6 +5,7 @@
 //!
 //! The current version for configuration is [`v2`].
 pub mod v2;
+pub mod validator;
 
 use std::collections::HashMap;
 use std::env;

--- a/packages/configuration/src/v2/core.rs
+++ b/packages/configuration/src/v2/core.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::network::Network;
 use crate::v2::database::Database;
+use crate::validator::{SemanticValidationError, Validator};
 use crate::{AnnouncePolicy, TrackerPolicy};
 
 #[allow(clippy::struct_excessive_bools)]
@@ -129,5 +130,15 @@ impl Default for PrivateMode {
 impl PrivateMode {
     fn default_check_keys_expiration() -> bool {
         true
+    }
+}
+
+impl Validator for Core {
+    fn validate(&self) -> Result<(), SemanticValidationError> {
+        if self.private_mode.is_some() && !self.private {
+            return Err(SemanticValidationError::UselessPrivateModeSection);
+        }
+
+        Ok(())
     }
 }

--- a/packages/configuration/src/v2/core.rs
+++ b/packages/configuration/src/v2/core.rs
@@ -1,3 +1,4 @@
+use derive_more::{Constructor, Display};
 use serde::{Deserialize, Serialize};
 
 use super::network::Network;
@@ -32,6 +33,10 @@ pub struct Core {
     #[serde(default = "Core::default_private")]
     pub private: bool,
 
+    // Configuration specific when the tracker is running in private mode.
+    #[serde(default = "Core::default_private_mode")]
+    pub private_mode: Option<PrivateMode>,
+
     // Tracker policy configuration.
     #[serde(default = "Core::default_tracker_policy")]
     pub tracker_policy: TrackerPolicy,
@@ -54,6 +59,7 @@ impl Default for Core {
             listed: Self::default_listed(),
             net: Self::default_network(),
             private: Self::default_private(),
+            private_mode: Self::default_private_mode(),
             tracker_policy: Self::default_tracker_policy(),
             tracker_usage_statistics: Self::default_tracker_usage_statistics(),
         }
@@ -85,10 +91,43 @@ impl Core {
         false
     }
 
+    fn default_private_mode() -> Option<PrivateMode> {
+        if Self::default_private() {
+            Some(PrivateMode::default())
+        } else {
+            None
+        }
+    }
+
     fn default_tracker_policy() -> TrackerPolicy {
         TrackerPolicy::default()
     }
     fn default_tracker_usage_statistics() -> bool {
+        true
+    }
+}
+
+/// Configuration specific when the tracker is running in private mode.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy, Constructor, Display)]
+pub struct PrivateMode {
+    /// A flag to disable expiration date for peer keys.
+    ///
+    /// When true, if the keys is not permanent the expiration date will be
+    /// ignored. The key will be accepted even if it has expired.
+    #[serde(default = "PrivateMode::default_check_keys_expiration")]
+    pub check_keys_expiration: bool,
+}
+
+impl Default for PrivateMode {
+    fn default() -> Self {
+        Self {
+            check_keys_expiration: Self::default_check_keys_expiration(),
+        }
+    }
+}
+
+impl PrivateMode {
+    fn default_check_keys_expiration() -> bool {
         true
     }
 }

--- a/packages/configuration/src/v2/mod.rs
+++ b/packages/configuration/src/v2/mod.rs
@@ -251,6 +251,7 @@ use self::health_check_api::HealthCheckApi;
 use self::http_tracker::HttpTracker;
 use self::tracker_api::HttpApi;
 use self::udp_tracker::UdpTracker;
+use crate::validator::{SemanticValidationError, Validator};
 use crate::{Error, Info, Metadata, Version};
 
 /// This configuration version
@@ -391,6 +392,12 @@ impl Configuration {
         }
 
         self
+    }
+}
+
+impl Validator for Configuration {
+    fn validate(&self) -> Result<(), SemanticValidationError> {
+        self.core.validate()
     }
 }
 

--- a/packages/configuration/src/validator.rs
+++ b/packages/configuration/src/validator.rs
@@ -1,0 +1,19 @@
+//! Trait to validate semantic errors.
+//!
+//! Errors could involve more than one configuration option. Some configuration
+//! combinations can be incompatible.
+use thiserror::Error;
+
+/// Errors that can occur validating the configuration.
+#[derive(Error, Debug)]
+pub enum SemanticValidationError {
+    #[error("Private mode section in configuration can only be included when the tracker is running in private mode.")]
+    UselessPrivateModeSection,
+}
+
+pub trait Validator {
+    /// # Errors
+    ///
+    /// Will return an error if the configuration is invalid.
+    fn validate(&self) -> Result<(), SemanticValidationError>;
+}

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -14,6 +14,7 @@
 use std::sync::Arc;
 
 use torrust_tracker_clock::static_time;
+use torrust_tracker_configuration::validator::Validator;
 use torrust_tracker_configuration::Configuration;
 use tracing::info;
 
@@ -24,9 +25,17 @@ use crate::core::Tracker;
 use crate::shared::crypto::ephemeral_instance_keys;
 
 /// It loads the configuration from the environment and builds the main domain [`Tracker`] struct.
+///
+/// # Panics
+///
+/// Setup can file if the configuration is invalid.
 #[must_use]
 pub fn setup() -> (Configuration, Arc<Tracker>) {
     let configuration = initialize_configuration();
+
+    if let Err(e) = configuration.validate() {
+        panic!("Configuration error: {e}");
+    }
 
     let tracker = initialize_with_configuration(&configuration);
 

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -33,7 +33,7 @@
 //!
 //! // And you can later verify it with:
 //!
-//! assert!(auth::verify_key(&expiring_key).is_ok());
+//! assert!(auth::verify_key_expiration(&expiring_key).is_ok());
 //! ```
 
 use std::panic::Location;
@@ -106,7 +106,7 @@ pub fn generate_key(lifetime: Option<Duration>) -> PeerKey {
 ///
 /// - `Error::KeyExpired` if `auth_key.valid_until` is past the `current_time`.
 /// - `Error::KeyInvalid` if `auth_key.valid_until` is past the `None`.
-pub fn verify_key(auth_key: &PeerKey) -> Result<(), Error> {
+pub fn verify_key_expiration(auth_key: &PeerKey) -> Result<(), Error> {
     let current_time: DurationSinceUnixEpoch = CurrentClock::now();
 
     match auth_key.valid_until {
@@ -322,7 +322,7 @@ mod tests {
         fn should_be_generated_with_a_expiration_time() {
             let expiring_key = auth::generate_key(Some(Duration::new(9999, 0)));
 
-            assert!(auth::verify_key(&expiring_key).is_ok());
+            assert!(auth::verify_key_expiration(&expiring_key).is_ok());
         }
 
         #[test]
@@ -336,12 +336,12 @@ mod tests {
             // Mock the time has passed 10 sec.
             clock::Stopped::local_add(&Duration::from_secs(10)).unwrap();
 
-            assert!(auth::verify_key(&expiring_key).is_ok());
+            assert!(auth::verify_key_expiration(&expiring_key).is_ok());
 
             // Mock the time has passed another 10 sec.
             clock::Stopped::local_add(&Duration::from_secs(10)).unwrap();
 
-            assert!(auth::verify_key(&expiring_key).is_err());
+            assert!(auth::verify_key_expiration(&expiring_key).is_err());
         }
     }
 }

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -4,7 +4,7 @@
 //! Tracker keys are tokens used to authenticate the tracker clients when the tracker runs
 //! in `private` or `private_listed` modes.
 //!
-//! There are services to [`generate_key`]  and [`verify_key`]  authentication keys.
+//! There are services to [`generate_key`]  and [`verify_key_expiration`]  authentication keys.
 //!
 //! Authentication keys are used only by [`HTTP`](crate::servers::http) trackers. All keys have an expiration time, that means
 //! they are only valid during a period of time. After that time the expiring key will no longer be valid.


### PR DESCRIPTION
When the tracker is running in private mode you can disable checking keys' expiration in the configuration with:

```toml
[core]
private = false

[core.private_mode]
check_keys_expiration = false
```

All keys will be valid as long as they exist in the database.