### PR TITLE
Overhaul stats events: merge HTTP core events with a different IP version

### DIFF
--- a/contrib/dev-tools/git/hooks/pre-commit.sh
+++ b/contrib/dev-tools/git/hooks/pre-commit.sh
@@ -6,4 +6,5 @@ cargo +nightly fmt --check &&
     cargo +nightly machete &&
     cargo +stable build &&
     CARGO_INCREMENTAL=0 cargo +stable clippy --no-deps --tests --benches --examples --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::complexity -D clippy::perf -D clippy::style -D clippy::pedantic &&
+    cargo +stable test --doc --workspace &&
     cargo +stable test --tests --benches --examples --workspace --all-targets --all-features

--- a/contrib/dev-tools/git/hooks/pre-push.sh
+++ b/contrib/dev-tools/git/hooks/pre-push.sh
@@ -6,5 +6,6 @@ cargo +nightly fmt --check &&
     cargo +nightly machete &&
     cargo +stable build &&
     CARGO_INCREMENTAL=0 cargo +stable clippy --no-deps --tests --benches --examples --workspace --all-targets --all-features -- -D clippy::correctness -D clippy::suspicious -D clippy::complexity -D clippy::perf -D clippy::style -D clippy::pedantic &&
+    cargo +stable test --doc --workspace &&
     cargo +stable test --tests --benches --examples --workspace --all-targets --all-features &&
     cargo +stable run --bin e2e_tests_runner -- --config-toml-path "./share/default/config/tracker.e2e.container.sqlite3.toml"

--- a/packages/axum-http-tracker-server/src/v1/extractors/client_ip_sources.rs
+++ b/packages/axum-http-tracker-server/src/v1/extractors/client_ip_sources.rs
@@ -63,13 +63,13 @@ where
             };
 
             let connection_info_ip = match ConnectInfo::<SocketAddr>::from_request_parts(parts, state).await {
-                Ok(connection_info_socket_addr) => Some(connection_info_socket_addr.0.ip()),
+                Ok(connection_info_socket_addr) => Some(connection_info_socket_addr.0),
                 Err(_) => None,
             };
 
             Ok(Extract(ClientIpSources {
                 right_most_x_forwarded_for,
-                connection_info_ip,
+                connection_info_socket_address: connection_info_ip,
             }))
         }
     }

--- a/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
@@ -2,6 +2,7 @@
 //!
 //! The handlers perform the authentication and authorization of the request,
 //! and resolve the client IP address.
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::extract::State;
@@ -22,27 +23,27 @@ use crate::v1::extractors::client_ip_sources::Extract as ExtractClientIpSources;
 /// authentication (no PATH `key` parameter required).
 #[allow(clippy::unused_async)]
 pub async fn handle_without_key(
-    State(state): State<Arc<AnnounceService>>,
+    State(state): State<(Arc<AnnounceService>, SocketAddr)>,
     ExtractRequest(announce_request): ExtractRequest,
     ExtractClientIpSources(client_ip_sources): ExtractClientIpSources,
 ) -> Response {
     tracing::debug!("http announce request: {:#?}", announce_request);
 
-    handle(&state, &announce_request, &client_ip_sources, None).await
+    handle(&state.0, &announce_request, &client_ip_sources, &state.1, None).await
 }
 
 /// It handles the `announce` request when the HTTP tracker requires
 /// authentication (PATH `key` parameter required).
 #[allow(clippy::unused_async)]
 pub async fn handle_with_key(
-    State(state): State<Arc<AnnounceService>>,
+    State(state): State<(Arc<AnnounceService>, SocketAddr)>,
     ExtractRequest(announce_request): ExtractRequest,
     ExtractClientIpSources(client_ip_sources): ExtractClientIpSources,
     ExtractKey(key): ExtractKey,
 ) -> Response {
     tracing::debug!("http announce request: {:#?}", announce_request);
 
-    handle(&state, &announce_request, &client_ip_sources, Some(key)).await
+    handle(&state.0, &announce_request, &client_ip_sources, &state.1, Some(key)).await
 }
 
 /// It handles the `announce` request.
@@ -53,9 +54,18 @@ async fn handle(
     announce_service: &Arc<AnnounceService>,
     announce_request: &Announce,
     client_ip_sources: &ClientIpSources,
+    server_socket_addr: &SocketAddr,
     maybe_key: Option<Key>,
 ) -> Response {
-    let announce_data = match handle_announce(announce_service, announce_request, client_ip_sources, maybe_key).await {
+    let announce_data = match handle_announce(
+        announce_service,
+        announce_request,
+        client_ip_sources,
+        server_socket_addr,
+        maybe_key,
+    )
+    .await
+    {
         Ok(announce_data) => announce_data,
         Err(error) => {
             let error_response = responses::error::Error {
@@ -71,10 +81,11 @@ async fn handle_announce(
     announce_service: &Arc<AnnounceService>,
     announce_request: &Announce,
     client_ip_sources: &ClientIpSources,
+    server_socket_addr: &SocketAddr,
     maybe_key: Option<Key>,
 ) -> Result<AnnounceData, HttpAnnounceError> {
     announce_service
-        .handle_announce(announce_request, client_ip_sources, maybe_key)
+        .handle_announce(announce_request, client_ip_sources, server_socket_addr, maybe_key)
         .await
 }
 
@@ -196,6 +207,7 @@ mod tests {
 
     mod with_tracker_in_private_mode {
 
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
         use bittorrent_http_tracker_protocol::v1::responses;
@@ -209,12 +221,15 @@ mod tests {
         async fn it_should_fail_when_the_authentication_key_is_missing() {
             let http_core_tracker_services = initialize_private_tracker();
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let maybe_key = None;
 
             let response = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &sample_client_ip_sources(),
+                &server_socket_addr,
                 maybe_key,
             )
             .await
@@ -236,12 +251,15 @@ mod tests {
 
             let unregistered_key = authentication::Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let maybe_key = Some(unregistered_key);
 
             let response = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &sample_client_ip_sources(),
+                &server_socket_addr,
                 maybe_key,
             )
             .await
@@ -260,6 +278,8 @@ mod tests {
 
     mod with_tracker_in_listed_mode {
 
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
         use bittorrent_http_tracker_protocol::v1::responses;
 
         use super::{initialize_listed_tracker, sample_announce_request, sample_client_ip_sources};
@@ -272,10 +292,13 @@ mod tests {
 
             let announce_request = sample_announce_request();
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let response = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &announce_request,
                 &sample_client_ip_sources(),
+                &server_socket_addr,
                 None,
             )
             .await
@@ -297,6 +320,8 @@ mod tests {
 
     mod with_tracker_on_reverse_proxy {
 
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
         use bittorrent_http_tracker_protocol::v1::responses;
         use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
@@ -313,10 +338,13 @@ mod tests {
                 connection_info_ip: None,
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let response = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &client_ip_sources,
+                &server_socket_addr,
                 None,
             )
             .await
@@ -335,6 +363,8 @@ mod tests {
 
     mod with_tracker_not_on_reverse_proxy {
 
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
         use bittorrent_http_tracker_protocol::v1::responses;
         use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
@@ -351,10 +381,13 @@ mod tests {
                 connection_info_ip: None,
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let response = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &client_ip_sources,
+                &server_socket_addr,
                 None,
             )
             .await

--- a/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-tracker-server/src/v1/handlers/announce.rs
@@ -194,7 +194,7 @@ mod tests {
     fn sample_client_ip_sources() -> ClientIpSources {
         ClientIpSources {
             right_most_x_forwarded_for: None,
-            connection_info_ip: None,
+            connection_info_socket_address: None,
         }
     }
 
@@ -335,7 +335,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: None,
+                connection_info_socket_address: None,
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -378,7 +378,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: None,
+                connection_info_socket_address: None,
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);

--- a/packages/axum-http-tracker-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-tracker-server/src/v1/handlers/scrape.rs
@@ -79,7 +79,7 @@ fn build_response(scrape_data: ScrapeData) -> Response {
 
 #[cfg(test)]
 mod tests {
-    use std::net::IpAddr;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -155,7 +155,7 @@ mod tests {
     fn sample_client_ip_sources() -> ClientIpSources {
         ClientIpSources {
             right_most_x_forwarded_for: Some(IpAddr::from_str("203.0.113.195").unwrap()),
-            connection_info_ip: Some(IpAddr::from_str("203.0.113.196").unwrap()),
+            connection_info_socket_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 196)), 8080)),
         }
     }
 
@@ -282,7 +282,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: None,
+                connection_info_socket_address: None,
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -327,7 +327,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: None,
+                connection_info_socket_address: None,
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);

--- a/packages/axum-http-tracker-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-tracker-server/src/v1/handlers/scrape.rs
@@ -2,6 +2,7 @@
 //!
 //! The handlers perform the authentication and authorization of the request,
 //! and resolve the client IP address.
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use axum::extract::State;
@@ -22,13 +23,13 @@ use crate::v1::extractors::scrape_request::ExtractRequest;
 /// to run in `public` mode.
 #[allow(clippy::unused_async)]
 pub async fn handle_without_key(
-    State(state): State<Arc<ScrapeService>>,
+    State(state): State<(Arc<ScrapeService>, SocketAddr)>,
     ExtractRequest(scrape_request): ExtractRequest,
     ExtractClientIpSources(client_ip_sources): ExtractClientIpSources,
 ) -> Response {
     tracing::debug!("http scrape request: {:#?}", &scrape_request);
 
-    handle(&state, &scrape_request, &client_ip_sources, None).await
+    handle(&state.0, &scrape_request, &client_ip_sources, &state.1, None).await
 }
 
 /// It handles the `scrape` request when the HTTP tracker is configured
@@ -37,24 +38,25 @@ pub async fn handle_without_key(
 /// In this case, the authentication `key` parameter is required.
 #[allow(clippy::unused_async)]
 pub async fn handle_with_key(
-    State(state): State<Arc<ScrapeService>>,
+    State(state): State<(Arc<ScrapeService>, SocketAddr)>,
     ExtractRequest(scrape_request): ExtractRequest,
     ExtractClientIpSources(client_ip_sources): ExtractClientIpSources,
     ExtractKey(key): ExtractKey,
 ) -> Response {
     tracing::debug!("http scrape request: {:#?}", &scrape_request);
 
-    handle(&state, &scrape_request, &client_ip_sources, Some(key)).await
+    handle(&state.0, &scrape_request, &client_ip_sources, &state.1, Some(key)).await
 }
 
 async fn handle(
     scrape_service: &Arc<ScrapeService>,
     scrape_request: &Scrape,
     client_ip_sources: &ClientIpSources,
+    server_socket_addr: &SocketAddr,
     maybe_key: Option<Key>,
 ) -> Response {
     let scrape_data = match scrape_service
-        .handle_scrape(scrape_request, client_ip_sources, maybe_key)
+        .handle_scrape(scrape_request, client_ip_sources, server_socket_addr, maybe_key)
         .await
     {
         Ok(scrape_data) => scrape_data,
@@ -165,6 +167,7 @@ mod tests {
     }
 
     mod with_tracker_in_private_mode {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
         use bittorrent_http_tracker_core::services::scrape::ScrapeService;
@@ -175,6 +178,8 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_missing() {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
 
             let scrape_request = sample_scrape_request();
@@ -188,7 +193,7 @@ mod tests {
             );
 
             let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &sample_client_ip_sources(), maybe_key)
+                .handle_scrape(&scrape_request, &sample_client_ip_sources(), &server_socket_addr, maybe_key)
                 .await
                 .unwrap();
 
@@ -199,6 +204,8 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_invalid() {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
 
             let scrape_request = sample_scrape_request();
@@ -213,7 +220,7 @@ mod tests {
             );
 
             let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &sample_client_ip_sources(), maybe_key)
+                .handle_scrape(&scrape_request, &sample_client_ip_sources(), &server_socket_addr, maybe_key)
                 .await
                 .unwrap();
 
@@ -224,6 +231,8 @@ mod tests {
     }
 
     mod with_tracker_in_listed_mode {
+
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         use bittorrent_http_tracker_core::services::scrape::ScrapeService;
         use torrust_tracker_primitives::core::ScrapeData;
@@ -236,6 +245,8 @@ mod tests {
 
             let scrape_request = sample_scrape_request();
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -244,7 +255,7 @@ mod tests {
             );
 
             let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &sample_client_ip_sources(), None)
+                .handle_scrape(&scrape_request, &sample_client_ip_sources(), &server_socket_addr, None)
                 .await
                 .unwrap();
 
@@ -255,6 +266,8 @@ mod tests {
     }
 
     mod with_tracker_on_reverse_proxy {
+
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         use bittorrent_http_tracker_core::services::scrape::ScrapeService;
         use bittorrent_http_tracker_protocol::v1::responses;
@@ -272,6 +285,8 @@ mod tests {
                 connection_info_ip: None,
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -280,7 +295,7 @@ mod tests {
             );
 
             let response = scrape_service
-                .handle_scrape(&sample_scrape_request(), &client_ip_sources, None)
+                .handle_scrape(&sample_scrape_request(), &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap_err();
 
@@ -296,6 +311,8 @@ mod tests {
     }
 
     mod with_tracker_not_on_reverse_proxy {
+
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
         use bittorrent_http_tracker_core::services::scrape::ScrapeService;
         use bittorrent_http_tracker_protocol::v1::responses;
@@ -313,6 +330,8 @@ mod tests {
                 connection_info_ip: None,
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -321,7 +340,7 @@ mod tests {
             );
 
             let response = scrape_service
-                .handle_scrape(&sample_scrape_request(), &client_ip_sources, None)
+                .handle_scrape(&sample_scrape_request(), &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap_err();
 

--- a/packages/axum-http-tracker-server/src/v1/routes.rs
+++ b/packages/axum-http-tracker-server/src/v1/routes.rs
@@ -38,20 +38,20 @@ pub fn router(http_tracker_container: Arc<HttpTrackerCoreContainer>, server_sock
         // Announce request
         .route(
             "/announce",
-            get(announce::handle_without_key).with_state(http_tracker_container.announce_service.clone()),
+            get(announce::handle_without_key).with_state((http_tracker_container.announce_service.clone(), server_socket_addr)),
         )
         .route(
             "/announce/{key}",
-            get(announce::handle_with_key).with_state(http_tracker_container.announce_service.clone()),
+            get(announce::handle_with_key).with_state((http_tracker_container.announce_service.clone(), server_socket_addr)),
         )
         // Scrape request
         .route(
             "/scrape",
-            get(scrape::handle_without_key).with_state(http_tracker_container.scrape_service.clone()),
+            get(scrape::handle_without_key).with_state((http_tracker_container.scrape_service.clone(), server_socket_addr)),
         )
         .route(
             "/scrape/{key}",
-            get(scrape::handle_with_key).with_state(http_tracker_container.scrape_service.clone()),
+            get(scrape::handle_with_key).with_state((http_tracker_container.scrape_service.clone(), server_socket_addr)),
         )
         // Add extension to get the client IP from the connection info
         .layer(SecureClientIpSource::ConnectInfo.into_extension())

--- a/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
+++ b/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
@@ -20,7 +20,7 @@
 //! ```
 //!
 //! Depending on the tracker configuration.
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::panic::Location;
 
 use serde::{Deserialize, Serialize};
@@ -31,8 +31,9 @@ use thiserror::Error;
 pub struct ClientIpSources {
     /// The right most IP from the `X-Forwarded-For` HTTP header.
     pub right_most_x_forwarded_for: Option<IpAddr>,
-    /// The IP from the connection info.
-    pub connection_info_ip: Option<IpAddr>,
+
+    /// The client's socket address from the connection info.
+    pub connection_info_socket_address: Option<SocketAddr>,
 }
 
 /// The error that can occur when resolving the peer IP.
@@ -45,6 +46,7 @@ pub enum PeerIpResolutionError {
         "missing or invalid the right most X-Forwarded-For IP (mandatory on reverse proxy tracker configuration) in {location}"
     )]
     MissingRightMostXForwardedForIp { location: &'static Location<'static> },
+
     /// The peer IP cannot be obtained because the tracker is not configured as
     /// a reverse proxy but the connection info was not provided to the Axum
     /// framework via a route extension.
@@ -71,7 +73,7 @@ pub enum PeerIpResolutionError {
 ///     on_reverse_proxy,
 ///     &ClientIpSources {
 ///         right_most_x_forwarded_for: Some(IpAddr::from_str("203.0.113.195").unwrap()),
-///         connection_info_ip: None,
+///         connection_info_socket_address: None,
 ///     },
 /// )
 /// .unwrap();
@@ -82,7 +84,7 @@ pub enum PeerIpResolutionError {
 /// With the tracker non running on reverse proxy mode:
 ///
 /// ```rust
-/// use std::net::IpAddr;
+/// use std::net::{IpAddr,Ipv4Addr,SocketAddr};
 /// use std::str::FromStr;
 ///
 /// use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
@@ -93,7 +95,7 @@ pub enum PeerIpResolutionError {
 ///     on_reverse_proxy,
 ///     &ClientIpSources {
 ///         right_most_x_forwarded_for: None,
-///         connection_info_ip: Some(IpAddr::from_str("203.0.113.195").unwrap()),
+///         connection_info_socket_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080))
 ///     },
 /// )
 /// .unwrap();
@@ -114,8 +116,8 @@ pub fn invoke(on_reverse_proxy: bool, client_ip_sources: &ClientIpSources) -> Re
 }
 
 fn resolve_peer_ip_without_reverse_proxy(remote_client_ip: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-    if let Some(ip) = remote_client_ip.connection_info_ip {
-        Ok(ip)
+    if let Some(socket_addr) = remote_client_ip.connection_info_socket_address {
+        Ok(socket_addr.ip())
     } else {
         Err(PeerIpResolutionError::MissingClientIp {
             location: Location::caller(),
@@ -138,7 +140,7 @@ mod tests {
     use super::invoke;
 
     mod working_without_reverse_proxy {
-        use std::net::IpAddr;
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
         use super::invoke;
@@ -152,7 +154,7 @@ mod tests {
                 on_reverse_proxy,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
-                    connection_info_ip: Some(IpAddr::from_str("203.0.113.195").unwrap()),
+                    connection_info_socket_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080)),
                 },
             )
             .unwrap();
@@ -168,7 +170,7 @@ mod tests {
                 on_reverse_proxy,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
-                    connection_info_ip: None,
+                    connection_info_socket_address: None,
                 },
             )
             .unwrap_err();
@@ -191,7 +193,7 @@ mod tests {
                 on_reverse_proxy,
                 &ClientIpSources {
                     right_most_x_forwarded_for: Some(IpAddr::from_str("203.0.113.195").unwrap()),
-                    connection_info_ip: None,
+                    connection_info_socket_address: None,
                 },
             )
             .unwrap();
@@ -207,7 +209,7 @@ mod tests {
                 on_reverse_proxy,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
-                    connection_info_ip: None,
+                    connection_info_socket_address: None,
                 },
             )
             .unwrap_err();

--- a/packages/http-tracker-core/benches/helpers/sync.rs
+++ b/packages/http-tracker-core/benches/helpers/sync.rs
@@ -1,3 +1,4 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::{Duration, Instant};
 
 use bittorrent_http_tracker_core::services::announce::AnnounceService;
@@ -20,12 +21,16 @@ pub async fn return_announce_data_once(samples: u64) -> Duration {
         core_http_tracker_services.http_stats_event_sender.clone(),
     );
 
+    let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
     let start = Instant::now();
+
     for _ in 0..samples {
         let _announce_data = announce_service
-            .handle_announce(&announce_request, &client_ip_sources, None)
+            .handle_announce(&announce_request, &client_ip_sources, &server_socket_addr, None)
             .await
             .unwrap();
     }
+
     start.elapsed()
 }

--- a/packages/http-tracker-core/benches/helpers/util.rs
+++ b/packages/http-tracker-core/benches/helpers/util.rs
@@ -93,7 +93,7 @@ pub fn sample_announce_request_for_peer(peer: Peer) -> (Announce, ClientIpSource
 
     let client_ip_sources = ClientIpSources {
         right_most_x_forwarded_for: None,
-        connection_info_ip: Some(peer.peer_addr.ip()),
+        connection_info_socket_address: Some(SocketAddr::new(peer.peer_addr.ip(), 8080)),
     };
 
     (announce_request, client_ip_sources)

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -75,7 +75,7 @@ impl AnnounceService {
 
         self.authorize(announce_request.info_hash).await?;
 
-        let remote_client_ip = self.resolve_remote_client_ip(client_ip_sources)?;
+        let (remote_client_ip, opt_remote_client_port) = self.resolve_remote_client_address(client_ip_sources)?;
 
         let mut peer = peer_from_request(announce_request, &remote_client_ip);
 
@@ -86,7 +86,8 @@ impl AnnounceService {
             .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        self.send_stats_event(remote_client_ip, *server_socket_addr).await;
+        self.send_stats_event(remote_client_ip, opt_remote_client_port, *server_socket_addr)
+            .await;
 
         Ok(announce_data)
     }
@@ -108,11 +109,24 @@ impl AnnounceService {
     }
 
     /// Resolves the client's real IP address considering proxy headers
-    fn resolve_remote_client_ip(&self, client_ip_sources: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-        match peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources) {
+    fn resolve_remote_client_address(
+        &self,
+        client_ip_sources: &ClientIpSources,
+    ) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
+        let ip = match peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources) {
             Ok(peer_ip) => Ok(peer_ip),
             Err(error) => Err(error),
-        }
+        }?;
+
+        let port = if client_ip_sources.connection_info_socket_address.is_some() {
+            client_ip_sources
+                .connection_info_socket_address
+                .map(|socket_addr| socket_addr.port())
+        } else {
+            None
+        };
+
+        Ok((ip, port))
     }
 
     /// Determines how many peers the client wants in the response
@@ -123,14 +137,11 @@ impl AnnounceService {
         }
     }
 
-    async fn send_stats_event(&self, peer_ip: IpAddr, server_socket_addr: SocketAddr) {
+    async fn send_stats_event(&self, peer_ip: IpAddr, opt_peer_ip_port: Option<u16>, server_socket_addr: SocketAddr) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             http_stats_event_sender
                 .send_event(statistics::event::Event::TcpAnnounce {
-                    connection: statistics::event::ConnectionContext {
-                        client_ip_addr: peer_ip,
-                        server_socket_addr,
-                    },
+                    connection: statistics::event::ConnectionContext::new(peer_ip, opt_peer_ip_port, server_socket_addr),
                 })
                 .await;
         }
@@ -381,10 +392,7 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpAnnounce {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        server_socket_addr,
-                    },
+                    connection: ConnectionContext::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), Some(8080), server_socket_addr),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
@@ -440,10 +448,7 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpAnnounce {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                        server_socket_addr,
-                    },
+                    connection: ConnectionContext::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), Some(8080), server_socket_addr),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
@@ -482,10 +487,11 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpAnnounce {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    connection: ConnectionContext::new(
+                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        Some(8080),
                         server_socket_addr,
-                    },
+                    ),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -296,7 +296,7 @@ mod tests {
 
         let client_ip_sources = ClientIpSources {
             right_most_x_forwarded_for: None,
-            connection_info_ip: Some(peer.peer_addr.ip()),
+            connection_info_socket_address: Some(SocketAddr::new(peer.peer_addr.ip(), 8080)),
         };
 
         (announce_request, client_ip_sources)

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -7,7 +7,7 @@
 //!
 //! It also sends an [`http_tracker_core::statistics::event::Event`]
 //! because events are specific for the HTTP tracker.
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::panic::Location;
 use std::sync::Arc;
 
@@ -68,6 +68,7 @@ impl AnnounceService {
         &self,
         announce_request: &Announce,
         client_ip_sources: &ClientIpSources,
+        server_socket_addr: &SocketAddr,
         maybe_key: Option<Key>,
     ) -> Result<AnnounceData, HttpAnnounceError> {
         self.authenticate(maybe_key).await?;
@@ -85,7 +86,7 @@ impl AnnounceService {
             .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        self.send_stats_event(remote_client_ip).await;
+        self.send_stats_event(remote_client_ip, *server_socket_addr).await;
 
         Ok(announce_data)
     }
@@ -122,17 +123,27 @@ impl AnnounceService {
         }
     }
 
-    async fn send_stats_event(&self, peer_ip: IpAddr) {
+    async fn send_stats_event(&self, peer_ip: IpAddr, server_socket_addr: SocketAddr) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             match peer_ip {
                 IpAddr::V4(_) => {
                     http_stats_event_sender
-                        .send_event(statistics::event::Event::Tcp4Announce)
+                        .send_event(statistics::event::Event::Tcp4Announce {
+                            connection: statistics::event::ConnectionContext {
+                                client_ip_addr: peer_ip,
+                                server_socket_addr,
+                            },
+                        })
                         .await;
                 }
                 IpAddr::V6(_) => {
                     http_stats_event_sender
-                        .send_event(statistics::event::Event::Tcp6Announce)
+                        .send_event(statistics::event::Event::Tcp6Announce {
+                            connection: statistics::event::ConnectionContext {
+                                client_ip_addr: peer_ip,
+                                server_socket_addr,
+                            },
+                        })
                         .await;
                 }
             }
@@ -338,6 +349,7 @@ mod tests {
         };
         use crate::services::announce::AnnounceService;
         use crate::statistics;
+        use crate::statistics::event::ConnectionContext;
 
         #[tokio::test]
         async fn it_should_return_the_announce_data() {
@@ -346,6 +358,8 @@ mod tests {
             let peer = sample_peer();
 
             let (announce_request, client_ip_sources) = sample_announce_request_for_peer(peer);
+
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
 
             let announce_service = AnnounceService::new(
                 core_tracker_services.core_config.clone(),
@@ -356,7 +370,7 @@ mod tests {
             );
 
             let announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
 
@@ -375,16 +389,24 @@ mod tests {
 
         #[tokio::test]
         async fn it_should_send_the_tcp_4_announce_event_when_the_peer_uses_ipv4() {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Announce))
+                .with(eq(statistics::event::Event::Tcp4Announce {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                        server_socket_addr,
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
                 Arc::new(Some(Box::new(http_stats_event_sender_mock)));
 
             let (core_tracker_services, mut core_http_tracker_services) = initialize_core_tracker_services();
+
             core_http_tracker_services.http_stats_event_sender = http_stats_event_sender;
 
             let peer = sample_peer_using_ipv4();
@@ -400,7 +422,7 @@ mod tests {
             );
 
             let _announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }
@@ -425,11 +447,18 @@ mod tests {
         {
             // Tracker changes the peer IP to the tracker external IP when the peer is using the loopback IP.
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             // Assert that the event sent is a TCP4 event
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Announce))
+                .with(eq(statistics::event::Event::Tcp4Announce {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                        server_socket_addr,
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -437,6 +466,7 @@ mod tests {
 
             let (core_tracker_services, mut core_http_tracker_services) =
                 initialize_core_tracker_services_with_config(&tracker_with_an_ipv6_external_ip());
+
             core_http_tracker_services.http_stats_event_sender = http_stats_event_sender;
 
             let peer = peer_with_the_ipv4_loopback_ip();
@@ -452,7 +482,7 @@ mod tests {
             );
 
             let _announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }
@@ -460,10 +490,17 @@ mod tests {
         #[tokio::test]
         async fn it_should_send_the_tcp_6_announce_event_when_the_peer_uses_ipv6_even_if_the_tracker_changes_the_peer_ip_to_ipv4()
         {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Announce))
+                .with(eq(statistics::event::Event::Tcp6Announce {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        server_socket_addr,
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -484,8 +521,10 @@ mod tests {
                 core_http_tracker_services.http_stats_event_sender.clone(),
             );
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let _announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -125,28 +125,14 @@ impl AnnounceService {
 
     async fn send_stats_event(&self, peer_ip: IpAddr, server_socket_addr: SocketAddr) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
-            match peer_ip {
-                IpAddr::V4(_) => {
-                    http_stats_event_sender
-                        .send_event(statistics::event::Event::Tcp4Announce {
-                            connection: statistics::event::ConnectionContext {
-                                client_ip_addr: peer_ip,
-                                server_socket_addr,
-                            },
-                        })
-                        .await;
-                }
-                IpAddr::V6(_) => {
-                    http_stats_event_sender
-                        .send_event(statistics::event::Event::Tcp6Announce {
-                            connection: statistics::event::ConnectionContext {
-                                client_ip_addr: peer_ip,
-                                server_socket_addr,
-                            },
-                        })
-                        .await;
-                }
-            }
+            http_stats_event_sender
+                .send_event(statistics::event::Event::TcpAnnounce {
+                    connection: statistics::event::ConnectionContext {
+                        client_ip_addr: peer_ip,
+                        server_socket_addr,
+                    },
+                })
+                .await;
         }
     }
 }
@@ -394,7 +380,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Announce {
+                .with(eq(statistics::event::Event::TcpAnnounce {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
                         server_socket_addr,
@@ -453,7 +439,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Announce {
+                .with(eq(statistics::event::Event::TcpAnnounce {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
                         server_socket_addr,
@@ -495,7 +481,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Announce {
+                .with(eq(statistics::event::Event::TcpAnnounce {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                         server_socket_addr,

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -80,9 +80,10 @@ impl ScrapeService {
             self.scrape_handler.scrape(&scrape_request.info_hashes).await?
         };
 
-        let remote_client_ip = self.resolve_remote_client_ip(client_ip_sources)?;
+        let (remote_client_ip, opt_client_port) = self.resolve_remote_client_ip(client_ip_sources)?;
 
-        self.send_stats_event(remote_client_ip, *server_socket_addr).await;
+        self.send_stats_event(remote_client_ip, opt_client_port, *server_socket_addr)
+            .await;
 
         Ok(scrape_data)
     }
@@ -100,18 +101,33 @@ impl ScrapeService {
     }
 
     /// Resolves the client's real IP address considering proxy headers.
-    fn resolve_remote_client_ip(&self, client_ip_sources: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-        peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources)
+    fn resolve_remote_client_ip(
+        &self,
+        client_ip_sources: &ClientIpSources,
+    ) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
+        let ip = peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
+
+        let port = if client_ip_sources.connection_info_socket_address.is_some() {
+            client_ip_sources
+                .connection_info_socket_address
+                .map(|socket_addr| socket_addr.port())
+        } else {
+            None
+        };
+
+        Ok((ip, port))
     }
 
-    async fn send_stats_event(&self, original_peer_ip: IpAddr, server_socket_addr: SocketAddr) {
+    async fn send_stats_event(
+        &self,
+        original_peer_ip: IpAddr,
+        opt_original_peer_port: Option<u16>,
+        server_socket_addr: SocketAddr,
+    ) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             http_stats_event_sender
                 .send_event(statistics::event::Event::TcpScrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: original_peer_ip,
-                        server_socket_addr,
-                    },
+                    connection: ConnectionContext::new(original_peer_ip, opt_original_peer_port, server_socket_addr),
                 })
                 .await;
         }
@@ -336,10 +352,11 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpScrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                    },
+                    connection: ConnectionContext::new(
+                        IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                        Some(8080),
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                    ),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
@@ -384,10 +401,11 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpScrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    connection: ConnectionContext::new(
+                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        Some(8080),
                         server_socket_addr,
-                    },
+                    ),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
@@ -504,10 +522,11 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpScrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                    },
+                    connection: ConnectionContext::new(
+                        IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                        Some(8080),
+                        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                    ),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
@@ -552,10 +571,11 @@ mod tests {
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(statistics::event::Event::TcpScrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    connection: ConnectionContext::new(
+                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        Some(8080),
                         server_socket_addr,
-                    },
+                    ),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -106,21 +106,14 @@ impl ScrapeService {
 
     async fn send_stats_event(&self, original_peer_ip: IpAddr, server_socket_addr: SocketAddr) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
-            let event = match original_peer_ip {
-                IpAddr::V4(_) => statistics::event::Event::Tcp4Scrape {
+            http_stats_event_sender
+                .send_event(statistics::event::Event::TcpScrape {
                     connection: ConnectionContext {
                         client_ip_addr: original_peer_ip,
                         server_socket_addr,
                     },
-                },
-                IpAddr::V6(_) => statistics::event::Event::Tcp6Scrape {
-                    connection: ConnectionContext {
-                        client_ip_addr: original_peer_ip,
-                        server_socket_addr,
-                    },
-                },
-            };
-            http_stats_event_sender.send_event(event).await;
+                })
+                .await;
         }
     }
 }
@@ -342,7 +335,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Scrape {
+                .with(eq(statistics::event::Event::TcpScrape {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
                         server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
@@ -390,7 +383,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Scrape {
+                .with(eq(statistics::event::Event::TcpScrape {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                         server_socket_addr,
@@ -510,7 +503,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Scrape {
+                .with(eq(statistics::event::Event::TcpScrape {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
                         server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
@@ -558,7 +551,7 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Scrape {
+                .with(eq(statistics::event::Event::TcpScrape {
                     connection: ConnectionContext {
                         client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                         server_socket_addr,

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -298,7 +298,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(original_peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(original_peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -356,7 +356,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -404,7 +404,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -472,7 +472,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(original_peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(original_peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -522,7 +522,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
@@ -570,7 +570,7 @@ mod tests {
 
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
-                connection_info_ip: Some(peer_ip),
+                connection_info_socket_address: Some(SocketAddr::new(peer_ip, 8080)),
             };
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -7,7 +7,7 @@
 //!
 //! It also sends an [`http_tracker_core::statistics::event::Event`]
 //! because events are specific for the HTTP tracker.
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
@@ -20,6 +20,7 @@ use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::ScrapeData;
 
 use crate::statistics;
+use crate::statistics::event::ConnectionContext;
 
 /// The HTTP tracker `scrape` service.
 ///
@@ -70,6 +71,7 @@ impl ScrapeService {
         &self,
         scrape_request: &Scrape,
         client_ip_sources: &ClientIpSources,
+        server_socket_addr: &SocketAddr,
         maybe_key: Option<Key>,
     ) -> Result<ScrapeData, HttpScrapeError> {
         let scrape_data = if self.authentication_is_required() && !self.is_authenticated(maybe_key).await {
@@ -80,7 +82,7 @@ impl ScrapeService {
 
         let remote_client_ip = self.resolve_remote_client_ip(client_ip_sources)?;
 
-        self.send_stats_event(&remote_client_ip).await;
+        self.send_stats_event(remote_client_ip, *server_socket_addr).await;
 
         Ok(scrape_data)
     }
@@ -102,11 +104,21 @@ impl ScrapeService {
         peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources)
     }
 
-    async fn send_stats_event(&self, original_peer_ip: &IpAddr) {
+    async fn send_stats_event(&self, original_peer_ip: IpAddr, server_socket_addr: SocketAddr) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             let event = match original_peer_ip {
-                IpAddr::V4(_) => statistics::event::Event::Tcp4Scrape,
-                IpAddr::V6(_) => statistics::event::Event::Tcp6Scrape,
+                IpAddr::V4(_) => statistics::event::Event::Tcp4Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: original_peer_ip,
+                        server_socket_addr,
+                    },
+                },
+                IpAddr::V6(_) => statistics::event::Event::Tcp6Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: original_peer_ip,
+                        server_socket_addr,
+                    },
+                },
             };
             http_stats_event_sender.send_event(event).await;
         }
@@ -246,7 +258,7 @@ mod tests {
     mod with_real_data {
 
         use std::future;
-        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
         use std::sync::Arc;
 
         use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
@@ -262,6 +274,7 @@ mod tests {
         };
         use crate::services::scrape::ScrapeService;
         use crate::statistics;
+        use crate::statistics::event::ConnectionContext;
         use crate::tests::sample_info_hash;
 
         #[tokio::test]
@@ -295,6 +308,8 @@ mod tests {
                 connection_info_ip: Some(original_peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 core_config.clone(),
                 container.scrape_handler.clone(),
@@ -303,7 +318,7 @@ mod tests {
             ));
 
             let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
 
@@ -327,7 +342,12 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Scrape))
+                .with(eq(statistics::event::Event::Tcp4Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                        server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -346,6 +366,8 @@ mod tests {
                 connection_info_ip: Some(peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 Arc::new(config.core),
                 container.scrape_handler.clone(),
@@ -354,19 +376,26 @@ mod tests {
             ));
 
             scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }
 
         #[tokio::test]
         async fn it_should_send_the_tcp_6_scrape_event_when_the_peer_uses_ipv6() {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let config = configuration::ephemeral();
 
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Scrape))
+                .with(eq(statistics::event::Event::Tcp6Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        server_socket_addr,
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -385,6 +414,8 @@ mod tests {
                 connection_info_ip: Some(peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 Arc::new(config.core),
                 container.scrape_handler.clone(),
@@ -393,7 +424,7 @@ mod tests {
             ));
 
             scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }
@@ -402,7 +433,7 @@ mod tests {
     mod with_zeroed_data {
 
         use std::future;
-        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+        use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
         use std::sync::Arc;
 
         use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
@@ -417,6 +448,7 @@ mod tests {
         };
         use crate::services::scrape::ScrapeService;
         use crate::statistics;
+        use crate::statistics::event::ConnectionContext;
         use crate::tests::sample_info_hash;
 
         #[tokio::test]
@@ -450,6 +482,8 @@ mod tests {
                 connection_info_ip: Some(original_peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 Arc::new(config.core),
                 container.scrape_handler.clone(),
@@ -458,7 +492,7 @@ mod tests {
             ));
 
             let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
 
@@ -476,7 +510,12 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp4Scrape))
+                .with(eq(statistics::event::Event::Tcp4Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                        server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -493,6 +532,8 @@ mod tests {
                 connection_info_ip: Some(peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 Arc::new(config.core),
                 container.scrape_handler.clone(),
@@ -501,13 +542,15 @@ mod tests {
             ));
 
             scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }
 
         #[tokio::test]
         async fn it_should_send_the_tcp_6_scrape_event_when_the_peer_uses_ipv6() {
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let config = configuration::ephemeral();
 
             let container = initialize_services_with_configuration(&config);
@@ -515,7 +558,12 @@ mod tests {
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(statistics::event::Event::Tcp6Scrape))
+                .with(eq(statistics::event::Event::Tcp6Scrape {
+                    connection: ConnectionContext {
+                        client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        server_socket_addr,
+                    },
+                }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(())))));
             let http_stats_event_sender: Arc<Option<Box<dyn statistics::event::sender::Sender>>> =
@@ -532,6 +580,8 @@ mod tests {
                 connection_info_ip: Some(peer_ip),
             };
 
+            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
+
             let scrape_service = Arc::new(ScrapeService::new(
                 Arc::new(config.core),
                 container.scrape_handler.clone(),
@@ -540,7 +590,7 @@ mod tests {
             ));
 
             scrape_service
-                .handle_scrape(&scrape_request, &client_ip_sources, None)
+                .handle_scrape(&scrape_request, &client_ip_sources, &server_socket_addr, None)
                 .await
                 .unwrap();
         }

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -9,35 +9,17 @@ use crate::statistics::repository::Repository;
 /// version of the event.
 pub async fn handle_event(event: Event, stats_repository: &Repository) {
     match event {
-        // TCP4
-        Event::Tcp4Announce { connection } => match connection.client_ip_addr {
+        Event::TcpAnnounce { connection } => match connection.client_ip_addr {
             IpAddr::V4(_) => {
                 stats_repository.increase_tcp4_announces().await;
-            }
-            IpAddr::V6(_) => {
-                panic!("A client IPv6 address was received in a TCP4 announce event");
-            }
-        },
-        Event::Tcp4Scrape { connection } => match connection.client_ip_addr {
-            IpAddr::V4(_) => {
-                stats_repository.increase_tcp4_scrapes().await;
-            }
-            IpAddr::V6(_) => {
-                panic!("A client IPv6 address was received in a TCP4 scrape event");
-            }
-        },
-        // TCP6
-        Event::Tcp6Announce { connection } => match connection.client_ip_addr {
-            IpAddr::V4(_) => {
-                panic!("A client IPv4 address was received in a TCP6 announce event");
             }
             IpAddr::V6(_) => {
                 stats_repository.increase_tcp6_announces().await;
             }
         },
-        Event::Tcp6Scrape { connection } => match connection.client_ip_addr {
+        Event::TcpScrape { connection } => match connection.client_ip_addr {
             IpAddr::V4(_) => {
-                panic!("A client IPv4 address was received in a TCP6 scrape event");
+                stats_repository.increase_tcp4_scrapes().await;
             }
             IpAddr::V6(_) => {
                 stats_repository.increase_tcp6_scrapes().await;
@@ -61,7 +43,7 @@ mod tests {
         let stats_repository = Repository::new();
 
         handle_event(
-            Event::Tcp4Announce {
+            Event::TcpAnnounce {
                 connection: ConnectionContext {
                     client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
                     server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
@@ -81,7 +63,7 @@ mod tests {
         let stats_repository = Repository::new();
 
         handle_event(
-            Event::Tcp4Scrape {
+            Event::TcpScrape {
                 connection: ConnectionContext {
                     client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
                     server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
@@ -101,7 +83,7 @@ mod tests {
         let stats_repository = Repository::new();
 
         handle_event(
-            Event::Tcp6Announce {
+            Event::TcpAnnounce {
                 connection: ConnectionContext {
                     client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                     server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
@@ -121,7 +103,7 @@ mod tests {
         let stats_repository = Repository::new();
 
         handle_event(
-            Event::Tcp6Scrape {
+            Event::TcpScrape {
                 connection: ConnectionContext {
                     client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                     server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -1,23 +1,48 @@
+use std::net::IpAddr;
+
 use crate::statistics::event::Event;
 use crate::statistics::repository::Repository;
 
+/// # Panics
+///
+/// This function panics if the client IP address is not the same as the IP
+/// version of the event.
 pub async fn handle_event(event: Event, stats_repository: &Repository) {
     match event {
         // TCP4
-        Event::Tcp4Announce => {
-            stats_repository.increase_tcp4_announces().await;
-        }
-        Event::Tcp4Scrape => {
-            stats_repository.increase_tcp4_scrapes().await;
-        }
-
+        Event::Tcp4Announce { connection } => match connection.client_ip_addr {
+            IpAddr::V4(_) => {
+                stats_repository.increase_tcp4_announces().await;
+            }
+            IpAddr::V6(_) => {
+                panic!("A client IPv6 address was received in a TCP4 announce event");
+            }
+        },
+        Event::Tcp4Scrape { connection } => match connection.client_ip_addr {
+            IpAddr::V4(_) => {
+                stats_repository.increase_tcp4_scrapes().await;
+            }
+            IpAddr::V6(_) => {
+                panic!("A client IPv6 address was received in a TCP4 scrape event");
+            }
+        },
         // TCP6
-        Event::Tcp6Announce => {
-            stats_repository.increase_tcp6_announces().await;
-        }
-        Event::Tcp6Scrape => {
-            stats_repository.increase_tcp6_scrapes().await;
-        }
+        Event::Tcp6Announce { connection } => match connection.client_ip_addr {
+            IpAddr::V4(_) => {
+                panic!("A client IPv4 address was received in a TCP6 announce event");
+            }
+            IpAddr::V6(_) => {
+                stats_repository.increase_tcp6_announces().await;
+            }
+        },
+        Event::Tcp6Scrape { connection } => match connection.client_ip_addr {
+            IpAddr::V4(_) => {
+                panic!("A client IPv4 address was received in a TCP6 scrape event");
+            }
+            IpAddr::V6(_) => {
+                stats_repository.increase_tcp6_scrapes().await;
+            }
+        },
     }
 
     tracing::debug!("stats: {:?}", stats_repository.get_stats().await);
@@ -25,15 +50,26 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
 
 #[cfg(test)]
 mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
     use crate::statistics::event::handler::handle_event;
-    use crate::statistics::event::Event;
+    use crate::statistics::event::{ConnectionContext, Event};
     use crate::statistics::repository::Repository;
 
     #[tokio::test]
     async fn should_increase_the_tcp4_announces_counter_when_it_receives_a_tcp4_announce_event() {
         let stats_repository = Repository::new();
 
-        handle_event(Event::Tcp4Announce, &stats_repository).await;
+        handle_event(
+            Event::Tcp4Announce {
+                connection: ConnectionContext {
+                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                },
+            },
+            &stats_repository,
+        )
+        .await;
 
         let stats = stats_repository.get_stats().await;
 
@@ -44,7 +80,16 @@ mod tests {
     async fn should_increase_the_tcp4_scrapes_counter_when_it_receives_a_tcp4_scrape_event() {
         let stats_repository = Repository::new();
 
-        handle_event(Event::Tcp4Scrape, &stats_repository).await;
+        handle_event(
+            Event::Tcp4Scrape {
+                connection: ConnectionContext {
+                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                },
+            },
+            &stats_repository,
+        )
+        .await;
 
         let stats = stats_repository.get_stats().await;
 
@@ -55,7 +100,16 @@ mod tests {
     async fn should_increase_the_tcp6_announces_counter_when_it_receives_a_tcp6_announce_event() {
         let stats_repository = Repository::new();
 
-        handle_event(Event::Tcp6Announce, &stats_repository).await;
+        handle_event(
+            Event::Tcp6Announce {
+                connection: ConnectionContext {
+                    client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                },
+            },
+            &stats_repository,
+        )
+        .await;
 
         let stats = stats_repository.get_stats().await;
 
@@ -66,7 +120,16 @@ mod tests {
     async fn should_increase_the_tcp6_scrapes_counter_when_it_receives_a_tcp6_scrape_event() {
         let stats_repository = Repository::new();
 
-        handle_event(Event::Tcp6Scrape, &stats_repository).await;
+        handle_event(
+            Event::Tcp6Scrape {
+                connection: ConnectionContext {
+                    client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                },
+            },
+            &stats_repository,
+        )
+        .await;
 
         let stats = stats_repository.get_stats().await;
 

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -9,7 +9,7 @@ use crate::statistics::repository::Repository;
 /// version of the event.
 pub async fn handle_event(event: Event, stats_repository: &Repository) {
     match event {
-        Event::TcpAnnounce { connection } => match connection.client_ip_addr {
+        Event::TcpAnnounce { connection } => match connection.client_ip_addr() {
             IpAddr::V4(_) => {
                 stats_repository.increase_tcp4_announces().await;
             }
@@ -17,7 +17,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository) {
                 stats_repository.increase_tcp6_announces().await;
             }
         },
-        Event::TcpScrape { connection } => match connection.client_ip_addr {
+        Event::TcpScrape { connection } => match connection.client_ip_addr() {
             IpAddr::V4(_) => {
                 stats_repository.increase_tcp4_scrapes().await;
             }
@@ -44,10 +44,11 @@ mod tests {
 
         handle_event(
             Event::TcpAnnounce {
-                connection: ConnectionContext {
-                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                },
+                connection: ConnectionContext::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    Some(8080),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                ),
             },
             &stats_repository,
         )
@@ -64,10 +65,11 @@ mod tests {
 
         handle_event(
             Event::TcpScrape {
-                connection: ConnectionContext {
-                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                },
+                connection: ConnectionContext::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    Some(8080),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                ),
             },
             &stats_repository,
         )
@@ -84,10 +86,11 @@ mod tests {
 
         handle_event(
             Event::TcpAnnounce {
-                connection: ConnectionContext {
-                    client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                },
+                connection: ConnectionContext::new(
+                    IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    Some(8080),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                ),
             },
             &stats_repository,
         )
@@ -104,10 +107,11 @@ mod tests {
 
         handle_event(
             Event::TcpScrape {
-                connection: ConnectionContext {
-                    client_ip_addr: IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                },
+                connection: ConnectionContext::new(
+                    IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    Some(8080),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                ),
             },
             &stats_repository,
         )

--- a/packages/http-tracker-core/src/statistics/event/mod.rs
+++ b/packages/http-tracker-core/src/statistics/event/mod.rs
@@ -5,9 +5,6 @@ pub mod listener;
 pub mod sender;
 
 /// An statistics event. It is used to collect tracker metrics.
-///
-/// - `Tcp` prefix means the event was triggered by the HTTP tracker.
-/// - The event suffix is the type of request: `announce` or `scrape`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Event {
     TcpAnnounce { connection: ConnectionContext },

--- a/packages/http-tracker-core/src/statistics/event/mod.rs
+++ b/packages/http-tracker-core/src/statistics/event/mod.rs
@@ -1,3 +1,5 @@
+use std::net::{IpAddr, SocketAddr};
+
 pub mod handler;
 pub mod listener;
 pub mod sender;
@@ -5,17 +7,18 @@ pub mod sender;
 /// An statistics event. It is used to collect tracker metrics.
 ///
 /// - `Tcp` prefix means the event was triggered by the HTTP tracker
-/// - `Udp` prefix means the event was triggered by the UDP tracker
 /// - `4` or `6` prefixes means the IP version used by the peer
-/// - Finally the event suffix is the type of request: `announce`, `scrape` or `connection`
-///
-/// > NOTE: HTTP trackers do not use `connection` requests.
+/// - Finally the event suffix is the type of request: `announce` or `scrape`
 #[derive(Debug, PartialEq, Eq)]
 pub enum Event {
-    // code-review: consider one single event for request type with data: Event::Announce { scheme: HTTPorUDP, ip_version: V4orV6 }
-    // Attributes are enums too.
-    Tcp4Announce,
-    Tcp4Scrape,
-    Tcp6Announce,
-    Tcp6Scrape,
+    Tcp4Announce { connection: ConnectionContext },
+    Tcp4Scrape { connection: ConnectionContext },
+    Tcp6Announce { connection: ConnectionContext },
+    Tcp6Scrape { connection: ConnectionContext },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ConnectionContext {
+    pub client_ip_addr: IpAddr,
+    pub server_socket_addr: SocketAddr,
 }

--- a/packages/http-tracker-core/src/statistics/event/mod.rs
+++ b/packages/http-tracker-core/src/statistics/event/mod.rs
@@ -13,6 +13,39 @@ pub enum Event {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConnectionContext {
-    pub client_ip_addr: IpAddr,
-    pub server_socket_addr: SocketAddr,
+    client: ClientConnectionContext,
+    server: ServerConnectionContext,
+}
+
+impl ConnectionContext {
+    #[must_use]
+    pub fn new(client_ip_addr: IpAddr, opt_client_port: Option<u16>, server_socket_addr: SocketAddr) -> Self {
+        Self {
+            client: ClientConnectionContext {
+                ip_addr: client_ip_addr,
+                port: opt_client_port,
+            },
+            server: ServerConnectionContext {
+                socket_addr: server_socket_addr,
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn client_ip_addr(&self) -> IpAddr {
+        self.client.ip_addr
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ClientConnectionContext {
+    ip_addr: IpAddr,
+
+    /// It's provided if you use the `torrust-axum-http-tracker-server` crate.
+    port: Option<u16>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ServerConnectionContext {
+    socket_addr: SocketAddr,
 }

--- a/packages/http-tracker-core/src/statistics/event/mod.rs
+++ b/packages/http-tracker-core/src/statistics/event/mod.rs
@@ -6,15 +6,12 @@ pub mod sender;
 
 /// An statistics event. It is used to collect tracker metrics.
 ///
-/// - `Tcp` prefix means the event was triggered by the HTTP tracker
-/// - `4` or `6` prefixes means the IP version used by the peer
-/// - Finally the event suffix is the type of request: `announce` or `scrape`
+/// - `Tcp` prefix means the event was triggered by the HTTP tracker.
+/// - The event suffix is the type of request: `announce` or `scrape`.
 #[derive(Debug, PartialEq, Eq)]
 pub enum Event {
-    Tcp4Announce { connection: ConnectionContext },
-    Tcp4Scrape { connection: ConnectionContext },
-    Tcp6Announce { connection: ConnectionContext },
-    Tcp6Scrape { connection: ConnectionContext },
+    TcpAnnounce { connection: ConnectionContext },
+    TcpScrape { connection: ConnectionContext },
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/packages/http-tracker-core/src/statistics/keeper.rs
+++ b/packages/http-tracker-core/src/statistics/keeper.rs
@@ -74,10 +74,11 @@ mod tests {
 
         let result = event_sender
             .send_event(Event::TcpAnnounce {
-                connection: ConnectionContext {
-                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
-                },
+                connection: ConnectionContext::new(
+                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    Some(8080),
+                    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                ),
             })
             .await;
 

--- a/packages/http-tracker-core/src/statistics/keeper.rs
+++ b/packages/http-tracker-core/src/statistics/keeper.rs
@@ -51,7 +51,9 @@ impl Keeper {
 
 #[cfg(test)]
 mod tests {
-    use crate::statistics::event::Event;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use crate::statistics::event::{ConnectionContext, Event};
     use crate::statistics::keeper::Keeper;
     use crate::statistics::metrics::Metrics;
 
@@ -70,7 +72,14 @@ mod tests {
 
         let event_sender = stats_tracker.run_event_listener();
 
-        let result = event_sender.send_event(Event::Tcp4Announce).await;
+        let result = event_sender
+            .send_event(Event::Tcp4Announce {
+                connection: ConnectionContext {
+                    client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),
+                },
+            })
+            .await;
 
         assert!(result.is_some());
     }

--- a/packages/http-tracker-core/src/statistics/keeper.rs
+++ b/packages/http-tracker-core/src/statistics/keeper.rs
@@ -73,7 +73,7 @@ mod tests {
         let event_sender = stats_tracker.run_event_listener();
 
         let result = event_sender
-            .send_event(Event::Tcp4Announce {
+            .send_event(Event::TcpAnnounce {
                 connection: ConnectionContext {
                     client_ip_addr: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
                     server_socket_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070),


### PR DESCRIPTION
Change HTTP core tracker events (`bittorrent_http_tracker_core::statistics::event::Event`) from this:

```rust
pub enum Event {
    Tcp4Announce,
    Tcp4Scrape,
    Tcp6Announce,
    Tcp6Scrape,
}
```

To this:

```rust
pub enum Event {
    TcpAnnounce { connection: ConnectionContext },
    TcpScrape { connection: ConnectionContext },
}

pub struct ConnectionContext {
    client: ClientConnectionContext,
    server: ServerConnectionContext,
}

pub struct ClientConnectionContext {
    ip_addr: IpAddr,
    port: Option<u16>,
}

pub struct ServerConnectionContext {
    socket_addr: SocketAddr,
}

```

### Sub-tasks

- [x] Add `ConnectionContext` to events.
- [x] Merge events with the same request type (`announce` and `scrape`).
- [x] Add client port to `ConnectionContext`. `ClientIpSources` type and the `packages/axum-http-tracker-server/src/v1/extractors/client_ip_sources.rs` Axum extractor have to be changed to include also the port.