### PR TITLE
Overhaul stats: Use only UDP server stats in the REST API

### DIFF
--- a/packages/axum-rest-tracker-api-server/src/v1/context/stats/handlers.rs
+++ b/packages/axum-rest-tracker-api-server/src/v1/context/stats/handlers.rs
@@ -43,19 +43,11 @@ pub async fn get_stats_handler(
         Arc<InMemoryTorrentRepository>,
         Arc<RwLock<BanService>>,
         Arc<bittorrent_http_tracker_core::statistics::repository::Repository>,
-        Arc<bittorrent_udp_tracker_core::statistics::repository::Repository>,
         Arc<torrust_udp_tracker_server::statistics::repository::Repository>,
     )>,
     params: Query<QueryParams>,
 ) -> Response {
-    let metrics = get_metrics(
-        state.0.clone(),
-        state.1.clone(),
-        state.2.clone(),
-        state.3.clone(),
-        state.4.clone(),
-    )
-    .await;
+    let metrics = get_metrics(state.0.clone(), state.1.clone(), state.2.clone(), state.3.clone()).await;
 
     match params.0.format {
         Some(format) => match format {

--- a/packages/axum-rest-tracker-api-server/src/v1/context/stats/routes.rs
+++ b/packages/axum-rest-tracker-api-server/src/v1/context/stats/routes.rs
@@ -19,7 +19,6 @@ pub fn add(prefix: &str, router: Router, http_api_container: &Arc<TrackerHttpApi
             http_api_container.in_memory_torrent_repository.clone(),
             http_api_container.ban_service.clone(),
             http_api_container.http_stats_repository.clone(),
-            http_api_container.udp_core_stats_repository.clone(),
             http_api_container.udp_server_stats_repository.clone(),
         )),
     )

--- a/packages/rest-tracker-api-core/src/statistics/services.rs
+++ b/packages/rest-tracker-api-core/src/statistics/services.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bittorrent_tracker_core::torrent::repository::in_memory::InMemoryTorrentRepository;
 use bittorrent_udp_tracker_core::services::banning::BanService;
-use bittorrent_udp_tracker_core::{self, statistics as udp_core_statistics};
+use bittorrent_udp_tracker_core::{self};
 use tokio::sync::RwLock;
 use torrust_tracker_primitives::swarm_metadata::AggregateSwarmMetadata;
 use torrust_udp_tracker_server::statistics as udp_server_statistics;
@@ -29,13 +29,11 @@ pub async fn get_metrics(
     in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
     ban_service: Arc<RwLock<BanService>>,
     http_stats_repository: Arc<bittorrent_http_tracker_core::statistics::repository::Repository>,
-    udp_core_stats_repository: Arc<udp_core_statistics::repository::Repository>,
     udp_server_stats_repository: Arc<udp_server_statistics::repository::Repository>,
 ) -> TrackerMetrics {
     let torrents_metrics = in_memory_torrent_repository.get_torrents_metrics();
     let udp_banned_ips_total = ban_service.read().await.get_banned_ips_total();
     let http_stats = http_stats_repository.get_stats().await;
-    let udp_core_stats = udp_core_stats_repository.get_stats().await;
     let udp_server_stats = udp_server_stats_repository.get_stats().await;
 
     // For backward compatibility we keep the `tcp4_connections_handled` and
@@ -63,16 +61,16 @@ pub async fn get_metrics(
             udp_avg_scrape_processing_time_ns: udp_server_stats.udp_avg_scrape_processing_time_ns,
             // UDPv4
             udp4_requests: udp_server_stats.udp4_requests,
-            udp4_connections_handled: udp_core_stats.udp4_connections_handled,
-            udp4_announces_handled: udp_core_stats.udp4_announces_handled,
-            udp4_scrapes_handled: udp_core_stats.udp4_scrapes_handled,
+            udp4_connections_handled: udp_server_stats.udp4_connections_handled,
+            udp4_announces_handled: udp_server_stats.udp4_announces_handled,
+            udp4_scrapes_handled: udp_server_stats.udp4_scrapes_handled,
             udp4_responses: udp_server_stats.udp4_responses,
             udp4_errors_handled: udp_server_stats.udp4_errors_handled,
             // UDPv6
             udp6_requests: udp_server_stats.udp6_requests,
-            udp6_connections_handled: udp_core_stats.udp6_connections_handled,
-            udp6_announces_handled: udp_core_stats.udp6_announces_handled,
-            udp6_scrapes_handled: udp_core_stats.udp6_scrapes_handled,
+            udp6_connections_handled: udp_server_stats.udp6_connections_handled,
+            udp6_announces_handled: udp_server_stats.udp6_announces_handled,
+            udp6_scrapes_handled: udp_server_stats.udp6_scrapes_handled,
             udp6_responses: udp_server_stats.udp6_responses,
             udp6_errors_handled: udp_server_stats.udp6_errors_handled,
         },
@@ -112,9 +110,8 @@ mod tests {
         let http_stats_repository = Arc::new(http_stats_repository);
 
         // UDP core stats
-        let (_udp_stats_event_sender, udp_stats_repository) =
+        let (_udp_stats_event_sender, _udp_stats_repository) =
             bittorrent_udp_tracker_core::statistics::setup::factory(config.core.tracker_usage_statistics);
-        let udp_stats_repository = Arc::new(udp_stats_repository);
 
         // UDP server stats
         let (_udp_server_stats_event_sender, udp_server_stats_repository) =
@@ -125,7 +122,6 @@ mod tests {
             in_memory_torrent_repository.clone(),
             ban_service.clone(),
             http_stats_repository.clone(),
-            udp_stats_repository.clone(),
             udp_server_stats_repository.clone(),
         )
         .await;


### PR DESCRIPTION
Overhaul stats: Use only UDP server stats in the REST API.