### PR TITLE
Log assertions: add assertions for log errors in UDP tracker

### DIFF
--- a/src/servers/udp/connection_cookie.rs
+++ b/src/servers/udp/connection_cookie.rs
@@ -121,7 +121,7 @@ use std::ops::Range;
 /// # Panics
 ///
 /// It would panic if the range start is not smaller than it's end.
-#[instrument(err)]
+#[instrument]
 pub fn check(cookie: &Cookie, fingerprint: u64, valid_range: Range<f64>) -> Result<f64, Error> {
     assert!(valid_range.start <= valid_range.end, "range start is larger than range end");
 

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -1,3 +1,4 @@
+use aquatic_udp_protocol::TransactionId;
 use bittorrent_primitives::info_hash::InfoHash;
 
 #[allow(dead_code)]
@@ -19,4 +20,10 @@ pub fn random_info_hash() -> InfoHash {
     let random_bytes: [u8; 20] = rand::Rng::gen(&mut rng);
 
     InfoHash::from_bytes(&random_bytes)
+}
+
+/// Returns a random transaction id.
+pub fn random_transaction_id() -> TransactionId {
+    let random_value = rand::Rng::gen::<i32>(&mut rand::thread_rng());
+    TransactionId::new(random_value)
 }


### PR DESCRIPTION
When you run this test:

```console
cargo test -- --nocapture should_ban_the_client_ip_if_it_sends_more_than_10_requests_with_a_cookie_value_not_normal
```

It produces errors in logs:

```
2024-12-26T16:36:47.110017Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1099956 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=37145179-19a4-4dee-8de4-38bf78adb947 transaction_id=-1197696568
2024-12-26T16:36:47.110065Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.110063 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=67ef896d-6cae-40d5-9579-861b3f0bcc08 transaction_id=-1981380796
2024-12-26T16:36:47.110083Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.110082 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=2c8468b5-dd98-42c6-a7f1-729e24fcd4d1 transaction_id=1019576994
2024-12-26T16:36:47.110101Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1100998 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=5136e93c-d37a-4170-b7d4-60c89085d716 transaction_id=-1112877121
2024-12-26T16:36:47.110120Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1101193 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=7d64e196-d5e1-4e9a-8d73-04edd6abd058 transaction_id=-178038086
2024-12-26T16:36:47.110140Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1101387 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=ca4649c8-182f-4478-9320-45bc5fbf05cf transaction_id=-1291900102
2024-12-26T16:36:47.110158Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1101577 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=a421124b-7dd8-40d0-aaee-adbc490633d0 transaction_id=-572700157
2024-12-26T16:36:47.110179Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1101787 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=5ee806b6-8774-407e-8fca-7ab2c8f9f614 transaction_id=-819492118
2024-12-26T16:36:47.110199Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1101985 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=f28523bc-4413-431d-85c6-63b4007a386d transaction_id=-958244248
2024-12-26T16:36:47.110220Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.110219 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=271ded0a-acc7-431d-abd9-ca56cb9139fc transaction_id=1716116781
2024-12-26T16:36:47.110241Z ERROR UDP TRACKER: response error error=cookie value is expired: -0.00000000000000000004989914643359549, expected > 1735230886.1102402 remote_addr=127.0.0.1:34493 local_addr=127.0.0.1:34443 request_id=af8211e6-3c42-49dc-b891-e936bdbb38ab transaction_id=539714610
```

This PR adds assertions for those logs.