### PR TITLE
Remove default configuration values for secrets

### DIFF
--- a/packages/configuration/src/v2_0_0/tracker_api.rs
+++ b/packages/configuration/src/v2_0_0/tracker_api.rs
@@ -52,14 +52,11 @@ impl HttpApi {
     }
 
     fn default_access_tokens() -> AccessTokens {
-        [(String::from("admin"), String::from("MyAccessToken"))]
-            .iter()
-            .cloned()
-            .collect()
+        [].iter().cloned().collect()
     }
 
-    pub fn override_admin_token(&mut self, api_admin_token: &str) {
-        self.access_tokens.insert("admin".to_string(), api_admin_token.to_string());
+    pub fn add_token(&mut self, key: &str, token: &str) {
+        self.access_tokens.insert(key.to_string(), token.to_string());
     }
 
     pub fn mask_secrets(&mut self) {
@@ -74,10 +71,18 @@ mod tests {
     use crate::v2_0_0::tracker_api::HttpApi;
 
     #[test]
-    fn http_api_configuration_should_check_if_it_contains_a_token() {
+    fn default_http_api_configuration_should_not_contains_any_token() {
         let configuration = HttpApi::default();
 
+        assert_eq!(configuration.access_tokens.values().len(), 0);
+    }
+
+    #[test]
+    fn http_api_configuration_should_allow_adding_tokens() {
+        let mut configuration = HttpApi::default();
+
+        configuration.add_token("admin", "MyAccessToken");
+
         assert!(configuration.access_tokens.values().any(|t| t == "MyAccessToken"));
-        assert!(!configuration.access_tokens.values().any(|t| t == "NonExistingToken"));
     }
 }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -32,10 +32,12 @@ pub fn ephemeral() -> Configuration {
 
     // Ephemeral socket address for API
     let api_port = 0u16;
-    config.http_api = Some(HttpApi {
+    let mut http_api = HttpApi {
         bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), api_port),
         ..Default::default()
-    });
+    };
+    http_api.add_token("admin", "MyAccessToken");
+    config.http_api = Some(http_api);
 
     // Ephemeral socket address for Health Check API
     let health_check_api_port = 0u16;

--- a/src/console/ci/e2e/tracker_container.rs
+++ b/src/console/ci/e2e/tracker_container.rs
@@ -105,14 +105,11 @@ impl TrackerContainer {
     ///
     /// Will panic if it can't remove the container.
     pub fn remove(&self) {
-        match &self.running {
-            Some(_running_container) => {
-                error!("Can't remove running container: {} ...", self.name);
-            }
-            None => {
-                info!("Removing docker tracker container: {} ...", self.name);
-                Docker::remove(&self.name).expect("Container should be removed");
-            }
+        if let Some(_running_container) = &self.running {
+            error!("Can't remove running container: {} ...", self.name);
+        } else {
+            info!("Removing docker tracker container: {} ...", self.name);
+            Docker::remove(&self.name).expect("Container should be removed");
         }
     }
 


### PR DESCRIPTION
Remove default configuration values for secrets. To avoid running the tracker unintentionally with known values.