### PR TITLE
docs: remove code-review comment

### DIFF
--- a/packages/tracker-core/src/announce_handler.rs
+++ b/packages/tracker-core/src/announce_handler.rs
@@ -162,10 +162,6 @@ impl AnnounceHandler {
         remote_client_ip: &IpAddr,
         peers_wanted: &PeersWanted,
     ) -> Result<AnnounceData, AnnounceError> {
-        // code-review: maybe instead of mutating the peer we could just return
-        // a tuple with the new peer and the announce data: (Peer, AnnounceData).
-        // It could even be a different struct: `StoredPeer` or `PublicPeer`.
-
         self.whitelist_authorization.authorize(info_hash).await?;
 
         tracing::debug!("Before: {peer:?}");


### PR DESCRIPTION
We decided not to change it.

- The returned value is simpler.
- We force the initial peer to change so there is no confusion about what was the final announced peer.