### PR TITLE
docs: update roadmap in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@
 Core:
 
 - [ ] New option `want_ip_from_query_string`. See <https://github.com/torrust/torrust-tracker/discussions/532#issuecomment-1836642956>.
-- [ ] Permanent keys. See <https://github.com/torrust/torrust-tracker/discussions/244>.
 - [ ] Peer and torrents specific statistics. See <https://github.com/torrust/torrust-tracker/discussions/139>.
 
 Persistence:


### PR DESCRIPTION
Remove the "Permanent keys" feature from the roadmap. They have already been implemented.