### PR TITLE
Improve HTTP announce error message

### DIFF
--- a/src/servers/http/v1/extractors/announce_request.rs
+++ b/src/servers/http/v1/extractors/announce_request.rs
@@ -19,13 +19,13 @@
 //! Missing query params for `announce` request: <http://0.0.0.0:7070/announce>
 //!
 //! ```text
-//! d14:failure reason149:Cannot parse query params for announce request: missing query params for announce request in src/servers/http/v1/extractors/announce_request.rs:54:23e
+//! d14:failure reason149:Bad request. Cannot parse query params for announce request: missing query params for announce request in src/servers/http/v1/extractors/announce_request.rs:54:23e
 //! ```
 //!
 //! Invalid query param (`info_hash`): <http://0.0.0.0:7070/announce?info_hash=invalid&peer_addr=2.137.87.41&downloaded=0&uploaded=0&peer_id=-qB00000000000000001&port=17548&left=0&event=completed&compact=0>
 //!
 //! ```text
-//! d14:failure reason240:Cannot parse query params for announce request: invalid param value invalid for info_hash in not enough bytes for infohash: got 7 bytes, expected 20 src/shared/bit_torrent/info_hash.rs:240:27, src/servers/http/v1/requests/announce.rs:182:42e
+//! d14:failure reason240:Bad request. Cannot parse query params for announce request: invalid param value invalid for info_hash in not enough bytes for infohash: got 7 bytes, expected 20 src/shared/bit_torrent/info_hash.rs:240:27, src/servers/http/v1/requests/announce.rs:182:42e
 //! ```
 use std::panic::Location;
 
@@ -137,7 +137,7 @@ mod tests {
 
         assert_error_response(
             &response,
-            "Cannot parse query params for announce request: missing query params for announce request",
+            "Bad request. Cannot parse query params for announce request: missing query params for announce request",
         );
     }
 
@@ -146,13 +146,13 @@ mod tests {
         let invalid_query = "param1=value1=value2";
         let response = extract_announce_from(Some(invalid_query)).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params");
+        assert_error_response(&response, "Bad request. Cannot parse query params");
     }
 
     #[test]
     fn it_should_reject_a_request_with_a_query_that_cannot_be_parsed_into_an_announce_request() {
         let response = extract_announce_from(Some("param1=value1")).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params for announce request");
+        assert_error_response(&response, "Bad request. Cannot parse query params for announce request");
     }
 }

--- a/src/servers/http/v1/extractors/scrape_request.rs
+++ b/src/servers/http/v1/extractors/scrape_request.rs
@@ -19,13 +19,13 @@
 //! Missing query params for scrape request: <http://0.0.0.0:7070/scrape>
 //!
 //! ```text
-//! d14:failure reason143:Cannot parse query params for scrape request: missing query params for scrape request in src/servers/http/v1/extractors/scrape_request.rs:52:23e
+//! d14:failure reason143:Bad request. Cannot parse query params for scrape request: missing query params for scrape request in src/servers/http/v1/extractors/scrape_request.rs:52:23e
 //! ```
 //!
 //! Invalid query params for scrape request: <http://0.0.0.0:7070/scrape?info_hash=invalid>
 //!
 //! ```text
-//! d14:failure reason235:Cannot parse query params for scrape request: invalid param value invalid for info_hash in not enough bytes for infohash: got 7 bytes, expected 20 src/shared/bit_torrent/info_hash.rs:240:27, src/servers/http/v1/requests/scrape.rs:66:46e
+//! d14:failure reason235:Bad request. Cannot parse query params for scrape request: invalid param value invalid for info_hash in not enough bytes for infohash: got 7 bytes, expected 20 src/shared/bit_torrent/info_hash.rs:240:27, src/servers/http/v1/requests/scrape.rs:66:46e
 //! ```
 use std::panic::Location;
 
@@ -158,7 +158,7 @@ mod tests {
 
         assert_error_response(
             &response,
-            "Cannot parse query params for scrape request: missing query params for scrape request",
+            "Bad request. Cannot parse query params for scrape request: missing query params for scrape request",
         );
     }
 
@@ -167,13 +167,13 @@ mod tests {
         let invalid_query = "param1=value1=value2";
         let response = extract_scrape_from(Some(invalid_query)).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params");
+        assert_error_response(&response, "Bad request. Cannot parse query params");
     }
 
     #[test]
     fn it_should_reject_a_request_with_a_query_that_cannot_be_parsed_into_a_scrape_request() {
         let response = extract_scrape_from(Some("param1=value1")).unwrap_err();
 
-        assert_error_response(&response, "Cannot parse query params for scrape request");
+        assert_error_response(&response, "Bad request. Cannot parse query params for scrape request");
     }
 }

--- a/src/servers/http/v1/requests/announce.rs
+++ b/src/servers/http/v1/requests/announce.rs
@@ -226,7 +226,7 @@ impl FromStr for Compact {
 impl From<ParseQueryError> for responses::error::Error {
     fn from(err: ParseQueryError) -> Self {
         responses::error::Error {
-            failure_reason: format!("Cannot parse query params: {err}"),
+            failure_reason: format!("Bad request. Cannot parse query params: {err}"),
         }
     }
 }
@@ -234,7 +234,7 @@ impl From<ParseQueryError> for responses::error::Error {
 impl From<ParseAnnounceQueryError> for responses::error::Error {
     fn from(err: ParseAnnounceQueryError) -> Self {
         responses::error::Error {
-            failure_reason: format!("Cannot parse query params for announce request: {err}"),
+            failure_reason: format!("Bad request. Cannot parse query params for announce request: {err}"),
         }
     }
 }

--- a/src/servers/http/v1/requests/scrape.rs
+++ b/src/servers/http/v1/requests/scrape.rs
@@ -39,7 +39,7 @@ pub enum ParseScrapeQueryError {
 impl From<ParseScrapeQueryError> for responses::error::Error {
     fn from(err: ParseScrapeQueryError) -> Self {
         responses::error::Error {
-            failure_reason: format!("Cannot parse query params for scrape request: {err}"),
+            failure_reason: format!("Bad request. Cannot parse query params for scrape request: {err}"),
         }
     }
 }

--- a/tests/servers/http/asserts.rs
+++ b/tests/servers/http/asserts.rs
@@ -133,7 +133,7 @@ pub async fn assert_cannot_parse_query_params_error_response(response: Response,
 
     assert_bencoded_error(
         &response.text().await.unwrap(),
-        &format!("Cannot parse query params{failure}"),
+        &format!("Bad request. Cannot parse query params{failure}"),
         Location::caller(),
     );
 }


### PR DESCRIPTION
- Updated error messages in test cases to include "Bad request" for better clarity when query parameters cannot be parsed. 
- Modified the `From` implementations for `ParseQueryError` and `ParseAnnounceQueryError` to include "Bad request" in the error messages.