### PR TITLE
Overhaul core Tracker: remove deprecated `core::Tracker`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,8 @@
 //! - UDP trackers: the user can enable multiple UDP tracker on several ports.
 //! - HTTP trackers: the user can enable multiple HTTP tracker on several ports.
 //! - Tracker REST API: the tracker API can be enabled/disabled.
+use std::sync::Arc;
+
 use tokio::task::JoinHandle;
 use torrust_tracker_configuration::Configuration;
 use tracing::instrument;
@@ -78,6 +80,7 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
             } else {
                 jobs.push(
                     udp_tracker::start_job(
+                        Arc::new(config.core.clone()),
                         udp_tracker_config,
                         app_container.tracker.clone(),
                         app_container.announce_handler.clone(),
@@ -100,6 +103,7 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
         for http_tracker_config in http_trackers {
             if let Some(job) = http_tracker::start_job(
                 http_tracker_config,
+                Arc::new(config.core.clone()),
                 app_container.tracker.clone(),
                 app_container.announce_handler.clone(),
                 app_container.scrape_handler.clone(),

--- a/src/bootstrap/jobs/udp_tracker.rs
+++ b/src/bootstrap/jobs/udp_tracker.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use torrust_tracker_configuration::UdpTracker;
+use torrust_tracker_configuration::{Core, UdpTracker};
 use tracing::instrument;
 
 use crate::core::announce_handler::AnnounceHandler;
@@ -46,6 +46,7 @@ use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
     form
 ))]
 pub async fn start_job(
+    core_config: Arc<Core>,
     config: &UdpTracker,
     tracker: Arc<core::Tracker>,
     announce_handler: Arc<AnnounceHandler>,
@@ -60,6 +61,7 @@ pub async fn start_job(
 
     let server = Server::new(Spawner::new(bind_to))
         .start(
+            core_config,
             tracker,
             announce_handler,
             scrape_handler,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -451,12 +451,11 @@ pub mod whitelist;
 
 pub mod peer_tests;
 
-use std::net::IpAddr;
 use std::sync::Arc;
 
 use torrent::repository::in_memory::InMemoryTorrentRepository;
 use torrent::repository::persisted::DatabasePersistentTorrentRepository;
-use torrust_tracker_configuration::{AnnouncePolicy, Core};
+use torrust_tracker_configuration::Core;
 
 /// The domain layer tracker service.
 ///
@@ -469,7 +468,7 @@ use torrust_tracker_configuration::{AnnouncePolicy, Core};
 /// > the network layer.
 pub struct Tracker {
     /// The tracker configuration.
-    config: Core,
+    _core_config: Core,
 
     /// The in-memory torrents repository.
     _in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
@@ -485,37 +484,15 @@ impl Tracker {
     ///
     /// Will return a `databases::error::Error` if unable to connect to database. The `Tracker` is responsible for the persistence.
     pub fn new(
-        config: &Core,
+        core_config: &Core,
         in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
         db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
     ) -> Result<Tracker, databases::error::Error> {
         Ok(Tracker {
-            config: config.clone(),
+            _core_config: core_config.clone(),
             _in_memory_torrent_repository: in_memory_torrent_repository.clone(),
             _db_torrent_repository: db_torrent_repository.clone(),
         })
-    }
-
-    /// Returns `true` if the tracker requires authentication.
-    #[must_use]
-    pub fn requires_authentication(&self) -> bool {
-        self.config.private
-    }
-
-    /// Returns `true` is the tracker is in whitelisted mode.
-    #[must_use]
-    pub fn is_behind_reverse_proxy(&self) -> bool {
-        self.config.net.on_reverse_proxy
-    }
-
-    #[must_use]
-    pub fn get_announce_policy(&self) -> AnnouncePolicy {
-        self.config.announce_policy
-    }
-
-    #[must_use]
-    pub fn get_maybe_external_ip(&self) -> Option<IpAddr> {
-        self.config.net.external_ip
     }
 }
 

--- a/src/servers/http/v1/routes.rs
+++ b/src/servers/http/v1/routes.rs
@@ -10,7 +10,7 @@ use axum::routing::get;
 use axum::{BoxError, Router};
 use axum_client_ip::SecureClientIpSource;
 use hyper::{Request, StatusCode};
-use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+use torrust_tracker_configuration::{Core, DEFAULT_TIMEOUT};
 use tower::timeout::TimeoutLayer;
 use tower::ServiceBuilder;
 use tower_http::classify::ServerErrorsFailureClass;
@@ -34,6 +34,7 @@ use crate::servers::logging::Latency;
 ///
 /// > **NOTICE**: it's added a layer to get the client IP from the connection
 /// > info. The tracker could use the connection info to get the client IP.
+#[allow(clippy::too_many_arguments)]
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(skip(
     tracker,
@@ -45,6 +46,7 @@ use crate::servers::logging::Latency;
     server_socket_addr
 ))]
 pub fn router(
+    core_config: Arc<Core>,
     tracker: Arc<Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
@@ -60,6 +62,7 @@ pub fn router(
         .route(
             "/announce",
             get(announce::handle_without_key).with_state((
+                core_config.clone(),
                 tracker.clone(),
                 announce_handler.clone(),
                 authentication_service.clone(),
@@ -70,6 +73,7 @@ pub fn router(
         .route(
             "/announce/{key}",
             get(announce::handle_with_key).with_state((
+                core_config.clone(),
                 tracker.clone(),
                 announce_handler.clone(),
                 authentication_service.clone(),
@@ -81,6 +85,7 @@ pub fn router(
         .route(
             "/scrape",
             get(scrape::handle_without_key).with_state((
+                core_config.clone(),
                 tracker.clone(),
                 scrape_handler.clone(),
                 authentication_service.clone(),
@@ -90,6 +95,7 @@ pub fn router(
         .route(
             "/scrape/{key}",
             get(scrape::handle_with_key).with_state((
+                core_config.clone(),
                 tracker.clone(),
                 scrape_handler.clone(),
                 authentication_service.clone(),

--- a/src/servers/http/v1/services/announce.rs
+++ b/src/servers/http/v1/services/announce.rs
@@ -63,6 +63,7 @@ mod tests {
 
     use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes, PeerId};
     use bittorrent_primitives::info_hash::InfoHash;
+    use torrust_tracker_configuration::Core;
     use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
     use torrust_tracker_test_helpers::configuration;
 
@@ -73,7 +74,7 @@ mod tests {
     use crate::core::Tracker;
 
     #[allow(clippy::type_complexity)]
-    fn public_tracker() -> (Arc<Tracker>, Arc<AnnounceHandler>, Arc<Option<Box<dyn Sender>>>) {
+    fn public_tracker() -> (Arc<Core>, Arc<Tracker>, Arc<AnnounceHandler>, Arc<Option<Box<dyn Sender>>>) {
         let config = configuration::ephemeral_public();
 
         let (
@@ -100,7 +101,9 @@ mod tests {
             &db_torrent_repository,
         ));
 
-        (tracker, announce_handler, stats_event_sender)
+        let core_config = Arc::new(config.core.clone());
+
+        (core_config, tracker, announce_handler, stats_event_sender)
     }
 
     fn sample_info_hash() -> InfoHash {
@@ -176,7 +179,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_the_announce_data() {
-            let (tracker, announce_handler, stats_event_sender) = public_tracker();
+            let (core_config, tracker, announce_handler, stats_event_sender) = public_tracker();
 
             let mut peer = sample_peer();
 
@@ -197,7 +200,7 @@ mod tests {
                     complete: 1,
                     incomplete: 0,
                 },
-                policy: tracker.get_announce_policy(),
+                policy: core_config.announce_policy,
             };
 
             assert_eq!(announce_data, expected_announce_data);

--- a/src/servers/udp/server/mod.rs
+++ b/src/servers/udp/server/mod.rs
@@ -82,6 +82,7 @@ mod tests {
 
         let started = stopped
             .start(
+                Arc::new(cfg.core.clone()),
                 app_container.tracker,
                 app_container.announce_handler,
                 app_container.scrape_handler,
@@ -117,6 +118,7 @@ mod tests {
 
         let started = stopped
             .start(
+                Arc::new(cfg.core.clone()),
                 app_container.tracker,
                 app_container.announce_handler,
                 app_container.scrape_handler,

--- a/src/servers/udp/server/processor.rs
+++ b/src/servers/udp/server/processor.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use aquatic_udp_protocol::Response;
 use tokio::sync::RwLock;
 use tokio::time::Instant;
+use torrust_tracker_configuration::Core;
 use tracing::{instrument, Level};
 
 use super::banning::BanService;
@@ -20,6 +21,7 @@ use crate::servers::udp::{handlers, RawRequest};
 
 pub struct Processor {
     socket: Arc<BoundSocket>,
+    core_config: Arc<Core>,
     tracker: Arc<Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
@@ -29,8 +31,10 @@ pub struct Processor {
 }
 
 impl Processor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         socket: Arc<BoundSocket>,
+        core_config: Arc<Core>,
         tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
@@ -40,6 +44,7 @@ impl Processor {
     ) -> Self {
         Self {
             socket,
+            core_config,
             tracker,
             announce_handler,
             scrape_handler,
@@ -57,6 +62,7 @@ impl Processor {
 
         let response = handlers::handle_packet(
             request,
+            &self.core_config,
             &self.tracker,
             &self.announce_handler,
             &self.scrape_handler,

--- a/src/servers/udp/server/spawner.rs
+++ b/src/servers/udp/server/spawner.rs
@@ -7,6 +7,7 @@ use derive_more::derive::Display;
 use derive_more::Constructor;
 use tokio::sync::{oneshot, RwLock};
 use tokio::task::JoinHandle;
+use torrust_tracker_configuration::Core;
 
 use super::banning::BanService;
 use super::launcher::Launcher;
@@ -32,6 +33,7 @@ impl Spawner {
     #[allow(clippy::too_many_arguments)]
     pub fn spawn_launcher(
         &self,
+        core_config: Arc<Core>,
         tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
@@ -46,6 +48,7 @@ impl Spawner {
 
         tokio::spawn(async move {
             Launcher::run_with_graceful_shutdown(
+                core_config,
                 tracker,
                 announce_handler,
                 scrape_handler,

--- a/src/servers/udp/server/states.rs
+++ b/src/servers/udp/server/states.rs
@@ -7,6 +7,7 @@ use derive_more::derive::Display;
 use derive_more::Constructor;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
+use torrust_tracker_configuration::Core;
 use tracing::{instrument, Level};
 
 use super::banning::BanService;
@@ -70,6 +71,7 @@ impl Server<Stopped> {
     #[instrument(skip(self, tracker, announce_handler, scrape_handler, whitelist_authorization, opt_stats_event_sender, ban_service, form), err, ret(Display, level = Level::INFO))]
     pub async fn start(
         self,
+        core_config: Arc<Core>,
         tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
@@ -86,6 +88,7 @@ impl Server<Stopped> {
 
         // May need to wrap in a task to about a tokio bug.
         let task = self.state.spawner.spawn_launcher(
+            core_config,
             tracker,
             announce_handler,
             scrape_handler,

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -449,7 +449,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.tracker.get_announce_policy();
+            let announce_policy = env.core_config.announce_policy;
 
             assert_announce_response(
                 response,
@@ -490,7 +490,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.tracker.get_announce_policy();
+            let announce_policy = env.core_config.announce_policy;
 
             // It should only contain the previously announced peer
             assert_announce_response(
@@ -543,7 +543,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.tracker.get_announce_policy();
+            let announce_policy = env.core_config.announce_policy;
 
             // The newly announced peer is not included on the response peer list,
             // but all the previously announced peers should be included regardless the IP version they are using.
@@ -872,7 +872,7 @@ mod for_all_config_modes {
             let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
-            assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
+            assert_eq!(peer_addr.ip(), env.core_config.net.external_ip.unwrap());
             assert_ne!(peer_addr.ip(), IpAddr::from_str("2.2.2.2").unwrap());
 
             env.stop().await;
@@ -914,7 +914,7 @@ mod for_all_config_modes {
             let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
-            assert_eq!(peer_addr.ip(), env.tracker.get_maybe_external_ip().unwrap());
+            assert_eq!(peer_addr.ip(), env.core_config.net.external_ip.unwrap());
             assert_ne!(peer_addr.ip(), IpAddr::from_str("2.2.2.2").unwrap());
 
             env.stop().await;


### PR DESCRIPTION
Overhaul core Tracker: remove deprecated `core::Tracker`