### PR TITLE
#1040: `continue` when finding errors

### DIFF
--- a/src/console/clients/checker/checks/udp.rs
+++ b/src/console/clients/checker/checks/udp.rs
@@ -50,7 +50,7 @@ pub async fn run(udp_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Checks
             Err(err) => {
                 checks.results.push((Check::Setup, Err(err)));
                 results.push(Err(checks));
-                break;
+                continue;
             }
         };
 
@@ -65,7 +65,7 @@ pub async fn run(udp_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Checks
             Err(err) => {
                 checks.results.push((Check::Connect, Err(err)));
                 results.push(Err(checks));
-                break;
+                continue;
             }
         };
 


### PR DESCRIPTION
Fix the behaviour of UDP checks exiting on first fail (#1040). Was `break`ing instead of `continue`ing when iterating over each test. 