### PR TITLE
Overhaul core Tracker: extract torrents context (part 2)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -118,7 +118,7 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
     if let Some(http_api_config) = &config.http_api {
         if let Some(job) = tracker_apis::start_job(
             http_api_config,
-            app_container.tracker.clone(),
+            app_container.in_memory_torrent_repository.clone(),
             app_container.keys_handler.clone(),
             app_container.whitelist_manager.clone(),
             app_container.ban_service.clone(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -875,23 +875,6 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_collect_torrent_metrics() {
-            let tracker = public_tracker();
-
-            let torrents_metrics = tracker.in_memory_torrent_repository.get_torrents_metrics();
-
-            assert_eq!(
-                torrents_metrics,
-                TorrentsMetrics {
-                    complete: 0,
-                    downloaded: 0,
-                    incomplete: 0,
-                    torrents: 0
-                }
-            );
-        }
-
-        #[tokio::test]
         async fn it_should_return_the_peers_for_a_given_torrent() {
             let tracker = public_tracker();
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -474,10 +474,10 @@ pub struct Tracker {
     config: Core,
 
     /// The service to check is a torrent is whitelisted.
-    pub whitelist_authorization: Arc<whitelist::authorization::Authorization>,
+    whitelist_authorization: Arc<whitelist::authorization::Authorization>,
 
     /// The in-memory torrents repository.
-    pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
+    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
 
     /// The persistent torrents repository.
     db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
@@ -1325,24 +1325,24 @@ mod tests {
 
                 #[tokio::test]
                 async fn it_should_authorize_the_announce_and_scrape_actions_on_whitelisted_torrents() {
-                    let (tracker, _whitelist_authorization, whitelist_manager) = whitelisted_tracker();
+                    let (_tracker, whitelist_authorization, whitelist_manager) = whitelisted_tracker();
 
                     let info_hash = sample_info_hash();
 
                     let result = whitelist_manager.add_torrent_to_whitelist(&info_hash).await;
                     assert!(result.is_ok());
 
-                    let result = tracker.whitelist_authorization.authorize(&info_hash).await;
+                    let result = whitelist_authorization.authorize(&info_hash).await;
                     assert!(result.is_ok());
                 }
 
                 #[tokio::test]
                 async fn it_should_not_authorize_the_announce_and_scrape_actions_on_not_whitelisted_torrents() {
-                    let (tracker, _whitelist_authorization, _whitelist_manager) = whitelisted_tracker();
+                    let (_tracker, whitelist_authorization, _whitelist_manager) = whitelisted_tracker();
 
                     let info_hash = sample_info_hash();
 
-                    let result = tracker.whitelist_authorization.authorize(&info_hash).await;
+                    let result = whitelist_authorization.authorize(&info_hash).await;
                     assert!(result.is_err());
                 }
             }

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -68,7 +68,7 @@ pub async fn get_metrics(
     ban_service: Arc<RwLock<BanService>>,
     stats_repository: Arc<Repository>,
 ) -> TrackerMetrics {
-    let torrents_metrics = tracker.get_torrents_metrics();
+    let torrents_metrics = tracker.in_memory_torrent_repository.get_torrents_metrics();
     let stats = stats_repository.get_stats().await;
     let udp_banned_ips_total = ban_service.read().await.get_banned_ips_total();
 

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -45,7 +45,7 @@ use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
 
 use crate::core::statistics::metrics::Metrics;
 use crate::core::statistics::repository::Repository;
-use crate::core::Tracker;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::servers::udp::server::banning::BanService;
 
 /// All the metrics collected by the tracker.
@@ -64,11 +64,11 @@ pub struct TrackerMetrics {
 
 /// It returns all the [`TrackerMetrics`]
 pub async fn get_metrics(
-    tracker: Arc<Tracker>,
+    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     ban_service: Arc<RwLock<BanService>>,
     stats_repository: Arc<Repository>,
 ) -> TrackerMetrics {
-    let torrents_metrics = tracker.in_memory_torrent_repository.get_torrents_metrics();
+    let torrents_metrics = in_memory_torrent_repository.get_torrents_metrics();
     let stats = stats_repository.get_stats().await;
     let udp_banned_ips_total = ban_service.read().await.get_banned_ips_total();
 
@@ -145,7 +145,7 @@ mod tests {
         let (_stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_repository = Arc::new(stats_repository);
 
-        let tracker = Arc::new(initialize_tracker(
+        let _tracker = Arc::new(initialize_tracker(
             &config,
             &whitelist_authorization,
             &in_memory_torrent_repository,
@@ -154,7 +154,12 @@ mod tests {
 
         let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
 
-        let tracker_metrics = get_metrics(tracker.clone(), ban_service.clone(), stats_repository.clone()).await;
+        let tracker_metrics = get_metrics(
+            in_memory_torrent_repository.clone(),
+            ban_service.clone(),
+            stats_repository.clone(),
+        )
+        .await;
 
         assert_eq!(
             tracker_metrics,

--- a/src/core/torrent/repository/in_memory.rs
+++ b/src/core/torrent/repository/in_memory.rs
@@ -101,3 +101,29 @@ impl InMemoryTorrentRepository {
         self.torrents.import_persistent(persistent_torrents);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
+
+    use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+    #[tokio::test]
+    async fn should_collect_torrent_metrics() {
+        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+        let torrents_metrics = in_memory_torrent_repository.get_torrents_metrics();
+
+        assert_eq!(
+            torrents_metrics,
+            TorrentsMetrics {
+                complete: 0,
+                downloaded: 0,
+                incomplete: 0,
+                torrents: 0
+            }
+        );
+    }
+}

--- a/src/servers/apis/routes.rs
+++ b/src/servers/apis/routes.rs
@@ -33,8 +33,8 @@ use super::v1::middlewares::auth::State;
 use crate::core::authentication::handler::KeysHandler;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::repository::Repository;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::core::whitelist::manager::WhiteListManager;
-use crate::core::Tracker;
 use crate::servers::apis::API_LOG_TARGET;
 use crate::servers::logging::Latency;
 use crate::servers::udp::server::banning::BanService;
@@ -43,7 +43,6 @@ use crate::servers::udp::server::banning::BanService;
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(skip(
-    tracker,
     keys_handler,
     whitelist_manager,
     ban_service,
@@ -52,7 +51,7 @@ use crate::servers::udp::server::banning::BanService;
     access_tokens
 ))]
 pub fn router(
-    tracker: Arc<Tracker>,
+    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     keys_handler: Arc<KeysHandler>,
     whitelist_manager: Arc<WhiteListManager>,
     ban_service: Arc<RwLock<BanService>>,
@@ -68,7 +67,7 @@ pub fn router(
     let router = v1::routes::add(
         api_url_prefix,
         router,
-        tracker.clone(),
+        &in_memory_torrent_repository.clone(),
         &keys_handler.clone(),
         &whitelist_manager.clone(),
         ban_service.clone(),

--- a/src/servers/apis/v1/context/stats/handlers.rs
+++ b/src/servers/apis/v1/context/stats/handlers.rs
@@ -11,7 +11,7 @@ use tokio::sync::RwLock;
 use super::responses::{metrics_response, stats_response};
 use crate::core::services::statistics::get_metrics;
 use crate::core::statistics::repository::Repository;
-use crate::core::Tracker;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::servers::udp::server::banning::BanService;
 
 #[derive(Deserialize, Debug, Default)]
@@ -40,7 +40,7 @@ pub struct QueryParams {
 /// for more information about this endpoint.
 #[allow(clippy::type_complexity)]
 pub async fn get_stats_handler(
-    State(state): State<(Arc<Tracker>, Arc<RwLock<BanService>>, Arc<Repository>)>,
+    State(state): State<(Arc<InMemoryTorrentRepository>, Arc<RwLock<BanService>>, Arc<Repository>)>,
     params: Query<QueryParams>,
 ) -> Response {
     let metrics = get_metrics(state.0.clone(), state.1.clone(), state.2.clone()).await;

--- a/src/servers/apis/v1/context/stats/routes.rs
+++ b/src/servers/apis/v1/context/stats/routes.rs
@@ -12,20 +12,20 @@ use tokio::sync::RwLock;
 use super::handlers::get_stats_handler;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::repository::Repository;
-use crate::core::Tracker;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::servers::udp::server::banning::BanService;
 
 /// It adds the routes to the router for the [`stats`](crate::servers::apis::v1::context::stats) API context.
 pub fn add(
     prefix: &str,
     router: Router,
-    tracker: Arc<Tracker>,
+    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     ban_service: Arc<RwLock<BanService>>,
     _stats_event_sender: Arc<Option<Box<dyn Sender>>>,
     stats_repository: Arc<Repository>,
 ) -> Router {
     router.route(
         &format!("{prefix}/stats"),
-        get(get_stats_handler).with_state((tracker, ban_service, stats_repository)),
+        get(get_stats_handler).with_state((in_memory_torrent_repository, ban_service, stats_repository)),
     )
 }

--- a/src/servers/apis/v1/context/torrent/routes.rs
+++ b/src/servers/apis/v1/context/torrent/routes.rs
@@ -10,15 +10,18 @@ use axum::routing::get;
 use axum::Router;
 
 use super::handlers::{get_torrent_handler, get_torrents_handler};
-use crate::core::Tracker;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 
 /// It adds the routes to the router for the [`torrent`](crate::servers::apis::v1::context::torrent) API context.
-pub fn add(prefix: &str, router: Router, tracker: Arc<Tracker>) -> Router {
+pub fn add(prefix: &str, router: Router, in_memory_torrent_repository: Arc<InMemoryTorrentRepository>) -> Router {
     // Torrents
     router
         .route(
             &format!("{prefix}/torrent/{{info_hash}}"),
-            get(get_torrent_handler).with_state(tracker.clone()),
+            get(get_torrent_handler).with_state(in_memory_torrent_repository.clone()),
         )
-        .route(&format!("{prefix}/torrents"), get(get_torrents_handler).with_state(tracker))
+        .route(
+            &format!("{prefix}/torrents"),
+            get(get_torrents_handler).with_state(in_memory_torrent_repository),
+        )
 }

--- a/src/servers/apis/v1/routes.rs
+++ b/src/servers/apis/v1/routes.rs
@@ -8,8 +8,8 @@ use super::context::{auth_key, stats, torrent, whitelist};
 use crate::core::authentication::handler::KeysHandler;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::repository::Repository;
+use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::core::whitelist::manager::WhiteListManager;
-use crate::core::Tracker;
 use crate::servers::udp::server::banning::BanService;
 
 /// Add the routes for the v1 API.
@@ -17,7 +17,7 @@ use crate::servers::udp::server::banning::BanService;
 pub fn add(
     prefix: &str,
     router: Router,
-    tracker: Arc<Tracker>,
+    in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
     keys_handler: &Arc<KeysHandler>,
     whitelist_manager: &Arc<WhiteListManager>,
     ban_service: Arc<RwLock<BanService>>,
@@ -30,12 +30,12 @@ pub fn add(
     let router = stats::routes::add(
         &v1_prefix,
         router,
-        tracker.clone(),
+        in_memory_torrent_repository.clone(),
         ban_service,
         stats_event_sender,
         stats_repository,
     );
     let router = whitelist::routes::add(&v1_prefix, router, whitelist_manager);
 
-    torrent::routes::add(&v1_prefix, router, tracker)
+    torrent::routes::add(&v1_prefix, router, in_memory_torrent_repository.clone())
 }

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -486,6 +486,7 @@ mod tests {
     use crate::app_test::initialize_tracker_dependencies;
     use crate::core::services::{initialize_tracker, initialize_whitelist_manager, statistics};
     use crate::core::statistics::event::sender::Sender;
+    use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
     use crate::core::whitelist::manager::WhiteListManager;
     use crate::core::whitelist::repository::in_memory::InMemoryWhitelist;
     use crate::core::{whitelist, Tracker};
@@ -493,6 +494,7 @@ mod tests {
 
     type TrackerAndDeps = (
         Arc<Tracker>,
+        Arc<InMemoryTorrentRepository>,
         Arc<Option<Box<dyn Sender>>>,
         Arc<InMemoryWhitelist>,
         Arc<WhiteListManager>,
@@ -539,6 +541,7 @@ mod tests {
 
         (
             tracker,
+            in_memory_torrent_repository,
             stats_event_sender,
             in_memory_whitelist,
             whitelist_manager,
@@ -887,8 +890,14 @@ mod tests {
 
             #[tokio::test]
             async fn an_announced_peer_should_be_added_to_the_tracker() {
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let client_ip = Ipv4Addr::new(126, 0, 0, 1);
                 let client_port = 8080;
@@ -916,7 +925,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 let expected_peer = TorrentPeerBuilder::new()
                     .with_peer_id(peer_id)
@@ -928,8 +937,14 @@ mod tests {
 
             #[tokio::test]
             async fn the_announced_peer_should_not_be_included_in_the_response() {
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let remote_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
 
@@ -969,8 +984,14 @@ mod tests {
                 // From the BEP 15 (https://www.bittorrent.org/beps/bep_0015.html):
                 // "Do note that most trackers will only honor the IP address field under limited circumstances."
 
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let info_hash = AquaticInfoHash([0u8; 20]);
                 let peer_id = AquaticPeerId([255u8; 20]);
@@ -1001,7 +1022,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V4(remote_client_ip), client_port));
             }
@@ -1048,8 +1069,14 @@ mod tests {
 
             #[tokio::test]
             async fn when_the_announce_request_comes_from_a_client_using_ipv4_the_response_should_not_include_peers_using_ipv6() {
-                let (tracker, _stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    _stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 add_a_torrent_peer_using_ipv6(&tracker);
 
@@ -1104,8 +1131,14 @@ mod tests {
 
                 #[tokio::test]
                 async fn the_peer_ip_should_be_changed_to_the_external_ip_in_the_tracker_configuration_if_defined() {
-                    let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                        public_tracker();
+                    let (
+                        tracker,
+                        in_memory_torrent_repository,
+                        stats_event_sender,
+                        _in_memory_whitelist,
+                        _whitelist_manager,
+                        whitelist_authorization,
+                    ) = public_tracker();
 
                     let client_ip = Ipv4Addr::new(127, 0, 0, 1);
                     let client_port = 8080;
@@ -1133,7 +1166,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                    let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                     let external_ip_in_tracker_configuration = tracker.get_maybe_external_ip().unwrap();
 
@@ -1170,8 +1203,14 @@ mod tests {
 
             #[tokio::test]
             async fn an_announced_peer_should_be_added_to_the_tracker() {
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let client_ip_v4 = Ipv4Addr::new(126, 0, 0, 1);
                 let client_ip_v6 = client_ip_v4.to_ipv6_compatible();
@@ -1200,7 +1239,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 let expected_peer = TorrentPeerBuilder::new()
                     .with_peer_id(peer_id)
@@ -1212,8 +1251,14 @@ mod tests {
 
             #[tokio::test]
             async fn the_announced_peer_should_not_be_included_in_the_response() {
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let client_ip_v4 = Ipv4Addr::new(126, 0, 0, 1);
                 let client_ip_v6 = client_ip_v4.to_ipv6_compatible();
@@ -1256,8 +1301,14 @@ mod tests {
                 // From the BEP 15 (https://www.bittorrent.org/beps/bep_0015.html):
                 // "Do note that most trackers will only honor the IP address field under limited circumstances."
 
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 let info_hash = AquaticInfoHash([0u8; 20]);
                 let peer_id = AquaticPeerId([255u8; 20]);
@@ -1288,7 +1339,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 // When using IPv6 the tracker converts the remote client ip into a IPv4 address
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V6(remote_client_ip), client_port));
@@ -1338,8 +1389,14 @@ mod tests {
 
             #[tokio::test]
             async fn when_the_announce_request_comes_from_a_client_using_ipv6_the_response_should_not_include_peers_using_ipv4() {
-                let (tracker, _stats_event_sender, _in_memory_whitelist, _whitelist_manager, whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    _stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    whitelist_authorization,
+                ) = public_tracker();
 
                 add_a_torrent_peer_using_ipv4(&tracker);
 
@@ -1466,7 +1523,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
+                    let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                     let external_ip_in_tracker_configuration = tracker.get_maybe_external_ip().unwrap();
 
@@ -1511,8 +1568,14 @@ mod tests {
 
         #[tokio::test]
         async fn should_return_no_stats_when_the_tracker_does_not_have_any_torrent() {
-            let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, _whitelist_authorization) =
-                public_tracker();
+            let (
+                tracker,
+                _in_memory_torrent_repository,
+                stats_event_sender,
+                _in_memory_whitelist,
+                _whitelist_manager,
+                _whitelist_authorization,
+            ) = public_tracker();
 
             let remote_addr = sample_ipv4_remote_addr();
 
@@ -1605,8 +1668,14 @@ mod tests {
 
             #[tokio::test]
             async fn should_return_torrent_statistics_when_the_tracker_has_the_requested_torrent() {
-                let (tracker, _stats_event_sender, _in_memory_whitelist, _whitelist_manager, _whitelist_authorization) =
-                    public_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    _stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    _whitelist_authorization,
+                ) = public_tracker();
 
                 let torrent_stats = match_scrape_response(add_a_sample_seeder_and_scrape(tracker.clone()).await);
 
@@ -1631,8 +1700,14 @@ mod tests {
 
             #[tokio::test]
             async fn should_return_the_torrent_statistics_when_the_requested_torrent_is_whitelisted() {
-                let (tracker, stats_event_sender, in_memory_whitelist, _whitelist_manager, _whitelist_authorization) =
-                    whitelisted_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    stats_event_sender,
+                    in_memory_whitelist,
+                    _whitelist_manager,
+                    _whitelist_authorization,
+                ) = whitelisted_tracker();
 
                 let remote_addr = sample_ipv4_remote_addr();
                 let info_hash = InfoHash([0u8; 20]);
@@ -1667,8 +1742,14 @@ mod tests {
 
             #[tokio::test]
             async fn should_return_zeroed_statistics_when_the_requested_torrent_is_not_whitelisted() {
-                let (tracker, stats_event_sender, _in_memory_whitelist, _whitelist_manager, _whitelist_authorization) =
-                    whitelisted_tracker();
+                let (
+                    tracker,
+                    _in_memory_torrent_repository,
+                    stats_event_sender,
+                    _in_memory_whitelist,
+                    _whitelist_manager,
+                    _whitelist_authorization,
+                ) = whitelisted_tracker();
 
                 let remote_addr = sample_ipv4_remote_addr();
                 let info_hash = InfoHash([0u8; 20]);

--- a/src/servers/udp/handlers.rs
+++ b/src/servers/udp/handlers.rs
@@ -916,7 +916,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 let expected_peer = TorrentPeerBuilder::new()
                     .with_peer_id(peer_id)
@@ -1001,7 +1001,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V4(remote_client_ip), client_port));
             }
@@ -1133,7 +1133,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                    let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                     let external_ip_in_tracker_configuration = tracker.get_maybe_external_ip().unwrap();
 
@@ -1200,7 +1200,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 let expected_peer = TorrentPeerBuilder::new()
                     .with_peer_id(peer_id)
@@ -1288,7 +1288,7 @@ mod tests {
                 .await
                 .unwrap();
 
-                let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                 // When using IPv6 the tracker converts the remote client ip into a IPv4 address
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V6(remote_client_ip), client_port));
@@ -1466,7 +1466,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                    let peers = tracker.get_torrent_peers(&info_hash.0.into());
+                    let peers = tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into());
 
                     let external_ip_in_tracker_configuration = tracker.get_maybe_external_ip().unwrap();
 

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -13,6 +13,7 @@ use torrust_tracker_lib::core::authentication::service::AuthenticationService;
 use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
+use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
 use torrust_tracker_lib::core::Tracker;
 use torrust_tracker_lib::servers::apis::server::{ApiServer, Launcher, Running, Stopped};
@@ -27,6 +28,7 @@ where
     pub config: Arc<HttpApi>,
     pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
+    pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,
     pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
@@ -65,6 +67,7 @@ impl Environment<Stopped> {
             config,
             database: app_container.database.clone(),
             tracker: app_container.tracker.clone(),
+            in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
             keys_handler: app_container.keys_handler.clone(),
             authentication_service: app_container.authentication_service.clone(),
             stats_event_sender: app_container.stats_event_sender.clone(),
@@ -83,6 +86,7 @@ impl Environment<Stopped> {
             config: self.config,
             database: self.database.clone(),
             tracker: self.tracker.clone(),
+            in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
             keys_handler: self.keys_handler.clone(),
             authentication_service: self.authentication_service.clone(),
             stats_event_sender: self.stats_event_sender.clone(),
@@ -93,7 +97,7 @@ impl Environment<Stopped> {
             server: self
                 .server
                 .start(
-                    self.tracker,
+                    self.in_memory_torrent_repository,
                     self.keys_handler,
                     self.whitelist_manager,
                     self.stats_event_sender,
@@ -118,6 +122,7 @@ impl Environment<Running> {
             config: self.config,
             database: self.database,
             tracker: self.tracker,
+            in_memory_torrent_repository: self.in_memory_torrent_repository,
             keys_handler: self.keys_handler,
             authentication_service: self.authentication_service,
             stats_event_sender: self.stats_event_sender,

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -10,6 +10,7 @@ use torrust_tracker_lib::core::authentication::service::AuthenticationService;
 use torrust_tracker_lib::core::databases::Database;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
+use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
 use torrust_tracker_lib::core::{whitelist, Tracker};
 use torrust_tracker_lib::servers::http::server::{HttpServer, Launcher, Running, Stopped};
@@ -20,6 +21,7 @@ pub struct Environment<S> {
     pub config: Arc<HttpTracker>,
     pub database: Arc<Box<dyn Database>>,
     pub tracker: Arc<Tracker>,
+    pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,
     pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
@@ -61,6 +63,7 @@ impl Environment<Stopped> {
             config,
             database: app_container.database.clone(),
             tracker: app_container.tracker.clone(),
+            in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
             keys_handler: app_container.keys_handler.clone(),
             authentication_service: app_container.authentication_service.clone(),
             stats_event_sender: app_container.stats_event_sender.clone(),
@@ -78,6 +81,7 @@ impl Environment<Stopped> {
             config: self.config,
             database: self.database.clone(),
             tracker: self.tracker.clone(),
+            in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
             keys_handler: self.keys_handler.clone(),
             authentication_service: self.authentication_service.clone(),
             whitelist_authorization: self.whitelist_authorization.clone(),
@@ -110,6 +114,7 @@ impl Environment<Running> {
             config: self.config,
             database: self.database,
             tracker: self.tracker,
+            in_memory_torrent_repository: self.in_memory_torrent_repository,
             keys_handler: self.keys_handler,
             authentication_service: self.authentication_service,
             whitelist_authorization: self.whitelist_authorization,

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -831,7 +831,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.get_torrent_peers(&info_hash);
+            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), client_ip);
@@ -869,7 +869,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.get_torrent_peers(&info_hash);
+            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
@@ -911,7 +911,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.get_torrent_peers(&info_hash);
+            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
@@ -951,7 +951,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.get_torrent_peers(&info_hash);
+            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), IpAddr::from_str("150.172.238.178").unwrap());

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -831,7 +831,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), client_ip);
@@ -869,7 +869,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
@@ -911,7 +911,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
@@ -951,7 +951,7 @@ mod for_all_config_modes {
                 assert_eq!(status, StatusCode::OK);
             }
 
-            let peers = env.tracker.in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
             assert_eq!(peer_addr.ip(), IpAddr::from_str("150.172.238.178").unwrap());


### PR DESCRIPTION
This is part 2 of the refactor initiated [here](https://github.com/torrust/torrust-tracker/pull/1202).

The core `Tracker` after this refactor:

```rust
pub struct Tracker {
    /// The tracker configuration.
    config: Core,

    /// The service to check is a torrent is whitelisted.
    whitelist_authorization: Arc<whitelist::authorization::Authorization>,

    /// The in-memory torrents repository.
    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,

    /// The persistent torrents repository.
    db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
}
```