### PR TITLE
Log assertions: add assertions for log errors in HTTP tracker

### DIFF
--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -1,3 +1,5 @@
+use bittorrent_primitives::info_hash::InfoHash;
+
 #[allow(dead_code)]
 pub fn invalid_info_hashes() -> Vec<String> {
     [
@@ -9,4 +11,12 @@ pub fn invalid_info_hashes() -> Vec<String> {
         "9c38422213e30bff212b30c360d26f9a0213642&".to_string(), // Invalid char
     ]
     .to_vec()
+}
+
+/// Returns a random info hash.
+pub fn random_info_hash() -> InfoHash {
+    let mut rng = rand::thread_rng();
+    let random_bytes: [u8; 20] = rand::Rng::gen(&mut rng);
+
+    InfoHash::from_bytes(&random_bytes)
 }


### PR DESCRIPTION
Log assertions: add assertions for log errors in HTTP tracker.

It's using the info-hash to find the ERROR in logs. It's generated a newly random info-hash for each test.

It could have been also used a `x-request-id` header in the HTTP request but this solution is simpler and the chances to have an info-hash collision is very low.