### PR TITLE
Overhaul stats: add a configuration option to enable/disable stats per server

### DIFF
--- a/packages/configuration/src/v2_0_0/core.rs
+++ b/packages/configuration/src/v2_0_0/core.rs
@@ -103,6 +103,7 @@ impl Core {
     fn default_tracker_policy() -> TrackerPolicy {
         TrackerPolicy::default()
     }
+
     fn default_tracker_usage_statistics() -> bool {
         true
     }

--- a/packages/configuration/src/v2_0_0/http_tracker.rs
+++ b/packages/configuration/src/v2_0_0/http_tracker.rs
@@ -19,6 +19,10 @@ pub struct HttpTracker {
     /// TSL config.
     #[serde(default = "HttpTracker::default_tsl_config")]
     pub tsl_config: Option<TslConfig>,
+
+    /// Weather the tracker should collect statistics about tracker usage.
+    #[serde(default = "HttpTracker::default_tracker_usage_statistics")]
+    pub tracker_usage_statistics: bool,
 }
 
 impl Default for HttpTracker {
@@ -26,6 +30,7 @@ impl Default for HttpTracker {
         Self {
             bind_address: Self::default_bind_address(),
             tsl_config: Self::default_tsl_config(),
+            tracker_usage_statistics: Self::default_tracker_usage_statistics(),
         }
     }
 }
@@ -37,5 +42,9 @@ impl HttpTracker {
 
     fn default_tsl_config() -> Option<TslConfig> {
         None
+    }
+
+    fn default_tracker_usage_statistics() -> bool {
+        false
     }
 }

--- a/packages/configuration/src/v2_0_0/udp_tracker.rs
+++ b/packages/configuration/src/v2_0_0/udp_tracker.rs
@@ -16,12 +16,17 @@ pub struct UdpTracker {
     /// the client as the `ConnectionId`.
     #[serde(default = "UdpTracker::default_cookie_lifetime")]
     pub cookie_lifetime: Duration,
+
+    /// Weather the tracker should collect statistics about tracker usage.
+    #[serde(default = "UdpTracker::default_tracker_usage_statistics")]
+    pub tracker_usage_statistics: bool,
 }
 impl Default for UdpTracker {
     fn default() -> Self {
         Self {
             bind_address: Self::default_bind_address(),
             cookie_lifetime: Self::default_cookie_lifetime(),
+            tracker_usage_statistics: Self::default_tracker_usage_statistics(),
         }
     }
 }
@@ -33,5 +38,9 @@ impl UdpTracker {
 
     fn default_cookie_lifetime() -> Duration {
         Duration::from_secs(120)
+    }
+
+    fn default_tracker_usage_statistics() -> bool {
+        false
     }
 }

--- a/packages/test-helpers/src/configuration.rs
+++ b/packages/test-helpers/src/configuration.rs
@@ -55,6 +55,7 @@ pub fn ephemeral() -> Configuration {
     config.udp_trackers = Some(vec![UdpTracker {
         bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), udp_port),
         cookie_lifetime: Duration::from_secs(120),
+        tracker_usage_statistics: true,
     }]);
 
     // Ephemeral socket address for HTTP tracker
@@ -62,6 +63,7 @@ pub fn ephemeral() -> Configuration {
     config.http_trackers = Some(vec![HttpTracker {
         bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), http_port),
         tsl_config: None,
+        tracker_usage_statistics: true,
     }]);
 
     let temp_file = ephemeral_sqlite_database();


### PR DESCRIPTION
Add a configuration option to enable/disable stats per server. It does not have any effect yet.