### PR TITLE
Overhaul core Tracker: remove deprecated `core::Tracker`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -82,7 +82,6 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
                     udp_tracker::start_job(
                         Arc::new(config.core.clone()),
                         udp_tracker_config,
-                        app_container.tracker.clone(),
                         app_container.announce_handler.clone(),
                         app_container.scrape_handler.clone(),
                         app_container.whitelist_authorization.clone(),
@@ -104,7 +103,6 @@ pub async fn start(config: &Configuration, app_container: &AppContainer) -> Vec<
             if let Some(job) = http_tracker::start_job(
                 http_tracker_config,
                 Arc::new(config.core.clone()),
-                app_container.tracker.clone(),
                 app_container.announce_handler.clone(),
                 app_container.scrape_handler.clone(),
                 app_container.authentication_service.clone(),

--- a/src/bootstrap/app.rs
+++ b/src/bootstrap/app.rs
@@ -28,7 +28,7 @@ use crate::core::authentication::key::repository::in_memory::InMemoryKeyReposito
 use crate::core::authentication::key::repository::persisted::DatabaseKeyRepository;
 use crate::core::authentication::service;
 use crate::core::scrape_handler::ScrapeHandler;
-use crate::core::services::{initialize_database, initialize_tracker, initialize_whitelist_manager, statistics};
+use crate::core::services::{initialize_database, initialize_whitelist_manager, statistics};
 use crate::core::torrent::manager::TorrentsManager;
 use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::core::torrent::repository::persisted::DatabasePersistentTorrentRepository;
@@ -116,12 +116,6 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
         &db_torrent_repository,
     ));
 
-    let tracker = Arc::new(initialize_tracker(
-        configuration,
-        &in_memory_torrent_repository,
-        &db_torrent_repository,
-    ));
-
     let announce_handler = Arc::new(AnnounceHandler::new(
         &configuration.core,
         &in_memory_torrent_repository,
@@ -132,7 +126,6 @@ pub fn initialize_app_container(configuration: &Configuration) -> AppContainer {
 
     AppContainer {
         database,
-        tracker,
         announce_handler,
         scrape_handler,
         keys_handler,

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -23,7 +23,7 @@ use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::service::AuthenticationService;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{self, statistics, whitelist};
+use crate::core::{statistics, whitelist};
 use crate::servers::http::server::{HttpServer, Launcher};
 use crate::servers::http::Version;
 use crate::servers::registar::ServiceRegistrationForm;
@@ -39,7 +39,6 @@ use crate::servers::registar::ServiceRegistrationForm;
 #[allow(clippy::too_many_arguments)]
 #[instrument(skip(
     config,
-    tracker,
     announce_handler,
     scrape_handler,
     authentication_service,
@@ -50,7 +49,6 @@ use crate::servers::registar::ServiceRegistrationForm;
 pub async fn start_job(
     config: &HttpTracker,
     core_config: Arc<Core>,
-    tracker: Arc<core::Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
     authentication_service: Arc<AuthenticationService>,
@@ -71,7 +69,6 @@ pub async fn start_job(
                 socket,
                 tls,
                 core_config.clone(),
-                tracker.clone(),
                 announce_handler.clone(),
                 scrape_handler.clone(),
                 authentication_service.clone(),
@@ -89,7 +86,6 @@ pub async fn start_job(
 #[instrument(skip(
     socket,
     tls,
-    tracker,
     announce_handler,
     scrape_handler,
     whitelist_authorization,
@@ -100,7 +96,6 @@ async fn start_v1(
     socket: SocketAddr,
     tls: Option<RustlsConfig>,
     config: Arc<Core>,
-    tracker: Arc<core::Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
     authentication_service: Arc<AuthenticationService>,
@@ -111,7 +106,6 @@ async fn start_v1(
     let server = HttpServer::new(Launcher::new(socket, tls))
         .start(
             config,
-            tracker,
             announce_handler,
             scrape_handler,
             authentication_service,
@@ -161,7 +155,6 @@ mod tests {
         start_job(
             config,
             Arc::new(cfg.core.clone()),
-            app_container.tracker,
             app_container.announce_handler,
             app_container.scrape_handler,
             app_container.authentication_service,

--- a/src/bootstrap/jobs/udp_tracker.rs
+++ b/src/bootstrap/jobs/udp_tracker.rs
@@ -16,7 +16,7 @@ use tracing::instrument;
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{self, whitelist};
+use crate::core::whitelist;
 use crate::servers::registar::ServiceRegistrationForm;
 use crate::servers::udp::server::banning::BanService;
 use crate::servers::udp::server::spawner::Spawner;
@@ -37,7 +37,6 @@ use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 #[allow(clippy::async_yields_async)]
 #[instrument(skip(
     config,
-    tracker,
     announce_handler,
     scrape_handler,
     whitelist_authorization,
@@ -48,7 +47,6 @@ use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 pub async fn start_job(
     core_config: Arc<Core>,
     config: &UdpTracker,
-    tracker: Arc<core::Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
     whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -62,7 +60,6 @@ pub async fn start_job(
     let server = Server::new(Spawner::new(bind_to))
         .start(
             core_config,
-            tracker,
             announce_handler,
             scrape_handler,
             whitelist_authorization,

--- a/src/container.rs
+++ b/src/container.rs
@@ -12,13 +12,12 @@ use crate::core::statistics::repository::Repository;
 use crate::core::torrent::manager::TorrentsManager;
 use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::core::torrent::repository::persisted::DatabasePersistentTorrentRepository;
+use crate::core::whitelist;
 use crate::core::whitelist::manager::WhiteListManager;
-use crate::core::{whitelist, Tracker};
 use crate::servers::udp::server::banning::BanService;
 
 pub struct AppContainer {
     pub database: Arc<Box<dyn Database>>,
-    pub tracker: Arc<Tracker>,
     pub announce_handler: Arc<AnnounceHandler>,
     pub scrape_handler: Arc<ScrapeHandler>,
     pub keys_handler: Arc<KeysHandler>,

--- a/src/core/services/mod.rs
+++ b/src/core/services/mod.rs
@@ -14,31 +14,9 @@ use torrust_tracker_configuration::v2_0_0::database;
 use torrust_tracker_configuration::Configuration;
 
 use super::databases::{self, Database};
-use super::torrent::repository::in_memory::InMemoryTorrentRepository;
-use super::torrent::repository::persisted::DatabasePersistentTorrentRepository;
 use super::whitelist::manager::WhiteListManager;
 use super::whitelist::repository::in_memory::InMemoryWhitelist;
 use super::whitelist::repository::persisted::DatabaseWhitelist;
-use crate::core::Tracker;
-
-/// It returns a new tracker building its dependencies.
-///
-/// # Panics
-///
-/// Will panic if tracker cannot be instantiated.
-#[must_use]
-pub fn initialize_tracker(
-    config: &Configuration,
-    in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
-    db_torrent_repository: &Arc<DatabasePersistentTorrentRepository>,
-) -> Tracker {
-    match Tracker::new(&Arc::new(config).core, in_memory_torrent_repository, db_torrent_repository) {
-        Ok(tracker) => tracker,
-        Err(error) => {
-            panic!("{}", error)
-        }
-    }
-}
 
 /// # Panics
 ///

--- a/src/core/services/statistics/mod.rs
+++ b/src/core/services/statistics/mod.rs
@@ -118,7 +118,6 @@ mod tests {
     use torrust_tracker_test_helpers::configuration;
 
     use crate::app_test::initialize_tracker_dependencies;
-    use crate::core::services::initialize_tracker;
     use crate::core::services::statistics::{self, get_metrics, TrackerMetrics};
     use crate::core::{self};
     use crate::servers::udp::server::banning::BanService;
@@ -138,18 +137,12 @@ mod tests {
             _whitelist_authorization,
             _authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
         let (_stats_event_sender, stats_repository) = statistics::setup::factory(config.core.tracker_usage_statistics);
         let stats_repository = Arc::new(stats_repository);
-
-        let _tracker = Arc::new(initialize_tracker(
-            &config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
 
         let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
 

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -119,28 +119,20 @@ mod tests {
     use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
 
     use crate::app_test::initialize_tracker_dependencies;
-    use crate::core::services::initialize_tracker;
     use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
-    use crate::core::Tracker;
 
-    fn initialize_tracker_and_deps(config: &Configuration) -> (Arc<Tracker>, Arc<InMemoryTorrentRepository>) {
+    fn initialize_in_memory_torrent_repository(config: &Configuration) -> Arc<InMemoryTorrentRepository> {
         let (
             _database,
             _in_memory_whitelist,
             _whitelist_authorization,
             _authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(config);
 
-        let tracker = Arc::new(initialize_tracker(
-            config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
-
-        (tracker, in_memory_torrent_repository)
+        in_memory_torrent_repository
     }
 
     fn sample_peer() -> peer::Peer {
@@ -164,7 +156,7 @@ mod tests {
         use torrust_tracker_configuration::Configuration;
         use torrust_tracker_test_helpers::configuration;
 
-        use crate::core::services::torrent::tests::{initialize_tracker_and_deps, sample_peer};
+        use crate::core::services::torrent::tests::{initialize_in_memory_torrent_repository, sample_peer};
         use crate::core::services::torrent::{get_torrent_info, Info};
         use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 
@@ -189,7 +181,7 @@ mod tests {
         async fn should_return_the_torrent_info_if_the_tracker_has_the_torrent() {
             let config = tracker_configuration();
 
-            let (_tracker, in_memory_torrent_repository) = initialize_tracker_and_deps(&config);
+            let in_memory_torrent_repository = initialize_in_memory_torrent_repository(&config);
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
@@ -221,7 +213,7 @@ mod tests {
         use torrust_tracker_configuration::Configuration;
         use torrust_tracker_test_helpers::configuration;
 
-        use crate::core::services::torrent::tests::{initialize_tracker_and_deps, sample_peer};
+        use crate::core::services::torrent::tests::{initialize_in_memory_torrent_repository, sample_peer};
         use crate::core::services::torrent::{get_torrents_page, BasicInfo, Pagination};
         use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 
@@ -242,7 +234,7 @@ mod tests {
         async fn should_return_a_summarized_info_for_all_torrents() {
             let config = tracker_configuration();
 
-            let (_tracker, in_memory_torrent_repository) = initialize_tracker_and_deps(&config);
+            let in_memory_torrent_repository = initialize_in_memory_torrent_repository(&config);
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash = InfoHash::from_str(&hash).unwrap();
@@ -266,7 +258,7 @@ mod tests {
         async fn should_allow_limiting_the_number_of_torrents_in_the_result() {
             let config = tracker_configuration();
 
-            let (_tracker, in_memory_torrent_repository) = initialize_tracker_and_deps(&config);
+            let in_memory_torrent_repository = initialize_in_memory_torrent_repository(&config);
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
@@ -289,7 +281,7 @@ mod tests {
         async fn should_allow_using_pagination_in_the_result() {
             let config = tracker_configuration();
 
-            let (_tracker, in_memory_torrent_repository) = initialize_tracker_and_deps(&config);
+            let in_memory_torrent_repository = initialize_in_memory_torrent_repository(&config);
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
@@ -321,7 +313,7 @@ mod tests {
         async fn should_return_torrents_ordered_by_info_hash() {
             let config = tracker_configuration();
 
-            let (_tracker, in_memory_torrent_repository) = initialize_tracker_and_deps(&config);
+            let in_memory_torrent_repository = initialize_in_memory_torrent_repository(&config);
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();

--- a/src/servers/http/server.rs
+++ b/src/servers/http/server.rs
@@ -15,7 +15,7 @@ use crate::bootstrap::jobs::Started;
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::service::AuthenticationService;
 use crate::core::scrape_handler::ScrapeHandler;
-use crate::core::{statistics, whitelist, Tracker};
+use crate::core::{statistics, whitelist};
 use crate::servers::custom_axum_server::{self, TimeoutAcceptor};
 use crate::servers::http::HTTP_TRACKER_LOG_TARGET;
 use crate::servers::logging::STARTED_ON;
@@ -49,7 +49,6 @@ impl Launcher {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip(
         self,
-        tracker,
         announce_handler,
         scrape_handler,
         authentication_service,
@@ -61,7 +60,6 @@ impl Launcher {
     fn start(
         &self,
         config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         authentication_service: Arc<AuthenticationService>,
@@ -88,7 +86,6 @@ impl Launcher {
 
         let app = router(
             config,
-            tracker,
             announce_handler,
             scrape_handler,
             authentication_service,
@@ -192,7 +189,6 @@ impl HttpServer<Stopped> {
     pub async fn start(
         self,
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         authentication_service: Arc<AuthenticationService>,
@@ -208,7 +204,6 @@ impl HttpServer<Stopped> {
         let task = tokio::spawn(async move {
             let server = launcher.start(
                 core_config,
-                tracker,
                 announce_handler,
                 scrape_handler,
                 authentication_service,
@@ -315,7 +310,6 @@ mod tests {
         let started = stopped
             .start(
                 Arc::new(cfg.core.clone()),
-                app_container.tracker,
                 app_container.announce_handler,
                 app_container.scrape_handler,
                 app_container.authentication_service,

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -20,7 +20,6 @@ use crate::core::authentication::service::AuthenticationService;
 use crate::core::authentication::Key;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::Tracker;
 use crate::servers::http::v1::extractors::authentication_key::Extract as ExtractKey;
 use crate::servers::http::v1::extractors::client_ip_sources::Extract as ExtractClientIpSources;
 use crate::servers::http::v1::extractors::scrape_request::ExtractRequest;
@@ -33,7 +32,6 @@ use crate::servers::http::v1::services;
 pub async fn handle_without_key(
     State(state): State<(
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<AuthenticationService>,
         Arc<Option<Box<dyn Sender>>>,
@@ -48,7 +46,6 @@ pub async fn handle_without_key(
         &state.1,
         &state.2,
         &state.3,
-        &state.4,
         &scrape_request,
         &client_ip_sources,
         None,
@@ -65,7 +62,6 @@ pub async fn handle_without_key(
 pub async fn handle_with_key(
     State(state): State<(
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<AuthenticationService>,
         Arc<Option<Box<dyn Sender>>>,
@@ -81,7 +77,6 @@ pub async fn handle_with_key(
         &state.1,
         &state.2,
         &state.3,
-        &state.4,
         &scrape_request,
         &client_ip_sources,
         Some(key),
@@ -92,7 +87,6 @@ pub async fn handle_with_key(
 #[allow(clippy::too_many_arguments)]
 async fn handle(
     core_config: &Arc<Core>,
-    tracker: &Arc<Tracker>,
     scrape_handler: &Arc<ScrapeHandler>,
     authentication_service: &Arc<AuthenticationService>,
     stats_event_sender: &Arc<Option<Box<dyn Sender>>>,
@@ -102,7 +96,6 @@ async fn handle(
 ) -> Response {
     let scrape_data = match handle_scrape(
         core_config,
-        tracker,
         scrape_handler,
         authentication_service,
         stats_event_sender,
@@ -127,7 +120,6 @@ async fn handle(
 #[allow(clippy::too_many_arguments)]
 async fn handle_scrape(
     core_config: &Arc<Core>,
-    _tracker: &Arc<Tracker>,
     scrape_handler: &Arc<ScrapeHandler>,
     authentication_service: &Arc<AuthenticationService>,
     opt_stats_event_sender: &Arc<Option<Box<dyn Sender>>>,
@@ -185,13 +177,11 @@ mod tests {
     use crate::app_test::initialize_tracker_dependencies;
     use crate::core::authentication::service::AuthenticationService;
     use crate::core::scrape_handler::ScrapeHandler;
-    use crate::core::services::{initialize_tracker, statistics};
-    use crate::core::Tracker;
+    use crate::core::services::statistics;
 
     #[allow(clippy::type_complexity)]
     fn private_tracker() -> (
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<Option<Box<dyn crate::core::statistics::event::sender::Sender>>>,
         Arc<AuthenticationService>,
@@ -204,7 +194,7 @@ mod tests {
             whitelist_authorization,
             authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
@@ -214,27 +204,14 @@ mod tests {
 
         let core_config = Arc::new(config.core.clone());
 
-        let tracker = Arc::new(initialize_tracker(
-            &config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
-
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
-        (
-            core_config,
-            tracker,
-            scrape_handler,
-            stats_event_sender,
-            authentication_service,
-        )
+        (core_config, scrape_handler, stats_event_sender, authentication_service)
     }
 
     #[allow(clippy::type_complexity)]
     fn whitelisted_tracker() -> (
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<Option<Box<dyn crate::core::statistics::event::sender::Sender>>>,
         Arc<AuthenticationService>,
@@ -247,7 +224,7 @@ mod tests {
             whitelist_authorization,
             authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
@@ -257,27 +234,14 @@ mod tests {
 
         let core_config = Arc::new(config.core.clone());
 
-        let tracker = Arc::new(initialize_tracker(
-            &config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
-
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
-        (
-            core_config,
-            tracker,
-            scrape_handler,
-            stats_event_sender,
-            authentication_service,
-        )
+        (core_config, scrape_handler, stats_event_sender, authentication_service)
     }
 
     #[allow(clippy::type_complexity)]
     fn tracker_on_reverse_proxy() -> (
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<Option<Box<dyn crate::core::statistics::event::sender::Sender>>>,
         Arc<AuthenticationService>,
@@ -290,7 +254,7 @@ mod tests {
             whitelist_authorization,
             authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
@@ -300,27 +264,14 @@ mod tests {
 
         let core_config = Arc::new(config.core.clone());
 
-        let tracker = Arc::new(initialize_tracker(
-            &config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
-
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
-        (
-            core_config,
-            tracker,
-            scrape_handler,
-            stats_event_sender,
-            authentication_service,
-        )
+        (core_config, scrape_handler, stats_event_sender, authentication_service)
     }
 
     #[allow(clippy::type_complexity)]
     fn tracker_not_on_reverse_proxy() -> (
         Arc<Core>,
-        Arc<Tracker>,
         Arc<ScrapeHandler>,
         Arc<Option<Box<dyn crate::core::statistics::event::sender::Sender>>>,
         Arc<AuthenticationService>,
@@ -333,7 +284,7 @@ mod tests {
             whitelist_authorization,
             authentication_service,
             in_memory_torrent_repository,
-            db_torrent_repository,
+            _db_torrent_repository,
             _torrents_manager,
         ) = initialize_tracker_dependencies(&config);
 
@@ -343,21 +294,9 @@ mod tests {
 
         let core_config = Arc::new(config.core.clone());
 
-        let tracker = Arc::new(initialize_tracker(
-            &config,
-            &in_memory_torrent_repository,
-            &db_torrent_repository,
-        ));
-
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
-        (
-            core_config,
-            tracker,
-            scrape_handler,
-            stats_event_sender,
-            authentication_service,
-        )
+        (core_config, scrape_handler, stats_event_sender, authentication_service)
     }
 
     fn sample_scrape_request() -> Scrape {
@@ -391,14 +330,13 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_missing() {
-            let (core_config, tracker, scrape_handler, stats_event_sender, authentication_service) = private_tracker();
+            let (core_config, scrape_handler, stats_event_sender, authentication_service) = private_tracker();
 
             let scrape_request = sample_scrape_request();
             let maybe_key = None;
 
             let scrape_data = handle_scrape(
                 &core_config,
-                &tracker,
                 &scrape_handler,
                 &authentication_service,
                 &stats_event_sender,
@@ -416,7 +354,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_invalid() {
-            let (core_config, tracker, scrape_handler, stats_event_sender, authentication_service) = private_tracker();
+            let (core_config, scrape_handler, stats_event_sender, authentication_service) = private_tracker();
 
             let scrape_request = sample_scrape_request();
             let unregistered_key = authentication::Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
@@ -424,7 +362,6 @@ mod tests {
 
             let scrape_data = handle_scrape(
                 &core_config,
-                &tracker,
                 &scrape_handler,
                 &authentication_service,
                 &stats_event_sender,
@@ -450,13 +387,12 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_torrent_is_not_whitelisted() {
-            let (core_config, tracker, scrape_handler, stats_event_sender, authentication_service) = whitelisted_tracker();
+            let (core_config, scrape_handler, stats_event_sender, authentication_service) = whitelisted_tracker();
 
             let scrape_request = sample_scrape_request();
 
             let scrape_data = handle_scrape(
                 &core_config,
-                &tracker,
                 &scrape_handler,
                 &authentication_service,
                 &stats_event_sender,
@@ -483,7 +419,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_fail_when_the_right_most_x_forwarded_for_header_ip_is_not_available() {
-            let (core_config, tracker, scrape_handler, stats_event_sender, authentication_service) = tracker_on_reverse_proxy();
+            let (core_config, scrape_handler, stats_event_sender, authentication_service) = tracker_on_reverse_proxy();
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
@@ -492,7 +428,6 @@ mod tests {
 
             let response = handle_scrape(
                 &core_config,
-                &tracker,
                 &scrape_handler,
                 &authentication_service,
                 &stats_event_sender,
@@ -520,8 +455,7 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_fail_when_the_client_ip_from_the_connection_info_is_not_available() {
-            let (core_config, tracker, scrape_handler, stats_event_sender, authentication_service) =
-                tracker_not_on_reverse_proxy();
+            let (core_config, scrape_handler, stats_event_sender, authentication_service) = tracker_not_on_reverse_proxy();
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
@@ -530,7 +464,6 @@ mod tests {
 
             let response = handle_scrape(
                 &core_config,
-                &tracker,
                 &scrape_handler,
                 &authentication_service,
                 &stats_event_sender,

--- a/src/servers/http/v1/routes.rs
+++ b/src/servers/http/v1/routes.rs
@@ -26,7 +26,7 @@ use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::service::AuthenticationService;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{whitelist, Tracker};
+use crate::core::whitelist;
 use crate::servers::http::HTTP_TRACKER_LOG_TARGET;
 use crate::servers::logging::Latency;
 
@@ -37,7 +37,6 @@ use crate::servers::logging::Latency;
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::needless_pass_by_value)]
 #[instrument(skip(
-    tracker,
     announce_handler,
     scrape_handler,
     authentication_service,
@@ -47,7 +46,6 @@ use crate::servers::logging::Latency;
 ))]
 pub fn router(
     core_config: Arc<Core>,
-    tracker: Arc<Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
     authentication_service: Arc<AuthenticationService>,
@@ -63,7 +61,6 @@ pub fn router(
             "/announce",
             get(announce::handle_without_key).with_state((
                 core_config.clone(),
-                tracker.clone(),
                 announce_handler.clone(),
                 authentication_service.clone(),
                 whitelist_authorization.clone(),
@@ -74,7 +71,6 @@ pub fn router(
             "/announce/{key}",
             get(announce::handle_with_key).with_state((
                 core_config.clone(),
-                tracker.clone(),
                 announce_handler.clone(),
                 authentication_service.clone(),
                 whitelist_authorization.clone(),
@@ -86,7 +82,6 @@ pub fn router(
             "/scrape",
             get(scrape::handle_without_key).with_state((
                 core_config.clone(),
-                tracker.clone(),
                 scrape_handler.clone(),
                 authentication_service.clone(),
                 stats_event_sender.clone(),
@@ -96,7 +91,6 @@ pub fn router(
             "/scrape/{key}",
             get(scrape::handle_with_key).with_state((
                 core_config.clone(),
-                tracker.clone(),
                 scrape_handler.clone(),
                 authentication_service.clone(),
                 stats_event_sender.clone(),

--- a/src/servers/udp/mod.rs
+++ b/src/servers/udp/mod.rs
@@ -52,8 +52,7 @@
 //! is designed to be as simple as possible. It uses a single UDP port and
 //! supports only three types of requests: `Connect`, `Announce` and `Scrape`.
 //!
-//! Request are parsed from UDP packets using the [`aquatic_udp_protocol`](https://crates.io/crates/aquatic_udp_protocol)
-//! crate and then handled by the [`Tracker`](crate::core::Tracker) struct.
+//! Request are parsed from UDP packets using the [`aquatic_udp_protocol`](https://crates.io/crates/aquatic_udp_protocol).
 //! And then the response is also build using the [`aquatic_udp_protocol`](https://crates.io/crates/aquatic_udp_protocol)
 //! and converted to a UDP packet.
 //!

--- a/src/servers/udp/server/launcher.rs
+++ b/src/servers/udp/server/launcher.rs
@@ -17,7 +17,7 @@ use crate::bootstrap::jobs::Started;
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{statistics, whitelist, Tracker};
+use crate::core::{statistics, whitelist};
 use crate::servers::logging::STARTED_ON;
 use crate::servers::registar::ServiceHealthCheckJob;
 use crate::servers::signals::{shutdown_signal_with_message, Halted};
@@ -45,7 +45,6 @@ impl Launcher {
     /// It panics if the udp server is loaded when the tracker is private.
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip(
-        tracker,
         announce_handler,
         scrape_handler,
         whitelist_authorization,
@@ -57,7 +56,6 @@ impl Launcher {
     ))]
     pub async fn run_with_graceful_shutdown(
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -103,7 +101,6 @@ impl Launcher {
                 let () = Self::run_udp_server_main(
                     receiver,
                     core_config.clone(),
-                    tracker.clone(),
                     announce_handler.clone(),
                     scrape_handler.clone(),
                     whitelist_authorization.clone(),
@@ -151,7 +148,6 @@ impl Launcher {
     #[allow(clippy::too_many_arguments)]
     #[instrument(skip(
         receiver,
-        tracker,
         announce_handler,
         scrape_handler,
         whitelist_authorization,
@@ -161,7 +157,6 @@ impl Launcher {
     async fn run_udp_server_main(
         mut receiver: Receiver,
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -235,7 +230,6 @@ impl Launcher {
                 let processor = Processor::new(
                     receiver.socket.clone(),
                     core_config.clone(),
-                    tracker.clone(),
                     announce_handler.clone(),
                     scrape_handler.clone(),
                     whitelist_authorization.clone(),

--- a/src/servers/udp/server/mod.rs
+++ b/src/servers/udp/server/mod.rs
@@ -83,7 +83,6 @@ mod tests {
         let started = stopped
             .start(
                 Arc::new(cfg.core.clone()),
-                app_container.tracker,
                 app_container.announce_handler,
                 app_container.scrape_handler,
                 app_container.whitelist_authorization,
@@ -119,7 +118,6 @@ mod tests {
         let started = stopped
             .start(
                 Arc::new(cfg.core.clone()),
-                app_container.tracker,
                 app_container.announce_handler,
                 app_container.scrape_handler,
                 app_container.whitelist_authorization,

--- a/src/servers/udp/server/processor.rs
+++ b/src/servers/udp/server/processor.rs
@@ -15,14 +15,13 @@ use crate::core::announce_handler::AnnounceHandler;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
 use crate::core::statistics::event::UdpResponseKind;
-use crate::core::{statistics, whitelist, Tracker};
+use crate::core::{statistics, whitelist};
 use crate::servers::udp::handlers::CookieTimeValues;
 use crate::servers::udp::{handlers, RawRequest};
 
 pub struct Processor {
     socket: Arc<BoundSocket>,
     core_config: Arc<Core>,
-    tracker: Arc<Tracker>,
     announce_handler: Arc<AnnounceHandler>,
     scrape_handler: Arc<ScrapeHandler>,
     whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -35,7 +34,6 @@ impl Processor {
     pub fn new(
         socket: Arc<BoundSocket>,
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -45,7 +43,6 @@ impl Processor {
         Self {
             socket,
             core_config,
-            tracker,
             announce_handler,
             scrape_handler,
             whitelist_authorization,
@@ -63,7 +60,6 @@ impl Processor {
         let response = handlers::handle_packet(
             request,
             &self.core_config,
-            &self.tracker,
             &self.announce_handler,
             &self.scrape_handler,
             &self.whitelist_authorization,

--- a/src/servers/udp/server/spawner.rs
+++ b/src/servers/udp/server/spawner.rs
@@ -15,7 +15,7 @@ use crate::bootstrap::jobs::Started;
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{whitelist, Tracker};
+use crate::core::whitelist;
 use crate::servers::signals::Halted;
 
 #[derive(Constructor, Copy, Clone, Debug, Display)]
@@ -34,7 +34,6 @@ impl Spawner {
     pub fn spawn_launcher(
         &self,
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -49,7 +48,6 @@ impl Spawner {
         tokio::spawn(async move {
             Launcher::run_with_graceful_shutdown(
                 core_config,
-                tracker,
                 announce_handler,
                 scrape_handler,
                 whitelist_authorization,

--- a/src/servers/udp/server/states.rs
+++ b/src/servers/udp/server/states.rs
@@ -17,7 +17,7 @@ use crate::bootstrap::jobs::Started;
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::scrape_handler::ScrapeHandler;
 use crate::core::statistics::event::sender::Sender;
-use crate::core::{whitelist, Tracker};
+use crate::core::whitelist;
 use crate::servers::registar::{ServiceRegistration, ServiceRegistrationForm};
 use crate::servers::signals::Halted;
 use crate::servers::udp::server::launcher::Launcher;
@@ -68,11 +68,10 @@ impl Server<Stopped> {
     ///
     /// It panics if unable to receive the bound socket address from service.
     #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(self, tracker, announce_handler, scrape_handler, whitelist_authorization, opt_stats_event_sender, ban_service, form), err, ret(Display, level = Level::INFO))]
+    #[instrument(skip(self, announce_handler, scrape_handler, whitelist_authorization, opt_stats_event_sender, ban_service, form), err, ret(Display, level = Level::INFO))]
     pub async fn start(
         self,
         core_config: Arc<Core>,
-        tracker: Arc<Tracker>,
         announce_handler: Arc<AnnounceHandler>,
         scrape_handler: Arc<ScrapeHandler>,
         whitelist_authorization: Arc<whitelist::authorization::Authorization>,
@@ -89,7 +88,6 @@ impl Server<Stopped> {
         // May need to wrap in a task to about a tokio bug.
         let task = self.state.spawner.spawn_launcher(
             core_config,
-            tracker,
             announce_handler,
             scrape_handler,
             whitelist_authorization,

--- a/tests/servers/api/environment.rs
+++ b/tests/servers/api/environment.rs
@@ -15,7 +15,6 @@ use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
-use torrust_tracker_lib::core::Tracker;
 use torrust_tracker_lib::servers::apis::server::{ApiServer, Launcher, Running, Stopped};
 use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_lib::servers::udp::server::banning::BanService;
@@ -27,7 +26,6 @@ where
 {
     pub config: Arc<HttpApi>,
     pub database: Arc<Box<dyn Database>>,
-    pub tracker: Arc<Tracker>,
     pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub keys_handler: Arc<KeysHandler>,
     pub authentication_service: Arc<AuthenticationService>,
@@ -66,7 +64,6 @@ impl Environment<Stopped> {
         Self {
             config,
             database: app_container.database.clone(),
-            tracker: app_container.tracker.clone(),
             in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
             keys_handler: app_container.keys_handler.clone(),
             authentication_service: app_container.authentication_service.clone(),
@@ -85,7 +82,6 @@ impl Environment<Stopped> {
         Environment {
             config: self.config,
             database: self.database.clone(),
-            tracker: self.tracker.clone(),
             in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
             keys_handler: self.keys_handler.clone(),
             authentication_service: self.authentication_service.clone(),
@@ -121,7 +117,6 @@ impl Environment<Running> {
         Environment {
             config: self.config,
             database: self.database,
-            tracker: self.tracker,
             in_memory_torrent_repository: self.in_memory_torrent_repository,
             keys_handler: self.keys_handler,
             authentication_service: self.authentication_service,

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -13,8 +13,8 @@ use torrust_tracker_lib::core::scrape_handler::ScrapeHandler;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
+use torrust_tracker_lib::core::whitelist;
 use torrust_tracker_lib::core::whitelist::manager::WhiteListManager;
-use torrust_tracker_lib::core::{whitelist, Tracker};
 use torrust_tracker_lib::servers::http::server::{HttpServer, Launcher, Running, Stopped};
 use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_primitives::peer;
@@ -23,7 +23,6 @@ pub struct Environment<S> {
     pub core_config: Arc<Core>,
     pub http_tracker_config: Arc<HttpTracker>,
     pub database: Arc<Box<dyn Database>>,
-    pub tracker: Arc<Tracker>,
     pub announce_handler: Arc<AnnounceHandler>,
     pub scrape_handler: Arc<ScrapeHandler>,
     pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
@@ -68,7 +67,6 @@ impl Environment<Stopped> {
             http_tracker_config: config,
             core_config: Arc::new(configuration.core.clone()),
             database: app_container.database.clone(),
-            tracker: app_container.tracker.clone(),
             announce_handler: app_container.announce_handler.clone(),
             scrape_handler: app_container.scrape_handler.clone(),
             in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
@@ -89,7 +87,6 @@ impl Environment<Stopped> {
             http_tracker_config: self.http_tracker_config,
             core_config: self.core_config.clone(),
             database: self.database.clone(),
-            tracker: self.tracker.clone(),
             announce_handler: self.announce_handler.clone(),
             scrape_handler: self.scrape_handler.clone(),
             in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
@@ -104,7 +101,6 @@ impl Environment<Stopped> {
                 .server
                 .start(
                     self.core_config,
-                    self.tracker,
                     self.announce_handler,
                     self.scrape_handler,
                     self.authentication_service,
@@ -128,7 +124,6 @@ impl Environment<Running> {
             http_tracker_config: self.http_tracker_config,
             core_config: self.core_config,
             database: self.database,
-            tracker: self.tracker,
             announce_handler: self.announce_handler,
             scrape_handler: self.scrape_handler,
             in_memory_torrent_repository: self.in_memory_torrent_repository,

--- a/tests/servers/udp/environment.rs
+++ b/tests/servers/udp/environment.rs
@@ -11,7 +11,7 @@ use torrust_tracker_lib::core::scrape_handler::ScrapeHandler;
 use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
-use torrust_tracker_lib::core::{whitelist, Tracker};
+use torrust_tracker_lib::core::whitelist;
 use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_lib::servers::udp::server::banning::BanService;
 use torrust_tracker_lib::servers::udp::server::spawner::Spawner;
@@ -26,7 +26,6 @@ where
     pub core_config: Arc<Core>,
     pub config: Arc<UdpTracker>,
     pub database: Arc<Box<dyn Database>>,
-    pub tracker: Arc<Tracker>,
     pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub announce_handler: Arc<AnnounceHandler>,
     pub scrape_handler: Arc<ScrapeHandler>,
@@ -68,7 +67,6 @@ impl Environment<Stopped> {
             core_config: Arc::new(configuration.core.clone()),
             config,
             database: app_container.database.clone(),
-            tracker: app_container.tracker.clone(),
             in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
             announce_handler: app_container.announce_handler.clone(),
             scrape_handler: app_container.scrape_handler.clone(),
@@ -88,7 +86,6 @@ impl Environment<Stopped> {
             core_config: self.core_config.clone(),
             config: self.config,
             database: self.database.clone(),
-            tracker: self.tracker.clone(),
             in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
             announce_handler: self.announce_handler.clone(),
             scrape_handler: self.scrape_handler.clone(),
@@ -101,7 +98,6 @@ impl Environment<Stopped> {
                 .server
                 .start(
                     self.core_config,
-                    self.tracker,
                     self.announce_handler,
                     self.scrape_handler,
                     self.whitelist_authorization,
@@ -133,7 +129,6 @@ impl Environment<Running> {
             core_config: self.core_config,
             config: self.config,
             database: self.database,
-            tracker: self.tracker,
             in_memory_torrent_repository: self.in_memory_torrent_repository,
             announce_handler: self.announce_handler,
             scrape_handler: self.scrape_handler,


### PR DESCRIPTION
Overhaul core Tracker: remove deprecated `core::Tracker`.

This is a missing commit in [this PR](https://github.com/torrust/torrust-tracker/pull/1210/commits). I forgot to push the commit before merging that PR.