### PR TITLE
Fix issue generating coverage report

### DIFF
--- a/packages/udp-tracker-core/Cargo.toml
+++ b/packages/udp-tracker-core/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0"
 lazy_static = "1"
 rand = "0"
 thiserror = "2"
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 tracing = "0"


### PR DESCRIPTION
There wass a missing feature for tokio crate in the `udp-tracker-core` package.

```output
error[E0432]: unresolved import `tokio::time`
   --> packages/udp-tracker-core/src/services/banning.rs:22:12
    |
22  | use tokio::time::Instant;
    |            ^^^^ could not find `time` in `tokio`
    |
note: found an item that was configured out
   --> /home/josecelano/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/lib.rs:556:13
    |
556 |     pub mod time;
    |             ^^^^
note: the item is gated behind the `time` feature
   --> /home/josecelano/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/lib.rs:555:1
    |
555 | / cfg_time! {
556 | |     pub mod time;
557 | | }
    | |_^
    = note: this error originates in the macro `cfg_time` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0433]: failed to resolve: could not find `time` in `tokio`
   --> packages/udp-tracker-core/src/services/banning.rs:40:53
    |
40  |             last_connection_id_errors_reset: tokio::time::Instant::now(),
    |                                                     ^^^^ could not find `time` in `tokio`
    |
note: found an item that was configured out
   --> /home/josecelano/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/lib.rs:556:13
    |
556 |     pub mod time;
    |             ^^^^
note: the item is gated behind the `time` feature
   --> /home/josecelano/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.43.0/src/lib.rs:555:1
    |
555 | / cfg_time! {
556 | |     pub mod time;
557 | | }
    | |_^
    = note: this error originates in the macro `cfg_time` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing this struct
    |
18  + use std::time::Instant;
    |
help: if you import `Instant`, refer to it directly
    |
40  -             last_connection_id_errors_reset: tokio::time::Instant::now(),
40  +             last_connection_id_errors_reset: Instant::now(),
    |

Some errors have detailed explanations: E0432, E0433.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `bittorrent-udp-tracker-core` (lib test) due to 2 previous errors
error: process didn't exit successfully: `/home/josecelano/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/bin/cargo test --tests --manifest-path /home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker/Cargo.toml --target-dir /home/josecelano/Documents/git/committer/me/github/torrust/torrust-tracker/target/llvm-cov-target --package bittorrent-udp-tracker-core` (exit status: 101)
```