### PR TITLE
Remove  tracing errors from tests execution output

### DIFF
--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -10,9 +10,11 @@
 //! ´´´
 //!
 
-use std::sync::Once;
+use std::io;
+use std::sync::{Arc, Mutex, Once};
 
 use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt::MakeWriter;
 
 #[allow(dead_code)]
 pub static INIT: Once = Once::new();
@@ -27,4 +29,95 @@ pub fn tracing_stderr_init(filter: LevelFilter) {
     builder.pretty().with_file(true).init();
 
     tracing::info!("Logging initialized");
+}
+
+#[allow(dead_code)]
+pub fn tracing_init_with_capturer(filter: LevelFilter, log_capturer: Arc<Mutex<LogCapturer>>) {
+    let writer = LogCapturerWrapper::new(log_capturer);
+
+    let builder = tracing_subscriber::fmt()
+        .with_max_level(filter)
+        .with_ansi(true)
+        .with_writer(writer);
+
+    builder.pretty().with_file(true).init();
+
+    tracing::info!("Logging initialized");
+}
+
+pub struct LogCapturerWrapper {
+    inner: Arc<Mutex<LogCapturer>>,
+}
+
+impl LogCapturerWrapper {
+    pub fn new(inner: Arc<Mutex<LogCapturer>>) -> Self {
+        Self { inner }
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogCapturerWrapper {
+    type Writer = LogCapturerGuard;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        LogCapturerGuard {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pub struct LogCapturerGuard {
+    inner: Arc<Mutex<LogCapturer>>,
+}
+
+impl io::Write for LogCapturerGuard {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut capturer = self.inner.lock().unwrap();
+        capturer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut capturer = self.inner.lock().unwrap();
+        capturer.flush()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct LogCapturer {
+    output: String,
+}
+
+impl LogCapturer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn contains(&self, message: &str) -> bool {
+        self.output.contains(message)
+    }
+}
+
+impl io::Write for LogCapturer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let out_str = String::from_utf8_lossy(buf);
+
+        // We print to stdout so that the output is visible in the terminal
+        // when you run the tests with `cargo test -- --nocapture`.
+        println!("{out_str}");
+
+        self.output.push_str(&out_str);
+
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for LogCapturer {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        Self::default()
+    }
 }


### PR DESCRIPTION
When you run tests you see some errors like this:

```output
running 1 test
  2024-12-18T11:06:54.443275Z ERROR tower_http::trace::on_failure: response failed, classification: Status code: 500 Internal Server Error, latency: 0 ms
    at /home/josecelano/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tower-http-0.6.2/src/trace/on_failure.rs:93

test servers::api::v1::contract::context::auth_key::should_fail_when_the_auth_key_cannot_be_deleted ... ok
```

Those errors are written by tracing to the standard error output. They are enabled by adding these lines to the tests:

```rust
INIT.call_once(|| {
    tracing_stderr_init(LevelFilter::ERROR);
});
```

Errors are expected. It's the **current API behaviour**. We need to change that in the next [major API version](https://github.com/torrust/torrust-tracker/issues/144). For now, we will capture them (not showing them in the output) and assert that they were written by tracing. This is something we should do every time we write into logs, as logs are an essential feature for the application, and it should be tested, too.

This PR adds a new tracing initialization function for tests `tracing_init_with_capturer` that can be used to capture logs and assert that logs contain certain messages. For example:

```rust
async fn should_fail_when_the_auth_key_cannot_be_deleted() {
    let log_capturer = Arc::new(Mutex::new(LogCapturer::new()));

    INIT.call_once(|| {
        tracing_init_with_capturer(LevelFilter::ERROR, log_capturer.clone());
    });

    let env = Started::new(&configuration::ephemeral().into()).await;

    let seconds_valid = 60;
    let auth_key = env
        .tracker
        .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
        .await
        .unwrap();

    force_database_error(&env.tracker);

    let response = Client::new(env.get_connection_info())
        .delete_auth_key(&auth_key.key.to_string())
        .await;

    assert_failed_to_delete_key(response).await;

    // We expect to see a 500 error; it's the current API behavior
    assert!(log_capturer.lock().unwrap().contains("ERROR"));
    assert!(log_capturer.lock().unwrap().contains("tower_http"));
    assert!(log_capturer.lock().unwrap().contains("500 Internal Server Error"));

    env.stop().await;
}
```

### Subtasks

- [x] Create a tracing "writer" to capture logs: log capturer.
- [x] Modify one test as an example.
- [ ] Modify the rest of the tests currently printing errors to the output when you run tests.

### Future PRs

- Modify all tests that affect logs, asserting lines that should be written included.


