### PR TITLE
Config overhaul: make some fields mandatory

### DIFF
--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -303,6 +303,9 @@ pub enum Error {
 
     #[error("Unsupported configuration version: {version}")]
     UnsupportedVersion { version: Version },
+
+    #[error("Missing mandatory configuration option. Option path: {path}")]
+    MissingMandatoryOption { path: String },
 }
 
 impl From<figment::Error> for Error {

--- a/share/default/config/tracker.container.mysql.toml
+++ b/share/default/config/tracker.container.mysql.toml
@@ -3,6 +3,13 @@ app = "torrust-tracker"
 purpose = "configuration"
 schema_version = "2.0.0"
 
+[logging]
+threshold = "info"
+
+[core]
+listed = false
+private = false
+
 [core.database]
 driver = "mysql"
 path = "mysql://db_user:db_user_secret_password@mysql:3306/torrust_tracker"

--- a/share/default/config/tracker.container.sqlite3.toml
+++ b/share/default/config/tracker.container.sqlite3.toml
@@ -3,6 +3,13 @@ app = "torrust-tracker"
 purpose = "configuration"
 schema_version = "2.0.0"
 
+[logging]
+threshold = "info"
+
+[core]
+listed = false
+private = false
+
 [core.database]
 path = "/var/lib/torrust/tracker/database/sqlite3.db"
 

--- a/share/default/config/tracker.development.sqlite3.toml
+++ b/share/default/config/tracker.development.sqlite3.toml
@@ -3,6 +3,13 @@ app = "torrust-tracker"
 purpose = "configuration"
 schema_version = "2.0.0"
 
+[logging]
+threshold = "info"
+
+[core]
+listed = false
+private = false
+
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"
 

--- a/share/default/config/tracker.e2e.container.sqlite3.toml
+++ b/share/default/config/tracker.e2e.container.sqlite3.toml
@@ -3,6 +3,13 @@ app = "torrust-tracker"
 purpose = "configuration"
 schema_version = "2.0.0"
 
+[logging]
+threshold = "info"
+
+[core]
+listed = false
+private = false
+
 [core.database]
 path = "/var/lib/torrust/tracker/database/sqlite3.db"
 

--- a/share/default/config/tracker.udp.benchmarking.toml
+++ b/share/default/config/tracker.udp.benchmarking.toml
@@ -7,6 +7,8 @@ schema_version = "2.0.0"
 threshold = "error"
 
 [core]
+listed = false
+private = false
 remove_peerless_torrents = false
 tracker_usage_statistics = false
 


### PR DESCRIPTION
Some configuration options are mandatory. The tracker will panic if the user doesn't provide an explicit value for them from one of the configuration sources: TOML or ENV VARS.

The mandatory options are:

```toml
[metadata]
schema_version = "2.0.0"

[logging]
threshold = "info"

[core]
private = false
listed = false
```