### PR TITLE
Feat: ban IPs not sending a valid connection ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +638,15 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec",
 ]
 
 [[package]]
@@ -3949,6 +3964,7 @@ dependencies = [
  "bittorrent-http-protocol",
  "bittorrent-primitives",
  "bittorrent-tracker-client",
+ "bloom",
  "blowfish",
  "camino",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ axum-server = { version = "0", features = ["tls-rustls-no-provider"] }
 bittorrent-http-protocol = { version = "3.0.0-develop", path = "packages/http-protocol" }
 bittorrent-primitives = "0.1.0"
 bittorrent-tracker-client = { version = "3.0.0-develop", path = "packages/tracker-client" }
+bloom = "0.3.2"
 blowfish = "0"
 camino = { version = "1", features = ["serde", "serde1"] }
 chrono = { version = "0", default-features = false, features = ["clock"] }

--- a/cSpell.json
+++ b/cSpell.json
@@ -5,6 +5,7 @@
         "alekitto",
         "appuser",
         "Arvid",
+        "ASMS",
         "asyn",
         "autoclean",
         "AUTOINCREMENT",

--- a/share/default/config/tracker.udp.benchmarking.toml
+++ b/share/default/config/tracker.udp.benchmarking.toml
@@ -18,4 +18,4 @@ persistent_torrent_completed_stat = false
 remove_peerless_torrents = false
 
 [[udp_trackers]]
-bind_address = "0.0.0.0:6969"
+bind_address = "0.0.0.0:3000"

--- a/src/servers/udp/server/banning.rs
+++ b/src/servers/udp/server/banning.rs
@@ -1,0 +1,150 @@
+//! Banning service for UDP tracker.
+//!
+//! It bans clients that send invalid connection id's.
+//!
+//! It uses two levels of filtering:
+//!
+//! 1. First, tt uses a Counting Bloom Filter to keep track of the number of
+//!    connection ID errors per ip. That means there can be false positives, but
+//!    not false negatives. 1 out of 100000 requests will be a false positive
+//!    and the client will be banned and not receive a response.
+//! 2. Since we want to avoid false positives (banning a client that is not
+//!    sending invalid connection id's), we use a `HashMap` to keep track of the
+//!    exact number of connection ID errors per ip.
+//!
+//! This two level filtering is to avoid false positives. It has the advantage
+//! of being fast by using a Counting Bloom Filter and not having false
+//! negatives at the cost of increasing the memory usage.
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use bloom::{CountingBloomFilter, ASMS};
+use tokio::time::Instant;
+use url::Url;
+
+use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
+
+pub struct BanService {
+    max_connection_id_errors_per_ip: u32,
+    fuzzy_error_counter: CountingBloomFilter,
+    accurate_error_counter: HashMap<IpAddr, u32>,
+    local_addr: Url,
+    last_connection_id_errors_reset: Instant,
+}
+
+impl BanService {
+    #[must_use]
+    pub fn new(max_connection_id_errors_per_ip: u32, local_addr: Url) -> Self {
+        Self {
+            max_connection_id_errors_per_ip,
+            local_addr,
+            fuzzy_error_counter: CountingBloomFilter::with_rate(4, 0.01, 100),
+            accurate_error_counter: HashMap::new(),
+            last_connection_id_errors_reset: tokio::time::Instant::now(),
+        }
+    }
+
+    pub fn increase_counter(&mut self, ip: &IpAddr) {
+        self.fuzzy_error_counter.insert(&ip.to_string());
+        *self.accurate_error_counter.entry(*ip).or_insert(0) += 1;
+    }
+
+    #[must_use]
+    pub fn get_count(&self, ip: &IpAddr) -> Option<u32> {
+        self.accurate_error_counter.get(ip).copied()
+    }
+
+    #[must_use]
+    pub fn get_estimate_count(&self, ip: &IpAddr) -> u32 {
+        self.fuzzy_error_counter.estimate_count(&ip.to_string())
+    }
+
+    /// Returns true if the given ip address is banned.
+    #[must_use]
+    pub fn is_banned(&self, ip: &IpAddr) -> bool {
+        // First check if the ip is in the bloom filter (fast check)
+        if self.fuzzy_error_counter.estimate_count(&ip.to_string()) <= self.max_connection_id_errors_per_ip {
+            return false;
+        }
+
+        // Check with the exact counter (to avoid false positives)
+        match self.get_count(ip) {
+            Some(count) => count > self.max_connection_id_errors_per_ip,
+            None => false,
+        }
+    }
+
+    /// Resets the filters and updates the reset timestamp.
+    pub fn reset_bans(&mut self) {
+        self.fuzzy_error_counter.clear();
+
+        self.accurate_error_counter.clear();
+
+        self.last_connection_id_errors_reset = Instant::now();
+
+        let local_addr = self.local_addr.to_string();
+        tracing::info!(target: UDP_TRACKER_LOG_TARGET, local_addr, "Udp::run_udp_server::loop (connection id errors filter cleared)");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::IpAddr;
+
+    use super::BanService;
+
+    /// Sample service with one day ban duration.
+    fn ban_service(counter_limit: u32) -> BanService {
+        let udp_tracker_url = "udp://127.0.0.1".parse().unwrap();
+        BanService::new(counter_limit, udp_tracker_url)
+    }
+
+    #[test]
+    fn it_should_increase_the_errors_counter_for_a_given_ip() {
+        let mut ban_service = ban_service(1);
+
+        let ip: IpAddr = "127.0.0.2".parse().unwrap();
+
+        ban_service.increase_counter(&ip);
+
+        assert_eq!(ban_service.get_count(&ip), Some(1));
+    }
+
+    #[test]
+    fn it_should_ban_ips_with_counters_exceeding_a_predefined_limit() {
+        let mut ban_service = ban_service(1);
+
+        let ip: IpAddr = "127.0.0.2".parse().unwrap();
+
+        ban_service.increase_counter(&ip); // Counter = 1
+        ban_service.increase_counter(&ip); // Counter = 2
+
+        println!("Counter: {}", ban_service.get_count(&ip).unwrap());
+
+        assert!(ban_service.is_banned(&ip));
+    }
+
+    #[test]
+    fn it_should_not_ban_ips_whose_counters_do_not_exceed_the_predefined_limit() {
+        let mut ban_service = ban_service(1);
+
+        let ip: IpAddr = "127.0.0.2".parse().unwrap();
+
+        ban_service.increase_counter(&ip);
+
+        assert!(!ban_service.is_banned(&ip));
+    }
+
+    #[test]
+    fn it_should_allow_resetting_all_the_counters() {
+        let mut ban_service = ban_service(1);
+
+        let ip: IpAddr = "127.0.0.2".parse().unwrap();
+
+        ban_service.increase_counter(&ip); // Counter = 1
+
+        ban_service.reset_bans();
+
+        assert_eq!(ban_service.get_estimate_count(&ip), 0);
+    }
+}

--- a/src/servers/udp/server/mod.rs
+++ b/src/servers/udp/server/mod.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 use super::RawRequest;
 
+pub mod banning;
 pub mod bound_socket;
 pub mod launcher;
 pub mod processor;


### PR DESCRIPTION
This PR uses a [Counting Bloom Filter](https://docs.rs/bloom/latest/bloom/#counting-bloom-filters) to count IP sending UDP requests with wrong connection IDs.

The IP is banned when the tracker receives more than 10 requests from a given IP with a bad connection ID. Bad connection IDs are cookie values that have expired or are from the future.

With the current `CountingBloomFilter` configuration (0.01 rate), we would have a **False Positive** for every 10000 IPs, meaning when two IPs have a collision, and one of them is misbehaving, the other one would also be banned.

To avoid false positives, we introduced a second counter with a HashMap. This consumes more memory, but it's reset every 120 seconds. The HashMap is only used when the CBF detects a potential bad client.

### TODO

- [x] Straightforward implementation
- [x] Benchmarking (how much this new feature affects performance)
- [x] Add an E2E test
- [x] Remove IPs from the banned list every hour
- [x] Review filter settings `CountingBloomFilter::with_rate(4, 0.01, 100)`
- [x] Refactor: extract the IP ban service from the main loop
- [x] Benchmarking after extracting `BanService`

### Questions

- [ ] Should we add a configuration option for the maximum number of errors allowed?

### Future PR

- [ ] Add a metric to tracker stats for the number of banned IPs.
- [ ] Ban subnets