### PR TITLE
Remove explicit declaration of workspace members from `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,18 +108,7 @@ torrust-tracker-api-client = { version = "3.0.0-develop", path = "packages/track
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "packages/test-helpers" }
 
 [workspace]
-members = [
-    "console/tracker-client",
-    "contrib/bencode",
-    "packages/configuration",
-    "packages/located-error",
-    "packages/primitives",
-    "packages/test-helpers",
-    "packages/torrent-repository",
-    "packages/tracker-api-client",
-    "packages/tracker-client",
-    "packages/tracker-core",
-]
+members = ["console/tracker-client"]
 
 [profile.dev]
 debug = 1


### PR DESCRIPTION
The application works anyway because _all [path dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies) residing in the workspace directory automatically become members_.

See https://doc.rust-lang.org/cargo/reference/workspaces.html#the-members-and-exclude-fields.