### PR TITLE
Overhaul core Tracker: extract torrents context (part 1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -137,7 +137,7 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
 
     // Start runners to remove torrents without peers, every interval
     if config.core.inactive_peer_cleanup_interval > 0 {
-        jobs.push(torrent_cleanup::start_job(&config.core, &app_container.tracker));
+        jobs.push(torrent_cleanup::start_job(&config.core, &app_container.torrents_manager));
     }
 
     // Start Health Check API

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -116,7 +116,6 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
 
     let tracker = Arc::new(initialize_tracker(
         configuration,
-        &database,
         &whitelist_authorization,
         &in_memory_torrent_repository,
         &db_torrent_repository,

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -124,6 +124,7 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
     ));
 
     AppContainer {
+        database,
         tracker,
         keys_handler,
         authentication_service,

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -119,7 +119,6 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
         &whitelist_authorization,
         &in_memory_torrent_repository,
         &db_torrent_repository,
-        &torrents_manager,
     ));
 
     AppContainer {
@@ -132,6 +131,9 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
         stats_event_sender,
         stats_repository,
         whitelist_manager,
+        in_memory_torrent_repository,
+        db_torrent_repository,
+        torrents_manager,
     }
 }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -7,6 +7,9 @@ use crate::core::authentication::service::AuthenticationService;
 use crate::core::databases::Database;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::repository::Repository;
+use crate::core::torrent::manager::TorrentsManager;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
+use crate::core::torrent::repository::persisted::DatabasePersistentTorrentRepository;
 use crate::core::whitelist::manager::WhiteListManager;
 use crate::core::{whitelist, Tracker};
 use crate::servers::udp::server::banning::BanService;
@@ -21,4 +24,7 @@ pub struct AppContainer {
     pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
     pub stats_repository: Arc<Repository>,
     pub whitelist_manager: Arc<WhiteListManager>,
+    pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
+    pub db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
+    pub torrents_manager: Arc<TorrentsManager>,
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -4,6 +4,7 @@ use tokio::sync::RwLock;
 
 use crate::core::authentication::handler::KeysHandler;
 use crate::core::authentication::service::AuthenticationService;
+use crate::core::databases::Database;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::repository::Repository;
 use crate::core::whitelist::manager::WhiteListManager;
@@ -11,6 +12,7 @@ use crate::core::{whitelist, Tracker};
 use crate::servers::udp::server::banning::BanService;
 
 pub struct AppContainer {
+    pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -653,28 +653,6 @@ impl Tracker {
         scrape_data
     }
 
-    /// It returns the data for a `scrape` response.
-    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
-        self.in_memory_torrent_repository.get_swarm_metadata(info_hash)
-    }
-
-    /// # Context: Tracker
-    ///
-    /// Get torrent peers for a given torrent and client.
-    ///
-    /// It filters out the client making the request.
-    fn get_peers_for(&self, info_hash: &InfoHash, peer: &peer::Peer, limit: usize) -> Vec<Arc<peer::Peer>> {
-        self.in_memory_torrent_repository.get_peers_for(info_hash, peer, limit)
-    }
-
-    /// # Context: Tracker
-    ///
-    /// Get torrent peers for a given torrent.
-    #[must_use]
-    pub fn get_torrent_peers(&self, info_hash: &InfoHash) -> Vec<Arc<peer::Peer>> {
-        self.in_memory_torrent_repository.get_torrent_peers(info_hash)
-    }
-
     /// It updates the torrent entry in memory, it also stores in the database
     /// the torrent info data which is persistent, and finally return the data
     /// needed for a `announce` request response.
@@ -711,6 +689,28 @@ impl Tracker {
 
             drop(self.db_torrent_repository.save(&info_hash, completed));
         }
+    }
+
+    /// It returns the data for a `scrape` response.
+    fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
+        self.in_memory_torrent_repository.get_swarm_metadata(info_hash)
+    }
+
+    /// # Context: Tracker
+    ///
+    /// Get torrent peers for a given torrent and client.
+    ///
+    /// It filters out the client making the request.
+    fn get_peers_for(&self, info_hash: &InfoHash, peer: &peer::Peer, limit: usize) -> Vec<Arc<peer::Peer>> {
+        self.in_memory_torrent_repository.get_peers_for(info_hash, peer, limit)
+    }
+
+    /// # Context: Tracker
+    ///
+    /// Get torrent peers for a given torrent.
+    #[must_use]
+    pub fn get_torrent_peers(&self, info_hash: &InfoHash) -> Vec<Arc<peer::Peer>> {
+        self.in_memory_torrent_repository.get_torrent_peers(info_hash)
     }
 
     /// It calculates and returns the general `Tracker`

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -666,18 +666,6 @@ impl Tracker {
         self.in_memory_torrent_repository.get_swarm_metadata(info_hash)
     }
 
-    /// It loads the torrents from database into memory. It only loads the torrent entry list with the number of seeders for each torrent.
-    /// Peers data is not persisted.
-    ///
-    /// # Context: Tracker
-    ///
-    /// # Errors
-    ///
-    /// Will return a `database::Error` if unable to load the list of `persistent_torrents` from the database.
-    pub fn load_torrents_from_database(&self) -> Result<(), databases::error::Error> {
-        self.torrents_manager.load_torrents_from_database()
-    }
-
     /// # Context: Tracker
     ///
     /// Get torrent peers for a given torrent and client.
@@ -1543,7 +1531,7 @@ mod tests {
                 // Remove the newly updated torrent from memory
                 let _unused = tracker.in_memory_torrent_repository.remove(&info_hash);
 
-                tracker.load_torrents_from_database().unwrap();
+                tracker.torrents_manager.load_torrents_from_database().unwrap();
 
                 let torrent_entry = tracker
                     .in_memory_torrent_repository

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -14,6 +14,9 @@ use torrust_tracker_configuration::v2_0_0::database;
 use torrust_tracker_configuration::Configuration;
 
 use super::databases::{self, Database};
+use super::torrent::manager::TorrentsManager;
+use super::torrent::repository::in_memory::InMemoryTorrentRepository;
+use super::torrent::repository::persisted::DatabasePersistentTorrentRepository;
 use super::whitelist;
 use super::whitelist::manager::WhiteListManager;
 use super::whitelist::repository::in_memory::InMemoryWhitelist;
@@ -30,8 +33,18 @@ pub fn initialize_tracker(
     config: &Configuration,
     database: &Arc<Box<dyn Database>>,
     whitelist_authorization: &Arc<whitelist::authorization::Authorization>,
+    in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
+    db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
+    torrents_manager: &Arc<TorrentsManager>,
 ) -> Tracker {
-    match Tracker::new(&Arc::new(config).core, database, whitelist_authorization) {
+    match Tracker::new(
+        &Arc::new(config).core,
+        database,
+        whitelist_authorization,
+        in_memory_torrent_repository,
+        db_torrent_repository,
+        torrents_manager,
+    ) {
         Ok(tracker) => tracker,
         Err(error) => {
             panic!("{}", error)

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -31,7 +31,6 @@ use crate::core::Tracker;
 #[must_use]
 pub fn initialize_tracker(
     config: &Configuration,
-    database: &Arc<Box<dyn Database>>,
     whitelist_authorization: &Arc<whitelist::authorization::Authorization>,
     in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
     db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
@@ -39,7 +38,6 @@ pub fn initialize_tracker(
 ) -> Tracker {
     match Tracker::new(
         &Arc::new(config).core,
-        database,
         whitelist_authorization,
         in_memory_torrent_repository,
         db_torrent_repository,

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -14,7 +14,6 @@ use torrust_tracker_configuration::v2_0_0::database;
 use torrust_tracker_configuration::Configuration;
 
 use super::databases::{self, Database};
-use super::torrent::manager::TorrentsManager;
 use super::torrent::repository::in_memory::InMemoryTorrentRepository;
 use super::torrent::repository::persisted::DatabasePersistentTorrentRepository;
 use super::whitelist;
@@ -34,14 +33,12 @@ pub fn initialize_tracker(
     whitelist_authorization: &Arc<whitelist::authorization::Authorization>,
     in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
     db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
-    torrents_manager: &Arc<TorrentsManager>,
 ) -> Tracker {
     match Tracker::new(
         &Arc::new(config).core,
         whitelist_authorization,
         in_memory_torrent_repository,
         db_torrent_repository,
-        torrents_manager,
     ) {
         Ok(tracker) => tracker,
         Err(error) => {

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -133,7 +133,7 @@ mod tests {
         let config = tracker_configuration();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -147,7 +147,6 @@ mod tests {
 
         let tracker = Arc::new(initialize_tracker(
             &config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -132,12 +132,27 @@ mod tests {
     async fn the_statistics_service_should_return_the_tracker_metrics() {
         let config = tracker_configuration();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
+
         let (_stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_repository = Arc::new(stats_repository);
 
-        let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+        let tracker = Arc::new(initialize_tracker(
+            &config,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        ));
 
         let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
 

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -139,7 +139,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (_stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -150,7 +150,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         ));
 
         let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -145,10 +145,24 @@ mod tests {
         async fn should_return_none_if_the_tracker_does_not_have_the_torrent() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = initialize_tracker(&config, &database, &whitelist_authorization);
+            let tracker = initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            );
 
             let tracker = Arc::new(tracker);
 
@@ -165,10 +179,24 @@ mod tests {
         async fn should_return_the_torrent_info_if_the_tracker_has_the_torrent() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
@@ -211,10 +239,24 @@ mod tests {
         async fn should_return_an_empty_result_if_the_tracker_does_not_have_any_torrent() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let torrents = get_torrents_page(tracker.clone(), Some(&Pagination::default())).await;
 
@@ -225,10 +267,24 @@ mod tests {
         async fn should_return_a_summarized_info_for_all_torrents() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
@@ -252,10 +308,24 @@ mod tests {
         async fn should_allow_limiting_the_number_of_torrents_in_the_result() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
@@ -277,10 +347,24 @@ mod tests {
         async fn should_allow_using_pagination_in_the_result() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
@@ -311,10 +395,24 @@ mod tests {
         async fn should_return_torrents_ordered_by_info_hash() {
             let config = tracker_configuration();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            let tracker = Arc::new(initialize_tracker(&config, &database, &whitelist_authorization));
+            let tracker = Arc::new(initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ));
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -125,7 +125,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(config);
 
         Arc::new(initialize_tracker(
@@ -133,7 +133,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         ))
     }
 
@@ -178,7 +177,7 @@ mod tests {
                 _authentication_service,
                 in_memory_torrent_repository,
                 db_torrent_repository,
-                torrents_manager,
+                _torrents_manager,
             ) = initialize_tracker_dependencies(&config);
 
             let tracker = initialize_tracker(
@@ -186,7 +185,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             );
 
             let tracker = Arc::new(tracker);

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -119,7 +119,7 @@ mod tests {
 
     fn initialize_tracker_and_deps(config: &Configuration) -> Arc<Tracker> {
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -130,7 +130,6 @@ mod tests {
 
         Arc::new(initialize_tracker(
             config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
@@ -173,7 +172,7 @@ mod tests {
             let config = tracker_configuration();
 
             let (
-                database,
+                _database,
                 _in_memory_whitelist,
                 whitelist_authorization,
                 _authentication_service,
@@ -184,7 +183,6 @@ mod tests {
 
             let tracker = initialize_tracker(
                 &config,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -10,7 +10,6 @@ use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_primitives::pagination::Pagination;
 use torrust_tracker_primitives::peer;
 use torrust_tracker_torrent_repository::entry::EntrySync;
-use torrust_tracker_torrent_repository::repository::Repository;
 
 use crate::core::Tracker;
 

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -45,7 +45,7 @@ pub struct BasicInfo {
 
 /// It returns all the information the tracker has about one torrent in a [Info] struct.
 pub async fn get_torrent_info(tracker: Arc<Tracker>, info_hash: &InfoHash) -> Option<Info> {
-    let torrent_entry_option = tracker.torrents.get(info_hash);
+    let torrent_entry_option = tracker.in_memory_torrent_repository.get(info_hash);
 
     let torrent_entry = torrent_entry_option?;
 
@@ -68,7 +68,7 @@ pub async fn get_torrent_info(tracker: Arc<Tracker>, info_hash: &InfoHash) -> Op
 pub async fn get_torrents_page(tracker: Arc<Tracker>, pagination: Option<&Pagination>) -> Vec<BasicInfo> {
     let mut basic_infos: Vec<BasicInfo> = vec![];
 
-    for (info_hash, torrent_entry) in tracker.torrents.get_paginated(pagination) {
+    for (info_hash, torrent_entry) in tracker.in_memory_torrent_repository.get_paginated(pagination) {
         let stats = torrent_entry.get_swarm_metadata();
 
         basic_infos.push(BasicInfo {
@@ -87,7 +87,11 @@ pub async fn get_torrents(tracker: Arc<Tracker>, info_hashes: &[InfoHash]) -> Ve
     let mut basic_infos: Vec<BasicInfo> = vec![];
 
     for info_hash in info_hashes {
-        if let Some(stats) = tracker.torrents.get(info_hash).map(|t| t.get_swarm_metadata()) {
+        if let Some(stats) = tracker
+            .in_memory_torrent_repository
+            .get(info_hash)
+            .map(|t| t.get_swarm_metadata())
+        {
             basic_infos.push(BasicInfo {
                 info_hash: *info_hash,
                 seeders: u64::from(stats.complete),

--- a/src/core/torrent/manager.rs
+++ b/src/core/torrent/manager.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use torrust_tracker_clock::clock::Time;
+use torrust_tracker_configuration::Core;
+
+use super::repository::in_memory::InMemoryTorrentRepository;
+use super::repository::persisted::DatabasePersistentTorrentRepository;
+use crate::core::databases;
+use crate::CurrentClock;
+
+pub struct TorrentsManager {
+    /// The tracker configuration.
+    config: Core,
+
+    /// The in-memory torrents repository.
+    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
+
+    /// The persistent torrents repository.
+    db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
+}
+
+impl TorrentsManager {
+    #[must_use]
+    pub fn new(
+        config: &Core,
+        in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
+        db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
+    ) -> Self {
+        Self {
+            config: config.clone(),
+            in_memory_torrent_repository: in_memory_torrent_repository.clone(),
+            db_torrent_repository: db_torrent_repository.clone(),
+        }
+    }
+
+    /// It loads the torrents from database into memory. It only loads the
+    /// torrent entry list with the number of seeders for each torrent. Peers
+    /// data is not persisted.
+    ///
+    /// # Errors
+    ///
+    /// Will return a `database::Error` if unable to load the list of `persistent_torrents` from the database.
+    pub fn load_torrents_from_database(&self) -> Result<(), databases::error::Error> {
+        let persistent_torrents = self.db_torrent_repository.load_all()?;
+
+        self.in_memory_torrent_repository.import_persistent(&persistent_torrents);
+
+        Ok(())
+    }
+
+    /// Remove inactive peers and (optionally) peerless torrents.
+    pub fn cleanup_torrents(&self) {
+        let current_cutoff = CurrentClock::now_sub(&Duration::from_secs(u64::from(self.config.tracker_policy.max_peer_timeout)))
+            .unwrap_or_default();
+
+        self.in_memory_torrent_repository.remove_inactive_peers(current_cutoff);
+
+        if self.config.tracker_policy.remove_peerless_torrents {
+            self.in_memory_torrent_repository
+                .remove_peerless_torrents(&self.config.tracker_policy);
+        }
+    }
+}

--- a/src/core/torrent/mod.rs
+++ b/src/core/torrent/mod.rs
@@ -25,6 +25,7 @@
 //! - The number of peers that have NOT completed downloading the torrent and are still active, that means they are actively participating in the network.
 //!   Peer that don not have a full copy of the torrent data are called "leechers".
 //!
+pub mod manager;
 pub mod repository;
 
 use torrust_tracker_torrent_repository::TorrentsSkipMapMutexStd;

--- a/src/core/torrent/mod.rs
+++ b/src/core/torrent/mod.rs
@@ -25,6 +25,8 @@
 //! - The number of peers that have NOT completed downloading the torrent and are still active, that means they are actively participating in the network.
 //!   Peer that don not have a full copy of the torrent data are called "leechers".
 //!
+pub mod repository;
+
 use torrust_tracker_torrent_repository::TorrentsSkipMapMutexStd;
 
 pub type Torrents = TorrentsSkipMapMutexStd; // Currently Used

--- a/src/core/torrent/repository/in_memory.rs
+++ b/src/core/torrent/repository/in_memory.rs
@@ -1,0 +1,103 @@
+use std::cmp::max;
+use std::sync::Arc;
+
+use bittorrent_primitives::info_hash::InfoHash;
+use torrust_tracker_configuration::{TrackerPolicy, TORRENT_PEERS_LIMIT};
+use torrust_tracker_primitives::pagination::Pagination;
+use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
+use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch, PersistentTorrents};
+use torrust_tracker_torrent_repository::entry::EntrySync;
+use torrust_tracker_torrent_repository::repository::Repository;
+use torrust_tracker_torrent_repository::EntryMutexStd;
+
+use crate::core::torrent::Torrents;
+
+/// The in-memory torrents repository.
+///
+/// There are many implementations of the repository trait. We tried with
+/// different types of data structures, but the best performance was with
+/// the one we use for production. We kept the other implementations for
+/// reference.
+#[derive(Debug, Default)]
+pub struct InMemoryTorrentRepository {
+    /// The in-memory torrents repository implementation.
+    torrents: Arc<Torrents>,
+}
+
+impl InMemoryTorrentRepository {
+    /// It inserts (or updates if it's already in the list) the peer in the
+    /// torrent entry.
+    pub fn upsert_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
+        self.torrents.upsert_peer(info_hash, peer);
+    }
+
+    #[must_use]
+    pub fn remove(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        self.torrents.remove(key)
+    }
+
+    pub fn remove_inactive_peers(&self, current_cutoff: DurationSinceUnixEpoch) {
+        self.torrents.remove_inactive_peers(current_cutoff);
+    }
+
+    pub fn remove_peerless_torrents(&self, policy: &TrackerPolicy) {
+        self.torrents.remove_peerless_torrents(policy);
+    }
+
+    #[must_use]
+    pub fn get(&self, key: &InfoHash) -> Option<EntryMutexStd> {
+        self.torrents.get(key)
+    }
+
+    #[must_use]
+    pub fn get_paginated(&self, pagination: Option<&Pagination>) -> Vec<(InfoHash, EntryMutexStd)> {
+        self.torrents.get_paginated(pagination)
+    }
+
+    /// It returns the data for a `scrape` response or empty if the torrent is
+    /// not found.
+    #[must_use]
+    pub fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
+        match self.torrents.get(info_hash) {
+            Some(torrent_entry) => torrent_entry.get_swarm_metadata(),
+            None => SwarmMetadata::default(),
+        }
+    }
+
+    /// It returns the data for a `scrape` response if the torrent is found.
+    #[must_use]
+    pub fn get_opt_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
+        self.torrents.get_swarm_metadata(info_hash)
+    }
+
+    /// Get torrent peers for a given torrent and client.
+    ///
+    /// It filters out the client making the request.
+    #[must_use]
+    pub fn get_peers_for(&self, info_hash: &InfoHash, peer: &peer::Peer, limit: usize) -> Vec<Arc<peer::Peer>> {
+        match self.torrents.get(info_hash) {
+            None => vec![],
+            Some(entry) => entry.get_peers_for_client(&peer.peer_addr, Some(max(limit, TORRENT_PEERS_LIMIT))),
+        }
+    }
+
+    /// Get torrent peers for a given torrent.
+    #[must_use]
+    pub fn get_torrent_peers(&self, info_hash: &InfoHash) -> Vec<Arc<peer::Peer>> {
+        match self.torrents.get(info_hash) {
+            None => vec![],
+            Some(entry) => entry.get_peers(Some(TORRENT_PEERS_LIMIT)),
+        }
+    }
+
+    /// It calculates and returns the general [`TorrentsMetrics`].
+    #[must_use]
+    pub fn get_torrents_metrics(&self) -> TorrentsMetrics {
+        self.torrents.get_metrics()
+    }
+
+    pub fn import_persistent(&self, persistent_torrents: &PersistentTorrents) {
+        self.torrents.import_persistent(persistent_torrents);
+    }
+}

--- a/src/core/torrent/repository/mod.rs
+++ b/src/core/torrent/repository/mod.rs
@@ -1,0 +1,1 @@
+pub mod in_memory;

--- a/src/core/torrent/repository/mod.rs
+++ b/src/core/torrent/repository/mod.rs
@@ -1,1 +1,2 @@
 pub mod in_memory;
+pub mod persisted;

--- a/src/core/torrent/repository/persisted.rs
+++ b/src/core/torrent/repository/persisted.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use bittorrent_primitives::info_hash::InfoHash;
+use torrust_tracker_primitives::PersistentTorrents;
+
+use crate::core::databases::error::Error;
+use crate::core::databases::Database;
+
+/// Torrent repository implementation that persists the torrents in a database.
+///
+/// Not all the torrent in-memory data is persisted. For now only some of the
+/// torrent metrics are persisted.
+pub struct DatabasePersistentTorrentRepository {
+    /// A database driver implementation: [`Sqlite3`](crate::core::databases::sqlite)
+    /// or [`MySQL`](crate::core::databases::mysql)
+    database: Arc<Box<dyn Database>>,
+}
+
+impl DatabasePersistentTorrentRepository {
+    #[must_use]
+    pub fn new(database: &Arc<Box<dyn Database>>) -> DatabasePersistentTorrentRepository {
+        Self {
+            database: database.clone(),
+        }
+    }
+
+    /// It loads the persistent torrents from the database.
+    ///
+    /// # Errors
+    ///
+    /// Will return a database `Err` if unable to load.
+    pub fn load_all(&self) -> Result<PersistentTorrents, Error> {
+        self.database.load_persistent_torrents()
+    }
+
+    /// It saves the persistent torrent into the database.
+    ///
+    /// # Errors
+    ///
+    /// Will return a database `Err` if unable to save.
+    pub fn save(&self, info_hash: &InfoHash, downloaded: u32) -> Result<(), Error> {
+        self.database.save_persistent_torrent(info_hash, downloaded)
+    }
+}

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -274,12 +274,26 @@ mod tests {
 
     /// Initialize tracker's dependencies and tracker.
     fn initialize_tracker_and_deps(config: &Configuration) -> TrackerAndDeps {
-        let (database, _in_memory_whitelist, whitelist_authorization, authentication_service) =
-            initialize_tracker_dependencies(config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(config);
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
 
-        let tracker = Arc::new(initialize_tracker(config, &database, &whitelist_authorization));
+        let tracker = Arc::new(initialize_tracker(
+            config,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        ));
 
         (tracker, stats_event_sender, whitelist_authorization, authentication_service)
     }

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -283,6 +283,7 @@ mod tests {
             db_torrent_repository,
             torrents_manager,
         ) = initialize_tracker_dependencies(config);
+        
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
 

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -275,7 +275,7 @@ mod tests {
     /// Initialize tracker's dependencies and tracker.
     fn initialize_tracker_and_deps(config: &Configuration) -> TrackerAndDeps {
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             authentication_service,
@@ -283,13 +283,12 @@ mod tests {
             db_torrent_repository,
             torrents_manager,
         ) = initialize_tracker_dependencies(config);
-        
+
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
 
         let tracker = Arc::new(initialize_tracker(
             config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,

--- a/src/servers/http/v1/handlers/announce.rs
+++ b/src/servers/http/v1/handlers/announce.rs
@@ -281,7 +281,7 @@ mod tests {
             authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -292,7 +292,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         ));
 
         (tracker, stats_event_sender, whitelist_authorization, authentication_service)

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -158,7 +158,7 @@ mod tests {
             authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -169,7 +169,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             ),
             stats_event_sender,
             authentication_service,
@@ -190,7 +189,7 @@ mod tests {
             authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -201,7 +200,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             ),
             stats_event_sender,
             authentication_service,
@@ -222,7 +220,7 @@ mod tests {
             authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -233,7 +231,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             ),
             stats_event_sender,
             authentication_service,
@@ -254,7 +251,7 @@ mod tests {
             authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -265,7 +262,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             ),
             stats_event_sender,
             authentication_service,

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -152,7 +152,7 @@ mod tests {
         let config = configuration::ephemeral_private();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             authentication_service,
@@ -166,7 +166,6 @@ mod tests {
         (
             initialize_tracker(
                 &config,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
@@ -185,7 +184,7 @@ mod tests {
         let config = configuration::ephemeral_listed();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             authentication_service,
@@ -199,7 +198,6 @@ mod tests {
         (
             initialize_tracker(
                 &config,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
@@ -218,7 +216,7 @@ mod tests {
         let config = configuration::ephemeral_with_reverse_proxy();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             authentication_service,
@@ -232,7 +230,6 @@ mod tests {
         (
             initialize_tracker(
                 &config,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
@@ -251,7 +248,7 @@ mod tests {
         let config = configuration::ephemeral_without_reverse_proxy();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             authentication_service,
@@ -265,7 +262,6 @@ mod tests {
         (
             initialize_tracker(
                 &config,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -151,13 +151,27 @@ mod tests {
     ) {
         let config = configuration::ephemeral_private();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
         (
-            initialize_tracker(&config, &database, &whitelist_authorization),
+            initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ),
             stats_event_sender,
             authentication_service,
         )
@@ -170,13 +184,27 @@ mod tests {
     ) {
         let config = configuration::ephemeral_listed();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
         (
-            initialize_tracker(&config, &database, &whitelist_authorization),
+            initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ),
             stats_event_sender,
             authentication_service,
         )
@@ -189,13 +217,27 @@ mod tests {
     ) {
         let config = configuration::ephemeral_with_reverse_proxy();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
         (
-            initialize_tracker(&config, &database, &whitelist_authorization),
+            initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ),
             stats_event_sender,
             authentication_service,
         )
@@ -208,13 +250,27 @@ mod tests {
     ) {
         let config = configuration::ephemeral_without_reverse_proxy();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
 
         (
-            initialize_tracker(&config, &database, &whitelist_authorization),
+            initialize_tracker(
+                &config,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            ),
             stats_event_sender,
             authentication_service,
         )

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -74,7 +74,7 @@ mod tests {
         let config = configuration::ephemeral_public();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -87,7 +87,6 @@ mod tests {
 
         let tracker = initialize_tracker(
             &config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
@@ -147,7 +146,7 @@ mod tests {
             let config = configuration::ephemeral();
 
             let (
-                database,
+                _database,
                 _in_memory_whitelist,
                 whitelist_authorization,
                 _authentication_service,
@@ -158,7 +157,6 @@ mod tests {
 
             Tracker::new(
                 &config.core,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -73,12 +73,26 @@ mod tests {
     fn public_tracker() -> (Tracker, Arc<Option<Box<dyn Sender>>>) {
         let config = configuration::ephemeral_public();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
 
-        let tracker = initialize_tracker(&config, &database, &whitelist_authorization);
+        let tracker = initialize_tracker(
+            &config,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        );
 
         (tracker, stats_event_sender)
     }
@@ -132,10 +146,25 @@ mod tests {
         fn test_tracker_factory() -> Tracker {
             let config = configuration::ephemeral();
 
-            let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                initialize_tracker_dependencies(&config);
+            let (
+                database,
+                _in_memory_whitelist,
+                whitelist_authorization,
+                _authentication_service,
+                in_memory_torrent_repository,
+                db_torrent_repository,
+                torrents_manager,
+            ) = initialize_tracker_dependencies(&config);
 
-            Tracker::new(&config.core, &database, &whitelist_authorization).unwrap()
+            Tracker::new(
+                &config.core,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            )
+            .unwrap()
         }
 
         #[tokio::test]

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -80,7 +80,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
@@ -90,7 +90,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         );
 
         (tracker, stats_event_sender)
@@ -152,7 +151,7 @@ mod tests {
                 _authentication_service,
                 in_memory_torrent_repository,
                 db_torrent_repository,
-                torrents_manager,
+                _torrents_manager,
             ) = initialize_tracker_dependencies(&config);
 
             Tracker::new(
@@ -160,7 +159,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             )
             .unwrap()
         }

--- a/src/servers/http/v1/services/scrape.rs
+++ b/src/servers/http/v1/services/scrape.rs
@@ -94,7 +94,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         initialize_tracker(
@@ -102,7 +102,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         )
     }
 
@@ -136,7 +135,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         Tracker::new(
@@ -144,7 +143,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         )
         .unwrap()
     }

--- a/src/servers/http/v1/services/scrape.rs
+++ b/src/servers/http/v1/services/scrape.rs
@@ -88,7 +88,7 @@ mod tests {
         let config = configuration::ephemeral_public();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -99,7 +99,6 @@ mod tests {
 
         initialize_tracker(
             &config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
@@ -131,7 +130,7 @@ mod tests {
         let config = configuration::ephemeral();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -142,7 +141,6 @@ mod tests {
 
         Tracker::new(
             &config.core,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,

--- a/src/servers/http/v1/services/scrape.rs
+++ b/src/servers/http/v1/services/scrape.rs
@@ -87,10 +87,24 @@ mod tests {
     fn public_tracker() -> Tracker {
         let config = configuration::ephemeral_public();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
-        initialize_tracker(&config, &database, &whitelist_authorization)
+        initialize_tracker(
+            &config,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        )
     }
 
     fn sample_info_hashes() -> Vec<InfoHash> {
@@ -116,10 +130,25 @@ mod tests {
     fn test_tracker_factory() -> Tracker {
         let config = configuration::ephemeral();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
-        Tracker::new(&config.core, &database, &whitelist_authorization).unwrap()
+        Tracker::new(
+            &config.core,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        )
+        .unwrap()
     }
 
     mod with_real_data {

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -525,6 +525,7 @@ mod tests {
             db_torrent_repository,
             torrents_manager,
         ) = initialize_tracker_dependencies(config);
+        
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
         let whitelist_manager = initialize_whitelist_manager(database.clone(), in_memory_whitelist.clone());

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -523,7 +523,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(config);
 
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
@@ -535,7 +535,6 @@ mod tests {
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
-            &torrents_manager,
         ));
 
         (
@@ -651,7 +650,7 @@ mod tests {
             _authentication_service,
             in_memory_torrent_repository,
             db_torrent_repository,
-            torrents_manager,
+            _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let tracker = Arc::new(
@@ -660,7 +659,6 @@ mod tests {
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
-                &torrents_manager,
             )
             .unwrap(),
         );
@@ -1415,7 +1413,7 @@ mod tests {
                         _authentication_service,
                         in_memory_torrent_repository,
                         db_torrent_repository,
-                        torrents_manager,
+                        _torrents_manager,
                     ) = initialize_tracker_dependencies(&config);
 
                     let mut stats_event_sender_mock = statistics::event::sender::MockSender::new();
@@ -1433,7 +1431,6 @@ mod tests {
                             &whitelist_authorization,
                             &in_memory_torrent_repository,
                             &db_torrent_repository,
-                            &torrents_manager,
                         )
                         .unwrap(),
                     );

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -525,14 +525,13 @@ mod tests {
             db_torrent_repository,
             torrents_manager,
         ) = initialize_tracker_dependencies(config);
-        
+
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
         let whitelist_manager = initialize_whitelist_manager(database.clone(), in_memory_whitelist.clone());
 
         let tracker = Arc::new(initialize_tracker(
             config,
-            &database,
             &whitelist_authorization,
             &in_memory_torrent_repository,
             &db_torrent_repository,
@@ -646,7 +645,7 @@ mod tests {
         let config = tracker_configuration();
 
         let (
-            database,
+            _database,
             _in_memory_whitelist,
             whitelist_authorization,
             _authentication_service,
@@ -658,7 +657,6 @@ mod tests {
         let tracker = Arc::new(
             Tracker::new(
                 &config.core,
-                &database,
                 &whitelist_authorization,
                 &in_memory_torrent_repository,
                 &db_torrent_repository,
@@ -1411,7 +1409,7 @@ mod tests {
                     let config = Arc::new(TrackerConfigurationBuilder::default().with_external_ip("::126.0.0.1").into());
 
                     let (
-                        database,
+                        _database,
                         _in_memory_whitelist,
                         whitelist_authorization,
                         _authentication_service,
@@ -1432,7 +1430,6 @@ mod tests {
                     let tracker = Arc::new(
                         core::Tracker::new(
                             &config.core,
-                            &database,
                             &whitelist_authorization,
                             &in_memory_torrent_repository,
                             &db_torrent_repository,

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -516,13 +516,27 @@ mod tests {
     }
 
     fn initialize_tracker_and_deps(config: &Configuration) -> TrackerAndDeps {
-        let (database, in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(config);
+        let (
+            database,
+            in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(config);
         let (stats_event_sender, _stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_event_sender = Arc::new(stats_event_sender);
         let whitelist_manager = initialize_whitelist_manager(database.clone(), in_memory_whitelist.clone());
 
-        let tracker = Arc::new(initialize_tracker(config, &database, &whitelist_authorization));
+        let tracker = Arc::new(initialize_tracker(
+            config,
+            &database,
+            &whitelist_authorization,
+            &in_memory_torrent_repository,
+            &db_torrent_repository,
+            &torrents_manager,
+        ));
 
         (
             tracker,
@@ -630,10 +644,27 @@ mod tests {
     fn test_tracker_factory() -> (Arc<Tracker>, Arc<whitelist::authorization::Authorization>) {
         let config = tracker_configuration();
 
-        let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-            initialize_tracker_dependencies(&config);
+        let (
+            database,
+            _in_memory_whitelist,
+            whitelist_authorization,
+            _authentication_service,
+            in_memory_torrent_repository,
+            db_torrent_repository,
+            torrents_manager,
+        ) = initialize_tracker_dependencies(&config);
 
-        let tracker = Arc::new(Tracker::new(&config.core, &database, &whitelist_authorization).unwrap());
+        let tracker = Arc::new(
+            Tracker::new(
+                &config.core,
+                &database,
+                &whitelist_authorization,
+                &in_memory_torrent_repository,
+                &db_torrent_repository,
+                &torrents_manager,
+            )
+            .unwrap(),
+        );
 
         (tracker, whitelist_authorization)
     }
@@ -1378,8 +1409,15 @@ mod tests {
                 async fn the_peer_ip_should_be_changed_to_the_external_ip_in_the_tracker_configuration() {
                     let config = Arc::new(TrackerConfigurationBuilder::default().with_external_ip("::126.0.0.1").into());
 
-                    let (database, _in_memory_whitelist, whitelist_authorization, _authentication_service) =
-                        initialize_tracker_dependencies(&config);
+                    let (
+                        database,
+                        _in_memory_whitelist,
+                        whitelist_authorization,
+                        _authentication_service,
+                        in_memory_torrent_repository,
+                        db_torrent_repository,
+                        torrents_manager,
+                    ) = initialize_tracker_dependencies(&config);
 
                     let mut stats_event_sender_mock = statistics::event::sender::MockSender::new();
                     stats_event_sender_mock
@@ -1390,7 +1428,17 @@ mod tests {
                     let stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
                         Arc::new(Some(Box::new(stats_event_sender_mock)));
 
-                    let tracker = Arc::new(core::Tracker::new(&config.core, &database, &whitelist_authorization).unwrap());
+                    let tracker = Arc::new(
+                        core::Tracker::new(
+                            &config.core,
+                            &database,
+                            &whitelist_authorization,
+                            &in_memory_torrent_repository,
+                            &db_torrent_repository,
+                            &torrents_manager,
+                        )
+                        .unwrap(),
+                    );
 
                     let loopback_ipv4 = Ipv4Addr::new(127, 0, 0, 1);
                     let loopback_ipv6 = Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1);

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -10,6 +10,7 @@ use torrust_tracker_lib::bootstrap::app::{initialize_app_container, initialize_g
 use torrust_tracker_lib::bootstrap::jobs::make_rust_tls;
 use torrust_tracker_lib::core::authentication::handler::KeysHandler;
 use torrust_tracker_lib::core::authentication::service::AuthenticationService;
+use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
@@ -24,6 +25,7 @@ where
     S: std::fmt::Debug + std::fmt::Display,
 {
     pub config: Arc<HttpApi>,
+    pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,
@@ -61,6 +63,7 @@ impl Environment<Stopped> {
 
         Self {
             config,
+            database: app_container.database.clone(),
             tracker: app_container.tracker.clone(),
             keys_handler: app_container.keys_handler.clone(),
             authentication_service: app_container.authentication_service.clone(),
@@ -78,6 +81,7 @@ impl Environment<Stopped> {
 
         Environment {
             config: self.config,
+            database: self.database.clone(),
             tracker: self.tracker.clone(),
             keys_handler: self.keys_handler.clone(),
             authentication_service: self.authentication_service.clone(),
@@ -112,6 +116,7 @@ impl Environment<Running> {
     pub async fn stop(self) -> Environment<Stopped> {
         Environment {
             config: self.config,
+            database: self.database,
             tracker: self.tracker,
             keys_handler: self.keys_handler,
             authentication_service: self.authentication_service,

--- a/tests/servers/api/mod.rs
+++ b/tests/servers/api/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use torrust_tracker_lib::core::Tracker;
+use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::servers::apis::server;
 
 pub mod connection_info;
@@ -9,12 +9,15 @@ pub mod v1;
 
 pub type Started = environment::Environment<server::Running>;
 
-/// It forces a database error by dropping all tables.
-/// That makes any query fail.
+/// It forces a database error by dropping all tables. That makes all queries
+/// fail.
+///
 /// code-review:
+///
 /// Alternatively we could:
+///
 /// - Inject a database mock in the future.
 /// - Inject directly the database reference passed to the Tracker type.
-pub fn force_database_error(tracker: &Arc<Tracker>) {
+pub fn force_database_error(tracker: &Arc<Box<dyn Database>>) {
     tracker.drop_database_tables().unwrap();
 }

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -126,7 +126,7 @@ async fn should_fail_when_the_auth_key_cannot_be_generated() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let request_id = Uuid::new_v4();
 
@@ -297,7 +297,7 @@ async fn should_fail_when_the_auth_key_cannot_be_deleted() {
         .await
         .unwrap();
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let request_id = Uuid::new_v4();
 
@@ -403,7 +403,7 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
         .await
         .unwrap();
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let response = Client::new(env.get_connection_info())
         .reload_keys(Some(headers_with_request_id(request_id)))
@@ -556,7 +556,7 @@ mod deprecated_generate_key_endpoint {
 
         let env = Started::new(&configuration::ephemeral().into()).await;
 
-        force_database_error(&env.tracker);
+        force_database_error(&env.database);
 
         let request_id = Uuid::new_v4();
         let seconds_valid = 60;

--- a/tests/servers/api/v1/contract/context/whitelist.rs
+++ b/tests/servers/api/v1/contract/context/whitelist.rs
@@ -111,7 +111,7 @@ async fn should_fail_when_the_torrent_cannot_be_whitelisted() {
 
     let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let request_id = Uuid::new_v4();
 
@@ -239,7 +239,7 @@ async fn should_fail_when_the_torrent_cannot_be_removed_from_the_whitelist() {
     let info_hash = InfoHash::from_str(&hash).unwrap();
     env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let request_id = Uuid::new_v4();
 
@@ -340,7 +340,7 @@ async fn should_fail_when_the_whitelist_cannot_be_reloaded_from_the_database() {
     let info_hash = InfoHash::from_str(&hash).unwrap();
     env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
 
-    force_database_error(&env.tracker);
+    force_database_error(&env.database);
 
     let request_id = Uuid::new_v4();
 

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -7,6 +7,7 @@ use torrust_tracker_lib::bootstrap::app::{initialize_app_container, initialize_g
 use torrust_tracker_lib::bootstrap::jobs::make_rust_tls;
 use torrust_tracker_lib::core::authentication::handler::KeysHandler;
 use torrust_tracker_lib::core::authentication::service::AuthenticationService;
+use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
@@ -17,6 +18,7 @@ use torrust_tracker_primitives::peer;
 
 pub struct Environment<S> {
     pub config: Arc<HttpTracker>,
+    pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,
@@ -57,6 +59,7 @@ impl Environment<Stopped> {
 
         Self {
             config,
+            database: app_container.database.clone(),
             tracker: app_container.tracker.clone(),
             keys_handler: app_container.keys_handler.clone(),
             authentication_service: app_container.authentication_service.clone(),
@@ -73,6 +76,7 @@ impl Environment<Stopped> {
     pub async fn start(self) -> Environment<Running> {
         Environment {
             config: self.config,
+            database: self.database.clone(),
             tracker: self.tracker.clone(),
             keys_handler: self.keys_handler.clone(),
             authentication_service: self.authentication_service.clone(),
@@ -104,6 +108,7 @@ impl Environment<Running> {
     pub async fn stop(self) -> Environment<Stopped> {
         Environment {
             config: self.config,
+            database: self.database,
             tracker: self.tracker,
             keys_handler: self.keys_handler,
             authentication_service: self.authentication_service,

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -5,6 +5,7 @@ use bittorrent_primitives::info_hash::InfoHash;
 use tokio::sync::RwLock;
 use torrust_tracker_configuration::{Configuration, UdpTracker, DEFAULT_TIMEOUT};
 use torrust_tracker_lib::bootstrap::app::{initialize_app_container, initialize_global_services};
+use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::{whitelist, Tracker};
@@ -20,6 +21,7 @@ where
     S: std::fmt::Debug + std::fmt::Display,
 {
     pub config: Arc<UdpTracker>,
+    pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
     pub whitelist_authorization: Arc<whitelist::authorization::Authorization>,
     pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
@@ -57,6 +59,7 @@ impl Environment<Stopped> {
 
         Self {
             config,
+            database: app_container.database.clone(),
             tracker: app_container.tracker.clone(),
             whitelist_authorization: app_container.whitelist_authorization.clone(),
             stats_event_sender: app_container.stats_event_sender.clone(),
@@ -72,6 +75,7 @@ impl Environment<Stopped> {
         let cookie_lifetime = self.config.cookie_lifetime;
         Environment {
             config: self.config,
+            database: self.database.clone(),
             tracker: self.tracker.clone(),
             whitelist_authorization: self.whitelist_authorization.clone(),
             stats_event_sender: self.stats_event_sender.clone(),
@@ -109,6 +113,7 @@ impl Environment<Running> {
 
         Environment {
             config: self.config,
+            database: self.database,
             tracker: self.tracker,
             whitelist_authorization: self.whitelist_authorization,
             stats_event_sender: self.stats_event_sender,


### PR DESCRIPTION
Overhaul core Tracker: extract torrents context.

The core Tracker is getting smaller and smaller. This PR reduces the dependencies to:

```rust
pub struct Tracker {
    /// The tracker configuration.
    config: Core,

    /// The service to check is a torrent is whitelisted.
    pub whitelist_authorization: Arc<whitelist::authorization::Authorization>,

    /// The in-memory torrents repository.
    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,

    /// The persistent torrents repository.
    db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
}
```

I will open a new PR (part 2) to continue extracting the rest of methods that are not used directly in a `announce` or `scrape` requests.