### PR TITLE
fix: benchmarking config template

### DIFF
--- a/share/default/config/tracker.udp.benchmarking.toml
+++ b/share/default/config/tracker.udp.benchmarking.toml
@@ -1,6 +1,4 @@
 [metadata]
-app = "torrust-tracker"
-purpose = "configuration"
 schema_version = "2.0.0"
 
 [logging]
@@ -9,8 +7,15 @@ threshold = "error"
 [core]
 listed = false
 private = false
-remove_peerless_torrents = false
 tracker_usage_statistics = false
+
+[core.database]
+driver = "sqlite3"
+path = "./sqlite3.db"
+
+[core.tracker_policy]
+persistent_torrent_completed_stat = false
+remove_peerless_torrents = false
 
 [[udp_trackers]]
 bind_address = "0.0.0.0:6969"


### PR DESCRIPTION
Fix benchmarking config template:

- Missing [core.tracker_policy] section. The configuration was changed.
- Missing database config. Needed when the default DB folder does not exist. With this config, a storage folder is not needed. We are not using DB, which requires DB for benchmarking.