### PR TITLE
New feature: capture recent logs for testing (rework)

### DIFF
--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -29,7 +29,12 @@ pub fn ephemeral() -> Configuration {
 
     let mut config = Configuration::default();
 
-    config.logging.threshold = Threshold::Off; // It should always be off here, the tests manage their own logging.
+    // This have to be Off otherwise the tracing global subscriber
+    // initialization will panic because you can't set a global subscriber more
+    // than once. You can use enable logging in tests with:
+    // `crate::common::logging::setup(LevelFilter::ERROR);`
+    // That will also allow you to capture logs and write assertions on them.
+    config.logging.threshold = Threshold::Off;
 
     // Ephemeral socket address for API
     let api_port = 0u16;

--- a/src/bootstrap/logging.rs
+++ b/src/bootstrap/logging.rs
@@ -28,7 +28,7 @@ pub fn setup(cfg: &Configuration) {
     }
 
     INIT.call_once(|| {
-        tracing_stdout_init(tracing_level, &TraceStyle::Default);
+        tracing_init(tracing_level, &TraceStyle::Default);
     });
 }
 
@@ -43,8 +43,11 @@ fn map_to_tracing_level_filter(threshold: &Threshold) -> LevelFilter {
     }
 }
 
-fn tracing_stdout_init(filter: LevelFilter, style: &TraceStyle) {
-    let builder = tracing_subscriber::fmt().with_max_level(filter).with_ansi(true);
+fn tracing_init(filter: LevelFilter, style: &TraceStyle) {
+    let builder = tracing_subscriber::fmt()
+        .with_max_level(filter)
+        .with_ansi(true)
+        .with_test_writer();
 
     let () = match style {
         TraceStyle::Default => builder.init(),

--- a/tests/common/clock.rs
+++ b/tests/common/clock.rs
@@ -1,17 +1,11 @@
 use std::time::Duration;
 
 use torrust_tracker_clock::clock::Time;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
 use crate::CurrentClock;
 
 #[test]
 fn it_should_use_stopped_time_for_testing() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
-
     assert_eq!(CurrentClock::dbg_clock_type(), "Stopped".to_owned());
 
     let time = CurrentClock::now();

--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -1,30 +1,156 @@
-#![allow(clippy::doc_markdown)]
-//! Logging for the Integration Tests
-//!
-//! Tests should start their own logging.
-//!
-//! To find tests that do not start their own logging:
-//!
-//! ´´´ sh
-//! awk 'BEGIN{RS=""; FS="\n"} /#\[tokio::test\]\s*async\s+fn\s+\w+\s*\(\s*\)\s*\{[^}]*\}/ && !/#\[tokio::test\]\s*async\s+fn\s+\w+\s*\(\s*\)\s*\{[^}]*INIT\.call_once/' $(find . -name "*.rs")
-//! ´´´
-//!
+//! Setup for logging in tests.
+use std::collections::VecDeque;
+use std::io;
+use std::sync::{Mutex, MutexGuard, Once, OnceLock};
 
-use std::sync::Once;
-
+use torrust_tracker::bootstrap::logging::TraceStyle;
 use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt::MakeWriter;
 
-#[allow(dead_code)]
-pub static INIT: Once = Once::new();
+static INIT: Once = Once::new();
 
-#[allow(dead_code)]
-pub fn tracing_stderr_init(filter: LevelFilter) {
+/// A global buffer containing the latest lines captured from logs.
+#[doc(hidden)]
+pub fn captured_logs_buffer() -> &'static Mutex<CircularBuffer> {
+    static CAPTURED_LOGS_GLOBAL_BUFFER: OnceLock<Mutex<CircularBuffer>> = OnceLock::new();
+    CAPTURED_LOGS_GLOBAL_BUFFER.get_or_init(|| Mutex::new(CircularBuffer::new(10000, 200)))
+}
+
+pub fn setup() {
+    INIT.call_once(|| {
+        tracing_init(LevelFilter::ERROR, &TraceStyle::Default);
+    });
+}
+
+fn tracing_init(level_filter: LevelFilter, style: &TraceStyle) {
+    let mock_writer = LogCapturer::new(captured_logs_buffer());
+
     let builder = tracing_subscriber::fmt()
-        .with_max_level(filter)
+        .with_max_level(level_filter)
         .with_ansi(true)
-        .with_writer(std::io::stderr);
+        .with_test_writer()
+        .with_writer(mock_writer);
 
-    builder.pretty().with_file(true).init();
+    let () = match style {
+        TraceStyle::Default => builder.init(),
+        TraceStyle::Pretty(display_filename) => builder.pretty().with_file(*display_filename).init(),
+        TraceStyle::Compact => builder.compact().init(),
+        TraceStyle::Json => builder.json().init(),
+    };
 
     tracing::info!("Logging initialized");
+}
+
+/// It returns true is there is a log line containing all the texts passed.
+///
+/// # Panics
+///
+/// Will panic if it can't get the lock for the global buffer or convert it into
+/// a vec.
+#[must_use]
+#[allow(dead_code)]
+pub fn logs_contains_a_line_with(texts: &[&str]) -> bool {
+    // code-review: we can search directly in the buffer instead of converting
+    // the buffer into a string but that would slow down the tests because
+    // cloning should be faster that locking the buffer for searching.
+    // Because the buffer is not big.
+    let logs = String::from_utf8(captured_logs_buffer().lock().unwrap().as_vec()).unwrap();
+
+    for line in logs.split('\n') {
+        if contains(line, texts) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[allow(dead_code)]
+fn contains(text: &str, texts: &[&str]) -> bool {
+    texts.iter().all(|&word| text.contains(word))
+}
+
+/// A tracing writer which captures the latests logs lines into a buffer.
+/// It's used to capture the logs in the tests.
+#[derive(Debug)]
+pub struct LogCapturer<'a> {
+    logs: &'a Mutex<CircularBuffer>,
+}
+
+impl<'a> LogCapturer<'a> {
+    pub fn new(buf: &'a Mutex<CircularBuffer>) -> Self {
+        Self { logs: buf }
+    }
+
+    fn buf(&self) -> io::Result<MutexGuard<'a, CircularBuffer>> {
+        self.logs.lock().map_err(|_| io::Error::from(io::ErrorKind::Other))
+    }
+}
+
+impl io::Write for LogCapturer<'_> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        print!("{}", String::from_utf8(buf.to_vec()).unwrap());
+
+        let mut target = self.buf()?;
+
+        target.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf()?.flush()
+    }
+}
+
+impl MakeWriter<'_> for LogCapturer<'_> {
+    type Writer = Self;
+
+    fn make_writer(&self) -> Self::Writer {
+        LogCapturer::new(self.logs)
+    }
+}
+
+#[derive(Debug)]
+pub struct CircularBuffer {
+    max_size: usize,
+    buffer: VecDeque<u8>,
+}
+
+impl CircularBuffer {
+    #[must_use]
+    pub fn new(max_lines: usize, average_line_size: usize) -> Self {
+        Self {
+            max_size: max_lines * average_line_size,
+            buffer: VecDeque::with_capacity(max_lines * average_line_size),
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Won't return any error.
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for &byte in buf {
+            if self.buffer.len() == self.max_size {
+                // Remove oldest byte to make space
+                self.buffer.pop_front();
+            }
+            self.buffer.push_back(byte);
+        }
+
+        Ok(buf.len())
+    }
+
+    /// # Errors
+    ///
+    /// Won't return any error.
+    #[allow(clippy::unnecessary_wraps)]
+    #[allow(clippy::unused_self)]
+    pub fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn as_vec(&self) -> Vec<u8> {
+        self.buffer.iter().copied().collect()
+    }
 }

--- a/tests/servers/api/v1/contract/authentication.rs
+++ b/tests/servers/api/v1/contract/authentication.rs
@@ -1,17 +1,14 @@
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
 use crate::common::http::{Query, QueryParam};
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging::{self};
 use crate::servers::api::v1::asserts::{assert_token_not_valid, assert_unauthorized};
 use crate::servers::api::v1::client::Client;
 use crate::servers::api::Started;
 
 #[tokio::test]
 async fn should_authenticate_requests_by_using_a_token_query_param() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -28,9 +25,7 @@ async fn should_authenticate_requests_by_using_a_token_query_param() {
 
 #[tokio::test]
 async fn should_not_authenticate_requests_when_the_token_is_missing() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -45,9 +40,7 @@ async fn should_not_authenticate_requests_when_the_token_is_missing() {
 
 #[tokio::test]
 async fn should_not_authenticate_requests_when_the_token_is_empty() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -62,9 +55,7 @@ async fn should_not_authenticate_requests_when_the_token_is_empty() {
 
 #[tokio::test]
 async fn should_not_authenticate_requests_when_the_token_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -79,9 +70,7 @@ async fn should_not_authenticate_requests_when_the_token_is_invalid() {
 
 #[tokio::test]
 async fn should_allow_the_token_query_param_to_be_at_any_position_in_the_url_query() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/api/v1/contract/configuration.rs
+++ b/tests/servers/api/v1/contract/configuration.rs
@@ -7,18 +7,10 @@
 // use crate::common::app::setup_with_configuration;
 // use crate::servers::api::environment::stopped_environment;
 
-use tracing::level_filters::LevelFilter;
-
-use crate::common::logging::{tracing_stderr_init, INIT};
-
 #[tokio::test]
 #[ignore]
 #[should_panic = "Could not receive bind_address."]
 async fn should_fail_with_ssl_enabled_and_bad_ssl_config() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
-
     // let tracker = setup_with_configuration(&Arc::new(configuration::ephemeral()));
 
     // let config = tracker.config.http_api.clone();
@@ -36,6 +28,5 @@ async fn should_fail_with_ssl_enabled_and_bad_ssl_config() {
     //     };
 
     // let env = new_stopped(tracker, bind_to, tls);
-
     // env.start().await;
 }

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -3,9 +3,8 @@ use std::time::Duration;
 use serde::Serialize;
 use torrust_tracker::core::auth::Key;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging::{self};
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{
     assert_auth_key_utf8, assert_failed_to_delete_key, assert_failed_to_generate_key, assert_failed_to_reload_keys,
@@ -17,9 +16,7 @@ use crate::servers::api::{force_database_error, Started};
 
 #[tokio::test]
 async fn should_allow_generating_a_new_random_auth_key() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -43,9 +40,7 @@ async fn should_allow_generating_a_new_random_auth_key() {
 
 #[tokio::test]
 async fn should_allow_uploading_a_preexisting_auth_key() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -69,9 +64,7 @@ async fn should_allow_uploading_a_preexisting_auth_key() {
 
 #[tokio::test]
 async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -98,9 +91,7 @@ async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() 
 
 #[tokio::test]
 async fn should_fail_when_the_auth_key_cannot_be_generated() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -120,9 +111,7 @@ async fn should_fail_when_the_auth_key_cannot_be_generated() {
 
 #[tokio::test]
 async fn should_allow_deleting_an_auth_key() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -151,9 +140,7 @@ async fn should_fail_generating_a_new_auth_key_when_the_provided_key_is_invalid(
         pub seconds_valid: u64,
     }
 
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -192,9 +179,7 @@ async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid(
         pub seconds_valid: String,
     }
 
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -223,9 +208,7 @@ async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid(
 
 #[tokio::test]
 async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -250,9 +233,7 @@ async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
 
 #[tokio::test]
 async fn should_fail_when_the_auth_key_cannot_be_deleted() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -276,9 +257,7 @@ async fn should_fail_when_the_auth_key_cannot_be_deleted() {
 
 #[tokio::test]
 async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -315,9 +294,7 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
 
 #[tokio::test]
 async fn should_allow_reloading_keys() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -336,9 +313,7 @@ async fn should_allow_reloading_keys() {
 
 #[tokio::test]
 async fn should_fail_when_keys_cannot_be_reloaded() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -359,9 +334,7 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
 
 #[tokio::test]
 async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -390,9 +363,8 @@ mod deprecated_generate_key_endpoint {
 
     use torrust_tracker::core::auth::Key;
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging::{self};
     use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
     use crate::servers::api::v1::asserts::{
         assert_auth_key_utf8, assert_failed_to_generate_key, assert_invalid_key_duration_param, assert_token_not_valid,
@@ -403,9 +375,7 @@ mod deprecated_generate_key_endpoint {
 
     #[tokio::test]
     async fn should_allow_generating_a_new_auth_key() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -426,9 +396,7 @@ mod deprecated_generate_key_endpoint {
 
     #[tokio::test]
     async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -451,9 +419,7 @@ mod deprecated_generate_key_endpoint {
 
     #[tokio::test]
     async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -476,9 +442,7 @@ mod deprecated_generate_key_endpoint {
 
     #[tokio::test]
     async fn should_fail_when_the_auth_key_cannot_be_generated() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/api/v1/contract/context/health_check.rs
+++ b/tests/servers/api/v1/contract/context/health_check.rs
@@ -1,16 +1,13 @@
 use torrust_tracker::servers::apis::v1::context::health_check::resources::{Report, Status};
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging;
 use crate::servers::api::v1::client::get;
 use crate::servers::api::Started;
 
 #[tokio::test]
 async fn health_check_endpoint_should_return_status_ok_if_api_is_running() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -4,9 +4,8 @@ use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker::servers::apis::v1::context::stats::resources::Stats;
 use torrust_tracker_primitives::peer::fixture::PeerBuilder;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging::{self};
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{assert_stats, assert_token_not_valid, assert_unauthorized};
 use crate::servers::api::v1::client::Client;
@@ -14,9 +13,7 @@ use crate::servers::api::Started;
 
 #[tokio::test]
 async fn should_allow_getting_tracker_statistics() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -64,9 +61,7 @@ async fn should_allow_getting_tracker_statistics() {
 
 #[tokio::test]
 async fn should_not_allow_getting_tracker_statistics_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/api/v1/contract/context/torrent.rs
+++ b/tests/servers/api/v1/contract/context/torrent.rs
@@ -5,10 +5,9 @@ use torrust_tracker::servers::apis::v1::context::torrent::resources::peer::Peer;
 use torrust_tracker::servers::apis::v1::context::torrent::resources::torrent::{self, Torrent};
 use torrust_tracker_primitives::peer::fixture::PeerBuilder;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
 use crate::common::http::{Query, QueryParam};
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging::{self};
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{
     assert_bad_request, assert_invalid_infohash_param, assert_not_found, assert_token_not_valid, assert_torrent_info,
@@ -22,9 +21,7 @@ use crate::servers::api::Started;
 
 #[tokio::test]
 async fn should_allow_getting_all_torrents() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -50,9 +47,7 @@ async fn should_allow_getting_all_torrents() {
 
 #[tokio::test]
 async fn should_allow_limiting_the_torrents_in_the_result() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -83,9 +78,7 @@ async fn should_allow_limiting_the_torrents_in_the_result() {
 
 #[tokio::test]
 async fn should_allow_the_torrents_result_pagination() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -116,9 +109,7 @@ async fn should_allow_the_torrents_result_pagination() {
 
 #[tokio::test]
 async fn should_allow_getting_a_list_of_torrents_providing_infohashes() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -162,9 +153,7 @@ async fn should_allow_getting_a_list_of_torrents_providing_infohashes() {
 
 #[tokio::test]
 async fn should_fail_getting_torrents_when_the_offset_query_parameter_cannot_be_parsed() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -183,9 +172,7 @@ async fn should_fail_getting_torrents_when_the_offset_query_parameter_cannot_be_
 
 #[tokio::test]
 async fn should_fail_getting_torrents_when_the_limit_query_parameter_cannot_be_parsed() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -204,9 +191,7 @@ async fn should_fail_getting_torrents_when_the_limit_query_parameter_cannot_be_p
 
 #[tokio::test]
 async fn should_fail_getting_torrents_when_the_info_hash_parameter_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -229,9 +214,7 @@ async fn should_fail_getting_torrents_when_the_info_hash_parameter_is_invalid() 
 
 #[tokio::test]
 async fn should_not_allow_getting_torrents_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -252,9 +235,7 @@ async fn should_not_allow_getting_torrents_for_unauthenticated_users() {
 
 #[tokio::test]
 async fn should_allow_getting_a_torrent_info() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -285,9 +266,7 @@ async fn should_allow_getting_a_torrent_info() {
 
 #[tokio::test]
 async fn should_fail_while_getting_a_torrent_info_when_the_torrent_does_not_exist() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -304,9 +283,7 @@ async fn should_fail_while_getting_a_torrent_info_when_the_torrent_does_not_exis
 
 #[tokio::test]
 async fn should_fail_getting_a_torrent_info_when_the_provided_infohash_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -327,9 +304,7 @@ async fn should_fail_getting_a_torrent_info_when_the_provided_infohash_is_invali
 
 #[tokio::test]
 async fn should_not_allow_getting_a_torrent_info_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/api/v1/contract/context/whitelist.rs
+++ b/tests/servers/api/v1/contract/context/whitelist.rs
@@ -2,9 +2,8 @@ use std::str::FromStr;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging::{self};
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{
     assert_failed_to_reload_whitelist, assert_failed_to_remove_torrent_from_whitelist, assert_failed_to_whitelist_torrent,
@@ -18,9 +17,7 @@ use crate::servers::api::{force_database_error, Started};
 
 #[tokio::test]
 async fn should_allow_whitelisting_a_torrent() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -40,9 +37,7 @@ async fn should_allow_whitelisting_a_torrent() {
 
 #[tokio::test]
 async fn should_allow_whitelisting_a_torrent_that_has_been_already_whitelisted() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -61,9 +56,7 @@ async fn should_allow_whitelisting_a_torrent_that_has_been_already_whitelisted()
 
 #[tokio::test]
 async fn should_not_allow_whitelisting_a_torrent_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -86,9 +79,7 @@ async fn should_not_allow_whitelisting_a_torrent_for_unauthenticated_users() {
 
 #[tokio::test]
 async fn should_fail_when_the_torrent_cannot_be_whitelisted() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -105,9 +96,7 @@ async fn should_fail_when_the_torrent_cannot_be_whitelisted() {
 
 #[tokio::test]
 async fn should_fail_whitelisting_a_torrent_when_the_provided_infohash_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -132,9 +121,7 @@ async fn should_fail_whitelisting_a_torrent_when_the_provided_infohash_is_invali
 
 #[tokio::test]
 async fn should_allow_removing_a_torrent_from_the_whitelist() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -154,9 +141,7 @@ async fn should_allow_removing_a_torrent_from_the_whitelist() {
 
 #[tokio::test]
 async fn should_not_fail_trying_to_remove_a_non_whitelisted_torrent_from_the_whitelist() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -173,9 +158,7 @@ async fn should_not_fail_trying_to_remove_a_non_whitelisted_torrent_from_the_whi
 
 #[tokio::test]
 async fn should_fail_removing_a_torrent_from_the_whitelist_when_the_provided_infohash_is_invalid() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -200,9 +183,7 @@ async fn should_fail_removing_a_torrent_from_the_whitelist_when_the_provided_inf
 
 #[tokio::test]
 async fn should_fail_when_the_torrent_cannot_be_removed_from_the_whitelist() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -223,9 +204,7 @@ async fn should_fail_when_the_torrent_cannot_be_removed_from_the_whitelist() {
 
 #[tokio::test]
 async fn should_not_allow_removing_a_torrent_from_the_whitelist_for_unauthenticated_users() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -251,9 +230,7 @@ async fn should_not_allow_removing_a_torrent_from_the_whitelist_for_unauthentica
 
 #[tokio::test]
 async fn should_allow_reload_the_whitelist_from_the_database() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -280,9 +257,7 @@ async fn should_allow_reload_the_whitelist_from_the_database() {
 
 #[tokio::test]
 async fn should_fail_when_the_whitelist_cannot_be_reloaded_from_the_database() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/health_check_api/contract.rs
+++ b/tests/servers/health_check_api/contract.rs
@@ -1,17 +1,14 @@
 use torrust_tracker::servers::health_check_api::resources::{Report, Status};
 use torrust_tracker::servers::registar::Registar;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging;
 use crate::servers::health_check_api::client::get;
 use crate::servers::health_check_api::Started;
 
 #[tokio::test]
 async fn health_check_endpoint_should_return_status_ok_when_there_is_no_services_registered() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let configuration = configuration::ephemeral_with_no_services();
 
@@ -37,18 +34,15 @@ mod api {
 
     use torrust_tracker::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::api;
     use crate::servers::health_check_api::client::get;
     use crate::servers::health_check_api::Started;
 
     #[tokio::test]
     pub(crate) async fn it_should_return_good_health_for_api_service() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 
@@ -95,9 +89,7 @@ mod api {
 
     #[tokio::test]
     pub(crate) async fn it_should_return_error_when_api_service_was_stopped_after_registration() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 
@@ -152,18 +144,15 @@ mod http {
 
     use torrust_tracker::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::health_check_api::client::get;
     use crate::servers::health_check_api::Started;
     use crate::servers::http;
 
     #[tokio::test]
     pub(crate) async fn it_should_return_good_health_for_http_service() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 
@@ -209,9 +198,7 @@ mod http {
 
     #[tokio::test]
     pub(crate) async fn it_should_return_error_when_http_service_was_stopped_after_registration() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 
@@ -266,18 +253,15 @@ mod udp {
 
     use torrust_tracker::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::health_check_api::client::get;
     use crate::servers::health_check_api::Started;
     use crate::servers::udp;
 
     #[tokio::test]
     pub(crate) async fn it_should_return_good_health_for_udp_service() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 
@@ -320,9 +304,7 @@ mod udp {
 
     #[tokio::test]
     pub(crate) async fn it_should_return_error_when_udp_service_was_stopped_after_registration() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
 

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -1,9 +1,12 @@
 use torrust_tracker_test_helpers::configuration;
 
+use crate::common::logging;
 use crate::servers::http::Started;
 
 #[tokio::test]
 async fn environment_should_be_started_and_stopped() {
+    logging::setup();
+
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     env.stop().await;
@@ -13,17 +16,14 @@ mod for_all_config_modes {
 
     use torrust_tracker::servers::http::v1::handlers::health_check::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::http::client::Client;
     use crate::servers::http::Started;
 
     #[tokio::test]
     async fn health_check_endpoint_should_return_ok_if_the_http_tracker_is_running() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
 
@@ -38,9 +38,8 @@ mod for_all_config_modes {
 
     mod and_running_on_reverse_proxy {
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging;
         use crate::servers::http::asserts::assert_could_not_find_remote_address_on_x_forwarded_for_header_error_response;
         use crate::servers::http::client::Client;
         use crate::servers::http::requests::announce::QueryBuilder;
@@ -48,9 +47,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_http_request_does_not_include_the_xff_http_request_header() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // If the tracker is running behind a reverse proxy, the peer IP is the
             // right most IP in the `X-Forwarded-For` HTTP header, which is the IP of the proxy's client.
@@ -68,9 +65,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_xff_http_request_header_contains_an_invalid_ip() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
 
@@ -109,10 +104,9 @@ mod for_all_config_modes {
         use tokio::net::TcpListener;
         use torrust_tracker_primitives::peer::fixture::PeerBuilder;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
         use crate::common::fixtures::invalid_info_hashes;
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging;
         use crate::servers::http::asserts::{
             assert_announce_response, assert_bad_announce_request_error_response, assert_cannot_parse_query_param_error_response,
             assert_cannot_parse_query_params_error_response, assert_compact_announce_response, assert_empty_announce_response,
@@ -125,9 +119,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn it_should_start_and_stop() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
             env.stop().await;
@@ -135,9 +127,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_respond_if_only_the_mandatory_fields_are_provided() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -154,9 +144,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_url_query_component_is_empty() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -169,9 +157,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_url_query_parameters_are_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -188,9 +174,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_a_mandatory_field_is_missing() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -229,9 +213,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_info_hash_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -250,9 +232,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_not_fail_when_the_peer_address_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // AnnounceQuery does not even contain the `peer_addr`
             // The peer IP is obtained in two ways:
@@ -274,9 +254,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_downloaded_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -297,9 +275,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_uploaded_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -320,9 +296,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_peer_id_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -350,9 +324,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_port_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -373,9 +345,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_left_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -396,9 +366,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_event_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -427,9 +395,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_compact_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -450,9 +416,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_numwant_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -473,9 +437,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_no_peers_if_the_announced_peer_is_the_first_one() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -506,9 +468,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_list_of_previously_announced_peers() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -550,9 +510,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_list_of_previously_announced_peers_including_peers_using_ipv4_and_ipv6() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -606,9 +564,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_consider_two_peers_to_be_the_same_when_they_have_the_same_peer_id_even_if_the_ip_is_different() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -634,9 +590,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_compact_response() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // Tracker Returns Compact Peer Lists
             // https://www.bittorrent.org/beps/bep_0023.html
@@ -677,9 +631,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_not_return_the_compact_response_by_default() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // code-review: the HTTP tracker does not return the compact response by default if the "compact"
             // param is not provided in the announce URL. The BEP 23 suggest to do so.
@@ -720,9 +672,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp4_connections_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -741,9 +691,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp6_connections_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             if TcpListener::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
                 .await
@@ -769,9 +717,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_not_increase_the_number_of_tcp6_connections_handled_if_the_client_is_not_using_an_ipv6_ip() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // The tracker ignores the peer address in the request param. It uses the client remote ip address.
 
@@ -796,9 +742,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp4_announce_requests_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -817,9 +761,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_of_tcp6_announce_requests_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             if TcpListener::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
                 .await
@@ -845,9 +787,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_not_increase_the_number_of_tcp6_announce_requests_handled_if_the_client_is_not_using_an_ipv6_ip() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // The tracker ignores the peer address in the request param. It uses the client remote ip address.
 
@@ -872,9 +812,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_assign_to_the_peer_ip_the_remote_client_ip_instead_of_the_peer_address_in_the_request_param() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -905,9 +843,7 @@ mod for_all_config_modes {
         #[tokio::test]
         async fn when_the_client_ip_is_a_loopback_ipv4_it_should_assign_to_the_peer_ip_the_external_ip_in_the_tracker_configuration(
         ) {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             /*  We assume that both the client and tracker share the same public IP.
 
@@ -945,9 +881,7 @@ mod for_all_config_modes {
         #[tokio::test]
         async fn when_the_client_ip_is_a_loopback_ipv6_it_should_assign_to_the_peer_ip_the_external_ip_in_the_tracker_configuration(
         ) {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             /* We assume that both the client and tracker share the same public IP.
 
@@ -989,9 +923,7 @@ mod for_all_config_modes {
         #[tokio::test]
         async fn when_the_tracker_is_behind_a_reverse_proxy_it_should_assign_to_the_peer_ip_the_ip_in_the_x_forwarded_for_http_header(
         ) {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             /*
             client          <-> http proxy                       <-> tracker                   <-> Internet
@@ -1046,10 +978,9 @@ mod for_all_config_modes {
         use tokio::net::TcpListener;
         use torrust_tracker_primitives::peer::fixture::PeerBuilder;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
         use crate::common::fixtures::invalid_info_hashes;
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging;
         use crate::servers::http::asserts::{
             assert_cannot_parse_query_params_error_response, assert_missing_query_params_for_scrape_request_error_response,
             assert_scrape_response,
@@ -1062,9 +993,7 @@ mod for_all_config_modes {
         #[tokio::test]
         #[allow(dead_code)]
         async fn should_fail_when_the_request_is_empty() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
             let response = Client::new(*env.bind_address()).get("scrape").await;
@@ -1076,9 +1005,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_fail_when_the_info_hash_param_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1097,9 +1024,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1139,9 +1064,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_the_file_with_the_complete_peer_when_there_is_one_peer_with_no_bytes_pending_to_download() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1181,9 +1104,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_return_a_file_with_zeroed_values_when_there_are_no_peers() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1204,9 +1125,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_accept_multiple_infohashes() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1234,9 +1153,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_ot_tcp4_scrape_requests_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_public().into()).await;
 
@@ -1261,9 +1178,7 @@ mod for_all_config_modes {
 
         #[tokio::test]
         async fn should_increase_the_number_ot_tcp6_scrape_requests_handled_in_statistics() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             if TcpListener::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
                 .await
@@ -1302,9 +1217,8 @@ mod configured_as_whitelisted {
 
         use bittorrent_primitives::info_hash::InfoHash;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging::{self};
         use crate::servers::http::asserts::{assert_is_announce_response, assert_torrent_not_in_whitelist_error_response};
         use crate::servers::http::client::Client;
         use crate::servers::http::requests::announce::QueryBuilder;
@@ -1312,9 +1226,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_fail_if_the_torrent_is_not_in_the_whitelist() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
@@ -1331,9 +1243,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_allow_announcing_a_whitelisted_torrent() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
@@ -1361,9 +1271,8 @@ mod configured_as_whitelisted {
         use bittorrent_primitives::info_hash::InfoHash;
         use torrust_tracker_primitives::peer::fixture::PeerBuilder;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging::{self};
         use crate::servers::http::asserts::assert_scrape_response;
         use crate::servers::http::client::Client;
         use crate::servers::http::responses::scrape::{File, ResponseBuilder};
@@ -1371,9 +1280,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_return_the_zeroed_file_when_the_requested_file_is_not_whitelisted() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
@@ -1404,9 +1311,7 @@ mod configured_as_whitelisted {
 
         #[tokio::test]
         async fn should_return_the_file_stats_when_the_requested_file_is_whitelisted() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_listed().into()).await;
 
@@ -1460,9 +1365,8 @@ mod configured_as_private {
         use bittorrent_primitives::info_hash::InfoHash;
         use torrust_tracker::core::auth::Key;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging;
         use crate::servers::http::asserts::{assert_authentication_error_response, assert_is_announce_response};
         use crate::servers::http::client::Client;
         use crate::servers::http::requests::announce::QueryBuilder;
@@ -1470,9 +1374,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_respond_to_authenticated_peers() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1489,9 +1391,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_peer_has_not_provided_the_authentication_key() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1508,9 +1408,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1527,9 +1425,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_peer_cannot_be_authenticated_with_the_provided_key() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1556,9 +1452,8 @@ mod configured_as_private {
         use torrust_tracker::core::auth::Key;
         use torrust_tracker_primitives::peer::fixture::PeerBuilder;
         use torrust_tracker_test_helpers::configuration;
-        use tracing::level_filters::LevelFilter;
 
-        use crate::common::logging::{tracing_stderr_init, INIT};
+        use crate::common::logging;
         use crate::servers::http::asserts::{assert_authentication_error_response, assert_scrape_response};
         use crate::servers::http::client::Client;
         use crate::servers::http::responses::scrape::{File, ResponseBuilder};
@@ -1566,9 +1461,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1585,9 +1478,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_return_the_zeroed_file_when_the_client_is_not_authenticated() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1618,9 +1509,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_return_the_real_file_stats_when_the_client_is_authenticated() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             let env = Started::new(&configuration::ephemeral_private().into()).await;
 
@@ -1662,9 +1551,7 @@ mod configured_as_private {
 
         #[tokio::test]
         async fn should_return_the_zeroed_file_when_the_authentication_key_provided_by_the_client_is_invalid() {
-            INIT.call_once(|| {
-                tracing_stderr_init(LevelFilter::ERROR);
-            });
+            logging::setup();
 
             // There is not authentication error
             // code-review: should this really be this way?

--- a/tests/servers/udp/contract.rs
+++ b/tests/servers/udp/contract.rs
@@ -10,9 +10,8 @@ use bittorrent_tracker_client::udp::client::UdpTrackerClient;
 use torrust_tracker::shared::bit_torrent::tracker::udp::MAX_PACKET_SIZE;
 use torrust_tracker_configuration::DEFAULT_TIMEOUT;
 use torrust_tracker_test_helpers::configuration;
-use tracing::level_filters::LevelFilter;
 
-use crate::common::logging::{tracing_stderr_init, INIT};
+use crate::common::logging;
 use crate::servers::udp::asserts::get_error_response_message;
 use crate::servers::udp::Started;
 
@@ -41,9 +40,7 @@ async fn send_connection_request(transaction_id: TransactionId, client: &UdpTrac
 
 #[tokio::test]
 async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_request() {
-    INIT.call_once(|| {
-        tracing_stderr_init(LevelFilter::ERROR);
-    });
+    logging::setup();
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -74,17 +71,14 @@ mod receiving_a_connection_request {
     use bittorrent_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_configuration::DEFAULT_TIMEOUT;
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::udp::asserts::is_connect_response;
     use crate::servers::udp::Started;
 
     #[tokio::test]
     async fn should_return_a_connect_response() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -123,9 +117,8 @@ mod receiving_an_announce_request {
     use bittorrent_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_configuration::DEFAULT_TIMEOUT;
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::udp::asserts::is_ipv4_announce_response;
     use crate::servers::udp::contract::send_connection_request;
     use crate::servers::udp::Started;
@@ -173,9 +166,7 @@ mod receiving_an_announce_request {
 
     #[tokio::test]
     async fn should_return_an_announce_response() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -195,9 +186,7 @@ mod receiving_an_announce_request {
 
     #[tokio::test]
     async fn should_return_many_announce_response() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -220,9 +209,7 @@ mod receiving_an_announce_request {
 
     #[tokio::test]
     async fn should_ban_the_client_ip_if_it_sends_more_than_10_requests_with_a_cookie_value_not_normal() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
@@ -266,18 +253,15 @@ mod receiving_an_scrape_request {
     use bittorrent_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_configuration::DEFAULT_TIMEOUT;
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::udp::asserts::is_scrape_response;
     use crate::servers::udp::contract::send_connection_request;
     use crate::servers::udp::Started;
 
     #[tokio::test]
     async fn should_return_a_scrape_response() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -101,16 +101,13 @@ mod tests {
 
     use tokio::time::sleep;
     use torrust_tracker_test_helpers::configuration;
-    use tracing::level_filters::LevelFilter;
 
-    use crate::common::logging::{tracing_stderr_init, INIT};
+    use crate::common::logging;
     use crate::servers::udp::Started;
 
     #[tokio::test]
     async fn it_should_make_and_stop_udp_server() {
-        INIT.call_once(|| {
-            tracing_stderr_init(LevelFilter::ERROR);
-        });
+        logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
         sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
Relates to: 
 - https://github.com/torrust/torrust-tracker/issues/1069
 - https://github.com/torrust/torrust-tracker/pull/1148

This feature will be used in the future to write assertions about logs.

It also changes when we show logs running tests. If you run tests with:

```console
cargo test
```

logs won't be shown. If you want to see the logs you have to execute tests
with:

```console
cargo test -- --nocapture
```