### PR TITLE
Don't execute slow doc tests

### DIFF
--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -196,7 +196,7 @@ impl Key {
 
 /// Error returned when a key cannot be parsed from a string.
 ///
-/// ```rust,no_run
+/// ```text
 /// use torrust_tracker::core::auth::Key;
 /// use std::str::FromStr;
 ///

--- a/src/core/databases/driver.rs
+++ b/src/core/databases/driver.rs
@@ -29,7 +29,7 @@ pub enum Driver {
 ///
 /// Example for `SQLite3`:
 ///
-/// ```rust,no_run
+/// ```text
 /// use torrust_tracker::core::databases;
 /// use torrust_tracker::core::databases::driver::Driver;
 ///
@@ -40,7 +40,7 @@ pub enum Driver {
 ///
 /// Example for `MySQL`:
 ///
-/// ```rust,no_run
+/// ```text
 /// use torrust_tracker::core::databases;
 /// use torrust_tracker::core::databases::driver::Driver;
 ///

--- a/src/servers/http/v1/query.rs
+++ b/src/servers/http/v1/query.rs
@@ -30,7 +30,7 @@ impl Query {
     /// It return `Some(value)` for a URL query param if the param with the
     /// input `name` exists. For example:
     ///
-    /// ```rust
+    /// ```text
     /// use torrust_tracker::servers::http::v1::query::Query;
     ///
     /// let raw_query = "param1=value1&param2=value2";
@@ -43,7 +43,7 @@ impl Query {
     ///
     /// It returns only the first param value even if it has multiple values:
     ///
-    /// ```rust
+    /// ```text
     /// use torrust_tracker::servers::http::v1::query::Query;
     ///
     /// let raw_query = "param1=value1&param1=value2";
@@ -59,7 +59,7 @@ impl Query {
 
     /// Returns all the param values as a vector.
     ///
-    /// ```rust
+    /// ```text
     /// use torrust_tracker::servers::http::v1::query::Query;
     ///
     /// let query = "param1=value1&param1=value2".parse::<Query>().unwrap();
@@ -72,7 +72,7 @@ impl Query {
     ///
     /// Returns all the param values as a vector even if it has only one value.
     ///
-    /// ```rust
+    /// ```text
     /// use torrust_tracker::servers::http::v1::query::Query;
     ///
     /// let query = "param1=value1".parse::<Query>().unwrap();

--- a/src/servers/http/v1/requests/announce.rs
+++ b/src/servers/http/v1/requests/announce.rs
@@ -29,7 +29,7 @@ const NUMWANT: &str = "numwant";
 /// The `Announce` request. Fields use the domain types after parsing the
 /// query params of the request.
 ///
-/// ```rust
+/// ```text
 /// use aquatic_udp_protocol::{NumberOfBytes, PeerId};
 /// use torrust_tracker::servers::http::v1::requests::announce::{Announce, Compact, Event};
 /// use bittorrent_primitives::info_hash::InfoHash;

--- a/src/servers/http/v1/responses/announce.rs
+++ b/src/servers/http/v1/responses/announce.rs
@@ -152,7 +152,7 @@ impl Into<Vec<u8>> for Compact {
 
 /// A [`NormalPeer`], for the [`Normal`] form.
 ///
-/// ```rust
+/// ```text
 /// use std::net::{IpAddr, Ipv4Addr};
 /// use torrust_tracker::servers::http::v1::responses::announce::{Normal, NormalPeer};
 ///
@@ -204,7 +204,7 @@ impl From<&NormalPeer> for BencodeMut<'_> {
 /// A part from reducing the size of the response, this format does not contain
 /// the peer's ID.
 ///
-/// ```rust
+/// ```text
 ///  use std::net::{IpAddr, Ipv4Addr};
 ///  use torrust_tracker::servers::http::v1::responses::announce::{Compact, CompactPeer, CompactPeerData};
 ///

--- a/src/servers/http/v1/responses/error.rs
+++ b/src/servers/http/v1/responses/error.rs
@@ -26,7 +26,7 @@ pub struct Error {
 impl Error {
     /// Returns the bencoded representation of the `Error` struct.
     ///
-    /// ```rust
+    /// ```text
     /// use torrust_tracker::servers::http::v1::responses::error::Error;
     ///
     /// let err = Error {

--- a/src/servers/http/v1/responses/scrape.rs
+++ b/src/servers/http/v1/responses/scrape.rs
@@ -11,7 +11,7 @@ use crate::core::ScrapeData;
 
 /// The `Scrape` response for the HTTP tracker.
 ///
-/// ```rust
+/// ```text
 /// use torrust_tracker::servers::http::v1::responses::scrape::Bencoded;
 /// use bittorrent_primitives::info_hash::InfoHash;
 /// use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;

--- a/src/servers/http/v1/services/peer_ip_resolver.rs
+++ b/src/servers/http/v1/services/peer_ip_resolver.rs
@@ -59,7 +59,7 @@ pub enum PeerIpResolutionError {
 ///
 /// With the tracker running on reverse proxy mode:
 ///
-/// ```rust
+/// ```text
 /// use std::net::IpAddr;
 /// use std::str::FromStr;
 ///
@@ -81,7 +81,7 @@ pub enum PeerIpResolutionError {
 ///
 /// With the tracker non running on reverse proxy mode:
 ///
-/// ```rust
+/// ```text
 /// use std::net::IpAddr;
 /// use std::str::FromStr;
 ///


### PR DESCRIPTION
This PR disables slow doc tests. They are slow because they include the main library, and each test has to compile it.

They will be enabled again after [moving the code to workspace sub-packages](https://github.com/torrust/torrust-tracker/issues/1140) that do not depend on the main tracker lib.