### PR TITLE
Tracker checker supports more service address formats

### DIFF
--- a/src/console/clients/checker/checks/http.rs
+++ b/src/console/clients/checker/checks/http.rs
@@ -28,6 +28,9 @@ pub async fn run(http_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Check
     tracing::debug!("HTTP trackers ...");
 
     for ref url in http_trackers {
+        let mut base_url = url.clone();
+        base_url.set_path("");
+
         let mut checks = Checks {
             url: url.clone(),
             results: Vec::default(),
@@ -35,14 +38,14 @@ pub async fn run(http_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Check
 
         // Announce
         {
-            let check = check_http_announce(url, timeout).await.map(|_| ());
+            let check = check_http_announce(&base_url, timeout).await.map(|_| ());
 
             checks.results.push((Check::Announce, check));
         }
 
         // Scrape
         {
-            let check = check_http_scrape(url, timeout).await.map(|_| ());
+            let check = check_http_scrape(&base_url, timeout).await.map(|_| ());
 
             checks.results.push((Check::Scrape, check));
         }

--- a/src/console/clients/checker/config.rs
+++ b/src/console/clients/checker/config.rs
@@ -215,7 +215,7 @@ mod tests {
         }
 
         mod http_trackers {
-            use crate::console::clients::checker::config::{Configuration, PlainConfiguration};
+            use crate::console::clients::checker::config::{Configuration, PlainConfiguration, ServiceUrl};
 
             #[test]
             fn it_should_fail_when_a_tracker_http_url_is_invalid() {
@@ -226,6 +226,41 @@ mod tests {
                 };
 
                 assert!(Configuration::try_from(plain_config).is_err());
+            }
+
+            #[test]
+            fn it_should_allow_the_url_to_contain_a_path() {
+                // This is the common format for HTTP tracker URLs:
+                // http://domain.com:7070/announce
+
+                let plain_config = PlainConfiguration {
+                    udp_trackers: vec![],
+                    http_trackers: vec!["http://127.0.0.1:7070/announce".to_string()],
+                    health_checks: vec![],
+                };
+
+                let config = Configuration::try_from(plain_config).expect("Invalid plain configuration");
+
+                assert_eq!(
+                    config.http_trackers[0],
+                    "http://127.0.0.1:7070/announce".parse::<ServiceUrl>().unwrap()
+                );
+            }
+
+            #[test]
+            fn it_should_allow_the_url_to_contain_an_empty_path() {
+                let plain_config = PlainConfiguration {
+                    udp_trackers: vec![],
+                    http_trackers: vec!["http://127.0.0.1:7070/".to_string()],
+                    health_checks: vec![],
+                };
+
+                let config = Configuration::try_from(plain_config).expect("Invalid plain configuration");
+
+                assert_eq!(
+                    config.http_trackers[0],
+                    "http://127.0.0.1:7070/".parse::<ServiceUrl>().unwrap()
+                );
             }
         }
 


### PR DESCRIPTION
### UDP Trackers

All the following URLs for UDP trackers are now allowed:

```console
TORRUST_CHECKER_CONFIG='{
    "udp_trackers": [
	"127.0.0.1:6969",
	"127.0.0.1:6969/",
	"127.0.0.1:6969/announce",
	"localhost:6969",
	"localhost:6969/",
	"localhost:6969/announce",
	"udp://127.0.0.1:6969",
	"udp://127.0.0.1:6969/",
	"udp://127.0.0.1:6969/announce",
	"udp://localhost:6969",
	"udp://localhost:6969/",
	"udp://localhost:6969/announce"
    ],
    "http_trackers": [],
    "health_checks": []
}' cargo run --bin tracker_checker
```

**NOTICE:** the client will resolve the domain to an IP address if it's needed.

### HTTP Trackers

  Now, it supports a path suffix (`/` or `/announce`). It will be removed by the client to build
  the "scrape" URLs.
  
  This type of URL is widespread in tracker lists like https://newtrackon.com/.
  
  ```console
  TORRUST_CHECKER_CONFIG='{
      "udp_trackers": [],
      "http_trackers": [
          "http://127.0.0.1:7070",
          "http://127.0.0.1:7070/",
          "http://127.0.0.1:7070/announce"
      ],
      "health_checks": []
  }' cargo run --bin tracker_checker
  ```