### PR TITLE
Refactor:  use atomics for tracker stats

### DIFF
--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1210,8 +1210,8 @@ impl Tracker {
     /// It return the `Tracker` [`statistics::metrics::Metrics`].
     ///
     /// # Context: Statistics
-    pub async fn get_stats(&self) -> tokio::sync::RwLockReadGuard<'_, statistics::metrics::Metrics> {
-        self.stats_repository.get_stats().await
+    pub fn get_stats(&self) -> statistics::metrics::Metrics {
+        self.stats_repository.get_stats()
     }
 
     /// It allows to send a statistic events which eventually will be used to update [`statistics::metrics::Metrics`].

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -62,7 +62,7 @@ pub struct TrackerMetrics {
 /// It returns all the [`TrackerMetrics`]
 pub async fn get_metrics(tracker: Arc<Tracker>) -> TrackerMetrics {
     let torrents_metrics = tracker.get_torrents_metrics();
-    let stats = tracker.get_stats().await;
+    let stats = tracker.get_stats();
 
     TrackerMetrics {
         torrents_metrics,

--- a/src/core/statistics/event/handler.rs
+++ b/src/core/statistics/event/handler.rs
@@ -5,71 +5,71 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
     match event {
         // TCP4
         Event::Tcp4Announce => {
-            stats_repository.increase_tcp4_announces().await;
-            stats_repository.increase_tcp4_connections().await;
+            stats_repository.increase_tcp4_announces();
+            stats_repository.increase_tcp4_connections();
         }
         Event::Tcp4Scrape => {
-            stats_repository.increase_tcp4_scrapes().await;
-            stats_repository.increase_tcp4_connections().await;
+            stats_repository.increase_tcp4_scrapes();
+            stats_repository.increase_tcp4_connections();
         }
 
         // TCP6
         Event::Tcp6Announce => {
-            stats_repository.increase_tcp6_announces().await;
-            stats_repository.increase_tcp6_connections().await;
+            stats_repository.increase_tcp6_announces();
+            stats_repository.increase_tcp6_connections();
         }
         Event::Tcp6Scrape => {
-            stats_repository.increase_tcp6_scrapes().await;
-            stats_repository.increase_tcp6_connections().await;
+            stats_repository.increase_tcp6_scrapes();
+            stats_repository.increase_tcp6_connections();
         }
 
         // UDP
         Event::Udp4RequestAborted => {
-            stats_repository.increase_udp_requests_aborted().await;
+            stats_repository.increase_udp_requests_aborted();
         }
 
         // UDP4
         Event::Udp4Request => {
-            stats_repository.increase_udp4_requests().await;
+            stats_repository.increase_udp4_requests();
         }
         Event::Udp4Connect => {
-            stats_repository.increase_udp4_connections().await;
+            stats_repository.increase_udp4_connections();
         }
         Event::Udp4Announce => {
-            stats_repository.increase_udp4_announces().await;
+            stats_repository.increase_udp4_announces();
         }
         Event::Udp4Scrape => {
-            stats_repository.increase_udp4_scrapes().await;
+            stats_repository.increase_udp4_scrapes();
         }
         Event::Udp4Response => {
-            stats_repository.increase_udp4_responses().await;
+            stats_repository.increase_udp4_responses();
         }
         Event::Udp4Error => {
-            stats_repository.increase_udp4_errors().await;
+            stats_repository.increase_udp4_errors();
         }
 
         // UDP6
         Event::Udp6Request => {
-            stats_repository.increase_udp6_requests().await;
+            stats_repository.increase_udp6_requests();
         }
         Event::Udp6Connect => {
-            stats_repository.increase_udp6_connections().await;
+            stats_repository.increase_udp6_connections();
         }
         Event::Udp6Announce => {
-            stats_repository.increase_udp6_announces().await;
+            stats_repository.increase_udp6_announces();
         }
         Event::Udp6Scrape => {
-            stats_repository.increase_udp6_scrapes().await;
+            stats_repository.increase_udp6_scrapes();
         }
         Event::Udp6Response => {
-            stats_repository.increase_udp6_responses().await;
+            stats_repository.increase_udp6_responses();
         }
         Event::Udp6Error => {
-            stats_repository.increase_udp6_errors().await;
+            stats_repository.increase_udp6_errors();
         }
     }
 
-    tracing::debug!("stats: {:?}", stats_repository.get_stats().await);
+    tracing::debug!("stats: {:?}", stats_repository.get_stats());
 }
 
 #[cfg(test)]
@@ -84,7 +84,7 @@ mod tests {
 
         handle_event(Event::Tcp4Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp4_announces_handled, 1);
     }
@@ -95,7 +95,7 @@ mod tests {
 
         handle_event(Event::Tcp4Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp4_connections_handled, 1);
     }
@@ -106,7 +106,7 @@ mod tests {
 
         handle_event(Event::Tcp4Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp4_scrapes_handled, 1);
     }
@@ -117,7 +117,7 @@ mod tests {
 
         handle_event(Event::Tcp4Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp4_connections_handled, 1);
     }
@@ -128,7 +128,7 @@ mod tests {
 
         handle_event(Event::Tcp6Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp6_announces_handled, 1);
     }
@@ -139,7 +139,7 @@ mod tests {
 
         handle_event(Event::Tcp6Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp6_connections_handled, 1);
     }
@@ -150,7 +150,7 @@ mod tests {
 
         handle_event(Event::Tcp6Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp6_scrapes_handled, 1);
     }
@@ -161,7 +161,7 @@ mod tests {
 
         handle_event(Event::Tcp6Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.tcp6_connections_handled, 1);
     }
@@ -172,7 +172,7 @@ mod tests {
 
         handle_event(Event::Udp4Connect, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp4_connections_handled, 1);
     }
@@ -183,7 +183,7 @@ mod tests {
 
         handle_event(Event::Udp4Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp4_announces_handled, 1);
     }
@@ -194,7 +194,7 @@ mod tests {
 
         handle_event(Event::Udp4Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp4_scrapes_handled, 1);
     }
@@ -205,7 +205,7 @@ mod tests {
 
         handle_event(Event::Udp6Connect, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp6_connections_handled, 1);
     }
@@ -216,7 +216,7 @@ mod tests {
 
         handle_event(Event::Udp6Announce, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp6_announces_handled, 1);
     }
@@ -227,7 +227,7 @@ mod tests {
 
         handle_event(Event::Udp6Scrape, &stats_repository).await;
 
-        let stats = stats_repository.get_stats().await;
+        let stats = stats_repository.get_stats();
 
         assert_eq!(stats.udp6_scrapes_handled, 1);
     }

--- a/src/core/statistics/keeper.rs
+++ b/src/core/statistics/keeper.rs
@@ -59,7 +59,7 @@ mod tests {
     async fn should_contain_the_tracker_statistics() {
         let stats_tracker = Keeper::new();
 
-        let stats = stats_tracker.repository.get_stats().await;
+        let stats = stats_tracker.repository.get_stats();
 
         assert_eq!(stats.tcp4_announces_handled, Metrics::default().tcp4_announces_handled);
     }

--- a/src/core/statistics/repository.rs
+++ b/src/core/statistics/repository.rs
@@ -1,13 +1,12 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-
-use tokio::sync::{RwLock, RwLockReadGuard};
 
 use super::metrics::Metrics;
 
 /// A repository for the tracker metrics.
 #[derive(Clone)]
 pub struct Repository {
-    pub stats: Arc<RwLock<Metrics>>,
+    atomic_stats: Arc<AtomicMetrics>,
 }
 
 impl Default for Repository {
@@ -20,125 +19,131 @@ impl Repository {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            stats: Arc::new(RwLock::new(Metrics::default())),
+            atomic_stats: Arc::new(AtomicMetrics::default()),
         }
     }
 
-    pub async fn get_stats(&self) -> RwLockReadGuard<'_, Metrics> {
-        self.stats.read().await
+    #[must_use]
+    pub fn get_stats(&self) -> Metrics {
+        Metrics {
+            tcp4_connections_handled: self.atomic_stats.tcp4_connections_handled.load(Ordering::SeqCst),
+            tcp4_announces_handled: self.atomic_stats.tcp4_announces_handled.load(Ordering::SeqCst),
+            tcp4_scrapes_handled: self.atomic_stats.tcp4_scrapes_handled.load(Ordering::SeqCst),
+            tcp6_connections_handled: self.atomic_stats.tcp6_connections_handled.load(Ordering::SeqCst),
+            tcp6_announces_handled: self.atomic_stats.tcp6_announces_handled.load(Ordering::SeqCst),
+            tcp6_scrapes_handled: self.atomic_stats.tcp6_scrapes_handled.load(Ordering::SeqCst),
+            udp_requests_aborted: self.atomic_stats.udp_requests_aborted.load(Ordering::SeqCst),
+            udp4_requests: self.atomic_stats.udp4_requests.load(Ordering::SeqCst),
+            udp4_connections_handled: self.atomic_stats.udp4_connections_handled.load(Ordering::SeqCst),
+            udp4_announces_handled: self.atomic_stats.udp4_announces_handled.load(Ordering::SeqCst),
+            udp4_scrapes_handled: self.atomic_stats.udp4_scrapes_handled.load(Ordering::SeqCst),
+            udp4_responses: self.atomic_stats.udp4_responses.load(Ordering::SeqCst),
+            udp4_errors_handled: self.atomic_stats.udp4_errors_handled.load(Ordering::SeqCst),
+            udp6_requests: self.atomic_stats.udp6_requests.load(Ordering::SeqCst),
+            udp6_connections_handled: self.atomic_stats.udp6_connections_handled.load(Ordering::SeqCst),
+            udp6_announces_handled: self.atomic_stats.udp6_announces_handled.load(Ordering::SeqCst),
+            udp6_scrapes_handled: self.atomic_stats.udp6_scrapes_handled.load(Ordering::SeqCst),
+            udp6_responses: self.atomic_stats.udp6_responses.load(Ordering::SeqCst),
+            udp6_errors_handled: self.atomic_stats.udp6_errors_handled.load(Ordering::SeqCst),
+        }
     }
 
-    pub async fn increase_tcp4_announces(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp4_announces_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp4_announces(&self) {
+        self.atomic_stats.tcp4_announces_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_tcp4_connections(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp4_connections_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp4_connections(&self) {
+        self.atomic_stats.tcp4_connections_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_tcp4_scrapes(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp4_scrapes_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp4_scrapes(&self) {
+        self.atomic_stats.tcp4_scrapes_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_tcp6_announces(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp6_announces_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp6_announces(&self) {
+        self.atomic_stats.tcp6_announces_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_tcp6_connections(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp6_connections_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp6_connections(&self) {
+        self.atomic_stats.tcp6_connections_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_tcp6_scrapes(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.tcp6_scrapes_handled += 1;
-        drop(stats_lock);
+    pub fn increase_tcp6_scrapes(&self) {
+        self.atomic_stats.tcp6_scrapes_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp_requests_aborted(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp_requests_aborted += 1;
-        drop(stats_lock);
+    pub fn increase_udp_requests_aborted(&self) {
+        self.atomic_stats.udp_requests_aborted.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_requests(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_requests += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_requests(&self) {
+        self.atomic_stats.udp4_requests.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_connections(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_connections_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_connections(&self) {
+        self.atomic_stats.udp4_connections_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_announces(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_announces_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_announces(&self) {
+        self.atomic_stats.udp4_announces_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_scrapes(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_scrapes_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_scrapes(&self) {
+        self.atomic_stats.udp4_scrapes_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_responses(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_responses += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_responses(&self) {
+        self.atomic_stats.udp4_responses.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp4_errors(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp4_errors_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp4_errors(&self) {
+        self.atomic_stats.udp4_errors_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_requests(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_requests += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_requests(&self) {
+        self.atomic_stats.udp6_requests.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_connections(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_connections_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_connections(&self) {
+        self.atomic_stats.udp6_connections_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_announces(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_announces_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_announces(&self) {
+        self.atomic_stats.udp6_announces_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_scrapes(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_scrapes_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_scrapes(&self) {
+        self.atomic_stats.udp6_scrapes_handled.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_responses(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_responses += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_responses(&self) {
+        self.atomic_stats.udp6_responses.fetch_add(1, Ordering::SeqCst);
     }
 
-    pub async fn increase_udp6_errors(&self) {
-        let mut stats_lock = self.stats.write().await;
-        stats_lock.udp6_errors_handled += 1;
-        drop(stats_lock);
+    pub fn increase_udp6_errors(&self) {
+        self.atomic_stats.udp6_errors_handled.fetch_add(1, Ordering::SeqCst);
     }
+}
+
+#[derive(Debug, Default)]
+struct AtomicMetrics {
+    pub tcp4_connections_handled: AtomicU64,
+    pub tcp4_announces_handled: AtomicU64,
+    pub tcp4_scrapes_handled: AtomicU64,
+    pub tcp6_connections_handled: AtomicU64,
+    pub tcp6_announces_handled: AtomicU64,
+    pub tcp6_scrapes_handled: AtomicU64,
+    pub udp_requests_aborted: AtomicU64,
+    pub udp4_requests: AtomicU64,
+    pub udp4_connections_handled: AtomicU64,
+    pub udp4_announces_handled: AtomicU64,
+    pub udp4_scrapes_handled: AtomicU64,
+    pub udp4_responses: AtomicU64,
+    pub udp4_errors_handled: AtomicU64,
+    pub udp6_requests: AtomicU64,
+    pub udp6_connections_handled: AtomicU64,
+    pub udp6_announces_handled: AtomicU64,
+    pub udp6_scrapes_handled: AtomicU64,
+    pub udp6_responses: AtomicU64,
+    pub udp6_errors_handled: AtomicU64,
 }

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -730,11 +730,9 @@ mod for_all_config_modes {
                 .announce(&QueryBuilder::default().query())
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp4_connections_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -758,11 +756,9 @@ mod for_all_config_modes {
                 .announce(&QueryBuilder::default().query())
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp6_connections_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -785,11 +781,9 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp6_connections_handled, 0);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -806,11 +800,9 @@ mod for_all_config_modes {
                 .announce(&QueryBuilder::default().query())
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp4_announces_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -834,11 +826,9 @@ mod for_all_config_modes {
                 .announce(&QueryBuilder::default().query())
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp6_announces_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -861,11 +851,9 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp6_announces_handled, 0);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -1250,11 +1238,9 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp4_scrapes_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }
@@ -1284,11 +1270,9 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let stats = env.tracker.get_stats().await;
+            let stats = env.tracker.get_stats();
 
             assert_eq!(stats.tcp6_scrapes_handled, 1);
-
-            drop(stats);
 
             env.stop().await;
         }


### PR DESCRIPTION
Use atomics for tracker stats instead of RwLock. Atomics are lock-free. This eliminates the overhead of locks and reduces contention.

### Subtasks

- [x] Replace global `RwLock` for Metrics with individual `AtomicU64` for each metric.
- [x] Benchmarking