### PR TITLE
Add coverage report for push event

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,57 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  report:
+    name: Generate Coverage Report
+    environment: coverage
+    runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-Cinstrument-coverage"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install LLVM tools
+        run: sudo apt-get update && sudo apt-get install -y llvm
+
+      - id: setup
+        name: Setup Toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly
+          components: llvm-tools-preview
+
+      - id: cache
+        name: Enable Workflow Cache
+        uses: Swatinem/rust-cache@v2
+
+      - id: tools
+        name: Install Tools
+        uses: taiki-e/install-action@v2
+        with:
+          tool: grcov,cargo-llvm-cov
+
+      - id: coverage
+        name: Generate Coverage Report
+        run: |
+          cargo clean 
+          cargo llvm-cov --all-features --workspace --codecov --output-path ./codecov.json
+
+      - id: upload
+        name: Upload Coverage Report
+        uses: codecov/codecov-action@v5
+        with:
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ github.workspace }}/codecov.json
+          fail_ci_if_error: true

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -1,9 +1,6 @@
-name: Generate Coverage Report
+name: Generate Coverage Report (PR)
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
     branches:
       - develop

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -1,10 +1,10 @@
-name: Upload Coverage Report
+name: Upload Coverage Report (PR)
 
 on:
   # This workflow is triggered after every successfull execution
   # of `Generate Coverage Report` workflow.
   workflow_run:
-    workflows: ["Generate Coverage Report"]
+    workflows: ["Generate Coverage Report (PR)"]
     types:
       - completed
 


### PR DESCRIPTION
The new coverage workflows ([generate_coverage.yaml](https://github.com/torrust/torrust-tracker/blob/develop/.github/workflows/generate_coverage.yaml) and [upload_coverage.yaml](https://github.com/torrust/torrust-tracker/blob/develop/.github/workflows/upload_coverage.yaml)) only work for PRs. We have to keep the old one for push events.