### PR TITLE
Log assertions: add assertions for API log errors

### DIFF
--- a/src/servers/apis/server.rs
+++ b/src/servers/apis/server.rs
@@ -243,9 +243,10 @@ impl Launcher {
         tx_start: Sender<Started>,
         rx_halt: Receiver<Halted>,
     ) -> BoxFuture<'static, ()> {
-        let router = router(tracker, access_tokens);
         let socket = std::net::TcpListener::bind(self.bind_to).expect("Could not bind tcp_listener to address.");
         let address = socket.local_addr().expect("Could not get local_addr from tcp_listener.");
+
+        let router = router(tracker, access_tokens, address);
 
         let handle = Handle::new();
 

--- a/tests/servers/api/v1/client.rs
+++ b/tests/servers/api/v1/client.rs
@@ -20,82 +20,94 @@ impl Client {
         }
     }
 
-    pub async fn generate_auth_key(&self, seconds_valid: i32) -> Response {
-        self.post_empty(&format!("key/{}", &seconds_valid)).await
+    pub async fn generate_auth_key(&self, seconds_valid: i32, headers: Option<HeaderMap>) -> Response {
+        self.post_empty(&format!("key/{}", &seconds_valid), headers).await
     }
 
-    pub async fn add_auth_key(&self, add_key_form: AddKeyForm) -> Response {
-        self.post_form("keys", &add_key_form).await
+    pub async fn add_auth_key(&self, add_key_form: AddKeyForm, headers: Option<HeaderMap>) -> Response {
+        self.post_form("keys", &add_key_form, headers).await
     }
 
-    pub async fn delete_auth_key(&self, key: &str) -> Response {
-        self.delete(&format!("key/{}", &key)).await
+    pub async fn delete_auth_key(&self, key: &str, headers: Option<HeaderMap>) -> Response {
+        self.delete(&format!("key/{}", &key), headers).await
     }
 
-    pub async fn reload_keys(&self) -> Response {
-        self.get("keys/reload", Query::default()).await
+    pub async fn reload_keys(&self, headers: Option<HeaderMap>) -> Response {
+        self.get("keys/reload", Query::default(), headers).await
     }
 
-    pub async fn whitelist_a_torrent(&self, info_hash: &str) -> Response {
-        self.post_empty(&format!("whitelist/{}", &info_hash)).await
+    pub async fn whitelist_a_torrent(&self, info_hash: &str, headers: Option<HeaderMap>) -> Response {
+        self.post_empty(&format!("whitelist/{}", &info_hash), headers).await
     }
 
-    pub async fn remove_torrent_from_whitelist(&self, info_hash: &str) -> Response {
-        self.delete(&format!("whitelist/{}", &info_hash)).await
+    pub async fn remove_torrent_from_whitelist(&self, info_hash: &str, headers: Option<HeaderMap>) -> Response {
+        self.delete(&format!("whitelist/{}", &info_hash), headers).await
     }
 
-    pub async fn reload_whitelist(&self) -> Response {
-        self.get("whitelist/reload", Query::default()).await
+    pub async fn reload_whitelist(&self, headers: Option<HeaderMap>) -> Response {
+        self.get("whitelist/reload", Query::default(), headers).await
     }
 
-    pub async fn get_torrent(&self, info_hash: &str) -> Response {
-        self.get(&format!("torrent/{}", &info_hash), Query::default()).await
+    pub async fn get_torrent(&self, info_hash: &str, headers: Option<HeaderMap>) -> Response {
+        self.get(&format!("torrent/{}", &info_hash), Query::default(), headers).await
     }
 
-    pub async fn get_torrents(&self, params: Query) -> Response {
-        self.get("torrents", params).await
+    pub async fn get_torrents(&self, params: Query, headers: Option<HeaderMap>) -> Response {
+        self.get("torrents", params, headers).await
     }
 
-    pub async fn get_tracker_statistics(&self) -> Response {
-        self.get("stats", Query::default()).await
+    pub async fn get_tracker_statistics(&self, headers: Option<HeaderMap>) -> Response {
+        self.get("stats", Query::default(), headers).await
     }
 
-    pub async fn get(&self, path: &str, params: Query) -> Response {
+    pub async fn get(&self, path: &str, params: Query, headers: Option<HeaderMap>) -> Response {
         let mut query: Query = params;
 
         if let Some(token) = &self.connection_info.api_token {
             query.add_param(QueryParam::new("token", token));
         };
 
-        self.get_request_with_query(path, query, None).await
+        self.get_request_with_query(path, query, headers).await
     }
 
-    pub async fn post_empty(&self, path: &str) -> Response {
-        reqwest::Client::new()
+    pub async fn post_empty(&self, path: &str, headers: Option<HeaderMap>) -> Response {
+        let builder = reqwest::Client::new()
+            .post(self.base_url(path).clone())
+            .query(&ReqwestQuery::from(self.query_with_token()));
+
+        let builder = match headers {
+            Some(headers) => builder.headers(headers),
+            None => builder,
+        };
+
+        builder.send().await.unwrap()
+    }
+
+    pub async fn post_form<T: Serialize + ?Sized>(&self, path: &str, form: &T, headers: Option<HeaderMap>) -> Response {
+        let builder = reqwest::Client::new()
             .post(self.base_url(path).clone())
             .query(&ReqwestQuery::from(self.query_with_token()))
-            .send()
-            .await
-            .unwrap()
+            .json(&form);
+
+        let builder = match headers {
+            Some(headers) => builder.headers(headers),
+            None => builder,
+        };
+
+        builder.send().await.unwrap()
     }
 
-    pub async fn post_form<T: Serialize + ?Sized>(&self, path: &str, form: &T) -> Response {
-        reqwest::Client::new()
-            .post(self.base_url(path).clone())
-            .query(&ReqwestQuery::from(self.query_with_token()))
-            .json(&form)
-            .send()
-            .await
-            .unwrap()
-    }
-
-    async fn delete(&self, path: &str) -> Response {
-        reqwest::Client::new()
+    async fn delete(&self, path: &str, headers: Option<HeaderMap>) -> Response {
+        let builder = reqwest::Client::new()
             .delete(self.base_url(path).clone())
-            .query(&ReqwestQuery::from(self.query_with_token()))
-            .send()
-            .await
-            .unwrap()
+            .query(&ReqwestQuery::from(self.query_with_token()));
+
+        let builder = match headers {
+            Some(headers) => builder.headers(headers),
+            None => builder,
+        };
+
+        builder.send().await.unwrap()
     }
 
     pub async fn get_request_with_query(&self, path: &str, params: Query, headers: Option<HeaderMap>) -> Response {

--- a/tests/servers/api/v1/contract/authentication.rs
+++ b/tests/servers/api/v1/contract/authentication.rs
@@ -1,9 +1,10 @@
 use torrust_tracker_test_helpers::configuration;
+use uuid::Uuid;
 
 use crate::common::http::{Query, QueryParam};
-use crate::common::logging::{self};
+use crate::common::logging::{self, logs_contains_a_line_with};
 use crate::servers::api::v1::asserts::{assert_token_not_valid, assert_unauthorized};
-use crate::servers::api::v1::client::Client;
+use crate::servers::api::v1::client::{headers_with_request_id, Client};
 use crate::servers::api::Started;
 
 #[tokio::test]
@@ -15,7 +16,7 @@ async fn should_authenticate_requests_by_using_a_token_query_param() {
     let token = env.get_connection_info().api_token.unwrap();
 
     let response = Client::new(env.get_connection_info())
-        .get_request_with_query("stats", Query::params([QueryParam::new("token", &token)].to_vec()))
+        .get_request_with_query("stats", Query::params([QueryParam::new("token", &token)].to_vec()), None)
         .await;
 
     assert_eq!(response.status(), 200);
@@ -30,7 +31,7 @@ async fn should_not_authenticate_requests_when_the_token_is_missing() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let response = Client::new(env.get_connection_info())
-        .get_request_with_query("stats", Query::default())
+        .get_request_with_query("stats", Query::default(), None)
         .await;
 
     assert_unauthorized(response).await;
@@ -44,13 +45,24 @@ async fn should_not_authenticate_requests_when_the_token_is_empty() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .get_request_with_query("stats", Query::params([QueryParam::new("token", "")].to_vec()))
+        .get_request_with_query(
+            "stats",
+            Query::params([QueryParam::new("token", "")].to_vec()),
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     assert_token_not_valid(response).await;
 
     env.stop().await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 }
 
 #[tokio::test]
@@ -60,7 +72,11 @@ async fn should_not_authenticate_requests_when_the_token_is_invalid() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let response = Client::new(env.get_connection_info())
-        .get_request_with_query("stats", Query::params([QueryParam::new("token", "INVALID TOKEN")].to_vec()))
+        .get_request_with_query(
+            "stats",
+            Query::params([QueryParam::new("token", "INVALID TOKEN")].to_vec()),
+            None,
+        )
         .await;
 
     assert_token_not_valid(response).await;

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -3,15 +3,16 @@ use std::time::Duration;
 use serde::Serialize;
 use torrust_tracker::core::auth::Key;
 use torrust_tracker_test_helpers::configuration;
+use uuid::Uuid;
 
-use crate::common::logging::{self};
+use crate::common::logging::{self, logs_contains_a_line_with};
 use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
 use crate::servers::api::v1::asserts::{
     assert_auth_key_utf8, assert_failed_to_delete_key, assert_failed_to_generate_key, assert_failed_to_reload_keys,
     assert_invalid_auth_key_get_param, assert_invalid_auth_key_post_param, assert_ok, assert_token_not_valid,
     assert_unauthorized, assert_unprocessable_auth_key_duration_param,
 };
-use crate::servers::api::v1::client::{AddKeyForm, Client};
+use crate::servers::api::v1::client::{headers_with_request_id, AddKeyForm, Client};
 use crate::servers::api::{force_database_error, Started};
 
 #[tokio::test]
@@ -20,11 +21,16 @@ async fn should_allow_generating_a_new_random_auth_key() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .add_auth_key(AddKeyForm {
-            opt_key: None,
-            seconds_valid: Some(60),
-        })
+        .add_auth_key(
+            AddKeyForm {
+                opt_key: None,
+                seconds_valid: Some(60),
+            },
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     let auth_key_resource = assert_auth_key_utf8(response).await;
@@ -44,11 +50,16 @@ async fn should_allow_uploading_a_preexisting_auth_key() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .add_auth_key(AddKeyForm {
-            opt_key: Some("Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z5".to_string()),
-            seconds_valid: Some(60),
-        })
+        .add_auth_key(
+            AddKeyForm {
+                opt_key: Some("Xc1L4PbQJSFGlrgSRZl8wxSFAuMa21z5".to_string()),
+                seconds_valid: Some(60),
+            },
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     let auth_key_resource = assert_auth_key_utf8(response).await;
@@ -68,23 +79,43 @@ async fn should_not_allow_generating_a_new_auth_key_for_unauthenticated_users() 
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
-        .add_auth_key(AddKeyForm {
-            opt_key: None,
-            seconds_valid: Some(60),
-        })
+        .add_auth_key(
+            AddKeyForm {
+                opt_key: None,
+                seconds_valid: Some(60),
+            },
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     assert_token_not_valid(response).await;
 
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
+
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
-        .add_auth_key(AddKeyForm {
-            opt_key: None,
-            seconds_valid: Some(60),
-        })
+        .add_auth_key(
+            AddKeyForm {
+                opt_key: None,
+                seconds_valid: Some(60),
+            },
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     assert_unauthorized(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -97,14 +128,24 @@ async fn should_fail_when_the_auth_key_cannot_be_generated() {
 
     force_database_error(&env.tracker);
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .add_auth_key(AddKeyForm {
-            opt_key: None,
-            seconds_valid: Some(60),
-        })
+        .add_auth_key(
+            AddKeyForm {
+                opt_key: None,
+                seconds_valid: Some(60),
+            },
+            Some(headers_with_request_id(request_id)),
+        )
         .await;
 
     assert_failed_to_generate_key(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -122,8 +163,10 @@ async fn should_allow_deleting_an_auth_key() {
         .await
         .unwrap();
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .delete_auth_key(&auth_key.key.to_string())
+        .delete_auth_key(&auth_key.key.to_string(), Some(headers_with_request_id(request_id)))
         .await;
 
     assert_ok(response).await;
@@ -154,6 +197,8 @@ async fn should_fail_generating_a_new_auth_key_when_the_provided_key_is_invalid(
     ];
 
     for invalid_key in invalid_keys {
+        let request_id = Uuid::new_v4();
+
         let response = Client::new(env.get_connection_info())
             .post_form(
                 "keys",
@@ -161,6 +206,7 @@ async fn should_fail_generating_a_new_auth_key_when_the_provided_key_is_invalid(
                     opt_key: Some(invalid_key.to_string()),
                     seconds_valid: 60,
                 },
+                Some(headers_with_request_id(request_id)),
             )
             .await;
 
@@ -190,6 +236,8 @@ async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid(
     ];
 
     for invalid_key_duration in invalid_key_durations {
+        let request_id = Uuid::new_v4();
+
         let response = Client::new(env.get_connection_info())
             .post_form(
                 "keys",
@@ -197,6 +245,7 @@ async fn should_fail_generating_a_new_auth_key_when_the_key_duration_is_invalid(
                     opt_key: None,
                     seconds_valid: invalid_key_duration.to_string(),
                 },
+                Some(headers_with_request_id(request_id)),
             )
             .await;
 
@@ -223,7 +272,11 @@ async fn should_fail_deleting_an_auth_key_when_the_key_id_is_invalid() {
     ];
 
     for invalid_auth_key in &invalid_auth_keys {
-        let response = Client::new(env.get_connection_info()).delete_auth_key(invalid_auth_key).await;
+        let request_id = Uuid::new_v4();
+
+        let response = Client::new(env.get_connection_info())
+            .delete_auth_key(invalid_auth_key, Some(headers_with_request_id(request_id)))
+            .await;
 
         assert_invalid_auth_key_get_param(response, invalid_auth_key).await;
     }
@@ -246,11 +299,18 @@ async fn should_fail_when_the_auth_key_cannot_be_deleted() {
 
     force_database_error(&env.tracker);
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(env.get_connection_info())
-        .delete_auth_key(&auth_key.key.to_string())
+        .delete_auth_key(&auth_key.key.to_string(), Some(headers_with_request_id(request_id)))
         .await;
 
     assert_failed_to_delete_key(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -270,11 +330,18 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
         .await
         .unwrap();
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
-        .delete_auth_key(&auth_key.key.to_string())
+        .delete_auth_key(&auth_key.key.to_string(), Some(headers_with_request_id(request_id)))
         .await;
 
     assert_token_not_valid(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     // Generate new auth key
     let auth_key = env
@@ -283,11 +350,18 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
         .await
         .unwrap();
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
-        .delete_auth_key(&auth_key.key.to_string())
+        .delete_auth_key(&auth_key.key.to_string(), Some(headers_with_request_id(request_id)))
         .await;
 
     assert_unauthorized(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -304,7 +378,11 @@ async fn should_allow_reloading_keys() {
         .await
         .unwrap();
 
-    let response = Client::new(env.get_connection_info()).reload_keys().await;
+    let request_id = Uuid::new_v4();
+
+    let response = Client::new(env.get_connection_info())
+        .reload_keys(Some(headers_with_request_id(request_id)))
+        .await;
 
     assert_ok(response).await;
 
@@ -317,7 +395,9 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
+    let request_id = Uuid::new_v4();
     let seconds_valid = 60;
+
     env.tracker
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
@@ -325,9 +405,16 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
 
     force_database_error(&env.tracker);
 
-    let response = Client::new(env.get_connection_info()).reload_keys().await;
+    let response = Client::new(env.get_connection_info())
+        .reload_keys(Some(headers_with_request_id(request_id)))
+        .await;
 
     assert_failed_to_reload_keys(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -344,17 +431,31 @@ async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
         .await
         .unwrap();
 
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
-        .reload_keys()
+        .reload_keys(Some(headers_with_request_id(request_id)))
         .await;
 
     assert_token_not_valid(response).await;
 
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
+
+    let request_id = Uuid::new_v4();
+
     let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
-        .reload_keys()
+        .reload_keys(Some(headers_with_request_id(request_id)))
         .await;
 
     assert_unauthorized(response).await;
+
+    assert!(
+        logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+        "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+    );
 
     env.stop().await;
 }
@@ -363,14 +464,15 @@ mod deprecated_generate_key_endpoint {
 
     use torrust_tracker::core::auth::Key;
     use torrust_tracker_test_helpers::configuration;
+    use uuid::Uuid;
 
-    use crate::common::logging::{self};
+    use crate::common::logging::{self, logs_contains_a_line_with};
     use crate::servers::api::connection_info::{connection_with_invalid_token, connection_with_no_token};
     use crate::servers::api::v1::asserts::{
         assert_auth_key_utf8, assert_failed_to_generate_key, assert_invalid_key_duration_param, assert_token_not_valid,
         assert_unauthorized,
     };
-    use crate::servers::api::v1::client::Client;
+    use crate::servers::api::v1::client::{headers_with_request_id, Client};
     use crate::servers::api::{force_database_error, Started};
 
     #[tokio::test]
@@ -381,7 +483,9 @@ mod deprecated_generate_key_endpoint {
 
         let seconds_valid = 60;
 
-        let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+        let response = Client::new(env.get_connection_info())
+            .generate_auth_key(seconds_valid, None)
+            .await;
 
         let auth_key_resource = assert_auth_key_utf8(response).await;
 
@@ -400,21 +504,27 @@ mod deprecated_generate_key_endpoint {
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
+        let request_id = Uuid::new_v4();
         let seconds_valid = 60;
 
         let response = Client::new(connection_with_invalid_token(env.get_connection_info().bind_address.as_str()))
-            .generate_auth_key(seconds_valid)
+            .generate_auth_key(seconds_valid, Some(headers_with_request_id(request_id)))
             .await;
 
         assert_token_not_valid(response).await;
 
         let response = Client::new(connection_with_no_token(env.get_connection_info().bind_address.as_str()))
-            .generate_auth_key(seconds_valid)
+            .generate_auth_key(seconds_valid, None)
             .await;
 
         assert_unauthorized(response).await;
 
         env.stop().await;
+
+        assert!(
+            logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+            "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+        );
     }
 
     #[tokio::test]
@@ -431,7 +541,7 @@ mod deprecated_generate_key_endpoint {
 
         for invalid_key_duration in invalid_key_durations {
             let response = Client::new(env.get_connection_info())
-                .post_empty(&format!("key/{invalid_key_duration}"))
+                .post_empty(&format!("key/{invalid_key_duration}"), None)
                 .await;
 
             assert_invalid_key_duration_param(response, invalid_key_duration).await;
@@ -448,11 +558,19 @@ mod deprecated_generate_key_endpoint {
 
         force_database_error(&env.tracker);
 
+        let request_id = Uuid::new_v4();
         let seconds_valid = 60;
-        let response = Client::new(env.get_connection_info()).generate_auth_key(seconds_valid).await;
+        let response = Client::new(env.get_connection_info())
+            .generate_auth_key(seconds_valid, Some(headers_with_request_id(request_id)))
+            .await;
 
         assert_failed_to_generate_key(response).await;
 
         env.stop().await;
+
+        assert!(
+            logs_contains_a_line_with(&["ERROR", "API", &format!("{request_id}")]),
+            "Expected logs to contain: ERROR ... API ... request_id={request_id}"
+        );
     }
 }

--- a/tests/servers/api/v1/contract/context/health_check.rs
+++ b/tests/servers/api/v1/contract/context/health_check.rs
@@ -13,7 +13,7 @@ async fn health_check_endpoint_should_return_status_ok_if_api_is_running() {
 
     let url = format!("http://{}/api/health_check", env.get_connection_info().bind_address);
 
-    let response = get(&url, None).await;
+    let response = get(&url, None, None).await;
 
     assert_eq!(response.status(), 200);
     assert_eq!(response.headers().get("content-type").unwrap(), "application/json");


### PR DESCRIPTION
It adds test assertions for log errors in the context of the tracker API.

Sample `ERROR` log:

```console
cargo test -- --nocapture servers::api::v1::contract::authentication::should_not_authenticate_requests_when_the_token_is_empty
```

```output
2024-12-26T11:13:00.203024Z ERROR API: response latency_ms=0 status_code=500 Internal Server Error server_socket_addr=127.0.0.1:35409 request_id=922cffeb-ed64-4d56-bbd0-400d6ea6f8d2
```

We are using the `request_id` to find the log line because the tracing setup is global (shared by all tests). When the tracker API request is sent, the `request_id` is injected as an HTTP header.