### PR TITLE
Overhaul core Tracker: create dependency containers for UDP tracker, HTTP tracker and Tracker API

### DIFF
--- a/console/tracker-client/src/console/clients/checker/checks/http.rs
+++ b/console/tracker-client/src/console/clients/checker/checks/http.rs
@@ -61,7 +61,7 @@ pub async fn run(http_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Check
 }
 
 async fn check_http_announce(url: &Url, timeout: Duration) -> Result<Announce, Error> {
-    let info_hash_str = "9c38422213e30bff212b30c360d26f9a02136422".to_string(); // # DevSkim: ignore DS173237
+    let info_hash_str = "9c38422213e30bff212b30c360d26f9a02136422".to_string(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&info_hash_str).expect("a valid info-hash is required");
 
     let client = Client::new(url.clone(), timeout).map_err(|err| Error::HttpClientError { err })?;
@@ -86,7 +86,7 @@ async fn check_http_announce(url: &Url, timeout: Duration) -> Result<Announce, E
 }
 
 async fn check_http_scrape(url: &Url, timeout: Duration) -> Result<scrape::Response, Error> {
-    let info_hashes: Vec<String> = vec!["9c38422213e30bff212b30c360d26f9a02136422".to_string()]; // # DevSkim: ignore DS173237
+    let info_hashes: Vec<String> = vec!["9c38422213e30bff212b30c360d26f9a02136422".to_string()]; // DevSkim: ignore DS173237
     let query = requests::scrape::Query::try_from(info_hashes).expect("a valid array of info-hashes is required");
 
     let client = Client::new(url.clone(), timeout).map_err(|err| Error::HttpClientError { err })?;

--- a/console/tracker-client/src/console/clients/checker/checks/udp.rs
+++ b/console/tracker-client/src/console/clients/checker/checks/udp.rs
@@ -29,7 +29,7 @@ pub async fn run(udp_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Checks
 
     tracing::debug!("UDP trackers ...");
 
-    let info_hash = aquatic_udp_protocol::InfoHash(hex!("9c38422213e30bff212b30c360d26f9a02136422")); // # DevSkim: ignore DS173237
+    let info_hash = aquatic_udp_protocol::InfoHash(hex!("9c38422213e30bff212b30c360d26f9a02136422")); // DevSkim: ignore DS173237
 
     for remote_url in udp_trackers {
         let remote_addr = resolve_socket_addr(&remote_url);

--- a/packages/tracker-client/src/http/client/requests/announce.rs
+++ b/packages/tracker-client/src/http/client/requests/announce.rs
@@ -95,7 +95,7 @@ impl QueryBuilder {
     #[must_use]
     pub fn with_default_values() -> QueryBuilder {
         let default_announce_query = Query {
-            info_hash: InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap().0, // # DevSkim: ignore DS173237
+            info_hash: InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap().0, // DevSkim: ignore DS173237
             peer_addr: IpAddr::V4(Ipv4Addr::new(192, 168, 1, 88)),
             downloaded: 0,
             uploaded: 0,

--- a/packages/tracker-client/src/http/client/requests/scrape.rs
+++ b/packages/tracker-client/src/http/client/requests/scrape.rs
@@ -90,7 +90,7 @@ pub struct QueryBuilder {
 impl Default for QueryBuilder {
     fn default() -> Self {
         let default_scrape_query = Query {
-            info_hash: [InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap().0].to_vec(), // # DevSkim: ignore DS173237
+            info_hash: [InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap().0].to_vec(), // DevSkim: ignore DS173237
         };
         Self {
             scrape_query: default_scrape_query,

--- a/src/console/profiling.rs
+++ b/src/console/profiling.rs
@@ -157,6 +157,7 @@
 //! kcachegrind callgrind.out
 //! ```
 use std::env;
+use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::time::sleep;
@@ -180,6 +181,8 @@ pub async fn run() {
     };
 
     let (config, app_container) = bootstrap::app::setup();
+
+    let app_container = Arc::new(app_container);
 
     let jobs = app::start(&config, &app_container).await;
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use torrust_tracker_configuration::{Core, UdpTracker};
+use torrust_tracker_configuration::{Core, HttpTracker, UdpTracker};
 
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::handler::KeysHandler;
@@ -55,6 +55,31 @@ impl UdpTrackerContainer {
             whitelist_authorization: app_container.whitelist_authorization.clone(),
             stats_event_sender: app_container.stats_event_sender.clone(),
             ban_service: app_container.ban_service.clone(),
+        }
+    }
+}
+
+pub struct HttpTrackerContainer {
+    pub core_config: Arc<Core>,
+    pub http_tracker_config: Arc<HttpTracker>,
+    pub announce_handler: Arc<AnnounceHandler>,
+    pub scrape_handler: Arc<ScrapeHandler>,
+    pub whitelist_authorization: Arc<whitelist::authorization::WhitelistAuthorization>,
+    pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
+    pub authentication_service: Arc<AuthenticationService>,
+}
+
+impl HttpTrackerContainer {
+    #[must_use]
+    pub fn from_app_container(http_tracker_config: &Arc<HttpTracker>, app_container: &Arc<AppContainer>) -> Self {
+        Self {
+            http_tracker_config: http_tracker_config.clone(),
+            core_config: app_container.core_config.clone(),
+            announce_handler: app_container.announce_handler.clone(),
+            scrape_handler: app_container.scrape_handler.clone(),
+            whitelist_authorization: app_container.whitelist_authorization.clone(),
+            stats_event_sender: app_container.stats_event_sender.clone(),
+            authentication_service: app_container.authentication_service.clone(),
         }
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
+use torrust_tracker_configuration::{Core, UdpTracker};
 
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::handler::KeysHandler;
@@ -17,6 +18,7 @@ use crate::core::whitelist::manager::WhitelistManager;
 use crate::servers::udp::server::banning::BanService;
 
 pub struct AppContainer {
+    pub core_config: Arc<Core>,
     pub database: Arc<Box<dyn Database>>,
     pub announce_handler: Arc<AnnounceHandler>,
     pub scrape_handler: Arc<ScrapeHandler>,
@@ -30,4 +32,29 @@ pub struct AppContainer {
     pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub db_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
     pub torrents_manager: Arc<TorrentsManager>,
+}
+
+pub struct UdpTrackerContainer {
+    pub core_config: Arc<Core>,
+    pub udp_tracker_config: Arc<UdpTracker>,
+    pub announce_handler: Arc<AnnounceHandler>,
+    pub scrape_handler: Arc<ScrapeHandler>,
+    pub whitelist_authorization: Arc<whitelist::authorization::WhitelistAuthorization>,
+    pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
+    pub ban_service: Arc<RwLock<BanService>>,
+}
+
+impl UdpTrackerContainer {
+    #[must_use]
+    pub fn from_app_container(udp_tracker_config: &Arc<UdpTracker>, app_container: &Arc<AppContainer>) -> Self {
+        Self {
+            udp_tracker_config: udp_tracker_config.clone(),
+            core_config: app_container.core_config.clone(),
+            announce_handler: app_container.announce_handler.clone(),
+            scrape_handler: app_container.scrape_handler.clone(),
+            whitelist_authorization: app_container.whitelist_authorization.clone(),
+            stats_event_sender: app_container.stats_event_sender.clone(),
+            ban_service: app_container.ban_service.clone(),
+        }
+    }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
-use torrust_tracker_configuration::{Core, HttpTracker, UdpTracker};
+use torrust_tracker_configuration::{Core, HttpApi, HttpTracker, UdpTracker};
 
 use crate::core::announce_handler::AnnounceHandler;
 use crate::core::authentication::handler::KeysHandler;
@@ -80,6 +80,33 @@ impl HttpTrackerContainer {
             whitelist_authorization: app_container.whitelist_authorization.clone(),
             stats_event_sender: app_container.stats_event_sender.clone(),
             authentication_service: app_container.authentication_service.clone(),
+        }
+    }
+}
+
+pub struct HttpApiContainer {
+    pub core_config: Arc<Core>,
+    pub http_api_config: Arc<HttpApi>,
+    pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
+    pub keys_handler: Arc<KeysHandler>,
+    pub whitelist_manager: Arc<WhitelistManager>,
+    pub ban_service: Arc<RwLock<BanService>>,
+    pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
+    pub stats_repository: Arc<Repository>,
+}
+
+impl HttpApiContainer {
+    #[must_use]
+    pub fn from_app_container(http_api_config: &Arc<HttpApi>, app_container: &Arc<AppContainer>) -> Self {
+        Self {
+            http_api_config: http_api_config.clone(),
+            core_config: app_container.core_config.clone(),
+            in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
+            keys_handler: app_container.keys_handler.clone(),
+            whitelist_manager: app_container.whitelist_manager.clone(),
+            ban_service: app_container.ban_service.clone(),
+            stats_event_sender: app_container.stats_event_sender.clone(),
+            stats_repository: app_container.stats_repository.clone(),
         }
     }
 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -498,7 +498,7 @@ mod tests {
                 async fn it_should_return_the_swarm_metadata_for_the_requested_file_if_the_tracker_has_that_torrent() {
                     let (announce_handler, scrape_handler) = initialize_handlers_for_public_tracker();
 
-                    let info_hash = "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(); // # DevSkim: ignore DS173237
+                    let info_hash = "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(); // DevSkim: ignore DS173237
 
                     // Announce a "complete" peer for the torrent
                     let mut complete_peer = complete_peer();
@@ -553,7 +553,7 @@ mod tests {
                 async fn it_should_return_the_zeroed_swarm_metadata_for_the_requested_file_if_it_is_not_whitelisted() {
                     let (announce_handler, scrape_handler) = initialize_handlers_for_listed_tracker();
 
-                    let info_hash = "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(); // # DevSkim: ignore DS173237
+                    let info_hash = "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(); // DevSkim: ignore DS173237
 
                     let mut peer = incomplete_peer();
                     announce_handler.announce(&info_hash, &mut peer, &peer_ip(), &PeersWanted::All);

--- a/src/core/scrape_handler.rs
+++ b/src/core/scrape_handler.rs
@@ -75,7 +75,7 @@ mod tests {
     async fn it_should_return_a_zeroed_swarm_metadata_for_the_requested_file_if_the_tracker_does_not_have_that_torrent() {
         let scrape_handler = scrape_handler();
 
-        let info_hashes = vec!["3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap()]; // # DevSkim: ignore DS173237
+        let info_hashes = vec!["3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap()]; // DevSkim: ignore DS173237
 
         let scrape_data = scrape_handler.scrape(&info_hashes).await;
 
@@ -91,8 +91,8 @@ mod tests {
         let scrape_handler = scrape_handler();
 
         let info_hashes = vec![
-            "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(), // # DevSkim: ignore DS173237
-            "99c82bb73505a3c0b453f9fa0e881d6e5a32a0c1".parse::<InfoHash>().unwrap(), // # DevSkim: ignore DS173237
+            "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(), // DevSkim: ignore DS173237
+            "99c82bb73505a3c0b453f9fa0e881d6e5a32a0c1".parse::<InfoHash>().unwrap(), // DevSkim: ignore DS173237
         ];
 
         let scrape_data = scrape_handler.scrape(&info_hashes).await;

--- a/src/core/services/torrent.rs
+++ b/src/core/services/torrent.rs
@@ -145,7 +145,7 @@ mod tests {
 
             let torrent_info = get_torrent_info(
                 in_memory_torrent_repository.clone(),
-                &InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap(),
+                &InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap(), // DevSkim: ignore DS173237
             )
             .await;
 
@@ -156,7 +156,7 @@ mod tests {
         async fn should_return_the_torrent_info_if_the_tracker_has_the_torrent() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+            let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash = InfoHash::from_str(&hash).unwrap();
             let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
 
@@ -201,7 +201,7 @@ mod tests {
         async fn should_return_a_summarized_info_for_all_torrents() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+            let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash = InfoHash::from_str(&hash).unwrap();
 
             let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
@@ -223,7 +223,7 @@ mod tests {
         async fn should_allow_limiting_the_number_of_torrents_in_the_result() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
 
             let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
@@ -244,7 +244,7 @@ mod tests {
         async fn should_allow_using_pagination_in_the_result() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
 
             let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
@@ -274,7 +274,7 @@ mod tests {
         async fn should_return_torrents_ordered_by_info_hash() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+            let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
             let () = in_memory_torrent_repository.upsert_peer(&info_hash1, &sample_peer());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+
 use torrust_tracker_lib::{app, bootstrap};
 
 #[tokio::main]
 async fn main() {
     let (config, app_container) = bootstrap::app::setup();
+
+    let app_container = Arc::new(app_container);
 
     let jobs = app::start(&config, &app_container).await;
 

--- a/src/servers/apis/v1/context/auth_key/routes.rs
+++ b/src/servers/apis/v1/context/auth_key/routes.rs
@@ -15,7 +15,7 @@ use super::handlers::{add_auth_key_handler, delete_auth_key_handler, generate_au
 use crate::core::authentication::handler::KeysHandler;
 
 /// It adds the routes to the router for the [`auth_key`](crate::servers::apis::v1::context::auth_key) API context.
-pub fn add(prefix: &str, router: Router, keys_handler: Arc<KeysHandler>) -> Router {
+pub fn add(prefix: &str, router: Router, keys_handler: &Arc<KeysHandler>) -> Router {
     // Keys
     router
         .route(
@@ -38,5 +38,8 @@ pub fn add(prefix: &str, router: Router, keys_handler: Arc<KeysHandler>) -> Rout
             &format!("{prefix}/keys/reload"),
             get(reload_keys_handler).with_state(keys_handler.clone()),
         )
-        .route(&format!("{prefix}/keys"), post(add_auth_key_handler).with_state(keys_handler))
+        .route(
+            &format!("{prefix}/keys"),
+            post(add_auth_key_handler).with_state(keys_handler.clone()),
+        )
 }

--- a/src/servers/apis/v1/context/stats/routes.rs
+++ b/src/servers/apis/v1/context/stats/routes.rs
@@ -7,25 +7,18 @@ use std::sync::Arc;
 
 use axum::routing::get;
 use axum::Router;
-use tokio::sync::RwLock;
 
 use super::handlers::get_stats_handler;
-use crate::core::statistics::event::sender::Sender;
-use crate::core::statistics::repository::Repository;
-use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
-use crate::servers::udp::server::banning::BanService;
+use crate::container::HttpApiContainer;
 
 /// It adds the routes to the router for the [`stats`](crate::servers::apis::v1::context::stats) API context.
-pub fn add(
-    prefix: &str,
-    router: Router,
-    in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
-    ban_service: Arc<RwLock<BanService>>,
-    _stats_event_sender: Arc<Option<Box<dyn Sender>>>,
-    stats_repository: Arc<Repository>,
-) -> Router {
+pub fn add(prefix: &str, router: Router, http_api_container: &Arc<HttpApiContainer>) -> Router {
     router.route(
         &format!("{prefix}/stats"),
-        get(get_stats_handler).with_state((in_memory_torrent_repository, ban_service, stats_repository)),
+        get(get_stats_handler).with_state((
+            http_api_container.in_memory_torrent_repository.clone(),
+            http_api_container.ban_service.clone(),
+            http_api_container.stats_repository.clone(),
+        )),
     )
 }

--- a/src/servers/apis/v1/context/torrent/resources/torrent.rs
+++ b/src/servers/apis/v1/context/torrent/resources/torrent.rs
@@ -122,14 +122,14 @@ mod tests {
     fn torrent_resource_should_be_converted_from_torrent_info() {
         assert_eq!(
             Torrent::from(Info {
-                info_hash: InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(),
+                info_hash: InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(), // DevSkim: ignore DS173237
                 seeders: 1,
                 completed: 2,
                 leechers: 3,
                 peers: Some(vec![sample_peer()]),
             }),
             Torrent {
-                info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(),
+                info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(), // DevSkim: ignore DS173237
                 seeders: 1,
                 completed: 2,
                 leechers: 3,
@@ -142,13 +142,13 @@ mod tests {
     fn torrent_resource_list_item_should_be_converted_from_the_basic_torrent_info() {
         assert_eq!(
             ListItem::from(BasicInfo {
-                info_hash: InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(),
+                info_hash: InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(), // DevSkim: ignore DS173237
                 seeders: 1,
                 completed: 2,
                 leechers: 3,
             }),
             ListItem {
-                info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(),
+                info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(), // DevSkim: ignore DS173237
                 seeders: 1,
                 completed: 2,
                 leechers: 3,

--- a/src/servers/apis/v1/context/torrent/routes.rs
+++ b/src/servers/apis/v1/context/torrent/routes.rs
@@ -13,7 +13,7 @@ use super::handlers::{get_torrent_handler, get_torrents_handler};
 use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
 
 /// It adds the routes to the router for the [`torrent`](crate::servers::apis::v1::context::torrent) API context.
-pub fn add(prefix: &str, router: Router, in_memory_torrent_repository: Arc<InMemoryTorrentRepository>) -> Router {
+pub fn add(prefix: &str, router: Router, in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>) -> Router {
     // Torrents
     router
         .route(
@@ -22,6 +22,6 @@ pub fn add(prefix: &str, router: Router, in_memory_torrent_repository: Arc<InMem
         )
         .route(
             &format!("{prefix}/torrents"),
-            get(get_torrents_handler).with_state(in_memory_torrent_repository),
+            get(get_torrents_handler).with_state(in_memory_torrent_repository.clone()),
         )
 }

--- a/src/servers/apis/v1/routes.rs
+++ b/src/servers/apis/v1/routes.rs
@@ -2,40 +2,17 @@
 use std::sync::Arc;
 
 use axum::Router;
-use tokio::sync::RwLock;
 
 use super::context::{auth_key, stats, torrent, whitelist};
-use crate::core::authentication::handler::KeysHandler;
-use crate::core::statistics::event::sender::Sender;
-use crate::core::statistics::repository::Repository;
-use crate::core::torrent::repository::in_memory::InMemoryTorrentRepository;
-use crate::core::whitelist::manager::WhitelistManager;
-use crate::servers::udp::server::banning::BanService;
+use crate::container::HttpApiContainer;
 
 /// Add the routes for the v1 API.
-#[allow(clippy::too_many_arguments)]
-pub fn add(
-    prefix: &str,
-    router: Router,
-    in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>,
-    keys_handler: &Arc<KeysHandler>,
-    whitelist_manager: &Arc<WhitelistManager>,
-    ban_service: Arc<RwLock<BanService>>,
-    stats_event_sender: Arc<Option<Box<dyn Sender>>>,
-    stats_repository: Arc<Repository>,
-) -> Router {
+pub fn add(prefix: &str, router: Router, http_api_container: &Arc<HttpApiContainer>) -> Router {
     let v1_prefix = format!("{prefix}/v1");
 
-    let router = auth_key::routes::add(&v1_prefix, router, keys_handler.clone());
-    let router = stats::routes::add(
-        &v1_prefix,
-        router,
-        in_memory_torrent_repository.clone(),
-        ban_service,
-        stats_event_sender,
-        stats_repository,
-    );
-    let router = whitelist::routes::add(&v1_prefix, router, whitelist_manager);
+    let router = auth_key::routes::add(&v1_prefix, router, &http_api_container.keys_handler.clone());
+    let router = stats::routes::add(&v1_prefix, router, http_api_container);
+    let router = whitelist::routes::add(&v1_prefix, router, &http_api_container.whitelist_manager);
 
-    torrent::routes::add(&v1_prefix, router, in_memory_torrent_repository.clone())
+    torrent::routes::add(&v1_prefix, router, &http_api_container.in_memory_torrent_repository.clone())
 }

--- a/src/servers/udp/server/processor.rs
+++ b/src/servers/udp/server/processor.rs
@@ -21,7 +21,6 @@ pub struct Processor {
 }
 
 impl Processor {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(socket: Arc<BoundSocket>, udp_tracker_container: Arc<UdpTrackerContainer>, cookie_lifetime: f64) -> Self {
         Self {
             socket,

--- a/src/servers/udp/server/states.rs
+++ b/src/servers/udp/server/states.rs
@@ -5,19 +5,13 @@ use std::time::Duration;
 
 use derive_more::derive::Display;
 use derive_more::Constructor;
-use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
-use torrust_tracker_configuration::Core;
 use tracing::{instrument, Level};
 
-use super::banning::BanService;
 use super::spawner::Spawner;
 use super::{Server, UdpError};
 use crate::bootstrap::jobs::Started;
-use crate::core::announce_handler::AnnounceHandler;
-use crate::core::scrape_handler::ScrapeHandler;
-use crate::core::statistics::event::sender::Sender;
-use crate::core::whitelist;
+use crate::container::UdpTrackerContainer;
 use crate::servers::registar::{ServiceRegistration, ServiceRegistrationForm};
 use crate::servers::signals::Halted;
 use crate::servers::udp::server::launcher::Launcher;
@@ -67,16 +61,10 @@ impl Server<Stopped> {
     /// # Panics
     ///
     /// It panics if unable to receive the bound socket address from service.
-    #[allow(clippy::too_many_arguments)]
-    #[instrument(skip(self, announce_handler, scrape_handler, whitelist_authorization, opt_stats_event_sender, ban_service, form), err, ret(Display, level = Level::INFO))]
+    #[instrument(skip(self, udp_tracker_container, form), err, ret(Display, level = Level::INFO))]
     pub async fn start(
         self,
-        core_config: Arc<Core>,
-        announce_handler: Arc<AnnounceHandler>,
-        scrape_handler: Arc<ScrapeHandler>,
-        whitelist_authorization: Arc<whitelist::authorization::WhitelistAuthorization>,
-        opt_stats_event_sender: Arc<Option<Box<dyn Sender>>>,
-        ban_service: Arc<RwLock<BanService>>,
+        udp_tracker_container: Arc<UdpTrackerContainer>,
         form: ServiceRegistrationForm,
         cookie_lifetime: Duration,
     ) -> Result<Server<Running>, std::io::Error> {
@@ -86,17 +74,10 @@ impl Server<Stopped> {
         assert!(!tx_halt.is_closed(), "Halt channel for UDP tracker should be open");
 
         // May need to wrap in a task to about a tokio bug.
-        let task = self.state.spawner.spawn_launcher(
-            core_config,
-            announce_handler,
-            scrape_handler,
-            whitelist_authorization,
-            opt_stats_event_sender,
-            ban_service,
-            cookie_lifetime,
-            tx_start,
-            rx_halt,
-        );
+        let task = self
+            .state
+            .spawner
+            .spawn_launcher(udp_tracker_container, cookie_lifetime, tx_start, rx_halt);
 
         let local_addr = rx_start.await.expect("it should be able to start the service").address;
 

--- a/tests/servers/api/v1/contract/context/auth_key.rs
+++ b/tests/servers/api/v1/contract/context/auth_key.rs
@@ -158,6 +158,7 @@ async fn should_allow_deleting_an_auth_key() {
 
     let seconds_valid = 60;
     let auth_key = env
+        .http_api_container
         .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
@@ -292,6 +293,7 @@ async fn should_fail_when_the_auth_key_cannot_be_deleted() {
 
     let seconds_valid = 60;
     let auth_key = env
+        .http_api_container
         .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
@@ -325,6 +327,7 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
 
     // Generate new auth key
     let auth_key = env
+        .http_api_container
         .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
@@ -345,6 +348,7 @@ async fn should_not_allow_deleting_an_auth_key_for_unauthenticated_users() {
 
     // Generate new auth key
     let auth_key = env
+        .http_api_container
         .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
@@ -373,7 +377,8 @@ async fn should_allow_reloading_keys() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let seconds_valid = 60;
-    env.keys_handler
+    env.http_api_container
+        .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
@@ -398,7 +403,8 @@ async fn should_fail_when_keys_cannot_be_reloaded() {
     let request_id = Uuid::new_v4();
     let seconds_valid = 60;
 
-    env.keys_handler
+    env.http_api_container
+        .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();
@@ -426,7 +432,8 @@ async fn should_not_allow_reloading_keys_for_unauthenticated_users() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let seconds_valid = 60;
-    env.keys_handler
+    env.http_api_container
+        .keys_handler
         .generate_auth_key(Some(Duration::from_secs(seconds_valid)))
         .await
         .unwrap();

--- a/tests/servers/api/v1/contract/context/stats.rs
+++ b/tests/servers/api/v1/contract/context/stats.rs
@@ -19,7 +19,7 @@ async fn should_allow_getting_tracker_statistics() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     env.add_torrent_peer(
-        &InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(),
+        &InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(), // DevSkim: ignore DS173237
         &PeerBuilder::default().into(),
     );
 

--- a/tests/servers/api/v1/contract/context/torrent.rs
+++ b/tests/servers/api/v1/contract/context/torrent.rs
@@ -26,7 +26,7 @@ async fn should_allow_getting_all_torrents() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
+    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
 
     env.add_torrent_peer(&info_hash, &PeerBuilder::default().into());
 
@@ -39,7 +39,7 @@ async fn should_allow_getting_all_torrents() {
     assert_torrent_list(
         response,
         vec![torrent::ListItem {
-            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(),
+            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(), // DevSkim: ignore DS173237
             seeders: 1,
             completed: 0,
             leechers: 0,
@@ -57,8 +57,8 @@ async fn should_allow_limiting_the_torrents_in_the_result() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     // torrents are ordered alphabetically by infohashes
-    let info_hash_1 = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
-    let info_hash_2 = InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap();
+    let info_hash_1 = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
+    let info_hash_2 = InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap(); // DevSkim: ignore DS173237
 
     env.add_torrent_peer(&info_hash_1, &PeerBuilder::default().into());
     env.add_torrent_peer(&info_hash_2, &PeerBuilder::default().into());
@@ -75,7 +75,7 @@ async fn should_allow_limiting_the_torrents_in_the_result() {
     assert_torrent_list(
         response,
         vec![torrent::ListItem {
-            info_hash: "0b3aea4adc213ce32295be85d3883a63bca25446".to_string(),
+            info_hash: "0b3aea4adc213ce32295be85d3883a63bca25446".to_string(), // DevSkim: ignore DS173237
             seeders: 1,
             completed: 0,
             leechers: 0,
@@ -93,8 +93,8 @@ async fn should_allow_the_torrents_result_pagination() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     // torrents are ordered alphabetically by infohashes
-    let info_hash_1 = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
-    let info_hash_2 = InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap();
+    let info_hash_1 = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
+    let info_hash_2 = InfoHash::from_str("0b3aea4adc213ce32295be85d3883a63bca25446").unwrap(); // DevSkim: ignore DS173237
 
     env.add_torrent_peer(&info_hash_1, &PeerBuilder::default().into());
     env.add_torrent_peer(&info_hash_2, &PeerBuilder::default().into());
@@ -111,7 +111,7 @@ async fn should_allow_the_torrents_result_pagination() {
     assert_torrent_list(
         response,
         vec![torrent::ListItem {
-            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(),
+            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(), // DevSkim: ignore DS173237
             seeders: 1,
             completed: 0,
             leechers: 0,
@@ -296,7 +296,7 @@ async fn should_allow_getting_a_torrent_info() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
+    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
 
     let peer = PeerBuilder::default().into();
 
@@ -311,7 +311,7 @@ async fn should_allow_getting_a_torrent_info() {
     assert_torrent_info(
         response,
         Torrent {
-            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(),
+            info_hash: "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_string(), // DevSkim: ignore DS173237
             seeders: 1,
             completed: 0,
             leechers: 0,
@@ -330,7 +330,7 @@ async fn should_fail_while_getting_a_torrent_info_when_the_torrent_does_not_exis
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let request_id = Uuid::new_v4();
-    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
+    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
 
     let response = Client::new(env.get_connection_info())
         .get_torrent(&info_hash.to_string(), Some(headers_with_request_id(request_id)))
@@ -376,7 +376,7 @@ async fn should_not_allow_getting_a_torrent_info_for_unauthenticated_users() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap();
+    let info_hash = InfoHash::from_str("9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d").unwrap(); // DevSkim: ignore DS173237
 
     env.add_torrent_peer(&info_hash, &PeerBuilder::default().into());
 

--- a/tests/servers/api/v1/contract/context/whitelist.rs
+++ b/tests/servers/api/v1/contract/context/whitelist.rs
@@ -23,7 +23,7 @@ async fn should_allow_whitelisting_a_torrent() {
     let env = Started::new(&configuration::ephemeral().into()).await;
 
     let request_id = Uuid::new_v4();
-    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
 
     let response = Client::new(env.get_connection_info())
         .whitelist_a_torrent(&info_hash, Some(headers_with_request_id(request_id)))
@@ -46,7 +46,7 @@ async fn should_allow_whitelisting_a_torrent_that_has_been_already_whitelisted()
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
 
     let api_client = Client::new(env.get_connection_info());
 
@@ -73,7 +73,7 @@ async fn should_not_allow_whitelisting_a_torrent_for_unauthenticated_users() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
 
     let request_id = Uuid::new_v4();
 
@@ -110,7 +110,7 @@ async fn should_fail_when_the_torrent_cannot_be_whitelisted() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let info_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
 
     force_database_error(&env.database);
 
@@ -165,7 +165,7 @@ async fn should_allow_removing_a_torrent_from_the_whitelist() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&hash).unwrap();
 
     env.http_api_container
@@ -197,7 +197,7 @@ async fn should_not_fail_trying_to_remove_a_non_whitelisted_torrent_from_the_whi
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let non_whitelisted_torrent_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let non_whitelisted_torrent_hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
 
     let request_id = Uuid::new_v4();
 
@@ -245,7 +245,7 @@ async fn should_fail_when_the_torrent_cannot_be_removed_from_the_whitelist() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&hash).unwrap();
     env.http_api_container
         .whitelist_manager
@@ -277,7 +277,7 @@ async fn should_not_allow_removing_a_torrent_from_the_whitelist_for_unauthentica
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&hash).unwrap();
 
     env.http_api_container
@@ -327,7 +327,7 @@ async fn should_allow_reload_the_whitelist_from_the_database() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&hash).unwrap();
     env.http_api_container
         .whitelist_manager
@@ -362,7 +362,7 @@ async fn should_fail_when_the_whitelist_cannot_be_reloaded_from_the_database() {
 
     let env = Started::new(&configuration::ephemeral().into()).await;
 
-    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
+    let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
     let info_hash = InfoHash::from_str(&hash).unwrap();
     env.http_api_container
         .whitelist_manager

--- a/tests/servers/api/v1/contract/context/whitelist.rs
+++ b/tests/servers/api/v1/contract/context/whitelist.rs
@@ -31,7 +31,8 @@ async fn should_allow_whitelisting_a_torrent() {
 
     assert_ok(response).await;
     assert!(
-        env.whitelist_manager
+        env.http_api_container
+            .whitelist_manager
             .is_info_hash_whitelisted(&InfoHash::from_str(&info_hash).unwrap())
             .await
     );
@@ -167,7 +168,11 @@ async fn should_allow_removing_a_torrent_from_the_whitelist() {
     let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
     let info_hash = InfoHash::from_str(&hash).unwrap();
 
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     let request_id = Uuid::new_v4();
 
@@ -176,7 +181,12 @@ async fn should_allow_removing_a_torrent_from_the_whitelist() {
         .await;
 
     assert_ok(response).await;
-    assert!(!env.whitelist_manager.is_info_hash_whitelisted(&info_hash).await);
+    assert!(
+        !env.http_api_container
+            .whitelist_manager
+            .is_info_hash_whitelisted(&info_hash)
+            .await
+    );
 
     env.stop().await;
 }
@@ -237,7 +247,11 @@ async fn should_fail_when_the_torrent_cannot_be_removed_from_the_whitelist() {
 
     let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
     let info_hash = InfoHash::from_str(&hash).unwrap();
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     force_database_error(&env.database);
 
@@ -266,7 +280,11 @@ async fn should_not_allow_removing_a_torrent_from_the_whitelist_for_unauthentica
     let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
     let info_hash = InfoHash::from_str(&hash).unwrap();
 
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     let request_id = Uuid::new_v4();
 
@@ -281,7 +299,11 @@ async fn should_not_allow_removing_a_torrent_from_the_whitelist_for_unauthentica
         "Expected logs to contain: ERROR ... API ... request_id={request_id}"
     );
 
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     let request_id = Uuid::new_v4();
 
@@ -307,7 +329,11 @@ async fn should_allow_reload_the_whitelist_from_the_database() {
 
     let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
     let info_hash = InfoHash::from_str(&hash).unwrap();
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     let request_id = Uuid::new_v4();
 
@@ -338,7 +364,11 @@ async fn should_fail_when_the_whitelist_cannot_be_reloaded_from_the_database() {
 
     let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned();
     let info_hash = InfoHash::from_str(&hash).unwrap();
-    env.whitelist_manager.add_torrent_to_whitelist(&info_hash).await.unwrap();
+    env.http_api_container
+        .whitelist_manager
+        .add_torrent_to_whitelist(&info_hash)
+        .await
+        .unwrap();
 
     force_database_error(&env.database);
 

--- a/tests/servers/http/environment.rs
+++ b/tests/servers/http/environment.rs
@@ -2,36 +2,28 @@ use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use futures::executor::block_on;
-use torrust_tracker_configuration::{Configuration, Core, HttpTracker};
+use torrust_tracker_configuration::Configuration;
 use torrust_tracker_lib::bootstrap::app::{initialize_app_container, initialize_global_services};
 use torrust_tracker_lib::bootstrap::jobs::make_rust_tls;
-use torrust_tracker_lib::core::announce_handler::AnnounceHandler;
+use torrust_tracker_lib::container::HttpTrackerContainer;
 use torrust_tracker_lib::core::authentication::handler::KeysHandler;
-use torrust_tracker_lib::core::authentication::service::AuthenticationService;
 use torrust_tracker_lib::core::databases::Database;
-use torrust_tracker_lib::core::scrape_handler::ScrapeHandler;
-use torrust_tracker_lib::core::statistics::event::sender::Sender;
 use torrust_tracker_lib::core::statistics::repository::Repository;
 use torrust_tracker_lib::core::torrent::repository::in_memory::InMemoryTorrentRepository;
-use torrust_tracker_lib::core::whitelist;
 use torrust_tracker_lib::core::whitelist::manager::WhitelistManager;
 use torrust_tracker_lib::servers::http::server::{HttpServer, Launcher, Running, Stopped};
 use torrust_tracker_lib::servers::registar::Registar;
 use torrust_tracker_primitives::peer;
 
 pub struct Environment<S> {
-    pub core_config: Arc<Core>,
-    pub http_tracker_config: Arc<HttpTracker>,
+    pub http_tracker_container: Arc<HttpTrackerContainer>,
+
     pub database: Arc<Box<dyn Database>>,
-    pub announce_handler: Arc<AnnounceHandler>,
-    pub scrape_handler: Arc<ScrapeHandler>,
     pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     pub keys_handler: Arc<KeysHandler>,
-    pub authentication_service: Arc<AuthenticationService>,
-    pub stats_event_sender: Arc<Option<Box<dyn Sender>>>,
     pub stats_repository: Arc<Repository>,
-    pub whitelist_authorization: Arc<whitelist::authorization::WhitelistAuthorization>,
     pub whitelist_manager: Arc<WhitelistManager>,
+
     pub registar: Registar,
     pub server: HttpServer<S>,
 }
@@ -54,28 +46,33 @@ impl Environment<Stopped> {
             .http_trackers
             .clone()
             .expect("missing HTTP tracker configuration");
+        let http_tracker_config = Arc::new(http_tracker[0].clone());
 
-        let config = Arc::new(http_tracker[0].clone());
+        let bind_to = http_tracker_config.bind_address;
 
-        let bind_to = config.bind_address;
-
-        let tls = block_on(make_rust_tls(&config.tsl_config)).map(|tls| tls.expect("tls config failed"));
+        let tls = block_on(make_rust_tls(&http_tracker_config.tsl_config)).map(|tls| tls.expect("tls config failed"));
 
         let server = HttpServer::new(Launcher::new(bind_to, tls));
 
-        Self {
-            http_tracker_config: config,
-            core_config: Arc::new(configuration.core.clone()),
-            database: app_container.database.clone(),
+        let http_tracker_container = Arc::new(HttpTrackerContainer {
+            core_config: app_container.core_config.clone(),
+            http_tracker_config: http_tracker_config.clone(),
             announce_handler: app_container.announce_handler.clone(),
             scrape_handler: app_container.scrape_handler.clone(),
+            whitelist_authorization: app_container.whitelist_authorization.clone(),
+            stats_event_sender: app_container.stats_event_sender.clone(),
+            authentication_service: app_container.authentication_service.clone(),
+        });
+
+        Self {
+            http_tracker_container,
+
+            database: app_container.database.clone(),
             in_memory_torrent_repository: app_container.in_memory_torrent_repository.clone(),
             keys_handler: app_container.keys_handler.clone(),
-            authentication_service: app_container.authentication_service.clone(),
-            stats_event_sender: app_container.stats_event_sender.clone(),
             stats_repository: app_container.stats_repository.clone(),
-            whitelist_authorization: app_container.whitelist_authorization.clone(),
             whitelist_manager: app_container.whitelist_manager.clone(),
+
             registar: Registar::default(),
             server,
         }
@@ -84,30 +81,18 @@ impl Environment<Stopped> {
     #[allow(dead_code)]
     pub async fn start(self) -> Environment<Running> {
         Environment {
-            http_tracker_config: self.http_tracker_config,
-            core_config: self.core_config.clone(),
+            http_tracker_container: self.http_tracker_container.clone(),
+
             database: self.database.clone(),
-            announce_handler: self.announce_handler.clone(),
-            scrape_handler: self.scrape_handler.clone(),
             in_memory_torrent_repository: self.in_memory_torrent_repository.clone(),
             keys_handler: self.keys_handler.clone(),
-            authentication_service: self.authentication_service.clone(),
-            whitelist_authorization: self.whitelist_authorization.clone(),
-            stats_event_sender: self.stats_event_sender.clone(),
             stats_repository: self.stats_repository.clone(),
             whitelist_manager: self.whitelist_manager.clone(),
+
             registar: self.registar.clone(),
             server: self
                 .server
-                .start(
-                    self.core_config,
-                    self.announce_handler,
-                    self.scrape_handler,
-                    self.authentication_service,
-                    self.whitelist_authorization,
-                    self.stats_event_sender,
-                    self.registar.give_form(),
-                )
+                .start(self.http_tracker_container, self.registar.give_form())
                 .await
                 .unwrap(),
         }
@@ -121,20 +106,15 @@ impl Environment<Running> {
 
     pub async fn stop(self) -> Environment<Stopped> {
         Environment {
-            http_tracker_config: self.http_tracker_config,
-            core_config: self.core_config,
+            http_tracker_container: self.http_tracker_container,
+
             database: self.database,
-            announce_handler: self.announce_handler,
-            scrape_handler: self.scrape_handler,
             in_memory_torrent_repository: self.in_memory_torrent_repository,
             keys_handler: self.keys_handler,
-            authentication_service: self.authentication_service,
-            whitelist_authorization: self.whitelist_authorization,
-            stats_event_sender: self.stats_event_sender,
             stats_repository: self.stats_repository,
             whitelist_manager: self.whitelist_manager,
-            registar: Registar::default(),
 
+            registar: Registar::default(),
             server: self.server.stop().await.unwrap(),
         }
     }

--- a/tests/servers/http/v1/contract.rs
+++ b/tests/servers/http/v1/contract.rs
@@ -449,7 +449,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.core_config.announce_policy;
+            let announce_policy = env.http_tracker_container.core_config.announce_policy;
 
             assert_announce_response(
                 response,
@@ -490,7 +490,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.core_config.announce_policy;
+            let announce_policy = env.http_tracker_container.core_config.announce_policy;
 
             // It should only contain the previously announced peer
             assert_announce_response(
@@ -543,7 +543,7 @@ mod for_all_config_modes {
                 )
                 .await;
 
-            let announce_policy = env.core_config.announce_policy;
+            let announce_policy = env.http_tracker_container.core_config.announce_policy;
 
             // The newly announced peer is not included on the response peer list,
             // but all the previously announced peers should be included regardless the IP version they are using.
@@ -872,7 +872,10 @@ mod for_all_config_modes {
             let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
-            assert_eq!(peer_addr.ip(), env.core_config.net.external_ip.unwrap());
+            assert_eq!(
+                peer_addr.ip(),
+                env.http_tracker_container.core_config.net.external_ip.unwrap()
+            );
             assert_ne!(peer_addr.ip(), IpAddr::from_str("2.2.2.2").unwrap());
 
             env.stop().await;
@@ -914,7 +917,10 @@ mod for_all_config_modes {
             let peers = env.in_memory_torrent_repository.get_torrent_peers(&info_hash);
             let peer_addr = peers[0].peer_addr;
 
-            assert_eq!(peer_addr.ip(), env.core_config.net.external_ip.unwrap());
+            assert_eq!(
+                peer_addr.ip(),
+                env.http_tracker_container.core_config.net.external_ip.unwrap()
+            );
             assert_ne!(peer_addr.ip(), IpAddr::from_str("2.2.2.2").unwrap());
 
             env.stop().await;

--- a/tests/servers/udp/contract.rs
+++ b/tests/servers/udp/contract.rs
@@ -229,7 +229,7 @@ mod receiving_an_announce_request {
         logging::setup();
 
         let env = Started::new(&configuration::ephemeral().into()).await;
-        let ban_service = env.ban_service.clone();
+        let ban_service = env.udp_tracker_container.ban_service.clone();
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,


### PR DESCRIPTION
Overhaul core Tracker: create dependency containers for UDP tracker, HTTP tracker and Tracker API.

### Subtasks

- [x] Extract `UdpTrackerContainer`
- [x] Extract `HttpTrackerContainer`
- [x] Extract `HttpApiContainer`