### PR TITLE
Some minor changes before adding unit tests to the tracker core `databases` module.

### DIFF
--- a/packages/tracker-core/src/databases/driver/mod.rs
+++ b/packages/tracker-core/src/databases/driver/mod.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlite::Sqlite;
 
 use super::error::Error;
-use super::{Builder, Database};
+use super::Database;
 
 /// The database management system used by the tracker.
 ///
@@ -74,10 +74,10 @@ pub mod sqlite;
 ///
 /// Will return `Error` if unable to build the driver.
 pub fn build(driver: &Driver, db_path: &str) -> Result<Box<dyn Database>, Error> {
-    let database = match driver {
-        Driver::Sqlite3 => Builder::<Sqlite>::build(db_path),
-        Driver::MySQL => Builder::<Mysql>::build(db_path),
-    }?;
+    let database: Box<dyn Database> = match driver {
+        Driver::Sqlite3 => Box::new(Sqlite::new(db_path)?),
+        Driver::MySQL => Box::new(Mysql::new(db_path)?),
+    };
 
     database.create_database_tables().expect("Could not create database tables.");
 

--- a/packages/tracker-core/src/databases/driver/mod.rs
+++ b/packages/tracker-core/src/databases/driver/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! See [`databases::driver::build`](crate::core::databases::driver::build)
 //! function for more information.
+use mysql::Mysql;
 use serde::{Deserialize, Serialize};
+use sqlite::Sqlite;
 
 use super::error::Error;
-use super::mysql::Mysql;
-use super::sqlite::Sqlite;
 use super::{Builder, Database};
 
 /// The database management system used by the tracker.
@@ -61,6 +61,18 @@ pub enum Driver {
 /// # Panics
 ///
 /// This function will panic if unable to create database tables.
+pub mod mysql;
+pub mod sqlite;
+
+/// It builds a new database driver.
+///
+/// # Panics
+///
+/// Will panic if unable to create database tables.
+///
+/// # Errors
+///
+/// Will return `Error` if unable to build the driver.
 pub fn build(driver: &Driver, db_path: &str) -> Result<Box<dyn Database>, Error> {
     let database = match driver {
         Driver::Sqlite3 => Builder::<Sqlite>::build(db_path),

--- a/packages/tracker-core/src/databases/driver/mysql.rs
+++ b/packages/tracker-core/src/databases/driver/mysql.rs
@@ -9,8 +9,7 @@ use r2d2_mysql::mysql::{params, Opts, OptsBuilder};
 use r2d2_mysql::MySqlConnectionManager;
 use torrust_tracker_primitives::PersistentTorrents;
 
-use super::driver::Driver;
-use super::{Database, Error};
+use super::{Database, Driver, Error};
 use crate::authentication::key::AUTH_KEY_LENGTH;
 use crate::authentication::{self, Key};
 

--- a/packages/tracker-core/src/databases/driver/mysql.rs
+++ b/packages/tracker-core/src/databases/driver/mysql.rs
@@ -19,7 +19,7 @@ pub struct Mysql {
     pool: Pool<MySqlConnectionManager>,
 }
 
-impl Database for Mysql {
+impl Mysql {
     /// It instantiates a new `MySQL` database driver.
     ///
     /// Refer to [`databases::Database::new`](crate::core::databases::Database::new).
@@ -27,7 +27,7 @@ impl Database for Mysql {
     /// # Errors
     ///
     /// Will return `r2d2::Error` if `db_path` is not able to create `MySQL` database.
-    fn new(db_path: &str) -> Result<Self, Error> {
+    pub fn new(db_path: &str) -> Result<Self, Error> {
         let opts = Opts::from_url(db_path)?;
         let builder = OptsBuilder::from_opts(opts);
         let manager = MySqlConnectionManager::new(builder);
@@ -35,7 +35,9 @@ impl Database for Mysql {
 
         Ok(Self { pool })
     }
+}
 
+impl Database for Mysql {
     /// Refer to [`databases::Database::create_database_tables`](crate::core::databases::Database::create_database_tables).
     fn create_database_tables(&self) -> Result<(), Error> {
         let create_whitelist_table = "

--- a/packages/tracker-core/src/databases/driver/sqlite.rs
+++ b/packages/tracker-core/src/databases/driver/sqlite.rs
@@ -18,7 +18,7 @@ pub struct Sqlite {
     pool: Pool<SqliteConnectionManager>,
 }
 
-impl Database for Sqlite {
+impl Sqlite {
     /// It instantiates a new `SQLite3` database driver.
     ///
     /// Refer to [`databases::Database::new`](crate::core::databases::Database::new).
@@ -26,11 +26,15 @@ impl Database for Sqlite {
     /// # Errors
     ///
     /// Will return `r2d2::Error` if `db_path` is not able to create `SqLite` database.
-    fn new(db_path: &str) -> Result<Sqlite, Error> {
-        let cm = SqliteConnectionManager::file(db_path);
-        Pool::new(cm).map_or_else(|err| Err((err, Driver::Sqlite3).into()), |pool| Ok(Sqlite { pool }))
-    }
+    pub fn new(db_path: &str) -> Result<Self, Error> {
+        let manager = SqliteConnectionManager::file(db_path);
+        let pool = r2d2::Pool::builder().build(manager).map_err(|e| (e, DRIVER))?;
 
+        Ok(Self { pool })
+    }
+}
+
+impl Database for Sqlite {
     /// Refer to [`databases::Database::create_database_tables`](crate::core::databases::Database::create_database_tables).
     fn create_database_tables(&self) -> Result<(), Error> {
         let create_whitelist_table = "

--- a/packages/tracker-core/src/databases/driver/sqlite.rs
+++ b/packages/tracker-core/src/databases/driver/sqlite.rs
@@ -9,8 +9,7 @@ use r2d2_sqlite::rusqlite::types::Null;
 use r2d2_sqlite::SqliteConnectionManager;
 use torrust_tracker_primitives::{DurationSinceUnixEpoch, PersistentTorrents};
 
-use super::driver::Driver;
-use super::{Database, Error};
+use super::{Database, Driver, Error};
 use crate::authentication::{self, Key};
 
 const DRIVER: Driver = Driver::Sqlite3;

--- a/packages/tracker-core/src/databases/mod.rs
+++ b/packages/tracker-core/src/databases/mod.rs
@@ -45,9 +45,7 @@
 //! > **NOTICE**: All keys must have an expiration date.
 pub mod driver;
 pub mod error;
-pub mod mysql;
 pub mod setup;
-pub mod sqlite;
 
 use std::marker::PhantomData;
 
@@ -69,8 +67,6 @@ impl<T> Builder<T>
 where
     T: Database + 'static,
 {
-    /// .
-    ///
     /// # Errors
     ///
     /// Will return `r2d2::Error` if `db_path` is not able to create a database.

--- a/packages/tracker-core/src/databases/mod.rs
+++ b/packages/tracker-core/src/databases/mod.rs
@@ -47,8 +47,6 @@ pub mod driver;
 pub mod error;
 pub mod setup;
 
-use std::marker::PhantomData;
-
 use bittorrent_primitives::info_hash::InfoHash;
 use mockall::automock;
 use torrust_tracker_primitives::PersistentTorrents;
@@ -56,39 +54,9 @@ use torrust_tracker_primitives::PersistentTorrents;
 use self::error::Error;
 use crate::authentication::{self, Key};
 
-struct Builder<T>
-where
-    T: Database,
-{
-    phantom: PhantomData<T>,
-}
-
-impl<T> Builder<T>
-where
-    T: Database + 'static,
-{
-    /// # Errors
-    ///
-    /// Will return `r2d2::Error` if `db_path` is not able to create a database.
-    pub(self) fn build(db_path: &str) -> Result<Box<dyn Database>, Error> {
-        Ok(Box::new(T::new(db_path)?))
-    }
-}
-
 /// The persistence trait. It contains all the methods to interact with the database.
 #[automock]
 pub trait Database: Sync + Send {
-    /// It instantiates a new database driver.
-    ///
-    /// # Errors
-    ///
-    /// Will return `r2d2::Error` if `db_path` is not able to create a database.
-    fn new(db_path: &str) -> Result<Self, Error>
-    where
-        Self: std::marker::Sized;
-
-    // Schema
-
     /// It generates the database tables. SQL queries are hardcoded in the trait
     /// implementation.
     ///


### PR DESCRIPTION
Some minor changes before [adding unit tests to the tracker core `databases` module](https://github.com/torrust/torrust-tracker/issues/1251).

- [x] Reorganize the module.
- [x] Remove the the `new` method from the `Database` trait.

I have removed the `new` method from the `Database` trait because:

- Drivers' dependencies might be different in the future for different drivers.
- You can have conflicts when mocking the trait. See https://github.com/asomers/mockall/commit/7c54ed1999c4c44cbc0c71701d5293e781c7d7a9
- The constructor is not part of the trait behavior in this case.