### PR TITLE
Rename lib to `torrust_tracker_lib`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ repository.workspace = true
 rust-version.workspace = true
 version.workspace = true
 
+[lib]
+name = "torrust_tracker_lib" 
+
 [workspace.package]
 authors = ["Nautilus Cyberneering <info@nautilus-cyberneering.de>, Mick van Dijke <mick@dutchbits.nl>"]
 categories = ["network-programming", "web-programming"]

--- a/src/bin/e2e_tests_runner.rs
+++ b/src/bin/e2e_tests_runner.rs
@@ -1,5 +1,5 @@
 //! Program to run E2E tests.
-use torrust_tracker::console::ci::e2e;
+use torrust_tracker_lib::console::ci::e2e;
 
 fn main() -> anyhow::Result<()> {
     e2e::runner::run()

--- a/src/bin/profiling.rs
+++ b/src/bin/profiling.rs
@@ -1,6 +1,6 @@
 //! This binary is used for profiling with [valgrind](https://valgrind.org/)
 //! and [kcachegrind](https://kcachegrind.github.io/).
-use torrust_tracker::console::profiling::run;
+use torrust_tracker_lib::console::profiling::run;
 
 #[tokio::main]
 async fn main() {

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -12,7 +12,7 @@
 //! Keys are stored in this struct:
 //!
 //! ```rust,no_run
-//! use torrust_tracker::core::auth::Key;
+//! use torrust_tracker_lib::core::auth::Key;
 //! use torrust_tracker_primitives::DurationSinceUnixEpoch;
 //!
 //! pub struct ExpiringKey {
@@ -26,7 +26,7 @@
 //! You can generate a new key valid for `9999` seconds and `0` nanoseconds from the current time with the following:
 //!
 //! ```rust,no_run
-//! use torrust_tracker::core::auth;
+//! use torrust_tracker_lib::core::auth;
 //! use std::time::Duration;
 //!
 //! let expiring_key = auth::generate_key(Some(Duration::new(9999, 0)));
@@ -197,7 +197,7 @@ impl Key {
 /// Error returned when a key cannot be parsed from a string.
 ///
 /// ```text
-/// use torrust_tracker::core::auth::Key;
+/// use torrust_tracker_lib::core::auth::Key;
 /// use std::str::FromStr;
 ///
 /// let key_string = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ";

--- a/src/core/databases/driver.rs
+++ b/src/core/databases/driver.rs
@@ -30,8 +30,8 @@ pub enum Driver {
 /// Example for `SQLite3`:
 ///
 /// ```text
-/// use torrust_tracker::core::databases;
-/// use torrust_tracker::core::databases::driver::Driver;
+/// use torrust_tracker_lib::core::databases;
+/// use torrust_tracker_lib::core::databases::driver::Driver;
 ///
 /// let db_driver = Driver::Sqlite3;
 /// let db_path = "./storage/tracker/lib/database/sqlite3.db".to_string();
@@ -41,8 +41,8 @@ pub enum Driver {
 /// Example for `MySQL`:
 ///
 /// ```text
-/// use torrust_tracker::core::databases;
-/// use torrust_tracker::core::databases::driver::Driver;
+/// use torrust_tracker_lib::core::databases;
+/// use torrust_tracker_lib::core::databases::driver::Driver;
 ///
 /// let db_driver = Driver::MySQL;
 /// let db_path = "mysql://db_user:db_user_secret_password@mysql:3306/torrust_tracker".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use torrust_tracker::{app, bootstrap};
+use torrust_tracker_lib::{app, bootstrap};
 
 #[tokio::main]
 async fn main() {

--- a/src/servers/http/v1/query.rs
+++ b/src/servers/http/v1/query.rs
@@ -31,7 +31,7 @@ impl Query {
     /// input `name` exists. For example:
     ///
     /// ```text
-    /// use torrust_tracker::servers::http::v1::query::Query;
+    /// use torrust_tracker_lib::servers::http::v1::query::Query;
     ///
     /// let raw_query = "param1=value1&param2=value2";
     ///
@@ -44,7 +44,7 @@ impl Query {
     /// It returns only the first param value even if it has multiple values:
     ///
     /// ```text
-    /// use torrust_tracker::servers::http::v1::query::Query;
+    /// use torrust_tracker_lib::servers::http::v1::query::Query;
     ///
     /// let raw_query = "param1=value1&param1=value2";
     ///
@@ -60,7 +60,7 @@ impl Query {
     /// Returns all the param values as a vector.
     ///
     /// ```text
-    /// use torrust_tracker::servers::http::v1::query::Query;
+    /// use torrust_tracker_lib::servers::http::v1::query::Query;
     ///
     /// let query = "param1=value1&param1=value2".parse::<Query>().unwrap();
     ///
@@ -73,7 +73,7 @@ impl Query {
     /// Returns all the param values as a vector even if it has only one value.
     ///
     /// ```text
-    /// use torrust_tracker::servers::http::v1::query::Query;
+    /// use torrust_tracker_lib::servers::http::v1::query::Query;
     ///
     /// let query = "param1=value1".parse::<Query>().unwrap();
     ///

--- a/src/servers/http/v1/requests/announce.rs
+++ b/src/servers/http/v1/requests/announce.rs
@@ -31,7 +31,7 @@ const NUMWANT: &str = "numwant";
 ///
 /// ```text
 /// use aquatic_udp_protocol::{NumberOfBytes, PeerId};
-/// use torrust_tracker::servers::http::v1::requests::announce::{Announce, Compact, Event};
+/// use torrust_tracker_lib::servers::http::v1::requests::announce::{Announce, Compact, Event};
 /// use bittorrent_primitives::info_hash::InfoHash;
 ///
 /// let request = Announce {

--- a/src/servers/http/v1/responses/announce.rs
+++ b/src/servers/http/v1/responses/announce.rs
@@ -154,7 +154,7 @@ impl Into<Vec<u8>> for Compact {
 ///
 /// ```text
 /// use std::net::{IpAddr, Ipv4Addr};
-/// use torrust_tracker::servers::http::v1::responses::announce::{Normal, NormalPeer};
+/// use torrust_tracker_lib::servers::http::v1::responses::announce::{Normal, NormalPeer};
 ///
 /// let peer = NormalPeer {
 ///     peer_id: *b"-qB00000000000000001",
@@ -206,7 +206,7 @@ impl From<&NormalPeer> for BencodeMut<'_> {
 ///
 /// ```text
 ///  use std::net::{IpAddr, Ipv4Addr};
-///  use torrust_tracker::servers::http::v1::responses::announce::{Compact, CompactPeer, CompactPeerData};
+///  use torrust_tracker_lib::servers::http::v1::responses::announce::{Compact, CompactPeer, CompactPeerData};
 ///
 ///  let peer = CompactPeer::V4(CompactPeerData {
 ///     ip: Ipv4Addr::new(0x69, 0x69, 0x69, 0x69), // 105.105.105.105

--- a/src/servers/http/v1/responses/error.rs
+++ b/src/servers/http/v1/responses/error.rs
@@ -27,7 +27,7 @@ impl Error {
     /// Returns the bencoded representation of the `Error` struct.
     ///
     /// ```text
-    /// use torrust_tracker::servers::http::v1::responses::error::Error;
+    /// use torrust_tracker_lib::servers::http::v1::responses::error::Error;
     ///
     /// let err = Error {
     ///    failure_reason: "error message".to_owned(),

--- a/src/servers/http/v1/responses/scrape.rs
+++ b/src/servers/http/v1/responses/scrape.rs
@@ -12,10 +12,10 @@ use crate::core::ScrapeData;
 /// The `Scrape` response for the HTTP tracker.
 ///
 /// ```text
-/// use torrust_tracker::servers::http::v1::responses::scrape::Bencoded;
+/// use torrust_tracker_lib::servers::http::v1::responses::scrape::Bencoded;
 /// use bittorrent_primitives::info_hash::InfoHash;
 /// use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
-/// use torrust_tracker::core::ScrapeData;
+/// use torrust_tracker_lib::core::ScrapeData;
 ///
 /// let info_hash = InfoHash::from_bytes(&[0x69; 20]);
 /// let mut scrape_data = ScrapeData::empty();

--- a/src/servers/http/v1/services/peer_ip_resolver.rs
+++ b/src/servers/http/v1/services/peer_ip_resolver.rs
@@ -63,7 +63,7 @@ pub enum PeerIpResolutionError {
 /// use std::net::IpAddr;
 /// use std::str::FromStr;
 ///
-/// use torrust_tracker::servers::http::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
+/// use torrust_tracker_lib::servers::http::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
 ///
 /// let on_reverse_proxy = true;
 ///
@@ -85,7 +85,7 @@ pub enum PeerIpResolutionError {
 /// use std::net::IpAddr;
 /// use std::str::FromStr;
 ///
-/// use torrust_tracker::servers::http::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
+/// use torrust_tracker_lib::servers::http::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
 ///
 /// let on_reverse_proxy = false;
 ///

--- a/tests/common/logging.rs
+++ b/tests/common/logging.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use std::io;
 use std::sync::{Mutex, MutexGuard, Once, OnceLock};
 
-use torrust_tracker::bootstrap::logging::TraceStyle;
+use torrust_tracker_lib::bootstrap::logging::TraceStyle;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt::MakeWriter;
 

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use futures::executor::block_on;
-use torrust_tracker::bootstrap::app::initialize_with_configuration;
-use torrust_tracker::bootstrap::jobs::make_rust_tls;
-use torrust_tracker::core::Tracker;
-use torrust_tracker::servers::apis::server::{ApiServer, Launcher, Running, Stopped};
-use torrust_tracker::servers::registar::Registar;
 use torrust_tracker_configuration::{Configuration, HttpApi};
+use torrust_tracker_lib::bootstrap::app::initialize_with_configuration;
+use torrust_tracker_lib::bootstrap::jobs::make_rust_tls;
+use torrust_tracker_lib::core::Tracker;
+use torrust_tracker_lib::servers::apis::server::{ApiServer, Launcher, Running, Stopped};
+use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_primitives::peer;
 
 use super::connection_info::ConnectionInfo;

--- a/tests/servers/api/mod.rs
+++ b/tests/servers/api/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use torrust_tracker::core::Tracker;
-use torrust_tracker::servers::apis::server;
+use torrust_tracker_lib::core::Tracker;
+use torrust_tracker_lib::servers::apis::server;
 
 pub mod connection_info;
 pub mod environment;

--- a/tests/servers/api/v1/asserts.rs
+++ b/tests/servers/api/v1/asserts.rs
@@ -1,9 +1,9 @@
 // code-review: should we use macros to return the exact line where the assert fails?
 
 use reqwest::Response;
-use torrust_tracker::servers::apis::v1::context::auth_key::resources::AuthKey;
-use torrust_tracker::servers::apis::v1::context::stats::resources::Stats;
-use torrust_tracker::servers::apis::v1::context::torrent::resources::torrent::{ListItem, Torrent};
+use torrust_tracker_lib::servers::apis::v1::context::auth_key::resources::AuthKey;
+use torrust_tracker_lib::servers::apis::v1::context::stats::resources::Stats;
+use torrust_tracker_lib::servers::apis::v1::context::torrent::resources::torrent::{ListItem, Torrent};
 
 // Resource responses
 

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use serde::Serialize;
-use torrust_tracker::core::auth::Key;
+use torrust_tracker_lib::core::auth::Key;
 use torrust_tracker_test_helpers::configuration;
 use uuid::Uuid;
 
@@ -462,7 +462,7 @@ async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
 
 mod deprecated_generate_key_endpoint {
 
-    use torrust_tracker::core::auth::Key;
+    use torrust_tracker_lib::core::auth::Key;
     use torrust_tracker_test_helpers::configuration;
     use uuid::Uuid;
 

--- a/tests/servers/api/v1/contract/context/health_check.rs
+++ b/tests/servers/api/v1/contract/context/health_check.rs
@@ -1,4 +1,4 @@
-use torrust_tracker::servers::apis::v1::context::health_check::resources::{Report, Status};
+use torrust_tracker_lib::servers::apis::v1::context::health_check::resources::{Report, Status};
 use torrust_tracker_test_helpers::configuration;
 
 use crate::common::logging;

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use bittorrent_primitives::info_hash::InfoHash;
-use torrust_tracker::servers::apis::v1::context::stats::resources::Stats;
+use torrust_tracker_lib::servers::apis::v1::context::stats::resources::Stats;
 use torrust_tracker_primitives::peer::fixture::PeerBuilder;
 use torrust_tracker_test_helpers::configuration;
 use uuid::Uuid;

--- a/tests/servers/api/v1/contract/context/torrent.rs
+++ b/tests/servers/api/v1/contract/context/torrent.rs
@@ -1,8 +1,8 @@
 use std::str::FromStr;
 
 use bittorrent_primitives::info_hash::InfoHash;
-use torrust_tracker::servers::apis::v1::context::torrent::resources::peer::Peer;
-use torrust_tracker::servers::apis::v1::context::torrent::resources::torrent::{self, Torrent};
+use torrust_tracker_lib::servers::apis::v1::context::torrent::resources::peer::Peer;
+use torrust_tracker_lib::servers::apis::v1::context::torrent::resources::torrent::{self, Torrent};
 use torrust_tracker_primitives::peer::fixture::PeerBuilder;
 use torrust_tracker_test_helpers::configuration;
 use uuid::Uuid;

--- a/tests/servers/health_check_api/contract.rs
+++ b/tests/servers/health_check_api/contract.rs
@@ -1,5 +1,5 @@
-use torrust_tracker::servers::health_check_api::resources::{Report, Status};
-use torrust_tracker::servers::registar::Registar;
+use torrust_tracker_lib::servers::health_check_api::resources::{Report, Status};
+use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_test_helpers::configuration;
 
 use crate::common::logging;
@@ -32,7 +32,7 @@ async fn health_check_endpoint_should_return_status_ok_when_there_is_no_services
 mod api {
     use std::sync::Arc;
 
-    use torrust_tracker::servers::health_check_api::resources::{Report, Status};
+    use torrust_tracker_lib::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
 
     use crate::common::logging;
@@ -142,7 +142,7 @@ mod api {
 mod http {
     use std::sync::Arc;
 
-    use torrust_tracker::servers::health_check_api::resources::{Report, Status};
+    use torrust_tracker_lib::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
 
     use crate::common::logging;
@@ -251,7 +251,7 @@ mod http {
 mod udp {
     use std::sync::Arc;
 
-    use torrust_tracker::servers::health_check_api::resources::{Report, Status};
+    use torrust_tracker_lib::servers::health_check_api::resources::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
 
     use crate::common::logging;

--- a/tests/servers/health_check_api/environment.rs
+++ b/tests/servers/health_check_api/environment.rs
@@ -3,11 +3,11 @@ use std::sync::Arc;
 
 use tokio::sync::oneshot::{self, Sender};
 use tokio::task::JoinHandle;
-use torrust_tracker::bootstrap::jobs::Started;
-use torrust_tracker::servers::health_check_api::{server, HEALTH_CHECK_API_LOG_TARGET};
-use torrust_tracker::servers::registar::Registar;
-use torrust_tracker::servers::signals::{self, Halted};
 use torrust_tracker_configuration::HealthCheckApi;
+use torrust_tracker_lib::bootstrap::jobs::Started;
+use torrust_tracker_lib::servers::health_check_api::{server, HEALTH_CHECK_API_LOG_TARGET};
+use torrust_tracker_lib::servers::registar::Registar;
+use torrust_tracker_lib::servers::signals::{self, Halted};
 
 #[derive(Debug)]
 pub enum Error {

--- a/tests/servers/http/client.rs
+++ b/tests/servers/http/client.rs
@@ -1,7 +1,7 @@
 use std::net::IpAddr;
 
 use reqwest::{Client as ReqwestClient, Response};
-use torrust_tracker::core::auth::Key;
+use torrust_tracker_lib::core::auth::Key;
 
 use super::requests::announce::{self, Query};
 use super::requests::scrape;

--- a/tests/servers/http/connection_info.rs
+++ b/tests/servers/http/connection_info.rs
@@ -1,4 +1,4 @@
-use torrust_tracker::core::auth::Key;
+use torrust_tracker_lib::core::auth::Key;
 
 #[derive(Clone, Debug)]
 pub struct ConnectionInfo {

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use futures::executor::block_on;
-use torrust_tracker::bootstrap::app::initialize_with_configuration;
-use torrust_tracker::bootstrap::jobs::make_rust_tls;
-use torrust_tracker::core::Tracker;
-use torrust_tracker::servers::http::server::{HttpServer, Launcher, Running, Stopped};
-use torrust_tracker::servers::registar::Registar;
 use torrust_tracker_configuration::{Configuration, HttpTracker};
+use torrust_tracker_lib::bootstrap::app::initialize_with_configuration;
+use torrust_tracker_lib::bootstrap::jobs::make_rust_tls;
+use torrust_tracker_lib::core::Tracker;
+use torrust_tracker_lib::servers::http::server::{HttpServer, Launcher, Running, Stopped};
+use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_primitives::peer;
 
 pub struct Environment<S> {

--- a/tests/servers/http/mod.rs
+++ b/tests/servers/http/mod.rs
@@ -8,7 +8,7 @@ pub mod v1;
 pub type Started = environment::Environment<server::Running>;
 
 use percent_encoding::NON_ALPHANUMERIC;
-use torrust_tracker::servers::http::server;
+use torrust_tracker_lib::servers::http::server;
 
 pub type ByteArray20 = [u8; 20];
 

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -14,7 +14,7 @@ async fn environment_should_be_started_and_stopped() {
 
 mod for_all_config_modes {
 
-    use torrust_tracker::servers::http::v1::handlers::health_check::{Report, Status};
+    use torrust_tracker_lib::servers::http::v1::handlers::health_check::{Report, Status};
     use torrust_tracker_test_helpers::configuration;
 
     use crate::common::logging;
@@ -1381,7 +1381,7 @@ mod configured_as_private {
         use std::time::Duration;
 
         use bittorrent_primitives::info_hash::InfoHash;
-        use torrust_tracker::core::auth::Key;
+        use torrust_tracker_lib::core::auth::Key;
         use torrust_tracker_test_helpers::configuration;
 
         use crate::common::logging;
@@ -1467,7 +1467,7 @@ mod configured_as_private {
 
         use aquatic_udp_protocol::PeerId;
         use bittorrent_primitives::info_hash::InfoHash;
-        use torrust_tracker::core::auth::Key;
+        use torrust_tracker_lib::core::auth::Key;
         use torrust_tracker_primitives::peer::fixture::PeerBuilder;
         use torrust_tracker_test_helpers::configuration;
 

--- a/tests/servers/udp/contract.rs
+++ b/tests/servers/udp/contract.rs
@@ -7,8 +7,8 @@ use core::panic;
 
 use aquatic_udp_protocol::{ConnectRequest, ConnectionId, Response, TransactionId};
 use bittorrent_tracker_client::udp::client::UdpTrackerClient;
-use torrust_tracker::shared::bit_torrent::tracker::udp::MAX_PACKET_SIZE;
 use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+use torrust_tracker_lib::shared::bit_torrent::tracker::udp::MAX_PACKET_SIZE;
 use torrust_tracker_test_helpers::configuration;
 
 use crate::common::logging;

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -2,13 +2,13 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
-use torrust_tracker::bootstrap::app::initialize_with_configuration;
-use torrust_tracker::core::Tracker;
-use torrust_tracker::servers::registar::Registar;
-use torrust_tracker::servers::udp::server::spawner::Spawner;
-use torrust_tracker::servers::udp::server::states::{Running, Stopped};
-use torrust_tracker::servers::udp::server::Server;
 use torrust_tracker_configuration::{Configuration, UdpTracker, DEFAULT_TIMEOUT};
+use torrust_tracker_lib::bootstrap::app::initialize_with_configuration;
+use torrust_tracker_lib::core::Tracker;
+use torrust_tracker_lib::servers::registar::Registar;
+use torrust_tracker_lib::servers::udp::server::spawner::Spawner;
+use torrust_tracker_lib::servers::udp::server::states::{Running, Stopped};
+use torrust_tracker_lib::servers::udp::server::Server;
 use torrust_tracker_primitives::peer;
 
 pub struct Environment<S>

--- a/tests/servers/udp/mod.rs
+++ b/tests/servers/udp/mod.rs
@@ -1,4 +1,4 @@
-use torrust_tracker::servers::udp::server::states::Running;
+use torrust_tracker_lib::servers::udp::server::states::Running;
 
 pub mod asserts;
 pub mod contract;


### PR DESCRIPTION
Rename lib to `torrust_tracker_lib` to avoid collisions in docs:

```console
cargo doc --no-deps --bins --examples --workspace --all-features
```

becuase the main binary and lib have the same name.