### PR TITLE
Overhaul core Tracker: move authentication to `http-tracker-core` and `udp-tracker-core`

### DIFF
--- a/packages/http-protocol/src/v1/responses/error.rs
+++ b/packages/http-protocol/src/v1/responses/error.rs
@@ -79,6 +79,14 @@ impl From<bittorrent_tracker_core::error::WhitelistError> for Error {
     }
 }
 
+impl From<bittorrent_tracker_core::authentication::Error> for Error {
+    fn from(err: bittorrent_tracker_core::authentication::Error) -> Self {
+        Error {
+            failure_reason: format!("Tracker authentication error: {err}"),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/packages/tracker-core/src/authentication/key/mod.rs
+++ b/packages/tracker-core/src/authentication/key/mod.rs
@@ -185,6 +185,10 @@ pub enum Error {
     /// Indicates that the key has expired.
     #[error("Key has expired, {location}")]
     KeyExpired { location: &'static Location<'static> },
+
+    /// Indicates that the required key for authentication was not provided.
+    #[error("Missing authentication key, {location}")]
+    MissingAuthKey { location: &'static Location<'static> },
 }
 
 impl From<r2d2_sqlite::rusqlite::Error> for Error {

--- a/src/packages/udp_tracker_core/connection_cookie.rs
+++ b/src/packages/udp_tracker_core/connection_cookie.rs
@@ -79,11 +79,24 @@
 
 use aquatic_udp_protocol::ConnectionId as Cookie;
 use cookie_builder::{assemble, decode, disassemble, encode};
+use thiserror::Error;
 use tracing::instrument;
 use zerocopy::AsBytes;
 
-use crate::servers::udp::error::ConnectionCookieError;
 use crate::shared::crypto::keys::CipherArrayBlowfish;
+
+/// Error returned when there was an error with the connection cookie.
+#[derive(Error, Debug)]
+pub enum ConnectionCookieError {
+    #[error("cookie value is not normal: {not_normal_value}")]
+    ValueNotNormal { not_normal_value: f64 },
+
+    #[error("cookie value is expired: {expired_value}, expected > {min_value}")]
+    ValueExpired { expired_value: f64, min_value: f64 },
+
+    #[error("cookie value is from future: {future_value}, expected < {max_value}")]
+    ValueFromFuture { future_value: f64, max_value: f64 },
+}
 
 /// Generates a new connection cookie.
 ///

--- a/src/packages/udp_tracker_core/mod.rs
+++ b/src/packages/udp_tracker_core/mod.rs
@@ -1,2 +1,3 @@
+pub mod connection_cookie;
 pub mod services;
 pub mod statistics;

--- a/src/packages/udp_tracker_core/services/connect.rs
+++ b/src/packages/udp_tracker_core/services/connect.rs
@@ -1,0 +1,129 @@
+//! The `connect` service.
+//!
+//! The service is responsible for handling the `connect` requests.
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aquatic_udp_protocol::ConnectionId;
+
+use crate::packages::udp_tracker_core;
+use crate::packages::udp_tracker_core::connection_cookie::{gen_remote_fingerprint, make};
+
+/// # Panics
+///
+/// IT will panic if there was an error making the connection cookie.
+pub async fn handle_connect(
+    remote_addr: SocketAddr,
+    opt_udp_stats_event_sender: &Arc<Option<Box<dyn udp_tracker_core::statistics::event::sender::Sender>>>,
+    cookie_issue_time: f64,
+) -> ConnectionId {
+    // todo: return a UDP response like the HTTP tracker instead of raw ConnectionId.
+
+    let connection_id = make(gen_remote_fingerprint(&remote_addr), cookie_issue_time).expect("it should be a normal value");
+
+    if let Some(udp_stats_event_sender) = opt_udp_stats_event_sender.as_deref() {
+        match remote_addr {
+            SocketAddr::V4(_) => {
+                udp_stats_event_sender
+                    .send_event(udp_tracker_core::statistics::event::Event::Udp4Connect)
+                    .await;
+            }
+            SocketAddr::V6(_) => {
+                udp_stats_event_sender
+                    .send_event(udp_tracker_core::statistics::event::Event::Udp6Connect)
+                    .await;
+            }
+        }
+    }
+
+    connection_id
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod connect_request {
+
+        use std::future;
+        use std::sync::Arc;
+
+        use mockall::predicate::eq;
+
+        use crate::packages::udp_tracker_core::connection_cookie::make;
+        use crate::packages::udp_tracker_core::services::connect::handle_connect;
+        use crate::packages::udp_tracker_core::services::tests::{
+            sample_ipv4_remote_addr, sample_ipv4_remote_addr_fingerprint, sample_ipv4_socket_address, sample_ipv6_remote_addr,
+            sample_ipv6_remote_addr_fingerprint, sample_issue_time, MockUdpStatsEventSender,
+        };
+        use crate::packages::{self, udp_tracker_core};
+
+        #[tokio::test]
+        async fn a_connect_response_should_contain_the_same_transaction_id_as_the_connect_request() {
+            let (udp_stats_event_sender, _udp_stats_repository) = packages::udp_tracker_core::statistics::setup::factory(false);
+            let udp_stats_event_sender = Arc::new(udp_stats_event_sender);
+
+            let response = handle_connect(sample_ipv4_remote_addr(), &udp_stats_event_sender, sample_issue_time()).await;
+
+            assert_eq!(
+                response,
+                make(sample_ipv4_remote_addr_fingerprint(), sample_issue_time()).unwrap()
+            );
+        }
+
+        #[tokio::test]
+        async fn a_connect_response_should_contain_a_new_connection_id() {
+            let (udp_stats_event_sender, _udp_stats_repository) = packages::udp_tracker_core::statistics::setup::factory(false);
+            let udp_stats_event_sender = Arc::new(udp_stats_event_sender);
+
+            let response = handle_connect(sample_ipv4_remote_addr(), &udp_stats_event_sender, sample_issue_time()).await;
+
+            assert_eq!(
+                response,
+                make(sample_ipv4_remote_addr_fingerprint(), sample_issue_time()).unwrap(),
+            );
+        }
+
+        #[tokio::test]
+        async fn a_connect_response_should_contain_a_new_connection_id_ipv6() {
+            let (udp_stats_event_sender, _udp_stats_repository) = packages::udp_tracker_core::statistics::setup::factory(false);
+            let udp_stats_event_sender = Arc::new(udp_stats_event_sender);
+
+            let response = handle_connect(sample_ipv6_remote_addr(), &udp_stats_event_sender, sample_issue_time()).await;
+
+            assert_eq!(
+                response,
+                make(sample_ipv6_remote_addr_fingerprint(), sample_issue_time()).unwrap(),
+            );
+        }
+
+        #[tokio::test]
+        async fn it_should_send_the_upd4_connect_event_when_a_client_tries_to_connect_using_a_ip4_socket_address() {
+            let mut udp_stats_event_sender_mock = MockUdpStatsEventSender::new();
+            udp_stats_event_sender_mock
+                .expect_send_event()
+                .with(eq(udp_tracker_core::statistics::event::Event::Udp4Connect))
+                .times(1)
+                .returning(|_| Box::pin(future::ready(Some(Ok(())))));
+            let udp_stats_event_sender: Arc<Option<Box<dyn udp_tracker_core::statistics::event::sender::Sender>>> =
+                Arc::new(Some(Box::new(udp_stats_event_sender_mock)));
+
+            let client_socket_address = sample_ipv4_socket_address();
+
+            handle_connect(client_socket_address, &udp_stats_event_sender, sample_issue_time()).await;
+        }
+
+        #[tokio::test]
+        async fn it_should_send_the_upd6_connect_event_when_a_client_tries_to_connect_using_a_ip6_socket_address() {
+            let mut udp_stats_event_sender_mock = MockUdpStatsEventSender::new();
+            udp_stats_event_sender_mock
+                .expect_send_event()
+                .with(eq(udp_tracker_core::statistics::event::Event::Udp6Connect))
+                .times(1)
+                .returning(|_| Box::pin(future::ready(Some(Ok(())))));
+            let udp_stats_event_sender: Arc<Option<Box<dyn udp_tracker_core::statistics::event::sender::Sender>>> =
+                Arc::new(Some(Box::new(udp_stats_event_sender_mock)));
+
+            handle_connect(sample_ipv6_remote_addr(), &udp_stats_event_sender, sample_issue_time()).await;
+        }
+    }
+}

--- a/src/packages/udp_tracker_core/services/mod.rs
+++ b/src/packages/udp_tracker_core/services/mod.rs
@@ -1,2 +1,51 @@
 pub mod announce;
+pub mod connect;
 pub mod scrape;
+
+#[cfg(test)]
+pub(crate) mod tests {
+
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    use futures::future::BoxFuture;
+    use mockall::mock;
+    use tokio::sync::mpsc::error::SendError;
+
+    use crate::packages::udp_tracker_core;
+    use crate::packages::udp_tracker_core::connection_cookie::gen_remote_fingerprint;
+
+    pub(crate) fn sample_ipv4_remote_addr() -> SocketAddr {
+        sample_ipv4_socket_address()
+    }
+
+    pub(crate) fn sample_ipv4_remote_addr_fingerprint() -> u64 {
+        gen_remote_fingerprint(&sample_ipv4_socket_address())
+    }
+
+    pub(crate) fn sample_ipv6_remote_addr() -> SocketAddr {
+        sample_ipv6_socket_address()
+    }
+
+    pub(crate) fn sample_ipv6_remote_addr_fingerprint() -> u64 {
+        gen_remote_fingerprint(&sample_ipv6_socket_address())
+    }
+
+    pub(crate) fn sample_ipv4_socket_address() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080)
+    }
+
+    fn sample_ipv6_socket_address() -> SocketAddr {
+        SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8080)
+    }
+
+    pub(crate) fn sample_issue_time() -> f64 {
+        1_000_000_000_f64
+    }
+
+    mock! {
+        pub(crate) UdpStatsEventSender {}
+        impl udp_tracker_core::statistics::event::sender::Sender for UdpStatsEventSender {
+             fn send_event(&self, event: udp_tracker_core::statistics::event::Event) -> BoxFuture<'static,Option<Result<(),SendError<udp_tracker_core::statistics::event::Event> > > > ;
+        }
+    }
+}

--- a/src/packages/udp_tracker_core/services/scrape.rs
+++ b/src/packages/udp_tracker_core/services/scrape.rs
@@ -8,15 +8,53 @@
 //! It also sends an [`udp_tracker_core::statistics::event::Event`]
 //! because events are specific for the UDP tracker.
 use std::net::SocketAddr;
+use std::ops::Range;
 use std::sync::Arc;
 
 use aquatic_udp_protocol::ScrapeRequest;
 use bittorrent_primitives::info_hash::InfoHash;
-use bittorrent_tracker_core::error::ScrapeError;
+use bittorrent_tracker_core::error::{ScrapeError, WhitelistError};
 use bittorrent_tracker_core::scrape_handler::ScrapeHandler;
 use torrust_tracker_primitives::core::ScrapeData;
 
 use crate::packages::udp_tracker_core;
+use crate::packages::udp_tracker_core::connection_cookie::{check, gen_remote_fingerprint, ConnectionCookieError};
+
+/// Errors related to scrape requests.
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum UdpScrapeError {
+    /// Error returned when there was an error with the connection cookie.
+    #[error("Connection cookie error: {source}")]
+    ConnectionCookieError { source: ConnectionCookieError },
+
+    /// Error returned when there was an error with the tracker core scrape handler.
+    #[error("Tracker core scrape error: {source}")]
+    TrackerCoreScrapeError { source: ScrapeError },
+
+    /// Error returned when there was an error with the tracker core whitelist.
+    #[error("Tracker core whitelist error: {source}")]
+    TrackerCoreWhitelistError { source: WhitelistError },
+}
+
+impl From<ConnectionCookieError> for UdpScrapeError {
+    fn from(connection_cookie_error: ConnectionCookieError) -> Self {
+        Self::ConnectionCookieError {
+            source: connection_cookie_error,
+        }
+    }
+}
+
+impl From<ScrapeError> for UdpScrapeError {
+    fn from(scrape_error: ScrapeError) -> Self {
+        Self::TrackerCoreScrapeError { source: scrape_error }
+    }
+}
+
+impl From<WhitelistError> for UdpScrapeError {
+    fn from(whitelist_error: WhitelistError) -> Self {
+        Self::TrackerCoreWhitelistError { source: whitelist_error }
+    }
+}
 
 /// It handles the `Scrape` request.
 ///
@@ -28,7 +66,16 @@ pub async fn handle_scrape(
     request: &ScrapeRequest,
     scrape_handler: &Arc<ScrapeHandler>,
     opt_udp_stats_event_sender: &Arc<Option<Box<dyn udp_tracker_core::statistics::event::sender::Sender>>>,
-) -> Result<ScrapeData, ScrapeError> {
+    cookie_valid_range: Range<f64>,
+) -> Result<ScrapeData, UdpScrapeError> {
+    // todo: return a UDP response like the HTTP tracker instead of raw ScrapeData.
+
+    check(
+        &request.connection_id,
+        gen_remote_fingerprint(&remote_addr),
+        cookie_valid_range,
+    )?;
+
     // Convert from aquatic infohashes
     let info_hashes: Vec<InfoHash> = request.info_hashes.iter().map(|&x| x.into()).collect();
 

--- a/src/servers/http/v1/extractors/authentication_key.rs
+++ b/src/servers/http/v1/extractors/authentication_key.rs
@@ -117,11 +117,6 @@ fn custom_error(rejection: &PathRejection) -> responses::error::Error {
                 location: Location::caller(),
             })
         }
-        axum::extract::rejection::PathRejection::MissingPathParams(_) => {
-            responses::error::Error::from(auth::Error::MissingAuthKey {
-                location: Location::caller(),
-            })
-        }
         _ => responses::error::Error::from(auth::Error::CannotExtractKeyParam {
             location: Location::caller(),
         }),
@@ -148,6 +143,9 @@ mod tests {
 
         let response = parse_key(invalid_key).unwrap_err();
 
-        assert_error_response(&response, "Authentication error: Invalid format for authentication key param");
+        assert_error_response(
+            &response,
+            "Tracker authentication error: Invalid format for authentication key param",
+        );
     }
 }

--- a/src/servers/http/v1/handlers/common/auth.rs
+++ b/src/servers/http/v1/handlers/common/auth.rs
@@ -14,10 +14,9 @@ use thiserror::Error;
 /// from the URL path.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Missing authentication key param for private tracker. Error in {location}")]
-    MissingAuthKey { location: &'static Location<'static> },
     #[error("Invalid format for authentication key param. Error in {location}")]
     InvalidKeyFormat { location: &'static Location<'static> },
+
     #[error("Cannot extract authentication key param from URL path. Error in {location}")]
     CannotExtractKeyParam { location: &'static Location<'static> },
 }
@@ -25,7 +24,7 @@ pub enum Error {
 impl From<Error> for responses::error::Error {
     fn from(err: Error) -> Self {
         responses::error::Error {
-            failure_reason: format!("Authentication error: {err}"),
+            failure_reason: format!("Tracker authentication error: {err}"),
         }
     }
 }
@@ -36,6 +35,6 @@ pub fn map_auth_error_to_error_response(err: &authentication::Error) -> response
     // impl From<authentication::Error> for responses::error::Error
     // Consider moving the trait implementation to the http-protocol package.
     responses::error::Error {
-        failure_reason: format!("Authentication error: {err}"),
+        failure_reason: format!("Tracker authentication error: {err}"),
     }
 }

--- a/src/servers/http/v1/handlers/scrape.rs
+++ b/src/servers/http/v1/handlers/scrape.rs
@@ -107,6 +107,7 @@ async fn handle(
         Ok(scrape_data) => scrape_data,
         Err(error) => return (StatusCode::OK, error.write()).into_response(),
     };
+
     build_response(scrape_data)
 }
 
@@ -120,28 +121,14 @@ async fn handle_scrape(
     client_ip_sources: &ClientIpSources,
     maybe_key: Option<Key>,
 ) -> Result<ScrapeData, responses::error::Error> {
-    // todo: move authentication inside `http_tracker_core::services::scrape::handle_scrape`
-
-    // Authentication
-    let return_fake_scrape_data = if core_config.private {
-        match maybe_key {
-            Some(key) => match authentication_service.authenticate(&key).await {
-                Ok(()) => false,
-                Err(_error) => true,
-            },
-            None => true,
-        }
-    } else {
-        false
-    };
-
     http_tracker_core::services::scrape::handle_scrape(
         core_config,
         scrape_handler,
+        authentication_service,
         opt_http_stats_event_sender,
         scrape_request,
         client_ip_sources,
-        return_fake_scrape_data,
+        maybe_key,
     )
     .await
 }

--- a/src/servers/udp/error.rs
+++ b/src/servers/udp/error.rs
@@ -6,6 +6,8 @@ use derive_more::derive::Display;
 use thiserror::Error;
 use torrust_tracker_located_error::LocatedError;
 
+use crate::packages::udp_tracker_core::connection_cookie::ConnectionCookieError;
+
 #[derive(Display, Debug)]
 #[display(":?")]
 pub struct ConnectionCookie(pub ConnectionId);
@@ -42,19 +44,6 @@ pub enum Error {
     /// Error returned when tracker requires authentication.
     #[error("domain tracker requires authentication but is not supported in current UDP implementation. Location: {location}")]
     TrackerAuthenticationRequired { location: &'static Location<'static> },
-}
-
-/// Error returned when there was an error with the connection cookie.
-#[derive(Error, Debug)]
-pub enum ConnectionCookieError {
-    #[error("cookie value is not normal: {not_normal_value}")]
-    ValueNotNormal { not_normal_value: f64 },
-
-    #[error("cookie value is expired: {expired_value}, expected > {min_value}")]
-    ValueExpired { expired_value: f64, min_value: f64 },
-
-    #[error("cookie value is from future: {future_value}, expected < {max_value}")]
-    ValueFromFuture { future_value: f64, max_value: f64 },
 }
 
 impl From<RequestParseError> for Error {

--- a/src/servers/udp/error.rs
+++ b/src/servers/udp/error.rs
@@ -6,7 +6,8 @@ use derive_more::derive::Display;
 use thiserror::Error;
 use torrust_tracker_located_error::LocatedError;
 
-use crate::packages::udp_tracker_core::connection_cookie::ConnectionCookieError;
+use crate::packages::udp_tracker_core::services::announce::UdpAnnounceError;
+use crate::packages::udp_tracker_core::services::scrape::UdpScrapeError;
 
 #[derive(Display, Debug)]
 #[display(":?")]
@@ -15,18 +16,17 @@ pub struct ConnectionCookie(pub ConnectionId);
 /// Error returned by the UDP server.
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Error returned when there was an error with the connection cookie.
-    #[error("Connection cookie error: {source}")]
-    ConnectionCookieError { source: ConnectionCookieError },
-
+    /// Error returned when the request is invalid.
     #[error("error when phrasing request: {request_parse_error:?}")]
     RequestParseError { request_parse_error: RequestParseError },
 
-    /// Error returned when the domain tracker returns an error.
-    #[error("tracker server error: {source}")]
-    TrackerError {
-        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
-    },
+    /// Error returned when the domain tracker returns an announce error.
+    #[error("tracker announce error: {source}")]
+    UdpAnnounceError { source: UdpAnnounceError },
+
+    /// Error returned when the domain tracker returns an scrape error.
+    #[error("tracker scrape error: {source}")]
+    UdpScrapeError { source: UdpScrapeError },
 
     /// Error returned from a third-party library (`aquatic_udp_protocol`).
     #[error("internal server error: {message}, {location}")]
@@ -52,10 +52,18 @@ impl From<RequestParseError> for Error {
     }
 }
 
-impl From<ConnectionCookieError> for Error {
-    fn from(connection_cookie_error: ConnectionCookieError) -> Self {
-        Self::ConnectionCookieError {
-            source: connection_cookie_error,
+impl From<UdpAnnounceError> for Error {
+    fn from(udp_announce_error: UdpAnnounceError) -> Self {
+        Self::UdpAnnounceError {
+            source: udp_announce_error,
+        }
+    }
+}
+
+impl From<UdpScrapeError> for Error {
+    fn from(udp_scrape_error: UdpScrapeError) -> Self {
+        Self::UdpScrapeError {
+            source: udp_scrape_error,
         }
     }
 }

--- a/src/servers/udp/error.rs
+++ b/src/servers/udp/error.rs
@@ -13,14 +13,9 @@ pub struct ConnectionCookie(pub ConnectionId);
 /// Error returned by the UDP server.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("cookie value is not normal: {not_normal_value}")]
-    CookieValueNotNormal { not_normal_value: f64 },
-
-    #[error("cookie value is expired: {expired_value}, expected > {min_value}")]
-    CookieValueExpired { expired_value: f64, min_value: f64 },
-
-    #[error("cookie value is from future: {future_value}, expected < {max_value}")]
-    CookieValueFromFuture { future_value: f64, max_value: f64 },
+    /// Error returned when there was an error with the connection cookie.
+    #[error("Connection cookie error: {source}")]
+    ConnectionCookieError { source: ConnectionCookieError },
 
     #[error("error when phrasing request: {request_parse_error:?}")]
     RequestParseError { request_parse_error: RequestParseError },
@@ -49,8 +44,29 @@ pub enum Error {
     TrackerAuthenticationRequired { location: &'static Location<'static> },
 }
 
+/// Error returned when there was an error with the connection cookie.
+#[derive(Error, Debug)]
+pub enum ConnectionCookieError {
+    #[error("cookie value is not normal: {not_normal_value}")]
+    ValueNotNormal { not_normal_value: f64 },
+
+    #[error("cookie value is expired: {expired_value}, expected > {min_value}")]
+    ValueExpired { expired_value: f64, min_value: f64 },
+
+    #[error("cookie value is from future: {future_value}, expected < {max_value}")]
+    ValueFromFuture { future_value: f64, max_value: f64 },
+}
+
 impl From<RequestParseError> for Error {
     fn from(request_parse_error: RequestParseError) -> Self {
         Self::RequestParseError { request_parse_error }
+    }
+}
+
+impl From<ConnectionCookieError> for Error {
+    fn from(connection_cookie_error: ConnectionCookieError) -> Self {
+        Self::ConnectionCookieError {
+            source: connection_cookie_error,
+        }
     }
 }

--- a/src/servers/udp/handlers/announce.rs
+++ b/src/servers/udp/handlers/announce.rs
@@ -14,8 +14,8 @@ use torrust_tracker_configuration::Core;
 use tracing::{instrument, Level};
 use zerocopy::network_endian::I32;
 
+use crate::packages::udp_tracker_core::connection_cookie::check;
 use crate::packages::udp_tracker_core::{self};
-use crate::servers::udp::connection_cookie::check;
 use crate::servers::udp::error::Error;
 use crate::servers::udp::handlers::gen_remote_fingerprint;
 
@@ -134,7 +134,7 @@ mod tests {
             PeerId as AquaticPeerId, PeerKey, Port, TransactionId,
         };
 
-        use crate::servers::udp::connection_cookie::make;
+        use crate::packages::udp_tracker_core::connection_cookie::make;
         use crate::servers::udp::handlers::tests::{sample_ipv4_remote_addr_fingerprint, sample_issue_time};
 
         struct AnnounceRequestBuilder {
@@ -213,8 +213,8 @@ mod tests {
             use mockall::predicate::eq;
             use torrust_tracker_configuration::Core;
 
+            use crate::packages::udp_tracker_core::connection_cookie::make;
             use crate::packages::{self, udp_tracker_core};
-            use crate::servers::udp::connection_cookie::make;
             use crate::servers::udp::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
             use crate::servers::udp::handlers::tests::{
                 initialize_core_tracker_services_for_default_tracker_configuration,
@@ -447,7 +447,7 @@ mod tests {
 
                 use aquatic_udp_protocol::{InfoHash as AquaticInfoHash, PeerId as AquaticPeerId};
 
-                use crate::servers::udp::connection_cookie::make;
+                use crate::packages::udp_tracker_core::connection_cookie::make;
                 use crate::servers::udp::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
                 use crate::servers::udp::handlers::tests::{
                     initialize_core_tracker_services_for_public_tracker, sample_cookie_valid_range, sample_issue_time,
@@ -520,8 +520,8 @@ mod tests {
             use mockall::predicate::eq;
             use torrust_tracker_configuration::Core;
 
+            use crate::packages::udp_tracker_core::connection_cookie::make;
             use crate::packages::{self, udp_tracker_core};
-            use crate::servers::udp::connection_cookie::make;
             use crate::servers::udp::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
             use crate::servers::udp::handlers::tests::{
                 initialize_core_tracker_services_for_default_tracker_configuration,
@@ -776,7 +776,7 @@ mod tests {
                 use mockall::predicate::eq;
 
                 use crate::packages::udp_tracker_core;
-                use crate::servers::udp::connection_cookie::make;
+                use crate::packages::udp_tracker_core::connection_cookie::make;
                 use crate::servers::udp::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
                 use crate::servers::udp::handlers::tests::{
                     sample_cookie_valid_range, sample_issue_time, MockUdpStatsEventSender, TrackerConfigurationBuilder,

--- a/src/servers/udp/handlers/announce.rs
+++ b/src/servers/udp/handlers/announce.rs
@@ -50,7 +50,7 @@ pub async fn handle_announce(
         gen_remote_fingerprint(&remote_addr),
         cookie_valid_range,
     )
-    .map_err(|e| (e, request.transaction_id))?;
+    .map_err(|e| (e.into(), request.transaction_id))?;
 
     let response = udp_tracker_core::services::announce::handle_announce(
         remote_addr,

--- a/src/servers/udp/handlers/connect.rs
+++ b/src/servers/udp/handlers/connect.rs
@@ -6,8 +6,7 @@ use aquatic_udp_protocol::{ConnectRequest, ConnectResponse, Response};
 use tracing::{instrument, Level};
 
 use crate::packages::udp_tracker_core;
-use crate::packages::udp_tracker_core::connection_cookie::make;
-use crate::servers::udp::handlers::gen_remote_fingerprint;
+use crate::packages::udp_tracker_core::connection_cookie::{gen_remote_fingerprint, make};
 
 /// It handles the `Connect` request. Refer to [`Connect`](crate::servers::udp#connect)
 /// request for more information.

--- a/src/servers/udp/handlers/connect.rs
+++ b/src/servers/udp/handlers/connect.rs
@@ -6,7 +6,7 @@ use aquatic_udp_protocol::{ConnectRequest, ConnectResponse, Response};
 use tracing::{instrument, Level};
 
 use crate::packages::udp_tracker_core;
-use crate::servers::udp::connection_cookie::make;
+use crate::packages::udp_tracker_core::connection_cookie::make;
 use crate::servers::udp::handlers::gen_remote_fingerprint;
 
 /// It handles the `Connect` request. Refer to [`Connect`](crate::servers::udp#connect)
@@ -62,8 +62,8 @@ mod tests {
         use aquatic_udp_protocol::{ConnectRequest, ConnectResponse, Response, TransactionId};
         use mockall::predicate::eq;
 
+        use crate::packages::udp_tracker_core::connection_cookie::make;
         use crate::packages::{self, udp_tracker_core};
-        use crate::servers::udp::connection_cookie::make;
         use crate::servers::udp::handlers::handle_connect;
         use crate::servers::udp::handlers::tests::{
             sample_ipv4_remote_addr, sample_ipv4_remote_addr_fingerprint, sample_ipv4_socket_address, sample_ipv6_remote_addr,

--- a/src/servers/udp/handlers/error.rs
+++ b/src/servers/udp/handlers/error.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 use zerocopy::network_endian::I32;
 
 use crate::packages::udp_tracker_core;
-use crate::servers::udp::connection_cookie::check;
+use crate::packages::udp_tracker_core::connection_cookie::check;
 use crate::servers::udp::error::Error;
 use crate::servers::udp::handlers::gen_remote_fingerprint;
 use crate::servers::udp::UDP_TRACKER_LOG_TARGET;

--- a/src/servers/udp/handlers/error.rs
+++ b/src/servers/udp/handlers/error.rs
@@ -9,9 +9,8 @@ use uuid::Uuid;
 use zerocopy::network_endian::I32;
 
 use crate::packages::udp_tracker_core;
-use crate::packages::udp_tracker_core::connection_cookie::check;
+use crate::packages::udp_tracker_core::connection_cookie::{check, gen_remote_fingerprint};
 use crate::servers::udp::error::Error;
-use crate::servers::udp::handlers::gen_remote_fingerprint;
 use crate::servers::udp::UDP_TRACKER_LOG_TARGET;
 
 #[allow(clippy::too_many_arguments)]

--- a/src/servers/udp/handlers/mod.rs
+++ b/src/servers/udp/handlers/mod.rs
@@ -78,15 +78,10 @@ pub(crate) async fn handle_packet(
             {
                 Ok(response) => return response,
                 Err((e, transaction_id)) => {
-                    match &e {
-                        Error::CookieValueNotNormal { .. }
-                        | Error::CookieValueExpired { .. }
-                        | Error::CookieValueFromFuture { .. } => {
-                            // code-review: should we include `RequestParseError` and `BadRequest`?
-                            let mut ban_service = udp_tracker_container.ban_service.write().await;
-                            ban_service.increase_counter(&udp_request.from.ip());
-                        }
-                        _ => {}
+                    if let Error::ConnectionCookieError { .. } = &e {
+                        // code-review: should we include `RequestParseError` and `BadRequest`?
+                        let mut ban_service = udp_tracker_container.ban_service.write().await;
+                        ban_service.increase_counter(&udp_request.from.ip());
                     }
 
                     handle_error(

--- a/src/servers/udp/handlers/scrape.rs
+++ b/src/servers/udp/handlers/scrape.rs
@@ -7,6 +7,7 @@ use aquatic_udp_protocol::{
     NumberOfDownloads, NumberOfPeers, Response, ScrapeRequest, ScrapeResponse, TorrentScrapeStatistics, TransactionId,
 };
 use bittorrent_tracker_core::scrape_handler::ScrapeHandler;
+use torrust_tracker_primitives::core::ScrapeData;
 use tracing::{instrument, Level};
 use zerocopy::network_endian::I32;
 
@@ -43,8 +44,10 @@ pub async fn handle_scrape(
     .await
     .map_err(|e| (e.into(), request.transaction_id))?;
 
-    // todo: extract `build_response` function.
+    Ok(build_response(request, &scrape_data))
+}
 
+fn build_response(request: &ScrapeRequest, scrape_data: &ScrapeData) -> Response {
     let mut torrent_stats: Vec<TorrentScrapeStatistics> = Vec::new();
 
     for file in &scrape_data.files {
@@ -67,7 +70,7 @@ pub async fn handle_scrape(
         torrent_stats,
     };
 
-    Ok(Response::from(response))
+    Response::from(response)
 }
 
 #[cfg(test)]

--- a/src/servers/udp/handlers/scrape.rs
+++ b/src/servers/udp/handlers/scrape.rs
@@ -42,7 +42,7 @@ pub async fn handle_scrape(
         gen_remote_fingerprint(&remote_addr),
         cookie_valid_range,
     )
-    .map_err(|e| (e, request.transaction_id))?;
+    .map_err(|e| (e.into(), request.transaction_id))?;
 
     let scrape_data =
         udp_tracker_core::services::scrape::handle_scrape(remote_addr, request, scrape_handler, opt_udp_stats_event_sender)

--- a/src/servers/udp/handlers/scrape.rs
+++ b/src/servers/udp/handlers/scrape.rs
@@ -11,7 +11,7 @@ use tracing::{instrument, Level};
 use zerocopy::network_endian::I32;
 
 use crate::packages::udp_tracker_core;
-use crate::servers::udp::connection_cookie::check;
+use crate::packages::udp_tracker_core::connection_cookie::check;
 use crate::servers::udp::error::Error;
 use crate::servers::udp::handlers::gen_remote_fingerprint;
 
@@ -94,7 +94,7 @@ mod tests {
         use bittorrent_tracker_core::torrent::repository::in_memory::InMemoryTorrentRepository;
 
         use crate::packages;
-        use crate::servers::udp::connection_cookie::make;
+        use crate::packages::udp_tracker_core::connection_cookie::make;
         use crate::servers::udp::handlers::tests::{
             initialize_core_tracker_services_for_public_tracker, sample_cookie_valid_range, sample_ipv4_remote_addr,
             sample_issue_time, TorrentPeerBuilder,

--- a/src/servers/udp/mod.rs
+++ b/src/servers/udp/mod.rs
@@ -105,7 +105,7 @@
 //! connection ID = hash(client IP + current time slot + secret seed)
 //! ```
 //!
-//! The BEP-15 recommends a two-minute time slot. Refer to [`connection_cookie`]
+//! The BEP-15 recommends a two-minute time slot. Refer to [`connection_cookie`](crate::packages::udp_tracker_core::connection_cookie)
 //! for more information about the connection ID generation with this method.
 //!
 //! #### Connect Request

--- a/src/servers/udp/mod.rs
+++ b/src/servers/udp/mod.rs
@@ -637,7 +637,6 @@
 
 use std::net::SocketAddr;
 
-pub mod connection_cookie;
 pub mod error;
 pub mod handlers;
 pub mod server;

--- a/tests/servers/http/asserts.rs
+++ b/tests/servers/http/asserts.rs
@@ -141,5 +141,9 @@ pub async fn assert_cannot_parse_query_params_error_response(response: Response,
 pub async fn assert_authentication_error_response(response: Response) {
     assert_eq!(response.status(), 200);
 
-    assert_bencoded_error(&response.text().await.unwrap(), "Authentication error", Location::caller());
+    assert_bencoded_error(
+        &response.text().await.unwrap(),
+        "Tracker authentication error",
+        Location::caller(),
+    );
 }


### PR DESCRIPTION
Overhaul core Tracker: move authentication to `http-tracker-core` and `udp-tracker-core`.

HTTP Tracker:
- [x] Announce
- [x] Scrape

UDP Tracker:
- [x] Announce
- [x] Scrape