### PR TITLE
Add missing tests to `udp_tracker_core::statistics::event::handler`

### DIFF
--- a/src/packages/udp_tracker_core/statistics/event/handler.rs
+++ b/src/packages/udp_tracker_core/statistics/event/handler.rs
@@ -151,4 +151,100 @@ mod tests {
 
         assert_eq!(stats.udp6_scrapes_handled, 1);
     }
+
+    #[tokio::test]
+    async fn should_increase_the_udp_abort_counter_when_it_receives_a_udp_abort_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::UdpRequestAborted, &stats_repository).await;
+        let stats = stats_repository.get_stats().await;
+        assert_eq!(stats.udp_requests_aborted, 1);
+    }
+    #[tokio::test]
+    async fn should_increase_the_udp_ban_counter_when_it_receives_a_udp_banned_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::UdpRequestBanned, &stats_repository).await;
+        let stats = stats_repository.get_stats().await;
+        assert_eq!(stats.udp_requests_banned, 1);
+    }
+
+    #[tokio::test]
+    async fn should_increase_the_udp4_requests_counter_when_it_receives_a_udp4_request_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::Udp4Request, &stats_repository).await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp4_requests, 1);
+    }
+
+    #[tokio::test]
+    async fn should_increase_the_udp4_responses_counter_when_it_receives_a_udp4_response_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(
+            Event::Udp4Response {
+                kind: crate::packages::udp_tracker_core::statistics::event::UdpResponseKind::Announce,
+                req_processing_time: std::time::Duration::from_secs(1),
+            },
+            &stats_repository,
+        )
+        .await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp4_responses, 1);
+    }
+
+    #[tokio::test]
+    async fn should_increase_the_udp4_errors_counter_when_it_receives_a_udp4_error_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::Udp4Error, &stats_repository).await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp4_errors_handled, 1);
+    }
+
+    #[tokio::test]
+    async fn should_increase_the_udp6_requests_counter_when_it_receives_a_udp6_request_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::Udp6Request, &stats_repository).await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp6_requests, 1);
+    }
+
+    #[tokio::test]
+    async fn should_increase_the_udp6_response_counter_when_it_receives_a_udp6_response_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(
+            Event::Udp6Response {
+                kind: crate::packages::udp_tracker_core::statistics::event::UdpResponseKind::Announce,
+                req_processing_time: std::time::Duration::from_secs(1),
+            },
+            &stats_repository,
+        )
+        .await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp6_responses, 1);
+    }
+    #[tokio::test]
+    async fn should_increase_the_udp6_errors_counter_when_it_receives_a_udp6_error_event() {
+        let stats_repository = Repository::new();
+
+        handle_event(Event::Udp6Error, &stats_repository).await;
+
+        let stats = stats_repository.get_stats().await;
+
+        assert_eq!(stats.udp6_errors_handled, 1);
+    }
 }


### PR DESCRIPTION
Add missing tests to `udp_tracker_core::statistics::event::handler`.

This PR includes the work done by @nuts-rice in this [PR](https://github.com/torrust/torrust-tracker/pull/1244).

I've opened this PR because the signature for the first commit in the other PR is invalid.

