### PR TITLE
Refactor packages:  review `AnnounceEvent` struct

### DIFF
--- a/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
@@ -4,11 +4,10 @@
 //! and resolve the client IP address.
 use std::sync::Arc;
 
-use aquatic_udp_protocol::AnnounceEvent;
 use axum::extract::State;
 use axum::response::{IntoResponse, Response};
 use bittorrent_http_tracker_core::services::announce::HttpAnnounceError;
-use bittorrent_http_tracker_protocol::v1::requests::announce::{Announce, Compact, Event};
+use bittorrent_http_tracker_protocol::v1::requests::announce::{Announce, Compact};
 use bittorrent_http_tracker_protocol::v1::responses::{self};
 use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 use bittorrent_tracker_core::announce_handler::AnnounceHandler;
@@ -155,30 +154,6 @@ fn build_response(announce_request: &Announce, announce_data: AnnounceData) -> R
         let response: responses::Announce<responses::Normal> = announce_data.into();
         let bytes: Vec<u8> = response.data.into();
         (StatusCode::OK, bytes).into_response()
-    }
-}
-
-#[must_use]
-pub fn map_to_aquatic_event(event: &Option<Event>) -> aquatic_udp_protocol::AnnounceEvent {
-    match event {
-        Some(event) => match &event {
-            Event::Started => aquatic_udp_protocol::AnnounceEvent::Started,
-            Event::Stopped => aquatic_udp_protocol::AnnounceEvent::Stopped,
-            Event::Completed => aquatic_udp_protocol::AnnounceEvent::Completed,
-        },
-        None => aquatic_udp_protocol::AnnounceEvent::None,
-    }
-}
-
-#[must_use]
-pub fn map_to_torrust_event(event: &Option<Event>) -> AnnounceEvent {
-    match event {
-        Some(event) => match &event {
-            Event::Started => AnnounceEvent::Started,
-            Event::Stopped => AnnounceEvent::Stopped,
-            Event::Completed => AnnounceEvent::Completed,
-        },
-        None => AnnounceEvent::None,
     }
 }
 

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -399,12 +399,12 @@ pub fn peer_from_request(announce_request: &Announce, peer_ip: &IpAddr) -> peer:
         uploaded: announce_request.uploaded.unwrap_or(NumberOfBytes::new(0)),
         downloaded: announce_request.downloaded.unwrap_or(NumberOfBytes::new(0)),
         left: announce_request.left.unwrap_or(NumberOfBytes::new(0)),
-        event: map_to_torrust_event(&announce_request.event),
+        event: convert_to_aquatic_event(&announce_request.event),
     }
 }
 
 #[must_use]
-pub fn map_to_torrust_event(event: &Option<Event>) -> AnnounceEvent {
+pub fn convert_to_aquatic_event(event: &Option<Event>) -> aquatic_udp_protocol::request::AnnounceEvent {
     match event {
         Some(event) => match &event {
             Event::Started => AnnounceEvent::Started,
@@ -444,7 +444,7 @@ mod tests {
             assert_eq!(
                 announce_request,
                 Announce {
-                    info_hash: "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(),
+                    info_hash: "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(), // DevSkim: ignore DS173237
                     peer_id: PeerId(*b"-qB00000000000000001"),
                     port: 17548,
                     downloaded: None,
@@ -479,7 +479,7 @@ mod tests {
             assert_eq!(
                 announce_request,
                 Announce {
-                    info_hash: "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(),
+                    info_hash: "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0".parse::<InfoHash>().unwrap(), // DevSkim: ignore DS173237
                     peer_id: PeerId(*b"-qB00000000000000001"),
                     port: 17548,
                     downloaded: Some(NumberOfBytes::new(1)),

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -145,15 +145,21 @@ pub enum ParseAnnounceQueryError {
 ///
 /// Refer to [BEP 03. The `BitTorrent Protocol` Specification](https://www.bittorrent.org/beps/bep_0003.html)
 /// for more information.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone)]
 pub enum Event {
     /// Event sent when a download first begins.
     Started,
+
     /// Event sent when the downloader cease downloading.
     Stopped,
+
     /// Event sent when the download is complete.
-    /// No `completed` is sent if the file was complete when started
+    /// No `completed` is sent if the file was complete when started.
     Completed,
+
+    /// It is the same as not being present. If not present, this is one of the
+    /// announcements done at regular intervals.
+    Empty,
 }
 
 impl FromStr for Event {
@@ -164,6 +170,7 @@ impl FromStr for Event {
             "started" => Ok(Self::Started),
             "stopped" => Ok(Self::Stopped),
             "completed" => Ok(Self::Completed),
+            "empty" => Ok(Self::Empty),
             _ => Err(ParseAnnounceQueryError::InvalidParam {
                 param_name: EVENT.to_owned(),
                 param_value: raw_param.to_owned(),
@@ -179,17 +186,29 @@ impl fmt::Display for Event {
             Event::Started => write!(f, "started"),
             Event::Stopped => write!(f, "stopped"),
             Event::Completed => write!(f, "completed"),
+            Event::Empty => write!(f, "empty"),
         }
     }
 }
 
 impl From<aquatic_udp_protocol::request::AnnounceEvent> for Event {
-    fn from(value: aquatic_udp_protocol::request::AnnounceEvent) -> Self {
-        match value {
+    fn from(event: aquatic_udp_protocol::request::AnnounceEvent) -> Self {
+        match event {
             AnnounceEvent::Started => Self::Started,
             AnnounceEvent::Stopped => Self::Stopped,
             AnnounceEvent::Completed => Self::Completed,
-            AnnounceEvent::None => panic!("can't convert announce event from aquatic for None variant"),
+            AnnounceEvent::None => Self::Empty,
+        }
+    }
+}
+
+impl From<Event> for aquatic_udp_protocol::request::AnnounceEvent {
+    fn from(event: Event) -> Self {
+        match event {
+            Event::Started => Self::Started,
+            Event::Stopped => Self::Stopped,
+            Event::Completed => Self::Completed,
+            Event::Empty => Self::None,
         }
     }
 }
@@ -399,19 +418,10 @@ pub fn peer_from_request(announce_request: &Announce, peer_ip: &IpAddr) -> peer:
         uploaded: announce_request.uploaded.unwrap_or(NumberOfBytes::new(0)),
         downloaded: announce_request.downloaded.unwrap_or(NumberOfBytes::new(0)),
         left: announce_request.left.unwrap_or(NumberOfBytes::new(0)),
-        event: convert_to_aquatic_event(&announce_request.event),
-    }
-}
-
-#[must_use]
-pub fn convert_to_aquatic_event(event: &Option<Event>) -> aquatic_udp_protocol::request::AnnounceEvent {
-    match event {
-        Some(event) => match &event {
-            Event::Started => AnnounceEvent::Started,
-            Event::Stopped => AnnounceEvent::Stopped,
-            Event::Completed => AnnounceEvent::Completed,
+        event: match &announce_request.event {
+            Some(event) => event.clone().into(),
+            None => AnnounceEvent::None,
         },
-        None => AnnounceEvent::None,
     }
 }
 


### PR DESCRIPTION
Refactor packages:  review `AnnounceEvent` struct.

- Modify the `bittorrent_http_tracker_protocol::v1::requests::announce::Event` introducing a new variant `Empty`. This aligns our implementation with the aquatic one and make conversions between HTTP and UDP Announce events direct. It's also part of the protocol in the [BEP 3](https://www.bittorrent.org/beps/bep_0003.html).
- Keep the UDP Announce Event as the primitive type used everywhere. I wanted to removed it from packages that are not the `udp-tracker-core` package but we are using other primitives types from the aquatic UDP tracker protocol crate. We need to carefully study it and open a new issue if we want to remove that dependency.