### PR TITLE
Overhaul core Tracker: add tests for `torrent` mod

### DIFF
--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -18,4 +18,5 @@ use bittorrent_primitives::info_hash::InfoHash;
 /// Duration since the Unix Epoch.
 pub type DurationSinceUnixEpoch = Duration;
 
-pub type PersistentTorrents = BTreeMap<InfoHash, u32>;
+pub type PersistentTorrent = u32;
+pub type PersistentTorrents = BTreeMap<InfoHash, PersistentTorrent>;

--- a/packages/tracker-core/README.md
+++ b/packages/tracker-core/README.md
@@ -10,6 +10,22 @@ You usually don’t need to use this library directly. Instead, you should use t
 
 [Crate documentation](https://docs.rs/bittorrent-tracker-core).
 
+## Testing
+
+Show coverage report:
+
+```console
+cargo +stable llvm-cov
+```
+
+Export coverage report to `lcov` format:
+
+```console
+cargo +stable llvm-cov --lcov --output-path=./.coverage/lcov.info
+```
+
+If you use Visual Studio Code, you can use the [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=semasquare.vscode-coverage-gutters) extension to view the coverage lines.
+
 ## License
 
 The project is licensed under the terms of the [GNU AFFERO GENERAL PUBLIC LICENSE](./LICENSE).

--- a/packages/tracker-core/src/announce_handler.rs
+++ b/packages/tracker-core/src/announce_handler.rs
@@ -82,17 +82,11 @@ impl AnnounceHandler {
     /// needed for a `announce` request response.
     #[must_use]
     fn upsert_peer_and_get_stats(&self, info_hash: &InfoHash, peer: &peer::Peer) -> SwarmMetadata {
-        let swarm_metadata_before = match self.in_memory_torrent_repository.get_opt_swarm_metadata(info_hash) {
-            Some(swarm_metadata) => swarm_metadata,
-            None => SwarmMetadata::zeroed(),
-        };
+        let swarm_metadata_before = self.in_memory_torrent_repository.get_swarm_metadata(info_hash);
 
         self.in_memory_torrent_repository.upsert_peer(info_hash, peer);
 
-        let swarm_metadata_after = match self.in_memory_torrent_repository.get_opt_swarm_metadata(info_hash) {
-            Some(swarm_metadata) => swarm_metadata,
-            None => SwarmMetadata::zeroed(),
-        };
+        let swarm_metadata_after = self.in_memory_torrent_repository.get_swarm_metadata(info_hash);
 
         if swarm_metadata_before != swarm_metadata_after {
             self.persist_stats(info_hash, &swarm_metadata_after);

--- a/packages/tracker-core/src/core_tests.rs
+++ b/packages/tracker-core/src/core_tests.rs
@@ -174,7 +174,21 @@ pub fn initialize_handlers(config: &Configuration) -> (Arc<AnnounceHandler>, Arc
 
 /// # Panics
 ///
-/// Will panic if the temporary file path is not a valid UFT string.
+/// Will panic if the temporary database file path is not a valid UFT string.
+#[cfg(test)]
+#[must_use]
+pub fn ephemeral_configuration() -> Core {
+    let mut config = Core::default();
+
+    let temp_file = ephemeral_sqlite_database();
+    temp_file.to_str().unwrap().clone_into(&mut config.database.path);
+
+    config
+}
+
+/// # Panics
+///
+/// Will panic if the temporary database file path is not a valid UFT string.
 #[cfg(test)]
 #[must_use]
 pub fn ephemeral_configuration_for_listed_tracker() -> Core {

--- a/packages/tracker-core/src/core_tests.rs
+++ b/packages/tracker-core/src/core_tests.rs
@@ -30,10 +30,74 @@ pub fn sample_info_hash() -> InfoHash {
         .expect("String should be a valid info hash")
 }
 
+/// # Panics
+///
+/// Will panic if the string representation of the info hash is not a valid info hash.
+#[must_use]
+pub fn sample_info_hash_one() -> InfoHash {
+    "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0" // DevSkim: ignore DS173237
+        .parse::<InfoHash>()
+        .expect("String should be a valid info hash")
+}
+
+/// # Panics
+///
+/// Will panic if the string representation of the info hash is not a valid info hash.
+#[must_use]
+pub fn sample_info_hash_two() -> InfoHash {
+    "99c82bb73505a3c0b453f9fa0e881d6e5a32a0c1" // DevSkim: ignore DS173237
+        .parse::<InfoHash>()
+        .expect("String should be a valid info hash")
+}
+
+/// # Panics
+///
+/// Will panic if the string representation of the info hash is not a valid info hash.
+#[must_use]
+pub fn sample_info_hash_alphabetically_ordered_after_sample_info_hash_one() -> InfoHash {
+    "99c82bb73505a3c0b453f9fa0e881d6e5a32a0c1" // DevSkim: ignore DS173237
+        .parse::<InfoHash>()
+        .expect("String should be a valid info hash")
+}
+
 /// Sample peer whose state is not relevant for the tests.
 #[must_use]
 pub fn sample_peer() -> Peer {
-    complete_peer()
+    Peer {
+        peer_id: PeerId(*b"-qB00000000000000000"),
+        peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),
+        updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+        uploaded: NumberOfBytes::new(0),
+        downloaded: NumberOfBytes::new(0),
+        left: NumberOfBytes::new(0), // No bytes left to download
+        event: AnnounceEvent::Completed,
+    }
+}
+
+#[must_use]
+pub fn sample_peer_one() -> Peer {
+    Peer {
+        peer_id: PeerId(*b"-qB00000000000000001"),
+        peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8081),
+        updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+        uploaded: NumberOfBytes::new(0),
+        downloaded: NumberOfBytes::new(0),
+        left: NumberOfBytes::new(0), // No bytes left to download
+        event: AnnounceEvent::Completed,
+    }
+}
+
+#[must_use]
+pub fn sample_peer_two() -> Peer {
+    Peer {
+        peer_id: PeerId(*b"-qB00000000000000002"),
+        peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 2)), 8082),
+        updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+        uploaded: NumberOfBytes::new(0),
+        downloaded: NumberOfBytes::new(0),
+        left: NumberOfBytes::new(0), // No bytes left to download
+        event: AnnounceEvent::Completed,
+    }
 }
 
 #[must_use]

--- a/packages/tracker-core/src/torrent/manager.rs
+++ b/packages/tracker-core/src/torrent/manager.rs
@@ -61,3 +61,151 @@ impl TorrentsManager {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use torrust_tracker_configuration::Core;
+    use torrust_tracker_torrent_repository::entry::EntrySync;
+
+    use super::{DatabasePersistentTorrentRepository, TorrentsManager};
+    use crate::core_tests::{ephemeral_configuration, sample_info_hash};
+    use crate::databases::setup::initialize_database;
+    use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+    struct TorrentsManagerDeps {
+        config: Arc<Core>,
+        in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
+        database_persistent_torrent_repository: Arc<DatabasePersistentTorrentRepository>,
+    }
+
+    fn initialize_torrents_manager() -> (Arc<TorrentsManager>, Arc<TorrentsManagerDeps>) {
+        let config = ephemeral_configuration();
+        initialize_torrents_manager_with(config.clone())
+    }
+
+    fn initialize_torrents_manager_with(config: Core) -> (Arc<TorrentsManager>, Arc<TorrentsManagerDeps>) {
+        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+        let database = initialize_database(&config);
+        let database_persistent_torrent_repository = Arc::new(DatabasePersistentTorrentRepository::new(&database));
+
+        let torrents_manager = Arc::new(TorrentsManager::new(
+            &config,
+            &in_memory_torrent_repository,
+            &database_persistent_torrent_repository,
+        ));
+
+        (
+            torrents_manager,
+            Arc::new(TorrentsManagerDeps {
+                config: Arc::new(config),
+                in_memory_torrent_repository,
+                database_persistent_torrent_repository,
+            }),
+        )
+    }
+
+    #[test]
+    fn it_should_load_the_numbers_of_downloads_for_all_torrents_from_the_database() {
+        let (torrents_manager, services) = initialize_torrents_manager();
+
+        let infohash = sample_info_hash();
+
+        services.database_persistent_torrent_repository.save(&infohash, 1).unwrap();
+
+        torrents_manager.load_torrents_from_database().unwrap();
+
+        assert_eq!(
+            services
+                .in_memory_torrent_repository
+                .get(&infohash)
+                .unwrap()
+                .get_swarm_metadata()
+                .downloaded,
+            1
+        );
+    }
+
+    mod cleaning_torrents {
+        use std::ops::Add;
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use bittorrent_primitives::info_hash::InfoHash;
+        use torrust_tracker_clock::clock::stopped::Stopped;
+        use torrust_tracker_clock::clock::{self};
+        use torrust_tracker_primitives::DurationSinceUnixEpoch;
+
+        use crate::core_tests::{ephemeral_configuration, sample_info_hash, sample_peer};
+        use crate::torrent::manager::tests::{initialize_torrents_manager, initialize_torrents_manager_with};
+        use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+        #[test]
+        fn it_should_remove_peers_that_have_not_been_updated_after_a_cutoff_time() {
+            let (torrents_manager, services) = initialize_torrents_manager();
+
+            let infohash = sample_info_hash();
+
+            clock::Stopped::local_set(&Duration::from_secs(0));
+
+            // Add a peer to the torrent
+            let mut peer = sample_peer();
+            peer.updated = DurationSinceUnixEpoch::new(0, 0);
+            let () = services.in_memory_torrent_repository.upsert_peer(&infohash, &peer);
+
+            // Simulate the time has passed 1 second more than the max peer timeout.
+            clock::Stopped::local_add(&Duration::from_secs(
+                (services.config.tracker_policy.max_peer_timeout + 1).into(),
+            ))
+            .unwrap();
+
+            torrents_manager.cleanup_torrents();
+
+            assert!(services.in_memory_torrent_repository.get(&infohash).is_none());
+        }
+
+        fn add_a_peerless_torrent(infohash: &InfoHash, in_memory_torrent_repository: &Arc<InMemoryTorrentRepository>) {
+            // Add a peer to the torrent
+            let mut peer = sample_peer();
+            peer.updated = DurationSinceUnixEpoch::new(0, 0);
+            let () = in_memory_torrent_repository.upsert_peer(infohash, &peer);
+
+            // Remove the peer. The torrent is now peerless.
+            in_memory_torrent_repository.remove_inactive_peers(peer.updated.add(Duration::from_secs(1)));
+        }
+
+        #[test]
+        fn it_should_remove_torrents_that_have_no_peers_when_it_is_configured_to_do_so() {
+            let mut config = ephemeral_configuration();
+            config.tracker_policy.remove_peerless_torrents = true;
+
+            let (torrents_manager, services) = initialize_torrents_manager_with(config);
+
+            let infohash = sample_info_hash();
+
+            add_a_peerless_torrent(&infohash, &services.in_memory_torrent_repository);
+
+            torrents_manager.cleanup_torrents();
+
+            assert!(services.in_memory_torrent_repository.get(&infohash).is_none());
+        }
+
+        #[test]
+        fn it_should_retain_peerless_torrents_when_it_is_configured_to_do_so() {
+            let mut config = ephemeral_configuration();
+            config.tracker_policy.remove_peerless_torrents = false;
+
+            let (torrents_manager, services) = initialize_torrents_manager_with(config);
+
+            let infohash = sample_info_hash();
+
+            add_a_peerless_torrent(&infohash, &services.in_memory_torrent_repository);
+
+            torrents_manager.cleanup_torrents();
+
+            assert!(services.in_memory_torrent_repository.get(&infohash).is_some());
+        }
+    }
+}

--- a/packages/tracker-core/src/torrent/mod.rs
+++ b/packages/tracker-core/src/torrent/mod.rs
@@ -29,6 +29,8 @@ pub mod manager;
 pub mod repository;
 pub mod services;
 
-use torrust_tracker_torrent_repository::TorrentsSkipMapMutexStd;
+use torrust_tracker_torrent_repository::{EntryMutexStd, TorrentsSkipMapMutexStd};
 
-pub type Torrents = TorrentsSkipMapMutexStd; // Currently Used
+// Currently used types from the torrent repository crate.
+pub type Torrents = TorrentsSkipMapMutexStd;
+pub type TorrentEntry = EntryMutexStd;

--- a/packages/tracker-core/src/torrent/repository/in_memory.rs
+++ b/packages/tracker-core/src/torrent/repository/in_memory.rs
@@ -61,14 +61,8 @@ impl InMemoryTorrentRepository {
     pub fn get_swarm_metadata(&self, info_hash: &InfoHash) -> SwarmMetadata {
         match self.torrents.get(info_hash) {
             Some(torrent_entry) => torrent_entry.get_swarm_metadata(),
-            None => SwarmMetadata::default(),
+            None => SwarmMetadata::zeroed(),
         }
-    }
-
-    /// It returns the data for a `scrape` response if the torrent is found.
-    #[must_use]
-    pub fn get_opt_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
-        self.torrents.get_swarm_metadata(info_hash)
     }
 
     /// Get torrent peers for a given torrent and client.
@@ -105,232 +99,655 @@ impl InMemoryTorrentRepository {
 #[cfg(test)]
 mod tests {
 
-    use aquatic_udp_protocol::PeerId;
+    mod the_in_memory_torrent_repository {
 
-    /// It generates a peer id from a number where the number is the last
-    /// part of the peer ID. For example, for `12` it returns
-    /// `-qB00000000000000012`.
-    fn numeric_peer_id(two_digits_value: i32) -> PeerId {
-        // Format idx as a string with leading zeros, ensuring it has exactly 2 digits
-        let idx_str = format!("{two_digits_value:02}");
+        use aquatic_udp_protocol::PeerId;
 
-        // Create the base part of the peer ID.
-        let base = b"-qB00000000000000000";
+        /// It generates a peer id from a number where the number is the last
+        /// part of the peer ID. For example, for `12` it returns
+        /// `-qB00000000000000012`.
+        fn numeric_peer_id(two_digits_value: i32) -> PeerId {
+            // Format idx as a string with leading zeros, ensuring it has exactly 2 digits
+            let idx_str = format!("{two_digits_value:02}");
 
-        // Concatenate the base with idx bytes, ensuring the total length is 20 bytes.
-        let mut peer_id_bytes = [0u8; 20];
-        peer_id_bytes[..base.len()].copy_from_slice(base);
-        peer_id_bytes[base.len() - idx_str.len()..].copy_from_slice(idx_str.as_bytes());
+            // Create the base part of the peer ID.
+            let base = b"-qB00000000000000000";
 
-        PeerId(peer_id_bytes)
-    }
+            // Concatenate the base with idx bytes, ensuring the total length is 20 bytes.
+            let mut peer_id_bytes = [0u8; 20];
+            peer_id_bytes[..base.len()].copy_from_slice(base);
+            peer_id_bytes[base.len() - idx_str.len()..].copy_from_slice(idx_str.as_bytes());
 
-    // The `InMemoryTorrentRepository` has these responsibilities:
-    // - To maintain the peer lists for each torrent.
-    // - To return the peer lists for a given torrent.
-    // - To return the torrent entries, which contains all the info about the
-    //   torrents, including the peer lists.
-    // - To return the torrent metrics.
-    // - To return the swarm metadata for a given torrent.
-    // - To handle the persistence of the torrent entries.
+            PeerId(peer_id_bytes)
+        }
 
-    mod maintaining_the_peer_lists {
-        // Methods:
-        // - upsert_peer
-        // - remove
-        // - remove_inactive_peers
-        // - remove_peerless_torrents
-    }
+        // The `InMemoryTorrentRepository` has these responsibilities:
+        // - To maintain the peer lists for each torrent.
+        // - To maintain the the torrent entries, which contains all the info about the
+        //   torrents, including the peer lists.
+        // - To return the torrent entries.
+        // - To return the peer lists for a given torrent.
+        // - To return the torrent metrics.
+        // - To return the swarm metadata for a given torrent.
+        // - To handle the persistence of the torrent entries.
 
-    mod returning_peer_lists_for_a_torrent {
-        // Methods:
-        // - get_peers_for
-        // - get_torrent_peers
+        mod maintaining_the_peer_lists {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-        use std::sync::Arc;
+            use std::sync::Arc;
 
-        use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
-        use torrust_tracker_configuration::TORRENT_PEERS_LIMIT;
-        use torrust_tracker_primitives::peer::Peer;
-        use torrust_tracker_primitives::DurationSinceUnixEpoch;
+            use crate::core_tests::{sample_info_hash, sample_peer};
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
 
-        use crate::core_tests::{sample_info_hash, sample_peer};
-        use crate::torrent::repository::in_memory::tests::numeric_peer_id;
-        use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+            #[tokio::test]
+            async fn it_should_add_the_first_peer_to_the_torrent_peer_list() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-        #[tokio::test]
-        async fn it_should_return_74_peers_at_the_most_for_a_given_torrent() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+                let info_hash = sample_info_hash();
 
-            let info_hash = sample_info_hash();
+                let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
 
-            for idx in 1..=75 {
-                let peer = Peer {
-                    peer_id: numeric_peer_id(idx),
-                    peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, idx.try_into().unwrap())), 8080),
-                    updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
-                    uploaded: NumberOfBytes::new(0),
-                    downloaded: NumberOfBytes::new(0),
-                    left: NumberOfBytes::new(0), // No bytes left to download
-                    event: AnnounceEvent::Completed,
-                };
+                assert!(in_memory_torrent_repository.get(&info_hash).is_some());
+            }
+
+            #[tokio::test]
+            async fn it_should_allow_adding_the_same_peer_twice_to_the_torrent_peer_list() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let info_hash = sample_info_hash();
+
+                let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
+                let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
+
+                assert!(in_memory_torrent_repository.get(&info_hash).is_some());
+            }
+        }
+
+        mod returning_peer_lists_for_a_torrent {
+
+            use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+            use std::sync::Arc;
+
+            use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
+            use torrust_tracker_primitives::peer::Peer;
+            use torrust_tracker_primitives::DurationSinceUnixEpoch;
+
+            use crate::core_tests::{sample_info_hash, sample_peer};
+            use crate::torrent::repository::in_memory::tests::the_in_memory_torrent_repository::numeric_peer_id;
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+            #[tokio::test]
+            async fn it_should_return_the_peers_for_a_given_torrent() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let info_hash = sample_info_hash();
+                let peer = sample_peer();
 
                 let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash);
+
+                assert_eq!(peers, vec![Arc::new(peer)]);
             }
 
-            let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            #[tokio::test]
+            async fn it_should_return_an_empty_list_or_peers_for_a_non_existing_torrent() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            assert_eq!(peers.len(), 74);
+                let peers = in_memory_torrent_repository.get_torrent_peers(&sample_info_hash());
+
+                assert!(peers.is_empty());
+            }
+
+            #[tokio::test]
+            async fn it_should_return_74_peers_at_the_most_for_a_given_torrent() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let info_hash = sample_info_hash();
+
+                for idx in 1..=75 {
+                    let peer = Peer {
+                        peer_id: numeric_peer_id(idx),
+                        peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, idx.try_into().unwrap())), 8080),
+                        updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+                        uploaded: NumberOfBytes::new(0),
+                        downloaded: NumberOfBytes::new(0),
+                        left: NumberOfBytes::new(0), // No bytes left to download
+                        event: AnnounceEvent::Completed,
+                    };
+
+                    let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+                }
+
+                let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash);
+
+                assert_eq!(peers.len(), 74);
+            }
+
+            mod excluding_the_client_peer {
+
+                use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+                use std::sync::Arc;
+
+                use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes};
+                use torrust_tracker_configuration::TORRENT_PEERS_LIMIT;
+                use torrust_tracker_primitives::peer::Peer;
+                use torrust_tracker_primitives::DurationSinceUnixEpoch;
+
+                use crate::core_tests::{sample_info_hash, sample_peer};
+                use crate::torrent::repository::in_memory::tests::the_in_memory_torrent_repository::numeric_peer_id;
+                use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+                #[tokio::test]
+                async fn it_should_return_an_empty_peer_list_for_a_non_existing_torrent() {
+                    let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                    let peers =
+                        in_memory_torrent_repository.get_peers_for(&sample_info_hash(), &sample_peer(), TORRENT_PEERS_LIMIT);
+
+                    assert_eq!(peers, vec![]);
+                }
+
+                #[tokio::test]
+                async fn it_should_return_the_peers_for_a_given_torrent_excluding_a_given_peer() {
+                    let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                    let info_hash = sample_info_hash();
+                    let peer = sample_peer();
+
+                    let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+
+                    let peers = in_memory_torrent_repository.get_peers_for(&info_hash, &peer, TORRENT_PEERS_LIMIT);
+
+                    assert_eq!(peers, vec![]);
+                }
+
+                #[tokio::test]
+                async fn it_should_return_74_peers_at_the_most_for_a_given_torrent_when_it_filters_out_a_given_peer() {
+                    let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                    let info_hash = sample_info_hash();
+
+                    let excluded_peer = sample_peer();
+
+                    let () = in_memory_torrent_repository.upsert_peer(&info_hash, &excluded_peer);
+
+                    // Add 74 peers
+                    for idx in 2..=75 {
+                        let peer = Peer {
+                            peer_id: numeric_peer_id(idx),
+                            peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, idx.try_into().unwrap())), 8080),
+                            updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+                            uploaded: NumberOfBytes::new(0),
+                            downloaded: NumberOfBytes::new(0),
+                            left: NumberOfBytes::new(0), // No bytes left to download
+                            event: AnnounceEvent::Completed,
+                        };
+
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+                    }
+
+                    let peers = in_memory_torrent_repository.get_peers_for(&info_hash, &excluded_peer, TORRENT_PEERS_LIMIT);
+
+                    assert_eq!(peers.len(), 74);
+                }
+            }
         }
 
-        #[tokio::test]
-        async fn it_should_return_the_peers_for_a_given_torrent() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+        mod maintaining_the_torrent_entries {
 
-            let info_hash = sample_info_hash();
-            let peer = sample_peer();
+            use std::ops::Add;
+            use std::sync::Arc;
+            use std::time::Duration;
 
-            let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+            use bittorrent_primitives::info_hash::InfoHash;
+            use torrust_tracker_configuration::TrackerPolicy;
+            use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
-            let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash);
+            use crate::core_tests::{sample_info_hash, sample_peer};
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
 
-            assert_eq!(peers, vec![Arc::new(peer)]);
-        }
+            #[tokio::test]
+            async fn it_should_remove_a_torrent_entry() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-        #[tokio::test]
-        async fn it_should_return_the_peers_for_a_given_torrent_excluding_a_given_peer() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+                let info_hash = sample_info_hash();
+                let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
 
-            let info_hash = sample_info_hash();
-            let peer = sample_peer();
+                let _unused = in_memory_torrent_repository.remove(&info_hash);
 
-            let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+                assert!(in_memory_torrent_repository.get(&info_hash).is_none());
+            }
 
-            let peers = in_memory_torrent_repository.get_peers_for(&info_hash, &peer, TORRENT_PEERS_LIMIT);
+            #[tokio::test]
+            async fn it_should_remove_peers_that_have_not_been_updated_after_a_cutoff_time() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            assert_eq!(peers, vec![]);
-        }
-
-        #[tokio::test]
-        async fn it_should_return_74_peers_at_the_most_for_a_given_torrent_when_it_filters_out_a_given_peer() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
-
-            let info_hash = sample_info_hash();
-
-            let excluded_peer = sample_peer();
-
-            let () = in_memory_torrent_repository.upsert_peer(&info_hash, &excluded_peer);
-
-            // Add 74 peers
-            for idx in 2..=75 {
-                let peer = Peer {
-                    peer_id: numeric_peer_id(idx),
-                    peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, idx.try_into().unwrap())), 8080),
-                    updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
-                    uploaded: NumberOfBytes::new(0),
-                    downloaded: NumberOfBytes::new(0),
-                    left: NumberOfBytes::new(0), // No bytes left to download
-                    event: AnnounceEvent::Completed,
-                };
+                let info_hash = sample_info_hash();
+                let mut peer = sample_peer();
+                peer.updated = DurationSinceUnixEpoch::new(0, 0);
 
                 let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+
+                // Cut off time is 1 second after the peer was updated
+                in_memory_torrent_repository.remove_inactive_peers(peer.updated.add(Duration::from_secs(1)));
+
+                assert!(!in_memory_torrent_repository
+                    .get_torrent_peers(&info_hash)
+                    .contains(&Arc::new(peer)));
             }
 
-            let peers = in_memory_torrent_repository.get_peers_for(&info_hash, &excluded_peer, TORRENT_PEERS_LIMIT);
+            fn initialize_repository_with_one_torrent_without_peers(info_hash: &InfoHash) -> Arc<InMemoryTorrentRepository> {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
-            assert_eq!(peers.len(), 74);
-        }
-    }
+                // Insert a sample peer for the torrent to force adding the torrent entry
+                let mut peer = sample_peer();
+                peer.updated = DurationSinceUnixEpoch::new(0, 0);
+                let () = in_memory_torrent_repository.upsert_peer(info_hash, &peer);
 
-    mod returning_torrent_entries {
-        // Methods:
-        // - get
-        // - get_paginated
-    }
+                // Remove the peer
+                in_memory_torrent_repository.remove_inactive_peers(peer.updated.add(Duration::from_secs(1)));
 
-    mod returning_torrent_metrics {
-        // Methods:
-        // - get_torrents_metrics
-
-        use std::sync::Arc;
-
-        use bittorrent_primitives::info_hash::fixture::gen_seeded_infohash;
-        use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
-
-        use crate::core_tests::{leecher, sample_info_hash};
-        use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
-
-        #[tokio::test]
-        async fn it_should_collect_torrent_metrics() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
-
-            let torrents_metrics = in_memory_torrent_repository.get_torrents_metrics();
-
-            assert_eq!(
-                torrents_metrics,
-                TorrentsMetrics {
-                    complete: 0,
-                    downloaded: 0,
-                    incomplete: 0,
-                    torrents: 0
-                }
-            );
-        }
-
-        #[tokio::test]
-        async fn it_should_return_the_torrent_metrics() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
-
-            let () = in_memory_torrent_repository.upsert_peer(&sample_info_hash(), &leecher());
-
-            let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
-
-            assert_eq!(
-                torrent_metrics,
-                TorrentsMetrics {
-                    complete: 0,
-                    downloaded: 0,
-                    incomplete: 1,
-                    torrents: 1,
-                }
-            );
-        }
-
-        #[tokio::test]
-        async fn it_should_get_many_the_torrent_metrics() {
-            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
-
-            let start_time = std::time::Instant::now();
-            for i in 0..1_000_000 {
-                let () = in_memory_torrent_repository.upsert_peer(&gen_seeded_infohash(&i), &leecher());
+                in_memory_torrent_repository
             }
-            let result_a = start_time.elapsed();
 
-            let start_time = std::time::Instant::now();
-            let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
-            let result_b = start_time.elapsed();
+            #[tokio::test]
+            async fn it_should_remove_torrents_without_peers() {
+                let info_hash = sample_info_hash();
 
-            assert_eq!(
-                (torrent_metrics),
-                (TorrentsMetrics {
-                    complete: 0,
-                    downloaded: 0,
-                    incomplete: 1_000_000,
-                    torrents: 1_000_000,
-                }),
-                "{result_a:?} {result_b:?}"
-            );
+                let in_memory_torrent_repository = initialize_repository_with_one_torrent_without_peers(&info_hash);
+
+                let tracker_policy = TrackerPolicy {
+                    remove_peerless_torrents: true,
+                    ..Default::default()
+                };
+
+                in_memory_torrent_repository.remove_peerless_torrents(&tracker_policy);
+
+                assert!(in_memory_torrent_repository.get(&info_hash).is_none());
+            }
         }
-    }
+        mod returning_torrent_entries {
 
-    mod returning_swarm_metadata {
-        // Methods:
-        // - get_swarm_metadata
-    }
+            use std::sync::Arc;
 
-    mod handling_persistence {
-        // Methods:
-        // - import_persistent
+            use torrust_tracker_primitives::peer::Peer;
+            use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+            use torrust_tracker_torrent_repository::entry::EntrySync;
+
+            use crate::core_tests::{sample_info_hash, sample_peer};
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+            use crate::torrent::TorrentEntry;
+
+            /// `TorrentEntry` data is not directly accessible. It's only
+            /// accessible through the trait methods. We need this temporary
+            /// DTO to write simple and more readable assertions.
+            #[derive(Debug, Clone, PartialEq)]
+            struct TorrentEntryInfo {
+                swarm_metadata: SwarmMetadata,
+                peers: Vec<Peer>,
+                number_of_peers: usize,
+            }
+
+            #[allow(clippy::from_over_into)]
+            impl Into<TorrentEntryInfo> for TorrentEntry {
+                fn into(self) -> TorrentEntryInfo {
+                    TorrentEntryInfo {
+                        swarm_metadata: self.get_swarm_metadata(),
+                        peers: self.get_peers(None).iter().map(|peer| *peer.clone()).collect(),
+                        number_of_peers: self.get_peers_len(),
+                    }
+                }
+            }
+
+            #[tokio::test]
+            async fn it_should_return_one_torrent_entry_by_infohash() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let info_hash = sample_info_hash();
+                let peer = sample_peer();
+
+                let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+
+                let torrent_entry = in_memory_torrent_repository.get(&info_hash).unwrap();
+
+                assert_eq!(
+                    TorrentEntryInfo {
+                        swarm_metadata: SwarmMetadata {
+                            downloaded: 0,
+                            complete: 1,
+                            incomplete: 0
+                        },
+                        peers: vec!(peer),
+                        number_of_peers: 1
+                    },
+                    torrent_entry.into()
+                );
+            }
+
+            mod it_should_return_many_torrent_entries {
+                use std::sync::Arc;
+
+                use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+
+                use crate::core_tests::{sample_info_hash, sample_peer};
+                use crate::torrent::repository::in_memory::tests::the_in_memory_torrent_repository::returning_torrent_entries::TorrentEntryInfo;
+                use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+                #[tokio::test]
+                async fn without_pagination() {
+                    let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                    let info_hash = sample_info_hash();
+                    let peer = sample_peer();
+                    let () = in_memory_torrent_repository.upsert_peer(&info_hash, &peer);
+
+                    let torrent_entries = in_memory_torrent_repository.get_paginated(None);
+
+                    assert_eq!(torrent_entries.len(), 1);
+
+                    let torrent_entry = torrent_entries.first().unwrap().1.clone();
+
+                    assert_eq!(
+                        TorrentEntryInfo {
+                            swarm_metadata: SwarmMetadata {
+                                downloaded: 0,
+                                complete: 1,
+                                incomplete: 0
+                            },
+                            peers: vec!(peer),
+                            number_of_peers: 1
+                        },
+                        torrent_entry.into()
+                    );
+                }
+
+                mod with_pagination {
+                    use std::sync::Arc;
+
+                    use torrust_tracker_primitives::pagination::Pagination;
+                    use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+
+                    use crate::core_tests::{
+                        sample_info_hash_alphabetically_ordered_after_sample_info_hash_one, sample_info_hash_one,
+                        sample_peer_one, sample_peer_two,
+                    };
+                    use crate::torrent::repository::in_memory::tests::the_in_memory_torrent_repository::returning_torrent_entries::TorrentEntryInfo;
+                    use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+                    #[tokio::test]
+                    async fn it_should_return_the_first_page() {
+                        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                        // Insert one torrent entry
+                        let info_hash_one = sample_info_hash_one();
+                        let peer_one = sample_peer_one();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_one);
+
+                        // Insert another torrent entry
+                        let info_hash_one = sample_info_hash_alphabetically_ordered_after_sample_info_hash_one();
+                        let peer_two = sample_peer_two();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_two);
+
+                        // Get only the first page where page size is 1
+                        let torrent_entries =
+                            in_memory_torrent_repository.get_paginated(Some(&Pagination { offset: 0, limit: 1 }));
+
+                        assert_eq!(torrent_entries.len(), 1);
+
+                        let torrent_entry = torrent_entries.first().unwrap().1.clone();
+
+                        assert_eq!(
+                            TorrentEntryInfo {
+                                swarm_metadata: SwarmMetadata {
+                                    downloaded: 0,
+                                    complete: 1,
+                                    incomplete: 0
+                                },
+                                peers: vec!(peer_one),
+                                number_of_peers: 1
+                            },
+                            torrent_entry.into()
+                        );
+                    }
+
+                    #[tokio::test]
+                    async fn it_should_return_the_second_page() {
+                        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                        // Insert one torrent entry
+                        let info_hash_one = sample_info_hash_one();
+                        let peer_one = sample_peer_one();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_one);
+
+                        // Insert another torrent entry
+                        let info_hash_one = sample_info_hash_alphabetically_ordered_after_sample_info_hash_one();
+                        let peer_two = sample_peer_two();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_two);
+
+                        // Get only the first page where page size is 1
+                        let torrent_entries =
+                            in_memory_torrent_repository.get_paginated(Some(&Pagination { offset: 1, limit: 1 }));
+
+                        assert_eq!(torrent_entries.len(), 1);
+
+                        let torrent_entry = torrent_entries.first().unwrap().1.clone();
+
+                        assert_eq!(
+                            TorrentEntryInfo {
+                                swarm_metadata: SwarmMetadata {
+                                    downloaded: 0,
+                                    complete: 1,
+                                    incomplete: 0
+                                },
+                                peers: vec!(peer_two),
+                                number_of_peers: 1
+                            },
+                            torrent_entry.into()
+                        );
+                    }
+
+                    #[tokio::test]
+                    async fn it_should_allow_changing_the_page_size() {
+                        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                        // Insert one torrent entry
+                        let info_hash_one = sample_info_hash_one();
+                        let peer_one = sample_peer_one();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_one);
+
+                        // Insert another torrent entry
+                        let info_hash_one = sample_info_hash_alphabetically_ordered_after_sample_info_hash_one();
+                        let peer_two = sample_peer_two();
+                        let () = in_memory_torrent_repository.upsert_peer(&info_hash_one, &peer_two);
+
+                        // Get only the first page where page size is 1
+                        let torrent_entries =
+                            in_memory_torrent_repository.get_paginated(Some(&Pagination { offset: 1, limit: 1 }));
+
+                        assert_eq!(torrent_entries.len(), 1);
+                    }
+                }
+            }
+        }
+
+        mod returning_torrent_metrics {
+
+            use std::sync::Arc;
+
+            use bittorrent_primitives::info_hash::fixture::gen_seeded_infohash;
+            use torrust_tracker_primitives::torrent_metrics::TorrentsMetrics;
+
+            use crate::core_tests::{complete_peer, leecher, sample_info_hash, seeder};
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+            // todo: refactor to use test parametrization
+
+            #[tokio::test]
+            async fn it_should_get_empty_torrent_metrics_when_there_are_no_torrents() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let torrents_metrics = in_memory_torrent_repository.get_torrents_metrics();
+
+                assert_eq!(
+                    torrents_metrics,
+                    TorrentsMetrics {
+                        complete: 0,
+                        downloaded: 0,
+                        incomplete: 0,
+                        torrents: 0
+                    }
+                );
+            }
+
+            #[tokio::test]
+            async fn it_should_return_the_torrent_metrics_when_there_is_a_leecher() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let () = in_memory_torrent_repository.upsert_peer(&sample_info_hash(), &leecher());
+
+                let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
+
+                assert_eq!(
+                    torrent_metrics,
+                    TorrentsMetrics {
+                        complete: 0,
+                        downloaded: 0,
+                        incomplete: 1,
+                        torrents: 1,
+                    }
+                );
+            }
+
+            #[tokio::test]
+            async fn it_should_return_the_torrent_metrics_when_there_is_a_seeder() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let () = in_memory_torrent_repository.upsert_peer(&sample_info_hash(), &seeder());
+
+                let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
+
+                assert_eq!(
+                    torrent_metrics,
+                    TorrentsMetrics {
+                        complete: 1,
+                        downloaded: 0,
+                        incomplete: 0,
+                        torrents: 1,
+                    }
+                );
+            }
+
+            #[tokio::test]
+            async fn it_should_return_the_torrent_metrics_when_there_is_a_completed_peer() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let () = in_memory_torrent_repository.upsert_peer(&sample_info_hash(), &complete_peer());
+
+                let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
+
+                assert_eq!(
+                    torrent_metrics,
+                    TorrentsMetrics {
+                        complete: 1,
+                        downloaded: 0,
+                        incomplete: 0,
+                        torrents: 1,
+                    }
+                );
+            }
+
+            #[tokio::test]
+            async fn it_should_return_the_torrent_metrics_when_there_are_multiple_torrents() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let start_time = std::time::Instant::now();
+                for i in 0..1_000_000 {
+                    let () = in_memory_torrent_repository.upsert_peer(&gen_seeded_infohash(&i), &leecher());
+                }
+                let result_a = start_time.elapsed();
+
+                let start_time = std::time::Instant::now();
+                let torrent_metrics = in_memory_torrent_repository.get_torrents_metrics();
+                let result_b = start_time.elapsed();
+
+                assert_eq!(
+                    (torrent_metrics),
+                    (TorrentsMetrics {
+                        complete: 0,
+                        downloaded: 0,
+                        incomplete: 1_000_000,
+                        torrents: 1_000_000,
+                    }),
+                    "{result_a:?} {result_b:?}"
+                );
+            }
+        }
+
+        mod returning_swarm_metadata {
+
+            use std::sync::Arc;
+
+            use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+
+            use crate::core_tests::{leecher, sample_info_hash};
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+            #[tokio::test]
+            async fn it_should_get_swarm_metadata_for_an_existing_torrent() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let infohash = sample_info_hash();
+
+                let () = in_memory_torrent_repository.upsert_peer(&infohash, &leecher());
+
+                let swarm_metadata = in_memory_torrent_repository.get_swarm_metadata(&infohash);
+
+                assert_eq!(
+                    swarm_metadata,
+                    SwarmMetadata {
+                        complete: 0,
+                        downloaded: 0,
+                        incomplete: 1,
+                    }
+                );
+            }
+
+            #[tokio::test]
+            async fn it_should_return_zeroed_swarm_metadata_for_a_non_existing_torrent() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let swarm_metadata = in_memory_torrent_repository.get_swarm_metadata(&sample_info_hash());
+
+                assert_eq!(swarm_metadata, SwarmMetadata::zeroed());
+            }
+        }
+
+        mod handling_persistence {
+
+            use std::sync::Arc;
+
+            use torrust_tracker_primitives::PersistentTorrents;
+
+            use crate::core_tests::sample_info_hash;
+            use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+
+            #[tokio::test]
+            async fn it_should_allow_importing_persisted_torrent_entries() {
+                let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+                let infohash = sample_info_hash();
+
+                let mut persistent_torrents = PersistentTorrents::default();
+
+                persistent_torrents.insert(infohash, 1);
+
+                in_memory_torrent_repository.import_persistent(&persistent_torrents);
+
+                let swarm_metadata = in_memory_torrent_repository.get_swarm_metadata(&infohash);
+
+                // Only the number of downloads is persisted.
+                assert_eq!(swarm_metadata.downloaded, 1);
+            }
+        }
     }
 }

--- a/packages/tracker-core/src/torrent/repository/persisted.rs
+++ b/packages/tracker-core/src/torrent/repository/persisted.rs
@@ -42,3 +42,51 @@ impl DatabasePersistentTorrentRepository {
         self.database.save_persistent_torrent(info_hash, downloaded)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use torrust_tracker_primitives::PersistentTorrents;
+
+    use super::DatabasePersistentTorrentRepository;
+    use crate::core_tests::{ephemeral_configuration, sample_info_hash, sample_info_hash_one, sample_info_hash_two};
+    use crate::databases::setup::initialize_database;
+
+    fn initialize_db_persistent_torrent_repository() -> DatabasePersistentTorrentRepository {
+        let config = ephemeral_configuration();
+        let database = initialize_database(&config);
+        DatabasePersistentTorrentRepository::new(&database)
+    }
+
+    #[test]
+    fn it_saves_the_numbers_of_downloads_for_a_torrent_into_the_database() {
+        let repository = initialize_db_persistent_torrent_repository();
+
+        let infohash = sample_info_hash();
+
+        repository.save(&infohash, 1).unwrap();
+
+        let torrents = repository.load_all().unwrap();
+
+        assert_eq!(torrents.get(&infohash), Some(1).as_ref());
+    }
+
+    #[test]
+    fn it_loads_the_numbers_of_downloads_for_all_torrents_from_the_database() {
+        let repository = initialize_db_persistent_torrent_repository();
+
+        let infohash_one = sample_info_hash_one();
+        let infohash_two = sample_info_hash_two();
+
+        repository.save(&infohash_one, 1).unwrap();
+        repository.save(&infohash_two, 2).unwrap();
+
+        let torrents = repository.load_all().unwrap();
+
+        let mut expected_torrents = PersistentTorrents::new();
+        expected_torrents.insert(infohash_one, 1);
+        expected_torrents.insert(infohash_two, 2);
+
+        assert_eq!(torrents, expected_torrents);
+    }
+}

--- a/packages/tracker-core/src/torrent/services.rs
+++ b/packages/tracker-core/src/torrent/services.rs
@@ -297,4 +297,44 @@ mod tests {
             );
         }
     }
+
+    mod getting_basic_torrent_info_for_multiple_torrents_at_once {
+
+        use std::sync::Arc;
+
+        use crate::core_tests::sample_info_hash;
+        use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
+        use crate::torrent::services::tests::sample_peer;
+        use crate::torrent::services::{get_torrents, BasicInfo};
+
+        #[tokio::test]
+        async fn it_should_return_an_empty_list_if_none_of_the_requested_torrents_is_found() {
+            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+            let torrent_info = get_torrents(&in_memory_torrent_repository, &[sample_info_hash()]);
+
+            assert!(torrent_info.is_empty());
+        }
+
+        #[tokio::test]
+        async fn it_should_return_a_list_with_basic_info_about_the_requested_torrents() {
+            let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
+
+            let info_hash = sample_info_hash();
+
+            let () = in_memory_torrent_repository.upsert_peer(&info_hash, &sample_peer());
+
+            let torrent_info = get_torrents(&in_memory_torrent_repository, &[info_hash]);
+
+            assert_eq!(
+                torrent_info,
+                vec!(BasicInfo {
+                    info_hash,
+                    seeders: 1,
+                    completed: 0,
+                    leechers: 0,
+                })
+            );
+        }
+    }
 }

--- a/packages/tracker-core/src/torrent/services.rs
+++ b/packages/tracker-core/src/torrent/services.rs
@@ -137,7 +137,7 @@ mod tests {
         use crate::torrent::services::{get_torrent_info, Info};
 
         #[tokio::test]
-        async fn should_return_none_if_the_tracker_does_not_have_the_torrent() {
+        async fn it_should_return_none_if_the_tracker_does_not_have_the_torrent() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let torrent_info = get_torrent_info(
@@ -149,7 +149,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_the_torrent_info_if_the_tracker_has_the_torrent() {
+        async fn it_should_return_the_torrent_info_if_the_tracker_has_the_torrent() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
@@ -183,7 +183,7 @@ mod tests {
         use crate::torrent::services::{get_torrents_page, BasicInfo, Pagination};
 
         #[tokio::test]
-        async fn should_return_an_empty_result_if_the_tracker_does_not_have_any_torrent() {
+        async fn it_should_return_an_empty_result_if_the_tracker_does_not_have_any_torrent() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let torrents = get_torrents_page(&in_memory_torrent_repository, Some(&Pagination::default()));
@@ -192,7 +192,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_a_summarized_info_for_all_torrents() {
+        async fn it_should_return_a_summarized_info_for_all_torrents() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let hash = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
@@ -214,13 +214,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_allow_limiting_the_number_of_torrents_in_the_result() {
+        async fn it_should_allow_limiting_the_number_of_torrents_in_the_result() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
 
-            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
+            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned(); // DevSkim: ignore DS173237
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
 
             let () = in_memory_torrent_repository.upsert_peer(&info_hash1, &sample_peer());
@@ -235,13 +235,13 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_allow_using_pagination_in_the_result() {
+        async fn it_should_allow_using_pagination_in_the_result() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
 
-            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
+            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned(); // DevSkim: ignore DS173237
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
 
             let () = in_memory_torrent_repository.upsert_peer(&info_hash1, &sample_peer());
@@ -265,14 +265,14 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_torrents_ordered_by_info_hash() {
+        async fn it_should_return_torrents_ordered_by_info_hash() {
             let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 
             let hash1 = "9e0217d0fa71c87332cd8bf9dbeabcb2c2cf3c4d".to_owned(); // DevSkim: ignore DS173237
             let info_hash1 = InfoHash::from_str(&hash1).unwrap();
             let () = in_memory_torrent_repository.upsert_peer(&info_hash1, &sample_peer());
 
-            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned();
+            let hash2 = "03840548643af2a7b63a9f5cbca348bc7150ca3a".to_owned(); // DevSkim: ignore DS173237
             let info_hash2 = InfoHash::from_str(&hash2).unwrap();
             let () = in_memory_torrent_repository.upsert_peer(&info_hash2, &sample_peer());
 


### PR DESCRIPTION
Overhaul core Tracker: add tests for `torrent` mod

### Sub-tasks

- [x] `repository` mod.
  - [x] `in_memory` mod.
  - [x] `persisted` mod.
- [x] `manager` mod.
- [x] `services` mod.