### PR TITLE
Add more metrics

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -113,6 +113,7 @@ pub async fn start(
         if let Some(job) = tracker_apis::start_job(
             http_api_config,
             tracker.clone(),
+            ban_service.clone(),
             registar.give_form(),
             servers::apis::Version::V1,
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,12 +23,14 @@
 //! - Tracker REST API: the tracker API can be enabled/disabled.
 use std::sync::Arc;
 
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use torrust_tracker_configuration::Configuration;
 use tracing::instrument;
 
 use crate::bootstrap::jobs::{health_check_api, http_tracker, torrent_cleanup, tracker_apis, udp_tracker};
 use crate::servers::registar::Registar;
+use crate::servers::udp::server::banning::BanService;
 use crate::{core, servers};
 
 /// # Panics
@@ -37,8 +39,12 @@ use crate::{core, servers};
 ///
 /// - Can't retrieve tracker keys from database.
 /// - Can't load whitelist from database.
-#[instrument(skip(config, tracker))]
-pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<JoinHandle<()>> {
+#[instrument(skip(config, tracker, ban_service))]
+pub async fn start(
+    config: &Configuration,
+    tracker: Arc<core::Tracker>,
+    ban_service: Arc<RwLock<BanService>>,
+) -> Vec<JoinHandle<()>> {
     if config.http_api.is_none()
         && (config.udp_trackers.is_none() || config.udp_trackers.as_ref().map_or(true, std::vec::Vec::is_empty))
         && (config.http_trackers.is_none() || config.http_trackers.as_ref().map_or(true, std::vec::Vec::is_empty))
@@ -75,7 +81,9 @@ pub async fn start(config: &Configuration, tracker: Arc<core::Tracker>) -> Vec<J
                     udp_tracker_config.bind_address
                 );
             } else {
-                jobs.push(udp_tracker::start_job(udp_tracker_config, tracker.clone(), registar.give_form()).await);
+                jobs.push(
+                    udp_tracker::start_job(udp_tracker_config, tracker.clone(), ban_service.clone(), registar.give_form()).await,
+                );
             }
         }
     } else {

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -47,11 +47,11 @@ pub fn setup() -> (Configuration, Arc<Tracker>, Arc<RwLock<BanService>>) {
 
     let tracker = initialize_with_configuration(&configuration);
 
-    let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
+    let udp_ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
 
     tracing::info!("Configuration:\n{}", configuration.clone().mask_secrets().to_json());
 
-    (configuration, tracker, ban_service)
+    (configuration, tracker, udp_ban_service)
 }
 
 /// checks if the seed is the instance seed in production.

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -13,6 +13,7 @@
 //! 4. Initialize the domain tracker.
 use std::sync::Arc;
 
+use tokio::sync::RwLock;
 use torrust_tracker_clock::static_time;
 use torrust_tracker_configuration::validator::Validator;
 use torrust_tracker_configuration::Configuration;
@@ -22,6 +23,8 @@ use super::config::initialize_configuration;
 use crate::bootstrap;
 use crate::core::services::tracker_factory;
 use crate::core::Tracker;
+use crate::servers::udp::server::banning::BanService;
+use crate::servers::udp::server::launcher::MAX_CONNECTION_ID_ERRORS_PER_IP;
 use crate::shared::crypto::ephemeral_instance_keys;
 use crate::shared::crypto::keys::{self, Keeper as _};
 
@@ -32,7 +35,7 @@ use crate::shared::crypto::keys::{self, Keeper as _};
 /// Setup can file if the configuration is invalid.
 #[must_use]
 #[instrument(skip())]
-pub fn setup() -> (Configuration, Arc<Tracker>) {
+pub fn setup() -> (Configuration, Arc<Tracker>, Arc<RwLock<BanService>>) {
     #[cfg(not(test))]
     check_seed();
 
@@ -44,9 +47,11 @@ pub fn setup() -> (Configuration, Arc<Tracker>) {
 
     let tracker = initialize_with_configuration(&configuration);
 
+    let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
+
     tracing::info!("Configuration:\n{}", configuration.clone().mask_secrets().to_json());
 
-    (configuration, tracker)
+    (configuration, tracker, ban_service)
 }
 
 /// checks if the seed is the instance seed in production.

--- a/src/console/profiling.rs
+++ b/src/console/profiling.rs
@@ -179,9 +179,9 @@ pub async fn run() {
         return;
     };
 
-    let (config, tracker) = bootstrap::app::setup();
+    let (config, tracker, ban_service) = bootstrap::app::setup();
 
-    let jobs = app::start(&config, tracker).await;
+    let jobs = app::start(&config, tracker, ban_service).await;
 
     // Run the tracker for a fixed duration
     let run_duration = sleep(Duration::from_secs(duration_secs));

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -76,6 +76,7 @@ pub async fn get_metrics(tracker: Arc<Tracker>) -> TrackerMetrics {
             tcp6_scrapes_handled: stats.tcp6_scrapes_handled,
             // UDP
             udp_requests_aborted: stats.udp_requests_aborted,
+            udp_requests_banned: stats.udp_requests_banned,
             udp4_requests: stats.udp4_requests,
             udp4_connections_handled: stats.udp4_connections_handled,
             udp4_announces_handled: stats.udp4_announces_handled,

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -70,10 +70,11 @@ pub async fn get_metrics(tracker: Arc<Tracker>, ban_service: Arc<RwLock<BanServi
     TrackerMetrics {
         torrents_metrics,
         protocol_metrics: Metrics {
-            // TCP
+            // TCPv4
             tcp4_connections_handled: stats.tcp4_connections_handled,
             tcp4_announces_handled: stats.tcp4_announces_handled,
             tcp4_scrapes_handled: stats.tcp4_scrapes_handled,
+            // TCPv6
             tcp6_connections_handled: stats.tcp6_connections_handled,
             tcp6_announces_handled: stats.tcp6_announces_handled,
             tcp6_scrapes_handled: stats.tcp6_scrapes_handled,
@@ -81,12 +82,17 @@ pub async fn get_metrics(tracker: Arc<Tracker>, ban_service: Arc<RwLock<BanServi
             udp_requests_aborted: stats.udp_requests_aborted,
             udp_requests_banned: stats.udp_requests_banned,
             udp_banned_ips_total: udp_banned_ips_total as u64,
+            udp_avg_connect_processing_time_ns: stats.udp_avg_connect_processing_time_ns,
+            udp_avg_announce_processing_time_ns: stats.udp_avg_announce_processing_time_ns,
+            udp_avg_scrape_processing_time_ns: stats.udp_avg_scrape_processing_time_ns,
+            // UDPv4
             udp4_requests: stats.udp4_requests,
             udp4_connections_handled: stats.udp4_connections_handled,
             udp4_announces_handled: stats.udp4_announces_handled,
             udp4_scrapes_handled: stats.udp4_scrapes_handled,
             udp4_responses: stats.udp4_responses,
             udp4_errors_handled: stats.udp4_errors_handled,
+            // UDPv6
             udp6_requests: stats.udp6_requests,
             udp6_connections_handled: stats.udp6_connections_handled,
             udp6_announces_handled: stats.udp6_announces_handled,

--- a/src/core/statistics/event/handler.rs
+++ b/src/core/statistics/event/handler.rs
@@ -1,4 +1,4 @@
-use crate::core::statistics::event::Event;
+use crate::core::statistics::event::{Event, UdpResponseKind};
 use crate::core::statistics::repository::Repository;
 
 pub async fn handle_event(event: Event, stats_repository: &Repository) {
@@ -45,10 +45,29 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
             stats_repository.increase_udp4_scrapes().await;
         }
         Event::Udp4Response {
-            kind: _,
-            req_processing_time: _,
+            kind,
+            req_processing_time,
         } => {
             stats_repository.increase_udp4_responses().await;
+
+            match kind {
+                UdpResponseKind::Connect => {
+                    stats_repository
+                        .recalculate_udp_avg_connect_processing_time_ns(req_processing_time)
+                        .await;
+                }
+                UdpResponseKind::Announce => {
+                    stats_repository
+                        .recalculate_udp_avg_announce_processing_time_ns(req_processing_time)
+                        .await;
+                }
+                UdpResponseKind::Scrape => {
+                    stats_repository
+                        .recalculate_udp_avg_scrape_processing_time_ns(req_processing_time)
+                        .await;
+                }
+                UdpResponseKind::Error => {}
+            }
         }
         Event::Udp4Error => {
             stats_repository.increase_udp4_errors().await;

--- a/src/core/statistics/event/handler.rs
+++ b/src/core/statistics/event/handler.rs
@@ -44,7 +44,10 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
         Event::Udp4Scrape => {
             stats_repository.increase_udp4_scrapes().await;
         }
-        Event::Udp4Response => {
+        Event::Udp4Response {
+            kind: _,
+            req_processing_time: _,
+        } => {
             stats_repository.increase_udp4_responses().await;
         }
         Event::Udp4Error => {
@@ -64,7 +67,10 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
         Event::Udp6Scrape => {
             stats_repository.increase_udp6_scrapes().await;
         }
-        Event::Udp6Response => {
+        Event::Udp6Response {
+            kind: _,
+            req_processing_time: _,
+        } => {
             stats_repository.increase_udp6_responses().await;
         }
         Event::Udp6Error => {

--- a/src/core/statistics/event/handler.rs
+++ b/src/core/statistics/event/handler.rs
@@ -27,6 +27,9 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
         Event::UdpRequestAborted => {
             stats_repository.increase_udp_requests_aborted().await;
         }
+        Event::UdpRequestBanned => {
+            stats_repository.increase_udp_requests_banned().await;
+        }
 
         // UDP4
         Event::Udp4Request => {

--- a/src/core/statistics/event/handler.rs
+++ b/src/core/statistics/event/handler.rs
@@ -24,7 +24,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
         }
 
         // UDP
-        Event::Udp4RequestAborted => {
+        Event::UdpRequestAborted => {
             stats_repository.increase_udp_requests_aborted().await;
         }
 

--- a/src/core/statistics/event/mod.rs
+++ b/src/core/statistics/event/mod.rs
@@ -18,7 +18,7 @@ pub enum Event {
     Tcp4Scrape,
     Tcp6Announce,
     Tcp6Scrape,
-    Udp4RequestAborted,
+    UdpRequestAborted,
     Udp4Request,
     Udp4Connect,
     Udp4Announce,

--- a/src/core/statistics/event/mod.rs
+++ b/src/core/statistics/event/mod.rs
@@ -19,6 +19,7 @@ pub enum Event {
     Tcp6Announce,
     Tcp6Scrape,
     UdpRequestAborted,
+    UdpRequestBanned,
     Udp4Request,
     Udp4Connect,
     Udp4Announce,

--- a/src/core/statistics/event/mod.rs
+++ b/src/core/statistics/event/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 pub mod handler;
 pub mod listener;
 pub mod sender;
@@ -24,12 +26,26 @@ pub enum Event {
     Udp4Connect,
     Udp4Announce,
     Udp4Scrape,
-    Udp4Response,
+    Udp4Response {
+        kind: UdpResponseKind,
+        req_processing_time: Duration,
+    },
     Udp4Error,
     Udp6Request,
     Udp6Connect,
     Udp6Announce,
     Udp6Scrape,
-    Udp6Response,
+    Udp6Response {
+        kind: UdpResponseKind,
+        req_processing_time: Duration,
+    },
     Udp6Error,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum UdpResponseKind {
+    Connect,
+    Announce,
+    Scrape,
+    Error,
 }

--- a/src/core/statistics/metrics.rs
+++ b/src/core/statistics/metrics.rs
@@ -31,6 +31,9 @@ pub struct Metrics {
     /// Total number of UDP (UDP tracker) requests aborted.
     pub udp_requests_aborted: u64,
 
+    /// Total number of UDP (UDP tracker) requests banned.
+    pub udp_requests_banned: u64,
+
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
 

--- a/src/core/statistics/metrics.rs
+++ b/src/core/statistics/metrics.rs
@@ -28,6 +28,7 @@ pub struct Metrics {
     /// Total number of TCP (HTTP tracker) `scrape` requests from IPv6 peers.
     pub tcp6_scrapes_handled: u64,
 
+    // UDP
     /// Total number of UDP (UDP tracker) requests aborted.
     pub udp_requests_aborted: u64,
 
@@ -37,6 +38,16 @@ pub struct Metrics {
     /// Total number of banned IPs.
     pub udp_banned_ips_total: u64,
 
+    /// Average rounded time spent processing UDP connect requests.
+    pub udp_avg_connect_processing_time_ns: u64,
+
+    /// Average rounded time spent processing UDP announce requests.
+    pub udp_avg_announce_processing_time_ns: u64,
+
+    /// Average rounded time spent processing UDP scrape requests.
+    pub udp_avg_scrape_processing_time_ns: u64,
+
+    // UDPv4
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
 
@@ -55,6 +66,7 @@ pub struct Metrics {
     /// Total number of UDP (UDP tracker) `error` requests from IPv4 peers.
     pub udp4_errors_handled: u64,
 
+    // UDPv6
     /// Total number of UDP (UDP tracker) requests from IPv6 peers.
     pub udp6_requests: u64,
 

--- a/src/core/statistics/metrics.rs
+++ b/src/core/statistics/metrics.rs
@@ -34,6 +34,9 @@ pub struct Metrics {
     /// Total number of UDP (UDP tracker) requests banned.
     pub udp_requests_banned: u64,
 
+    /// Total number of banned IPs.
+    pub udp_banned_ips_total: u64,
+
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
 

--- a/src/core/statistics/repository.rs
+++ b/src/core/statistics/repository.rs
@@ -70,6 +70,12 @@ impl Repository {
         drop(stats_lock);
     }
 
+    pub async fn increase_udp_requests_banned(&self) {
+        let mut stats_lock = self.stats.write().await;
+        stats_lock.udp_requests_banned += 1;
+        drop(stats_lock);
+    }
+
     pub async fn increase_udp4_requests(&self) {
         let mut stats_lock = self.stats.write().await;
         stats_lock.udp4_requests += 1;

--- a/src/core/statistics/repository.rs
+++ b/src/core/statistics/repository.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::{RwLock, RwLockReadGuard};
 
@@ -109,6 +110,64 @@ impl Repository {
     pub async fn increase_udp4_errors(&self) {
         let mut stats_lock = self.stats.write().await;
         stats_lock.udp4_errors_handled += 1;
+        drop(stats_lock);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    pub async fn recalculate_udp_avg_connect_processing_time_ns(&self, req_processing_time: Duration) {
+        let mut stats_lock = self.stats.write().await;
+
+        let req_processing_time = req_processing_time.as_nanos() as f64;
+        let udp_connections_handled = (stats_lock.udp4_connections_handled + stats_lock.udp6_connections_handled) as f64;
+
+        let previous_avg = stats_lock.udp_avg_connect_processing_time_ns;
+
+        // Moving average: https://en.wikipedia.org/wiki/Moving_average
+        let new_avg = previous_avg as f64 + (req_processing_time - previous_avg as f64) / udp_connections_handled;
+
+        stats_lock.udp_avg_connect_processing_time_ns = new_avg.ceil() as u64;
+
+        drop(stats_lock);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    pub async fn recalculate_udp_avg_announce_processing_time_ns(&self, req_processing_time: Duration) {
+        let mut stats_lock = self.stats.write().await;
+
+        let req_processing_time = req_processing_time.as_nanos() as f64;
+
+        let udp_announces_handled = (stats_lock.udp4_announces_handled + stats_lock.udp6_announces_handled) as f64;
+
+        let previous_avg = stats_lock.udp_avg_announce_processing_time_ns;
+
+        // Moving average: https://en.wikipedia.org/wiki/Moving_average
+        let new_avg = previous_avg as f64 + (req_processing_time - previous_avg as f64) / udp_announces_handled;
+
+        stats_lock.udp_avg_announce_processing_time_ns = new_avg.ceil() as u64;
+
+        drop(stats_lock);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    #[allow(clippy::cast_possible_truncation)]
+    #[allow(clippy::cast_sign_loss)]
+    pub async fn recalculate_udp_avg_scrape_processing_time_ns(&self, req_processing_time: Duration) {
+        let mut stats_lock = self.stats.write().await;
+
+        let req_processing_time = req_processing_time.as_nanos() as f64;
+        let udp_scrapes_handled = (stats_lock.udp4_scrapes_handled + stats_lock.udp6_scrapes_handled) as f64;
+
+        let previous_avg = stats_lock.udp_avg_scrape_processing_time_ns;
+
+        // Moving average: https://en.wikipedia.org/wiki/Moving_average
+        let new_avg = previous_avg as f64 + (req_processing_time - previous_avg as f64) / udp_scrapes_handled;
+
+        stats_lock.udp_avg_scrape_processing_time_ns = new_avg.ceil() as u64;
+
         drop(stats_lock);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ use torrust_tracker_lib::{app, bootstrap};
 
 #[tokio::main]
 async fn main() {
-    let (config, tracker, ban_service) = bootstrap::app::setup();
+    let (config, tracker, udp_ban_service) = bootstrap::app::setup();
 
-    let jobs = app::start(&config, tracker, ban_service).await;
+    let jobs = app::start(&config, tracker, udp_ban_service).await;
 
     // handle the signals
     tokio::select! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,9 @@ use torrust_tracker_lib::{app, bootstrap};
 
 #[tokio::main]
 async fn main() {
-    let (config, tracker) = bootstrap::app::setup();
+    let (config, tracker, ban_service) = bootstrap::app::setup();
 
-    let jobs = app::start(&config, tracker).await;
+    let jobs = app::start(&config, tracker, ban_service).await;
 
     // handle the signals
     tokio::select! {

--- a/src/servers/apis/v1/context/stats/resources.rs
+++ b/src/servers/apis/v1/context/stats/resources.rs
@@ -36,6 +36,8 @@ pub struct Stats {
 
     /// Total number of UDP (UDP tracker) requests aborted.
     pub udp_requests_aborted: u64,
+    /// Total number of UDP (UDP tracker) requests banned.
+    pub udp_requests_banned: u64,
 
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
@@ -80,6 +82,7 @@ impl From<TrackerMetrics> for Stats {
             tcp6_scrapes_handled: metrics.protocol_metrics.tcp6_scrapes_handled,
             // UDP
             udp_requests_aborted: metrics.protocol_metrics.udp_requests_aborted,
+            udp_requests_banned: metrics.protocol_metrics.udp_requests_banned,
             udp4_requests: metrics.protocol_metrics.udp4_requests,
             udp4_connections_handled: metrics.protocol_metrics.udp4_connections_handled,
             udp4_announces_handled: metrics.protocol_metrics.udp4_announces_handled,
@@ -124,18 +127,19 @@ mod tests {
                     tcp6_scrapes_handled: 10,
                     // UDP
                     udp_requests_aborted: 11,
-                    udp4_requests: 12,
-                    udp4_connections_handled: 13,
-                    udp4_announces_handled: 14,
-                    udp4_scrapes_handled: 15,
-                    udp4_responses: 16,
-                    udp4_errors_handled: 17,
-                    udp6_requests: 18,
-                    udp6_connections_handled: 19,
-                    udp6_announces_handled: 20,
-                    udp6_scrapes_handled: 21,
-                    udp6_responses: 22,
-                    udp6_errors_handled: 23
+                    udp_requests_banned: 12,
+                    udp4_requests: 13,
+                    udp4_connections_handled: 14,
+                    udp4_announces_handled: 15,
+                    udp4_scrapes_handled: 16,
+                    udp4_responses: 17,
+                    udp4_errors_handled: 18,
+                    udp6_requests: 19,
+                    udp6_connections_handled: 20,
+                    udp6_announces_handled: 21,
+                    udp6_scrapes_handled: 22,
+                    udp6_responses: 23,
+                    udp6_errors_handled: 24
                 }
             }),
             Stats {
@@ -152,18 +156,19 @@ mod tests {
                 tcp6_scrapes_handled: 10,
                 // UDP
                 udp_requests_aborted: 11,
-                udp4_requests: 12,
-                udp4_connections_handled: 13,
-                udp4_announces_handled: 14,
-                udp4_scrapes_handled: 15,
-                udp4_responses: 16,
-                udp4_errors_handled: 17,
-                udp6_requests: 18,
-                udp6_connections_handled: 19,
-                udp6_announces_handled: 20,
-                udp6_scrapes_handled: 21,
-                udp6_responses: 22,
-                udp6_errors_handled: 23
+                udp_requests_banned: 12,
+                udp4_requests: 13,
+                udp4_connections_handled: 14,
+                udp4_announces_handled: 15,
+                udp4_scrapes_handled: 16,
+                udp4_responses: 17,
+                udp4_errors_handled: 18,
+                udp6_requests: 19,
+                udp6_connections_handled: 20,
+                udp6_announces_handled: 21,
+                udp6_scrapes_handled: 22,
+                udp6_responses: 23,
+                udp6_errors_handled: 24
             }
         );
     }

--- a/src/servers/apis/v1/context/stats/resources.rs
+++ b/src/servers/apis/v1/context/stats/resources.rs
@@ -34,13 +34,21 @@ pub struct Stats {
     /// Total number of TCP (HTTP tracker) `scrape` requests from IPv6 peers.
     pub tcp6_scrapes_handled: u64,
 
+    // UDP
     /// Total number of UDP (UDP tracker) requests aborted.
     pub udp_requests_aborted: u64,
     /// Total number of UDP (UDP tracker) requests banned.
     pub udp_requests_banned: u64,
     /// Total number of IPs banned for UDP (UDP tracker) requests.
     pub udp_banned_ips_total: u64,
+    /// Average rounded time spent processing UDP connect requests.
+    pub udp_avg_connect_processing_time_ns: u64,
+    /// Average rounded time spent processing UDP announce requests.
+    pub udp_avg_announce_processing_time_ns: u64,
+    /// Average rounded time spent processing UDP scrape requests.
+    pub udp_avg_scrape_processing_time_ns: u64,
 
+    // UDPv4
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
     /// Total number of UDP (UDP tracker) connections from IPv4 peers.
@@ -54,6 +62,7 @@ pub struct Stats {
     /// Total number of UDP (UDP tracker) `scrape` requests from IPv4 peers.
     pub udp4_errors_handled: u64,
 
+    // UDPv6
     /// Total number of UDP (UDP tracker) requests from IPv6 peers.
     pub udp6_requests: u64,
     /// Total number of UDP (UDP tracker) `connection` requests from IPv6 peers.
@@ -86,12 +95,17 @@ impl From<TrackerMetrics> for Stats {
             udp_requests_aborted: metrics.protocol_metrics.udp_requests_aborted,
             udp_requests_banned: metrics.protocol_metrics.udp_requests_banned,
             udp_banned_ips_total: metrics.protocol_metrics.udp_banned_ips_total,
+            udp_avg_connect_processing_time_ns: metrics.protocol_metrics.udp_avg_connect_processing_time_ns,
+            udp_avg_announce_processing_time_ns: metrics.protocol_metrics.udp_avg_announce_processing_time_ns,
+            udp_avg_scrape_processing_time_ns: metrics.protocol_metrics.udp_avg_scrape_processing_time_ns,
+            // UDPv4
             udp4_requests: metrics.protocol_metrics.udp4_requests,
             udp4_connections_handled: metrics.protocol_metrics.udp4_connections_handled,
             udp4_announces_handled: metrics.protocol_metrics.udp4_announces_handled,
             udp4_scrapes_handled: metrics.protocol_metrics.udp4_scrapes_handled,
             udp4_responses: metrics.protocol_metrics.udp4_responses,
             udp4_errors_handled: metrics.protocol_metrics.udp4_errors_handled,
+            // UDPv6
             udp6_requests: metrics.protocol_metrics.udp6_requests,
             udp6_connections_handled: metrics.protocol_metrics.udp6_connections_handled,
             udp6_announces_handled: metrics.protocol_metrics.udp6_announces_handled,
@@ -132,18 +146,23 @@ mod tests {
                     udp_requests_aborted: 11,
                     udp_requests_banned: 12,
                     udp_banned_ips_total: 13,
-                    udp4_requests: 14,
-                    udp4_connections_handled: 15,
-                    udp4_announces_handled: 16,
-                    udp4_scrapes_handled: 17,
-                    udp4_responses: 18,
-                    udp4_errors_handled: 19,
-                    udp6_requests: 20,
-                    udp6_connections_handled: 21,
-                    udp6_announces_handled: 22,
-                    udp6_scrapes_handled: 23,
-                    udp6_responses: 24,
-                    udp6_errors_handled: 25
+                    udp_avg_connect_processing_time_ns: 14,
+                    udp_avg_announce_processing_time_ns: 15,
+                    udp_avg_scrape_processing_time_ns: 16,
+                    // UDPv4
+                    udp4_requests: 17,
+                    udp4_connections_handled: 18,
+                    udp4_announces_handled: 19,
+                    udp4_scrapes_handled: 20,
+                    udp4_responses: 21,
+                    udp4_errors_handled: 22,
+                    // UDPv6
+                    udp6_requests: 23,
+                    udp6_connections_handled: 24,
+                    udp6_announces_handled: 25,
+                    udp6_scrapes_handled: 26,
+                    udp6_responses: 27,
+                    udp6_errors_handled: 28
                 }
             }),
             Stats {
@@ -151,10 +170,11 @@ mod tests {
                 seeders: 1,
                 completed: 2,
                 leechers: 3,
-                // TCP
+                // TCPv4
                 tcp4_connections_handled: 5,
                 tcp4_announces_handled: 6,
                 tcp4_scrapes_handled: 7,
+                // TCPv6
                 tcp6_connections_handled: 8,
                 tcp6_announces_handled: 9,
                 tcp6_scrapes_handled: 10,
@@ -162,18 +182,23 @@ mod tests {
                 udp_requests_aborted: 11,
                 udp_requests_banned: 12,
                 udp_banned_ips_total: 13,
-                udp4_requests: 14,
-                udp4_connections_handled: 15,
-                udp4_announces_handled: 16,
-                udp4_scrapes_handled: 17,
-                udp4_responses: 18,
-                udp4_errors_handled: 19,
-                udp6_requests: 20,
-                udp6_connections_handled: 21,
-                udp6_announces_handled: 22,
-                udp6_scrapes_handled: 23,
-                udp6_responses: 24,
-                udp6_errors_handled: 25
+                udp_avg_connect_processing_time_ns: 14,
+                udp_avg_announce_processing_time_ns: 15,
+                udp_avg_scrape_processing_time_ns: 16,
+                // UDPv4
+                udp4_requests: 17,
+                udp4_connections_handled: 18,
+                udp4_announces_handled: 19,
+                udp4_scrapes_handled: 20,
+                udp4_responses: 21,
+                udp4_errors_handled: 22,
+                // UDPv6
+                udp6_requests: 23,
+                udp6_connections_handled: 24,
+                udp6_announces_handled: 25,
+                udp6_scrapes_handled: 26,
+                udp6_responses: 27,
+                udp6_errors_handled: 28
             }
         );
     }

--- a/src/servers/apis/v1/context/stats/resources.rs
+++ b/src/servers/apis/v1/context/stats/resources.rs
@@ -38,6 +38,8 @@ pub struct Stats {
     pub udp_requests_aborted: u64,
     /// Total number of UDP (UDP tracker) requests banned.
     pub udp_requests_banned: u64,
+    /// Total number of IPs banned for UDP (UDP tracker) requests.
+    pub udp_banned_ips_total: u64,
 
     /// Total number of UDP (UDP tracker) requests from IPv4 peers.
     pub udp4_requests: u64,
@@ -83,6 +85,7 @@ impl From<TrackerMetrics> for Stats {
             // UDP
             udp_requests_aborted: metrics.protocol_metrics.udp_requests_aborted,
             udp_requests_banned: metrics.protocol_metrics.udp_requests_banned,
+            udp_banned_ips_total: metrics.protocol_metrics.udp_banned_ips_total,
             udp4_requests: metrics.protocol_metrics.udp4_requests,
             udp4_connections_handled: metrics.protocol_metrics.udp4_connections_handled,
             udp4_announces_handled: metrics.protocol_metrics.udp4_announces_handled,
@@ -128,18 +131,19 @@ mod tests {
                     // UDP
                     udp_requests_aborted: 11,
                     udp_requests_banned: 12,
-                    udp4_requests: 13,
-                    udp4_connections_handled: 14,
-                    udp4_announces_handled: 15,
-                    udp4_scrapes_handled: 16,
-                    udp4_responses: 17,
-                    udp4_errors_handled: 18,
-                    udp6_requests: 19,
-                    udp6_connections_handled: 20,
-                    udp6_announces_handled: 21,
-                    udp6_scrapes_handled: 22,
-                    udp6_responses: 23,
-                    udp6_errors_handled: 24
+                    udp_banned_ips_total: 13,
+                    udp4_requests: 14,
+                    udp4_connections_handled: 15,
+                    udp4_announces_handled: 16,
+                    udp4_scrapes_handled: 17,
+                    udp4_responses: 18,
+                    udp4_errors_handled: 19,
+                    udp6_requests: 20,
+                    udp6_connections_handled: 21,
+                    udp6_announces_handled: 22,
+                    udp6_scrapes_handled: 23,
+                    udp6_responses: 24,
+                    udp6_errors_handled: 25
                 }
             }),
             Stats {
@@ -157,18 +161,19 @@ mod tests {
                 // UDP
                 udp_requests_aborted: 11,
                 udp_requests_banned: 12,
-                udp4_requests: 13,
-                udp4_connections_handled: 14,
-                udp4_announces_handled: 15,
-                udp4_scrapes_handled: 16,
-                udp4_responses: 17,
-                udp4_errors_handled: 18,
-                udp6_requests: 19,
-                udp6_connections_handled: 20,
-                udp6_announces_handled: 21,
-                udp6_scrapes_handled: 22,
-                udp6_responses: 23,
-                udp6_errors_handled: 24
+                udp_banned_ips_total: 13,
+                udp4_requests: 14,
+                udp4_connections_handled: 15,
+                udp4_announces_handled: 16,
+                udp4_scrapes_handled: 17,
+                udp4_responses: 18,
+                udp4_errors_handled: 19,
+                udp6_requests: 20,
+                udp6_connections_handled: 21,
+                udp6_announces_handled: 22,
+                udp6_scrapes_handled: 23,
+                udp6_responses: 24,
+                udp6_errors_handled: 25
             }
         );
     }

--- a/src/servers/apis/v1/context/stats/responses.rs
+++ b/src/servers/apis/v1/context/stats/responses.rs
@@ -21,6 +21,10 @@ pub fn metrics_response(tracker_metrics: &TrackerMetrics) -> Response {
     lines.push(format!("completed {}", tracker_metrics.torrents_metrics.downloaded));
     lines.push(format!("leechers {}", tracker_metrics.torrents_metrics.incomplete));
 
+    // TCP
+
+    // TCPv4
+
     lines.push(format!(
         "tcp4_connections_handled {}",
         tracker_metrics.protocol_metrics.tcp4_connections_handled
@@ -33,6 +37,8 @@ pub fn metrics_response(tracker_metrics: &TrackerMetrics) -> Response {
         "tcp4_scrapes_handled {}",
         tracker_metrics.protocol_metrics.tcp4_scrapes_handled
     ));
+
+    // TCPv6
 
     lines.push(format!(
         "tcp6_connections_handled {}",
@@ -47,10 +53,34 @@ pub fn metrics_response(tracker_metrics: &TrackerMetrics) -> Response {
         tracker_metrics.protocol_metrics.tcp6_scrapes_handled
     ));
 
+    // UDP
+
     lines.push(format!(
         "udp_requests_aborted {}",
         tracker_metrics.protocol_metrics.udp_requests_aborted
     ));
+    lines.push(format!(
+        "udp_requests_banned {}",
+        tracker_metrics.protocol_metrics.udp_requests_banned
+    ));
+    lines.push(format!(
+        "udp_banned_ips_total {}",
+        tracker_metrics.protocol_metrics.udp_banned_ips_total
+    ));
+    lines.push(format!(
+        "udp_avg_connect_processing_time_ns {}",
+        tracker_metrics.protocol_metrics.udp_avg_connect_processing_time_ns
+    ));
+    lines.push(format!(
+        "udp_avg_announce_processing_time_ns {}",
+        tracker_metrics.protocol_metrics.udp_avg_announce_processing_time_ns
+    ));
+    lines.push(format!(
+        "udp_avg_scrape_processing_time_ns {}",
+        tracker_metrics.protocol_metrics.udp_avg_scrape_processing_time_ns
+    ));
+
+    // UDPv4
 
     lines.push(format!("udp4_requests {}", tracker_metrics.protocol_metrics.udp4_requests));
     lines.push(format!(
@@ -70,6 +100,8 @@ pub fn metrics_response(tracker_metrics: &TrackerMetrics) -> Response {
         "udp4_errors_handled {}",
         tracker_metrics.protocol_metrics.udp4_errors_handled
     ));
+
+    // UDPv6
 
     lines.push(format!("udp6_requests {}", tracker_metrics.protocol_metrics.udp6_requests));
     lines.push(format!(

--- a/src/servers/apis/v1/context/stats/routes.rs
+++ b/src/servers/apis/v1/context/stats/routes.rs
@@ -7,11 +7,16 @@ use std::sync::Arc;
 
 use axum::routing::get;
 use axum::Router;
+use tokio::sync::RwLock;
 
 use super::handlers::get_stats_handler;
 use crate::core::Tracker;
+use crate::servers::udp::server::banning::BanService;
 
 /// It adds the routes to the router for the [`stats`](crate::servers::apis::v1::context::stats) API context.
-pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
-    router.route(&format!("{prefix}/stats"), get(get_stats_handler).with_state(tracker))
+pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>, ban_service: Arc<RwLock<BanService>>) -> Router {
+    router.route(
+        &format!("{prefix}/stats"),
+        get(get_stats_handler).with_state((tracker, ban_service)),
+    )
 }

--- a/src/servers/apis/v1/routes.rs
+++ b/src/servers/apis/v1/routes.rs
@@ -2,16 +2,18 @@
 use std::sync::Arc;
 
 use axum::Router;
+use tokio::sync::RwLock;
 
 use super::context::{auth_key, stats, torrent, whitelist};
 use crate::core::Tracker;
+use crate::servers::udp::server::banning::BanService;
 
 /// Add the routes for the v1 API.
-pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
+pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>, ban_service: Arc<RwLock<BanService>>) -> Router {
     let v1_prefix = format!("{prefix}/v1");
 
     let router = auth_key::routes::add(&v1_prefix, router, tracker.clone());
-    let router = stats::routes::add(&v1_prefix, router, tracker.clone());
+    let router = stats::routes::add(&v1_prefix, router, tracker.clone(), ban_service);
     let router = whitelist::routes::add(&v1_prefix, router, tracker.clone());
 
     torrent::routes::add(&v1_prefix, router, tracker)

--- a/src/servers/udp/server/banning.rs
+++ b/src/servers/udp/server/banning.rs
@@ -52,6 +52,11 @@ impl BanService {
     }
 
     #[must_use]
+    pub fn get_banned_ips_total(&self) -> usize {
+        self.accurate_error_counter.len()
+    }
+
+    #[must_use]
     pub fn get_estimate_count(&self, ip: &IpAddr) -> u32 {
         self.fuzzy_error_counter.estimate_count(&ip.to_string())
     }

--- a/src/servers/udp/server/launcher.rs
+++ b/src/servers/udp/server/launcher.rs
@@ -175,6 +175,9 @@ impl Launcher {
 
                 if ban_service.read().await.is_banned(&req.from.ip()) {
                     tracing::debug!(target: UDP_TRACKER_LOG_TARGET, local_addr,  "Udp::run_udp_server::loop continue: (banned ip)");
+
+                    tracker.send_stats_event(statistics::event::Event::UdpRequestBanned).await;
+
                     continue;
                 }
 

--- a/src/servers/udp/server/launcher.rs
+++ b/src/servers/udp/server/launcher.rs
@@ -24,7 +24,7 @@ use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 
 /// The maximum number of connection id errors per ip. Clients will be banned if
 /// they exceed this limit.
-const MAX_CONNECTION_ID_ERRORS_PER_IP: u32 = 10;
+pub const MAX_CONNECTION_ID_ERRORS_PER_IP: u32 = 10;
 const IP_BANS_RESET_INTERVAL_IN_SECS: u64 = 3600;
 
 /// A UDP server instance launcher.
@@ -40,9 +40,10 @@ impl Launcher {
     /// It panics if unable to send address of socket.
     /// It panics if the udp server is loaded when the tracker is private.
     ///
-    #[instrument(skip(tracker, bind_to, tx_start, rx_halt))]
+    #[instrument(skip(tracker, ban_service, bind_to, tx_start, rx_halt))]
     pub async fn run_with_graceful_shutdown(
         tracker: Arc<Tracker>,
+        ban_service: Arc<RwLock<BanService>>,
         bind_to: SocketAddr,
         cookie_lifetime: Duration,
         tx_start: oneshot::Sender<Started>,
@@ -80,7 +81,7 @@ impl Launcher {
             let local_addr = local_udp_url.clone();
             tokio::task::spawn(async move {
                 tracing::debug!(target: UDP_TRACKER_LOG_TARGET, local_addr, "Udp::run_with_graceful_shutdown::task (listening...)");
-                let () = Self::run_udp_server_main(receiver, tracker.clone(), cookie_lifetime).await;
+                let () = Self::run_udp_server_main(receiver, tracker.clone(), ban_service.clone(), cookie_lifetime).await;
             })
         };
 
@@ -117,8 +118,13 @@ impl Launcher {
         ServiceHealthCheckJob::new(binding, info, job)
     }
 
-    #[instrument(skip(receiver, tracker))]
-    async fn run_udp_server_main(mut receiver: Receiver, tracker: Arc<Tracker>, cookie_lifetime: Duration) {
+    #[instrument(skip(receiver, tracker, ban_service))]
+    async fn run_udp_server_main(
+        mut receiver: Receiver,
+        tracker: Arc<Tracker>,
+        ban_service: Arc<RwLock<BanService>>,
+        cookie_lifetime: Duration,
+    ) {
         let active_requests = &mut ActiveRequests::default();
 
         let addr = receiver.bound_socket_address();
@@ -126,11 +132,6 @@ impl Launcher {
         let local_addr = format!("udp://{addr}");
 
         let cookie_lifetime = cookie_lifetime.as_secs_f64();
-
-        let ban_service = Arc::new(RwLock::new(BanService::new(
-            MAX_CONNECTION_ID_ERRORS_PER_IP,
-            local_addr.parse().unwrap(),
-        )));
 
         let ban_cleaner = ban_service.clone();
 

--- a/src/servers/udp/server/launcher.rs
+++ b/src/servers/udp/server/launcher.rs
@@ -202,7 +202,7 @@ impl Launcher {
 
                 if old_request_aborted {
                     // Evicted task from active requests buffer was aborted.
-                    tracker.send_stats_event(statistics::event::Event::Udp4RequestAborted).await;
+                    tracker.send_stats_event(statistics::event::Event::UdpRequestAborted).await;
                 }
             } else {
                 tokio::task::yield_now().await;

--- a/src/servers/udp/server/spawner.rs
+++ b/src/servers/udp/server/spawner.rs
@@ -5,9 +5,10 @@ use std::time::Duration;
 
 use derive_more::derive::Display;
 use derive_more::Constructor;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, RwLock};
 use tokio::task::JoinHandle;
 
+use super::banning::BanService;
 use super::launcher::Launcher;
 use crate::bootstrap::jobs::Started;
 use crate::core::Tracker;
@@ -28,6 +29,7 @@ impl Spawner {
     pub fn spawn_launcher(
         &self,
         tracker: Arc<Tracker>,
+        ban_service: Arc<RwLock<BanService>>,
         cookie_lifetime: Duration,
         tx_start: oneshot::Sender<Started>,
         rx_halt: oneshot::Receiver<Halted>,
@@ -35,7 +37,7 @@ impl Spawner {
         let spawner = Self::new(self.bind_to);
 
         tokio::spawn(async move {
-            Launcher::run_with_graceful_shutdown(tracker, spawner.bind_to, cookie_lifetime, tx_start, rx_halt).await;
+            Launcher::run_with_graceful_shutdown(tracker, ban_service, spawner.bind_to, cookie_lifetime, tx_start, rx_halt).await;
             spawner
         })
     }

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -47,12 +47,17 @@ async fn should_allow_getting_tracker_statistics() {
             udp_requests_aborted: 0,
             udp_requests_banned: 0,
             udp_banned_ips_total: 0,
+            udp_avg_connect_processing_time_ns: 0,
+            udp_avg_announce_processing_time_ns: 0,
+            udp_avg_scrape_processing_time_ns: 0,
+            // UDPv4
             udp4_requests: 0,
             udp4_connections_handled: 0,
             udp4_announces_handled: 0,
             udp4_scrapes_handled: 0,
             udp4_responses: 0,
             udp4_errors_handled: 0,
+            // UDPv6
             udp6_requests: 0,
             udp6_connections_handled: 0,
             udp6_announces_handled: 0,

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -45,6 +45,7 @@ async fn should_allow_getting_tracker_statistics() {
             tcp6_scrapes_handled: 0,
             // UDP
             udp_requests_aborted: 0,
+            udp_requests_banned: 0,
             udp4_requests: 0,
             udp4_connections_handled: 0,
             udp4_announces_handled: 0,

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -46,6 +46,7 @@ async fn should_allow_getting_tracker_statistics() {
             // UDP
             udp_requests_aborted: 0,
             udp_requests_banned: 0,
+            udp_banned_ips_total: 0,
             udp4_requests: 0,
             udp4_connections_handled: 0,
             udp4_announces_handled: 0,

--- a/tests/servers/udp/contract.rs
+++ b/tests/servers/udp/contract.rs
@@ -230,11 +230,14 @@ mod receiving_an_announce_request {
 
         let env = Started::new(&configuration::ephemeral().into()).await;
         let tracker = env.tracker.clone();
+        let ban_service = env.ban_service.clone();
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
             Err(err) => panic!("{err}"),
         };
+
+        let udp_banned_ips_total_before = ban_service.read().await.get_banned_ips_total();
 
         // The eleven first requests should be fine
 
@@ -279,9 +282,13 @@ mod receiving_an_announce_request {
         assert!(client.receive().await.is_err());
 
         let udp_requests_banned_after = tracker.get_stats().await.udp_requests_banned;
+        let udp_banned_ips_total_after = ban_service.read().await.get_banned_ips_total();
 
         // UDP counter for banned requests should be increased by 1
         assert_eq!(udp_requests_banned_after, udp_requests_banned_before + 1);
+
+        // UDP counter for banned IPs should be increased by 1
+        assert_eq!(udp_banned_ips_total_after, udp_banned_ips_total_before + 1);
 
         env.stop().await;
     }


### PR DESCRIPTION
Add more metrics useful for detecting tracker errors and load level.

### UDP

- [x] `udp_requests_banned`: the total number of UDP requests that have been banned.
- [x] `udp_banned_ips_total`: the total number of IPs that have been banned for sending wrong connection IDs.
- [x] `udp_avg_connect_processing_time_ns`: the average time processing a UDP connect request.
- [x] `udp_avg_announce_processing_time_ns`: the average time processing a UDP announce request.
- [x] `udp_avg_scrape_processing_time_ns`: the average time processing a UDP scrape request.

### Important refactor

I needed to pass the Ban Service to the stats handler to get some values. I did not want to add the ban service to the tracker because the tracker is already to "fat". It has many responsibilities. In fact, I want to extract new services out of the tracker like whitelist, authorization, etc. My plan was to extract them and leave the tracker as the application services container. However I think it will be easier if we:

- We pass new services like `BanService` directly to handlers instead of using the tracker as a facade.
- Move other services out of the `Tracker` and also pass them directly to handlers.

At the end, the `Tracker` should have only a couple of methods like `announce` and `scrape`.