### PR TITLE
Fix: wrong req type name in tracker checker output

### DIFF
--- a/src/console/clients/checker/checks/udp.rs
+++ b/src/console/clients/checker/checks/udp.rs
@@ -83,7 +83,7 @@ pub async fn run(udp_trackers: Vec<SocketAddr>, timeout: Duration) -> Vec<Result
                 .await
                 .map(|_| ());
 
-            checks.results.push((Check::Announce, check));
+            checks.results.push((Check::Scrape, check));
         }
 
         if checks.results.iter().any(|f| f.1.is_err()) {


### PR DESCRIPTION
Fix wrong req type name in tracker checker output.

Command:

```console
$ TORRUST_CHECKER_CONFIG='{
    "udp_trackers": ["127.0.0.1:6969"],
    "http_trackers": [],
    "health_checks": []
}' cargo run --bin tracker_checker
```

```output
   Compiling torrust-tracker v3.0.0-rc.1-develop (/home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker)
    Finished `dev` profile [optimized + debuginfo] target(s) in 15.42s
     Running `target/debug/tracker_checker`
2024-09-11T09:44:57.432395Z  INFO torrust_tracker::console::clients::checker::service: Running checks for trackers ...
```

Fixed output:

```json
[
  {
    "Udp": {
      "Ok": {
        "remote_addr": "127.0.0.1:6969",
        "results": [
          [
            "Setup",
            {
              "Ok": null
            }
          ],
          [
            "Connect",
            {
              "Ok": null
            }
          ],
          [
            "Announce",
            {
              "Ok": null
            }
          ],
          [
            "Scrape",
            {
              "Ok": null
            }
          ]
        ]
      }
    }
  }
]
```

The previous output was: 

```json
[
  {
    "Udp": {
      "Ok": {
        "remote_addr": "127.0.0.1:6969",
        "results": [
          [
            "Setup",
            {
              "Ok": null
            }
          ],
          [
            "Connect",
            {
              "Ok": null
            }
          ],
          [
            "Announce",
            {
              "Ok": null
            }
          ],
          [
            "Announce",
            {
              "Ok": null
            }
          ]
        ]
      }
    }
  }
]
```