### PR TITLE
Udpate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -146,7 +146,7 @@ dependencies = [
  "quickcheck",
  "regex",
  "serde",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -158,7 +158,7 @@ dependencies = [
  "aquatic_peer_id",
  "byteorder",
  "either",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -588,7 +588,7 @@ dependencies = [
  "torrust-tracker-located-error",
  "torrust-tracker-primitives",
  "tracing",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -606,7 +606,7 @@ dependencies = [
  "r2d2",
  "r2d2_mysql",
  "r2d2_sqlite",
- "rand",
+ "rand 0.9.0",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -735,9 +735,9 @@ checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytecheck"
@@ -938,9 +938,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]
@@ -991,9 +991,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -1598,7 +1598,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1749,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -1761,9 +1773,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2263,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2368,7 +2380,7 @@ dependencies = [
  "mysql-common-derive",
  "num-bigint",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rust_decimal",
  "saturating",
@@ -2395,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
 dependencies = [
  "libc",
  "log",
@@ -2518,9 +2530,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "f5e534d133a060a3c19daec1eb3e98ec6f4685978834f2dbadfe2ec215bab64e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2544,9 +2556,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
@@ -2660,7 +2672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2782,7 +2794,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -2892,7 +2904,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2949,8 +2961,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -2960,7 +2983,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -2969,7 +3002,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -3097,7 +3140,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -3197,7 +3240,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -3261,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-webpki"
@@ -3284,9 +3327,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -3416,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "indexmap 2.7.1",
  "itoa",
@@ -3710,13 +3753,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -3986,7 +4029,7 @@ dependencies = [
  "r2d2",
  "r2d2_mysql",
  "r2d2_sqlite",
- "rand",
+ "rand 0.9.0",
  "regex",
  "reqwest",
  "ringbuf",
@@ -4011,7 +4054,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4106,14 +4149,14 @@ dependencies = [
  "tdyne-peer-id-registry",
  "thiserror 2.0.11",
  "torrust-tracker-configuration",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
 name = "torrust-tracker-test-helpers"
 version = "3.0.0-develop"
 dependencies = [
- "rand",
+ "rand 0.9.0",
  "torrust-tracker-configuration",
 ]
 
@@ -4134,7 +4177,7 @@ dependencies = [
  "torrust-tracker-clock",
  "torrust-tracker-configuration",
  "torrust-tracker-primitives",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4285,7 +4328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -4306,9 +4349,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-xid"
@@ -4358,8 +4401,8 @@ version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4410,6 +4453,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4646,11 +4698,20 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -4711,7 +4772,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -4719,6 +4789,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/contrib/bencode/src/mutable/bencode_mut.rs
+++ b/contrib/bencode/src/mutable/bencode_mut.rs
@@ -82,10 +82,7 @@ impl<'a> BRefAccess for BencodeMut<'a> {
     fn str(&self) -> Option<&str> {
         let bytes = self.bytes()?;
 
-        match str::from_utf8(bytes) {
-            Ok(n) => Some(n),
-            Err(_) => None,
-        }
+        str::from_utf8(bytes).ok()
     }
 
     fn int(&self) -> Option<i64> {

--- a/contrib/bencode/src/reference/bencode_ref.rs
+++ b/contrib/bencode/src/reference/bencode_ref.rs
@@ -107,10 +107,7 @@ impl<'a> BRefAccessExt<'a> for BencodeRef<'a> {
     fn str_ext(&self) -> Option<&'a str> {
         let bytes = self.bytes_ext()?;
 
-        match str::from_utf8(bytes) {
-            Ok(n) => Some(n),
-            Err(_) => None,
-        }
+        str::from_utf8(bytes).ok()
     }
 
     fn bytes_ext(&self) -> Option<&'a [u8]> {

--- a/contrib/bencode/src/reference/decode.rs
+++ b/contrib/bencode/src/reference/decode.rs
@@ -129,7 +129,8 @@ fn decode_dict(
                 })
             }
             _ => (),
-        };
+        }
+
         curr_pos = next_pos;
 
         let (value, next_pos) = decode(bytes, curr_pos, opts, depth + 1)?;

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -153,7 +153,7 @@ pub fn ephemeral_ipv6() -> Configuration {
 
     if let Some(ref mut http_api) = cfg.http_api {
         http_api.bind_address.clone_from(&ipv6);
-    };
+    }
 
     if let Some(ref mut http_trackers) = cfg.http_trackers {
         http_trackers[0].bind_address.clone_from(&ipv6);

--- a/packages/test-helpers/src/random.rs
+++ b/packages/test-helpers/src/random.rs
@@ -1,10 +1,10 @@
 //! Random data generators for testing.
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::distr::Alphanumeric;
+use rand::{rng, Rng};
 
 /// Returns a random alphanumeric string of a certain size.
 ///
 /// It is useful for generating random names, IDs, etc for testing.
 pub fn string(size: usize) -> String {
-    thread_rng().sample_iter(&Alphanumeric).take(size).map(char::from).collect()
+    rng().sample_iter(&Alphanumeric).take(size).map(char::from).collect()
 }

--- a/packages/torrent-repository/tests/common/repo.rs
+++ b/packages/torrent-repository/tests/common/repo.rs
@@ -232,7 +232,7 @@ impl Repo {
             Repo::DashMapMutexStd(repo) => {
                 repo.torrents.insert(*info_hash, torrent.into());
             }
-        };
+        }
         self.get(info_hash).await
     }
 }

--- a/packages/tracker-api-client/src/v1/client.rs
+++ b/packages/tracker-api-client/src/v1/client.rs
@@ -67,7 +67,7 @@ impl Client {
 
         if let Some(token) = &self.connection_info.api_token {
             query.add_param(QueryParam::new("token", token));
-        };
+        }
 
         self.get_request_with_query(path, query, headers).await
     }

--- a/packages/tracker-client/src/udp/client.rs
+++ b/packages/tracker-client/src/udp/client.rs
@@ -243,7 +243,7 @@ pub async fn check(remote_addr: &SocketAddr) -> Result<String, String> {
             match client.send(connect_request.into()).await {
                 Ok(_) => (),
                 Err(e) => tracing::debug!("Error: {e:?}."),
-            };
+            }
 
             let process = move |response| {
                 if matches!(response, Response::Connect(_connect_response)) {

--- a/packages/tracker-core/src/authentication/key/mod.rs
+++ b/packages/tracker-core/src/authentication/key/mod.rs
@@ -45,8 +45,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use derive_more::Display;
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::distr::Alphanumeric;
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use torrust_tracker_clock::clock::Time;
@@ -81,7 +81,7 @@ pub fn generate_permanent_key() -> PeerKey {
 /// * `lifetime`: if `None` the key will be permanent.
 #[must_use]
 pub fn generate_key(lifetime: Option<Duration>) -> PeerKey {
-    let random_id: String = thread_rng()
+    let random_id: String = rng()
         .sample_iter(&Alphanumeric)
         .take(AUTH_KEY_LENGTH)
         .map(char::from)

--- a/src/app.rs
+++ b/src/app.rs
@@ -98,7 +98,7 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
                 http_tracker::start_job(http_tracker_container, registar.give_form(), servers::http::Version::V1).await
             {
                 jobs.push(job);
-            };
+            }
         }
     } else {
         tracing::info!("No HTTP blocks in configuration");
@@ -111,7 +111,7 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
 
         if let Some(job) = tracker_apis::start_job(http_api_container, registar.give_form(), servers::apis::Version::V1).await {
             jobs.push(job);
-        };
+        }
     } else {
         tracing::info!("No API block in configuration");
     }

--- a/src/console/ci/e2e/logs_parser.rs
+++ b/src/console/ci/e2e/logs_parser.rs
@@ -76,7 +76,7 @@ impl RunningServices {
 
             if !line.contains(INFO_THRESHOLD) {
                 continue;
-            };
+            }
 
             if line.contains(UDP_TRACKER_LOG_TARGET) {
                 if let Some(captures) = udp_re.captures(&clean_line) {

--- a/src/console/ci/e2e/tracker_container.rs
+++ b/src/console/ci/e2e/tracker_container.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use rand::distributions::Alphanumeric;
+use rand::distr::Alphanumeric;
 use rand::Rng;
 
 use super::docker::{RunOptions, RunningContainer};
@@ -113,11 +113,7 @@ impl TrackerContainer {
     }
 
     fn generate_random_container_name(prefix: &str) -> String {
-        let rand_string: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(20)
-            .map(char::from)
-            .collect();
+        let rand_string: String = rand::rng().sample_iter(&Alphanumeric).take(20).map(char::from).collect();
 
         format!("{prefix}{rand_string}")
     }

--- a/src/servers/apis/v1/context/auth_key/handlers.rs
+++ b/src/servers/apis/v1/context/auth_key/handlers.rs
@@ -22,11 +22,11 @@ use crate::servers::apis::v1::responses::{invalid_auth_key_param_response, ok_re
 /// It returns these types of responses:
 ///
 /// - `200` with a json [`AuthKey`]
-///    resource. If the key was generated successfully.
+///   resource. If the key was generated successfully.
 /// - `400` with an error if the key couldn't been added because of an invalid
-///    request.
+///   request.
 /// - `500` with serialized error in debug format. If the key couldn't be
-///    generated.
+///   generated.
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::auth_key#generate-a-new-authentication-key)
 /// for more information about this endpoint.
@@ -57,9 +57,9 @@ pub async fn add_auth_key_handler(
 /// It returns two types of responses:
 ///
 /// - `200` with an json [`AuthKey`]
-///    resource. If the key was generated successfully.
+///   resource. If the key was generated successfully.
 /// - `500` with serialized error in debug format. If the key couldn't be
-///    generated.
+///   generated.
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::auth_key#generate-a-new-authentication-key)
 /// for more information about this endpoint.
@@ -99,9 +99,9 @@ pub struct KeyParam(String);
 /// It returns two types of responses:
 ///
 /// - `200` with an json [`ActionStatus::Ok`](crate::servers::apis::v1::responses::ActionStatus::Ok)
-///    response. If the key was deleted successfully.
+///   response. If the key was deleted successfully.
 /// - `500` with serialized error in debug format. If the key couldn't be
-///    deleted.
+///   deleted.
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::auth_key#delete-an-authentication-key)
 /// for more information about this endpoint.
@@ -124,9 +124,9 @@ pub async fn delete_auth_key_handler(
 /// It returns two types of responses:
 ///
 /// - `200` with an json [`ActionStatus::Ok`](crate::servers::apis::v1::responses::ActionStatus::Ok)
-///    response. If the keys were successfully reloaded.
+///   response. If the keys were successfully reloaded.
 /// - `500` with serialized error in debug format. If the they couldn't be
-///    reloaded.
+///   reloaded.
 ///
 /// Refer to the [API endpoint documentation](crate::servers::apis::v1::context::auth_key#reload-authentication-keys)
 /// for more information about this endpoint.

--- a/src/servers/udp/server/launcher.rs
+++ b/src/servers/udp/server/launcher.rs
@@ -213,7 +213,7 @@ impl Launcher {
                         stats_event_sender
                             .send_event(statistics::event::Event::UdpRequestAborted)
                             .await;
-                    };
+                    }
                 }
             } else {
                 tokio::task::yield_now().await;

--- a/src/shared/crypto/ephemeral_instance_keys.rs
+++ b/src/shared/crypto/ephemeral_instance_keys.rs
@@ -15,10 +15,10 @@ pub type CipherArrayBlowfish = GenericArray<u8, <CipherBlowfish as BlockSizeUser
 
 lazy_static! {
     /// The random static seed.
-    pub static ref RANDOM_SEED: Seed = Rng::gen(&mut ThreadRng::default());
+    pub static ref RANDOM_SEED: Seed = Rng::random(&mut ThreadRng::default());
 
     /// The random cipher from the seed.
-    pub static ref RANDOM_CIPHER_BLOWFISH: CipherBlowfish = CipherBlowfish::new_from_slice(&Rng::gen::<Seed>(&mut ThreadRng::default())).expect("it could not generate key");
+    pub static ref RANDOM_CIPHER_BLOWFISH: CipherBlowfish = CipherBlowfish::new_from_slice(&Rng::random::<Seed>(&mut ThreadRng::default())).expect("it could not generate key");
 
     /// The constant cipher for testing.
     pub static ref ZEROED_TEST_CIPHER_BLOWFISH: CipherBlowfish = CipherBlowfish::new_from_slice(&[0u8; 32]).expect("it could not generate key");

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -8,7 +8,7 @@ pub fn invalid_info_hashes() -> Vec<String> {
         "-1".to_string(),
         "1.1".to_string(),
         "INVALID INFOHASH".to_string(),
-        "9c38422213e30bff212b30c360d26f9a0213642".to_string(), // 39-char length instead of 40
+        "9c38422213e30bff212b30c360d26f9a0213642".to_string(), // 39-char length instead of 40. DevSkim: ignore DS173237
         "9c38422213e30bff212b30c360d26f9a0213642&".to_string(), // Invalid char
     ]
     .to_vec()
@@ -16,14 +16,14 @@ pub fn invalid_info_hashes() -> Vec<String> {
 
 /// Returns a random info hash.
 pub fn random_info_hash() -> InfoHash {
-    let mut rng = rand::thread_rng();
-    let random_bytes: [u8; 20] = rand::Rng::gen(&mut rng);
+    let mut rng = rand::rng();
+    let random_bytes: [u8; 20] = rand::Rng::random(&mut rng);
 
     InfoHash::from_bytes(&random_bytes)
 }
 
 /// Returns a random transaction id.
 pub fn random_transaction_id() -> TransactionId {
-    let random_value = rand::Rng::gen::<i32>(&mut rand::thread_rng());
+    let random_value = rand::Rng::random::<i32>(&mut rand::rng());
     TransactionId::new(random_value)
 }

--- a/tests/servers/udp/contract.rs
+++ b/tests/servers/udp/contract.rs
@@ -25,7 +25,7 @@ async fn send_connection_request(transaction_id: TransactionId, client: &UdpTrac
     match client.send(connect_request.into()).await {
         Ok(_) => (),
         Err(err) => panic!("{err}"),
-    };
+    }
 
     let response = match client.receive().await {
         Ok(response) => response,
@@ -52,7 +52,7 @@ async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_req
     match client.client.send(&empty_udp_request()).await {
         Ok(_) => (),
         Err(err) => panic!("{err}"),
-    };
+    }
 
     let response = match client.client.receive().await {
         Ok(response) => response,
@@ -94,7 +94,7 @@ mod receiving_a_connection_request {
         match client.send(connect_request.into()).await {
             Ok(_) => (),
             Err(err) => panic!("{err}"),
-        };
+        }
 
         let response = match client.receive().await {
             Ok(response) => response,
@@ -146,7 +146,7 @@ mod receiving_an_announce_request {
         match client.send(announce_request.into()).await {
             Ok(_) => (),
             Err(err) => panic!("{err}"),
-        };
+        }
 
         match client.receive().await {
             Ok(response) => response,
@@ -276,7 +276,7 @@ mod receiving_an_announce_request {
         match client.send(announce_request.into()).await {
             Ok(_) => (),
             Err(err) => panic!("{err}"),
-        };
+        }
 
         assert!(client.receive().await.is_err());
 
@@ -333,7 +333,7 @@ mod receiving_an_scrape_request {
         match client.send(scrape_request.into()).await {
             Ok(_) => (),
             Err(err) => panic!("{err}"),
-        };
+        }
 
         let response = match client.receive().await {
             Ok(response) => response,


### PR DESCRIPTION
```
cargo update
    Updating crates.io index
     Locking 22 packages to latest compatible versions
    Updating bumpalo v3.16.0 -> v3.17.0
    Updating cmake v0.1.52 -> v0.1.53
    Updating cpufeatures v0.2.16 -> v0.2.17
      Adding getrandom v0.3.1
    Updating httparse v1.9.5 -> v1.10.0
    Updating hyper v1.5.2 -> v1.6.0
    Updating native-tls v0.2.12 -> v0.2.13
    Updating openssl v0.10.68 -> v0.10.69
    Updating openssl-probe v0.1.5 -> v0.1.6
      Adding rand v0.9.0
      Adding rand_chacha v0.9.0
      Adding rand_core v0.9.0
    Updating rustls-pki-types v1.10.1 -> v1.11.0
    Updating ryu v1.0.18 -> v1.0.19
    Updating serde_json v1.0.137 -> v1.0.138
    Updating tempfile v3.15.0 -> v3.16.0
    Updating unicode-ident v1.0.14 -> v1.0.16
      Adding wasi v0.13.3+wasi-0.2.2
    Updating winnow v0.6.24 -> v0.6.25
      Adding wit-bindgen-rt v0.33.0
      Adding zerocopy v0.8.14
      Adding zerocopy-derive v0.8.14
```