### PR TITLE
resolve(#1104): Improve error message in `announce` response

### DIFF
--- a/src/servers/http/v1/extractors/announce_request.rs
+++ b/src/servers/http/v1/extractors/announce_request.rs
@@ -137,7 +137,7 @@ mod tests {
 
         assert_error_response(
             &response,
-            "Cannot parse query params for announce request: missing query params for announce request",
+            "Bad request. Cannot parse query params for announce request: missing query params for announce request",
         );
     }
 
@@ -146,13 +146,13 @@ mod tests {
         let invalid_query = "param1=value1=value2";
         let response = extract_announce_from(Some(invalid_query)).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params");
+        assert_error_response(&response, "Bad request. Cannot parse query params");
     }
 
     #[test]
     fn it_should_reject_a_request_with_a_query_that_cannot_be_parsed_into_an_announce_request() {
         let response = extract_announce_from(Some("param1=value1")).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params for announce request");
+        assert_error_response(&response, "Bad request. Cannot parse query params for announce request");
     }
 }

--- a/src/servers/http/v1/requests/announce.rs
+++ b/src/servers/http/v1/requests/announce.rs
@@ -226,7 +226,7 @@ impl FromStr for Compact {
 impl From<ParseQueryError> for responses::error::Error {
     fn from(err: ParseQueryError) -> Self {
         responses::error::Error {
-            failure_reason: format!("Cannot parse query params: {err}"),
+            failure_reason: format!("Bad request. Cannot parse query params: {err}"),
         }
     }
 }
@@ -234,7 +234,7 @@ impl From<ParseQueryError> for responses::error::Error {
 impl From<ParseAnnounceQueryError> for responses::error::Error {
     fn from(err: ParseAnnounceQueryError) -> Self {
         responses::error::Error {
-            failure_reason: format!("Cannot parse query params for announce request: {err}"),
+            failure_reason: format!("Bad request. Cannot parse query params for announce request: {err}"),
         }
     }
 }


### PR DESCRIPTION
This PR try to resolve https://github.com/torrust/torrust-tracker/issues/1104: 

- Updated error messages in test cases to include "Bad request" for better clarity when query parameters cannot be parsed. 
- Modified the `From` implementations for `ParseQueryError` and `ParseAnnounceQueryError` to include "Bad request" in the error messages.