### PR TITLE
Override `tower-http` tracing errors

### DIFF
--- a/src/servers/logging.rs
+++ b/src/servers/logging.rs
@@ -1,3 +1,8 @@
+use std::fmt;
+use std::time::Duration;
+
+use tower_http::LatencyUnit;
+
 /// This is the prefix used in logs to identify a started service.
 ///
 /// For example:
@@ -27,3 +32,27 @@ We should use something like:
 ```
 
 */
+
+pub struct Latency {
+    unit: LatencyUnit,
+    duration: Duration,
+}
+
+impl Latency {
+    #[must_use]
+    pub fn new(unit: LatencyUnit, duration: Duration) -> Self {
+        Self { unit, duration }
+    }
+}
+
+impl fmt::Display for Latency {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unit {
+            LatencyUnit::Seconds => write!(f, "{} s", self.duration.as_secs_f64()),
+            LatencyUnit::Millis => write!(f, "{} ms", self.duration.as_millis()),
+            LatencyUnit::Micros => write!(f, "{} μs", self.duration.as_micros()),
+            LatencyUnit::Nanos => write!(f, "{} ns", self.duration.as_nanos()),
+            _ => panic!("Invalid latency unit"),
+        }
+    }
+}


### PR DESCRIPTION
This overrides the default log errors when a 500 response is sent to the client.

From:

```
2024-12-23T15:54:25.842837Z ERROR tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=0 ms
```

To:

```
2024-12-23T16:06:53.553023Z ERROR API: response failed classification=Status code: 500 Internal Server Error latency=0 ms
```

The target has been changed:

```
2024-12-23T15:54:25.842837Z ERROR tower_http::trace::on_failure: response failed classification=Status code: 500 Internal Server Error latency=0 ms
2024-12-23T16:06:53.553023Z ERROR API:                           response failed classification=Status code: 500 Internal Server Error latency=0 ms
```

It was changed to:

- Easily identify the origin of the error in our code.
- Allow for the inserting of more fields in the future, for example, to write assertions about logs.