### PR TITLE
Refactor: `AppContainer` to initialize all services in the setup phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4535,6 +4535,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "torrust-axum-health-check-api-server",
  "torrust-axum-http-tracker-server",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ regex = "1"
 reqwest = { version = "0", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
+thiserror = "2.0.12"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 torrust-axum-health-check-api-server = { version = "3.0.0-develop", path = "packages/axum-health-check-api-server" }
 torrust-axum-http-tracker-server = { version = "3.0.0-develop", path = "packages/axum-http-tracker-server" }

--- a/packages/axum-http-tracker-server/src/environment.rs
+++ b/packages/axum-http-tracker-server/src/environment.rs
@@ -115,7 +115,8 @@ impl EnvContainer {
         let http_tracker_config = Arc::new(http_tracker_config[0].clone());
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
-        let http_tracker_container = HttpTrackerCoreContainer::initialize_from(&tracker_core_container, &http_tracker_config);
+        let http_tracker_container =
+            HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &http_tracker_config);
 
         Self {
             tracker_core_container,

--- a/packages/axum-rest-tracker-api-server/src/environment.rs
+++ b/packages/axum-rest-tracker-api-server/src/environment.rs
@@ -175,7 +175,8 @@ impl EnvContainer {
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
         let http_tracker_core_container =
             HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &http_tracker_config);
-        let udp_tracker_core_container = UdpTrackerCoreContainer::initialize_from(&tracker_core_container, &udp_tracker_config);
+        let udp_tracker_core_container =
+            UdpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &udp_tracker_config);
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 
         let tracker_http_api_core_container = TrackerHttpApiCoreContainer::initialize_from(

--- a/packages/axum-rest-tracker-api-server/src/environment.rs
+++ b/packages/axum-rest-tracker-api-server/src/environment.rs
@@ -174,7 +174,7 @@ impl EnvContainer {
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
         let http_tracker_core_container =
-            HttpTrackerCoreContainer::initialize_from(&tracker_core_container, &http_tracker_config);
+            HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &http_tracker_config);
         let udp_tracker_core_container = UdpTrackerCoreContainer::initialize_from(&tracker_core_container, &udp_tracker_config);
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 

--- a/packages/http-tracker-core/src/container.rs
+++ b/packages/http-tracker-core/src/container.rs
@@ -5,11 +5,14 @@ use torrust_tracker_configuration::{Core, HttpTracker};
 
 use crate::services::announce::AnnounceService;
 use crate::services::scrape::ScrapeService;
-use crate::{event, statistics};
+use crate::{event, services, statistics};
 
 pub struct HttpTrackerCoreContainer {
-    pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_tracker_config: Arc<HttpTracker>,
+
+    pub tracker_core_container: Arc<TrackerCoreContainer>,
+
+    // `HttpTrackerCoreServices`
     pub http_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>>,
     pub http_stats_repository: Arc<statistics::repository::Repository>,
     pub announce_service: Arc<AnnounceService>,
@@ -20,28 +23,57 @@ impl HttpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Arc<Self> {
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(core_config));
-        Self::initialize_from(&tracker_core_container, http_tracker_config)
+        Self::initialize_from_tracker_core(&tracker_core_container, http_tracker_config)
     }
 
     #[must_use]
-    pub fn initialize_from(
+    pub fn initialize_from_tracker_core(
         tracker_core_container: &Arc<TrackerCoreContainer>,
         http_tracker_config: &Arc<HttpTracker>,
     ) -> Arc<Self> {
+        let http_tracker_core_services = HttpTrackerCoreServices::initialize_from(tracker_core_container);
+        Self::initialize_from_services(tracker_core_container, &http_tracker_core_services, http_tracker_config)
+    }
+
+    #[must_use]
+    pub fn initialize_from_services(
+        tracker_core_container: &Arc<TrackerCoreContainer>,
+        http_tracker_core_services: &Arc<HttpTrackerCoreServices>,
+        http_tracker_config: &Arc<HttpTracker>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            tracker_core_container: tracker_core_container.clone(),
+            http_tracker_config: http_tracker_config.clone(),
+            http_stats_event_sender: http_tracker_core_services.http_stats_event_sender.clone(),
+            http_stats_repository: http_tracker_core_services.http_stats_repository.clone(),
+            announce_service: http_tracker_core_services.http_announce_service.clone(),
+            scrape_service: http_tracker_core_services.http_scrape_service.clone(),
+        })
+    }
+}
+
+pub struct HttpTrackerCoreServices {
+    pub http_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>>,
+    pub http_stats_repository: Arc<statistics::repository::Repository>,
+    pub http_announce_service: Arc<services::announce::AnnounceService>,
+    pub http_scrape_service: Arc<services::scrape::ScrapeService>,
+}
+
+impl HttpTrackerCoreServices {
+    #[must_use]
+    pub fn initialize_from(tracker_core_container: &Arc<TrackerCoreContainer>) -> Arc<Self> {
         let (http_stats_event_sender, http_stats_repository) =
             statistics::setup::factory(tracker_core_container.core_config.tracker_usage_statistics);
         let http_stats_event_sender = Arc::new(http_stats_event_sender);
         let http_stats_repository = Arc::new(http_stats_repository);
-
-        let announce_service = Arc::new(AnnounceService::new(
+        let http_announce_service = Arc::new(AnnounceService::new(
             tracker_core_container.core_config.clone(),
             tracker_core_container.announce_handler.clone(),
             tracker_core_container.authentication_service.clone(),
             tracker_core_container.whitelist_authorization.clone(),
             http_stats_event_sender.clone(),
         ));
-
-        let scrape_service = Arc::new(ScrapeService::new(
+        let http_scrape_service = Arc::new(ScrapeService::new(
             tracker_core_container.core_config.clone(),
             tracker_core_container.scrape_handler.clone(),
             tracker_core_container.authentication_service.clone(),
@@ -49,12 +81,10 @@ impl HttpTrackerCoreContainer {
         ));
 
         Arc::new(Self {
-            tracker_core_container: tracker_core_container.clone(),
-            http_tracker_config: http_tracker_config.clone(),
-            http_stats_event_sender: http_stats_event_sender.clone(),
-            http_stats_repository: http_stats_repository.clone(),
-            announce_service: announce_service.clone(),
-            scrape_service: scrape_service.clone(),
+            http_stats_event_sender,
+            http_stats_repository,
+            http_announce_service,
+            http_scrape_service,
         })
     }
 }

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -29,7 +29,8 @@ impl TrackerHttpApiCoreContainer {
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(core_config));
         let http_tracker_core_container =
             HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, http_tracker_config);
-        let udp_tracker_core_container = UdpTrackerCoreContainer::initialize_from(&tracker_core_container, udp_tracker_config);
+        let udp_tracker_core_container =
+            UdpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, udp_tracker_config);
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(core_config);
 
         Self::initialize_from(

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -10,12 +10,12 @@ use torrust_tracker_configuration::{Core, HttpApi, HttpTracker, UdpTracker};
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 
 pub struct TrackerHttpApiCoreContainer {
+    pub http_api_config: Arc<HttpApi>,
     pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_stats_repository: Arc<bittorrent_http_tracker_core::statistics::repository::Repository>,
     pub ban_service: Arc<RwLock<BanService>>,
     pub udp_core_stats_repository: Arc<bittorrent_udp_tracker_core::statistics::repository::Repository>,
     pub udp_server_stats_repository: Arc<torrust_udp_tracker_server::statistics::repository::Repository>,
-    pub http_api_config: Arc<HttpApi>,
 }
 
 impl TrackerHttpApiCoreContainer {

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -27,7 +27,8 @@ impl TrackerHttpApiCoreContainer {
         http_api_config: &Arc<HttpApi>,
     ) -> Arc<TrackerHttpApiCoreContainer> {
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(core_config));
-        let http_tracker_core_container = HttpTrackerCoreContainer::initialize_from(&tracker_core_container, http_tracker_config);
+        let http_tracker_core_container =
+            HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, http_tracker_config);
         let udp_tracker_core_container = UdpTrackerCoreContainer::initialize_from(&tracker_core_container, udp_tracker_config);
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(core_config);
 

--- a/packages/udp-tracker-core/src/container.rs
+++ b/packages/udp-tracker-core/src/container.rs
@@ -8,11 +8,14 @@ use crate::services::announce::AnnounceService;
 use crate::services::banning::BanService;
 use crate::services::connect::ConnectService;
 use crate::services::scrape::ScrapeService;
-use crate::{event, statistics, MAX_CONNECTION_ID_ERRORS_PER_IP};
+use crate::{event, services, statistics, MAX_CONNECTION_ID_ERRORS_PER_IP};
 
 pub struct UdpTrackerCoreContainer {
-    pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub udp_tracker_config: Arc<UdpTracker>,
+
+    pub tracker_core_container: Arc<TrackerCoreContainer>,
+
+    // `UdpTrackerCoreServices`
     pub udp_core_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>>,
     pub udp_core_stats_repository: Arc<statistics::repository::Repository>,
     pub ban_service: Arc<RwLock<BanService>>,
@@ -25,14 +28,52 @@ impl UdpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Arc<UdpTrackerCoreContainer> {
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(core_config));
-        Self::initialize_from(&tracker_core_container, udp_tracker_config)
+        Self::initialize_from_tracker_core(&tracker_core_container, udp_tracker_config)
     }
 
     #[must_use]
-    pub fn initialize_from(
+    pub fn initialize_from_tracker_core(
         tracker_core_container: &Arc<TrackerCoreContainer>,
         udp_tracker_config: &Arc<UdpTracker>,
     ) -> Arc<UdpTrackerCoreContainer> {
+        let udp_tracker_core_services = UdpTrackerCoreServices::initialize_from(tracker_core_container);
+        Self::initialize_from_services(tracker_core_container, &udp_tracker_core_services, udp_tracker_config)
+    }
+
+    #[must_use]
+    pub fn initialize_from_services(
+        tracker_core_container: &Arc<TrackerCoreContainer>,
+        udp_tracker_core_services: &Arc<UdpTrackerCoreServices>,
+        udp_tracker_config: &Arc<UdpTracker>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            udp_tracker_config: udp_tracker_config.clone(),
+
+            tracker_core_container: tracker_core_container.clone(),
+
+            // `UdpTrackerCoreServices`
+            udp_core_stats_event_sender: udp_tracker_core_services.udp_core_stats_event_sender.clone(),
+            udp_core_stats_repository: udp_tracker_core_services.udp_core_stats_repository.clone(),
+            ban_service: udp_tracker_core_services.udp_ban_service.clone(),
+            connect_service: udp_tracker_core_services.udp_connect_service.clone(),
+            announce_service: udp_tracker_core_services.udp_announce_service.clone(),
+            scrape_service: udp_tracker_core_services.udp_scrape_service.clone(),
+        })
+    }
+}
+
+pub struct UdpTrackerCoreServices {
+    pub udp_core_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>>,
+    pub udp_core_stats_repository: Arc<statistics::repository::Repository>,
+    pub udp_ban_service: Arc<RwLock<services::banning::BanService>>,
+    pub udp_connect_service: Arc<services::connect::ConnectService>,
+    pub udp_announce_service: Arc<services::announce::AnnounceService>,
+    pub udp_scrape_service: Arc<services::scrape::ScrapeService>,
+}
+
+impl UdpTrackerCoreServices {
+    #[must_use]
+    pub fn initialize_from(tracker_core_container: &Arc<TrackerCoreContainer>) -> Arc<Self> {
         let (udp_core_stats_event_sender, udp_core_stats_repository) =
             statistics::setup::factory(tracker_core_container.core_config.tracker_usage_statistics);
         let udp_core_stats_event_sender = Arc::new(udp_core_stats_event_sender);
@@ -49,15 +90,13 @@ impl UdpTrackerCoreContainer {
             udp_core_stats_event_sender.clone(),
         ));
 
-        Arc::new(UdpTrackerCoreContainer {
-            tracker_core_container: tracker_core_container.clone(),
-            udp_tracker_config: udp_tracker_config.clone(),
-            udp_core_stats_event_sender: udp_core_stats_event_sender.clone(),
-            udp_core_stats_repository: udp_core_stats_repository.clone(),
-            ban_service: ban_service.clone(),
-            connect_service: connect_service.clone(),
-            announce_service: announce_service.clone(),
-            scrape_service: scrape_service.clone(),
+        Arc::new(Self {
+            udp_core_stats_event_sender,
+            udp_core_stats_repository,
+            udp_ban_service: ban_service,
+            udp_connect_service: connect_service,
+            udp_announce_service: announce_service,
+            udp_scrape_service: scrape_service,
         })
     }
 }

--- a/packages/udp-tracker-server/src/container.rs
+++ b/packages/udp-tracker-server/src/container.rs
@@ -12,6 +12,23 @@ pub struct UdpTrackerServerContainer {
 impl UdpTrackerServerContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>) -> Arc<Self> {
+        let udp_tracker_server_services = UdpTrackerServerServices::initialize(core_config);
+
+        Arc::new(Self {
+            udp_server_stats_event_sender: udp_tracker_server_services.udp_server_stats_event_sender.clone(),
+            udp_server_stats_repository: udp_tracker_server_services.udp_server_stats_repository.clone(),
+        })
+    }
+}
+
+pub struct UdpTrackerServerServices {
+    pub udp_server_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>>,
+    pub udp_server_stats_repository: Arc<statistics::repository::Repository>,
+}
+
+impl UdpTrackerServerServices {
+    #[must_use]
+    pub fn initialize(core_config: &Arc<Core>) -> Arc<Self> {
         let (udp_server_stats_event_sender, udp_server_stats_repository) =
             statistics::setup::factory(core_config.tracker_usage_statistics);
         let udp_server_stats_event_sender = Arc::new(udp_server_stats_event_sender);

--- a/packages/udp-tracker-server/src/environment.rs
+++ b/packages/udp-tracker-server/src/environment.rs
@@ -131,7 +131,8 @@ impl EnvContainer {
         let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
-        let udp_tracker_core_container = UdpTrackerCoreContainer::initialize_from(&tracker_core_container, &udp_tracker_config);
+        let udp_tracker_core_container =
+            UdpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &udp_tracker_config);
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 
         Self {

--- a/src/app.rs
+++ b/src/app.rs
@@ -90,9 +90,10 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
                     udp_tracker_config.bind_address
                 );
             } else {
-                let udp_tracker_config = Arc::new(udp_tracker_config.clone());
-                let udp_tracker_container = Arc::new(app_container.udp_tracker_container(&udp_tracker_config));
-                let udp_tracker_server_container = Arc::new(app_container.udp_tracker_server_container());
+                let udp_tracker_container = app_container
+                    .udp_tracker_container(udp_tracker_config.bind_address)
+                    .expect("Could not create UDP tracker container");
+                let udp_tracker_server_container = app_container.udp_tracker_server_container();
 
                 jobs.push(
                     udp_tracker::start_job(udp_tracker_container, udp_tracker_server_container, registar.give_form()).await,
@@ -106,8 +107,9 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
     // Start the HTTP blocks
     if let Some(http_trackers) = &config.http_trackers {
         for http_tracker_config in http_trackers {
-            let http_tracker_config = Arc::new(http_tracker_config.clone());
-            let http_tracker_container = Arc::new(app_container.http_tracker_container(&http_tracker_config));
+            let http_tracker_container = app_container
+                .http_tracker_container(http_tracker_config.bind_address)
+                .expect("Could not create HTTP tracker container");
 
             if let Some(job) = http_tracker::start_job(
                 http_tracker_container,
@@ -126,7 +128,7 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
     // Start HTTP API
     if let Some(http_api_config) = &config.http_api {
         let http_api_config = Arc::new(http_api_config.clone());
-        let http_api_container = Arc::new(app_container.tracker_http_api_container(&http_api_config));
+        let http_api_container = app_container.tracker_http_api_container(&http_api_config);
 
         if let Some(job) = tracker_apis::start_job(
             http_api_container,
@@ -148,8 +150,6 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
             &app_container.tracker_core_container.torrents_manager,
         ));
     }
-
-    println!("Registar entries: {:?}", registar.entries());
 
     // Start Health Check API
     jobs.push(health_check_api::start_job(&config.health_check_api, registar.entries()).await);

--- a/src/container.rs
+++ b/src/container.rs
@@ -21,14 +21,11 @@ pub enum Error {
 }
 
 pub struct AppContainer {
-    pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_api_config: Arc<Option<HttpApi>>,
+
+    pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_tracker_core_services: Arc<HttpTrackerCoreServices>,
     pub udp_tracker_core_services: Arc<UdpTrackerCoreServices>,
-
-    // UDP Tracker Server Services
-    pub udp_server_stats_event_sender: Arc<Option<Box<dyn torrust_udp_tracker_server::event::sender::Sender>>>,
-    pub udp_server_stats_repository: Arc<torrust_udp_tracker_server::statistics::repository::Repository>,
 
     // UDP Tracker Server Container
     pub udp_tracker_server_container: Arc<UdpTrackerServerContainer>,
@@ -51,17 +48,7 @@ impl AppContainer {
 
         let udp_tracker_core_services = UdpTrackerCoreServices::initialize_from(&tracker_core_container);
 
-        // UDP Tracker Server Services
-        let (udp_server_stats_event_sender, udp_server_stats_repository) =
-            torrust_udp_tracker_server::statistics::setup::factory(configuration.core.tracker_usage_statistics);
-        let udp_server_stats_event_sender = Arc::new(udp_server_stats_event_sender);
-        let udp_server_stats_repository = Arc::new(udp_server_stats_repository);
-
-        // UDP Tracker Server Container
-        let udp_tracker_server_container = Arc::new(UdpTrackerServerContainer {
-            udp_server_stats_event_sender: udp_server_stats_event_sender.clone(),
-            udp_server_stats_repository: udp_server_stats_repository.clone(),
-        });
+        let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 
         // Tracker Instance Containers
 
@@ -100,14 +87,11 @@ impl AppContainer {
         let udp_tracker_containers = Arc::new(udp_tracker_containers);
 
         AppContainer {
-            tracker_core_container,
             http_api_config,
+
+            tracker_core_container,
             http_tracker_core_services,
             udp_tracker_core_services,
-
-            // UDP Tracker Server Services
-            udp_server_stats_event_sender,
-            udp_server_stats_repository,
 
             // UDP Tracker Server Container
             udp_tracker_server_container,
@@ -153,7 +137,7 @@ impl AppContainer {
             ban_service: self.udp_tracker_core_services.udp_ban_service.clone(),
             http_stats_repository: self.http_tracker_core_services.http_stats_repository.clone(),
             udp_core_stats_repository: self.udp_tracker_core_services.udp_core_stats_repository.clone(),
-            udp_server_stats_repository: self.udp_server_stats_repository.clone(),
+            udp_server_stats_repository: self.udp_tracker_server_container.udp_server_stats_repository.clone(),
         }
         .into()
     }

--- a/src/container.rs
+++ b/src/container.rs
@@ -21,42 +21,44 @@ pub enum Error {
 }
 
 pub struct AppContainer {
+    // Configuration
     pub http_api_config: Arc<Option<HttpApi>>,
 
+    // Core
     pub tracker_core_container: Arc<TrackerCoreContainer>,
+
+    // HTTP
     pub http_tracker_core_services: Arc<HttpTrackerCoreServices>,
+    pub http_tracker_instance_containers: Arc<HashMap<SocketAddr, Arc<HttpTrackerCoreContainer>>>,
+
+    // UDP
     pub udp_tracker_core_services: Arc<UdpTrackerCoreServices>,
-
-    // UDP Tracker Server Container
     pub udp_tracker_server_container: Arc<UdpTrackerServerContainer>,
-
-    // Tracker Instance Containers
-    pub http_tracker_containers: Arc<HashMap<SocketAddr, Arc<HttpTrackerCoreContainer>>>,
-    pub udp_tracker_containers: Arc<HashMap<SocketAddr, Arc<UdpTrackerCoreContainer>>>,
+    pub udp_tracker_instance_containers: Arc<HashMap<SocketAddr, Arc<UdpTrackerCoreContainer>>>,
 }
 
 impl AppContainer {
     #[instrument(skip())]
     pub fn initialize(configuration: &Configuration) -> AppContainer {
+        // Configuration
+
         let core_config = Arc::new(configuration.core.clone());
 
         let http_api_config = Arc::new(configuration.http_api.clone());
 
+        // Core
+
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
+
+        // HTTP
 
         let http_tracker_core_services = HttpTrackerCoreServices::initialize_from(&tracker_core_container);
 
-        let udp_tracker_core_services = UdpTrackerCoreServices::initialize_from(&tracker_core_container);
-
-        let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
-
-        // Tracker Instance Containers
-
-        let mut http_tracker_containers = HashMap::new();
+        let mut http_tracker_instance_containers = HashMap::new();
 
         if let Some(http_trackers) = &configuration.http_trackers {
             for http_tracker_config in http_trackers {
-                http_tracker_containers.insert(
+                http_tracker_instance_containers.insert(
                     http_tracker_config.bind_address,
                     HttpTrackerCoreContainer::initialize_from_services(
                         &tracker_core_container,
@@ -67,13 +69,19 @@ impl AppContainer {
             }
         }
 
-        let http_tracker_containers = Arc::new(http_tracker_containers);
+        let http_tracker_instance_containers = Arc::new(http_tracker_instance_containers);
 
-        let mut udp_tracker_containers = HashMap::new();
+        // UDP
+
+        let udp_tracker_core_services = UdpTrackerCoreServices::initialize_from(&tracker_core_container);
+
+        let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
+
+        let mut udp_tracker_instance_containers = HashMap::new();
 
         if let Some(udp_trackers) = &configuration.udp_trackers {
             for udp_tracker_config in udp_trackers {
-                udp_tracker_containers.insert(
+                udp_tracker_instance_containers.insert(
                     udp_tracker_config.bind_address,
                     UdpTrackerCoreContainer::initialize_from_services(
                         &tracker_core_container,
@@ -84,21 +92,23 @@ impl AppContainer {
             }
         }
 
-        let udp_tracker_containers = Arc::new(udp_tracker_containers);
+        let udp_tracker_instance_containers = Arc::new(udp_tracker_instance_containers);
 
         AppContainer {
+            // Configuration
             http_api_config,
 
+            // Core
             tracker_core_container,
+
+            // HTTP
             http_tracker_core_services,
+            http_tracker_instance_containers,
+
+            // UDP
             udp_tracker_core_services,
-
-            // UDP Tracker Server Container
             udp_tracker_server_container,
-
-            // Tracker Instance Containers
-            http_tracker_containers,
-            udp_tracker_containers,
+            udp_tracker_instance_containers,
         }
     }
 
@@ -112,7 +122,7 @@ impl AppContainer {
     /// Return an error if there is no HTTP tracker server instance bound to the
     /// socket address.
     pub fn http_tracker_container(&self, bind_address: SocketAddr) -> Result<Arc<HttpTrackerCoreContainer>, Error> {
-        match self.http_tracker_containers.get(&bind_address) {
+        match self.http_tracker_instance_containers.get(&bind_address) {
             Some(http_tracker_container) => Ok(http_tracker_container.clone()),
             None => Err(Error::MissingHttpTrackerCoreContainer { bind_address }),
         }
@@ -123,7 +133,7 @@ impl AppContainer {
     /// Return an error if there is no UDP tracker server instance bound to the
     /// socket address.
     pub fn udp_tracker_container(&self, bind_address: SocketAddr) -> Result<Arc<UdpTrackerCoreContainer>, Error> {
-        match self.udp_tracker_containers.get(&bind_address) {
+        match self.udp_tracker_instance_containers.get(&bind_address) {
             Some(udp_tracker_container) => Ok(udp_tracker_container.clone()),
             None => Err(Error::MissingUdpTrackerCoreContainer { bind_address }),
         }

--- a/src/container.rs
+++ b/src/container.rs
@@ -4,10 +4,8 @@ use std::sync::Arc;
 
 use bittorrent_http_tracker_core::container::{HttpTrackerCoreContainer, HttpTrackerCoreServices};
 use bittorrent_tracker_core::container::TrackerCoreContainer;
-use bittorrent_udp_tracker_core::container::UdpTrackerCoreContainer;
-use bittorrent_udp_tracker_core::services::banning::BanService;
-use bittorrent_udp_tracker_core::{self, MAX_CONNECTION_ID_ERRORS_PER_IP};
-use tokio::sync::RwLock;
+use bittorrent_udp_tracker_core::container::{UdpTrackerCoreContainer, UdpTrackerCoreServices};
+use bittorrent_udp_tracker_core::{self};
 use torrust_rest_tracker_api_core::container::TrackerHttpApiCoreContainer;
 use torrust_tracker_configuration::{Configuration, HttpApi};
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
@@ -26,14 +24,7 @@ pub struct AppContainer {
     pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_api_config: Arc<Option<HttpApi>>,
     pub http_tracker_core_services: Arc<HttpTrackerCoreServices>,
-
-    // UDP Tracker Core Services
-    pub udp_core_stats_event_sender: Arc<Option<Box<dyn bittorrent_udp_tracker_core::event::sender::Sender>>>,
-    pub udp_core_stats_repository: Arc<bittorrent_udp_tracker_core::statistics::repository::Repository>,
-    pub udp_ban_service: Arc<RwLock<BanService>>,
-    pub udp_connect_service: Arc<bittorrent_udp_tracker_core::services::connect::ConnectService>,
-    pub udp_announce_service: Arc<bittorrent_udp_tracker_core::services::announce::AnnounceService>,
-    pub udp_scrape_service: Arc<bittorrent_udp_tracker_core::services::scrape::ScrapeService>,
+    pub udp_tracker_core_services: Arc<UdpTrackerCoreServices>,
 
     // UDP Tracker Server Services
     pub udp_server_stats_event_sender: Arc<Option<Box<dyn torrust_udp_tracker_server::event::sender::Sender>>>,
@@ -58,24 +49,7 @@ impl AppContainer {
 
         let http_tracker_core_services = HttpTrackerCoreServices::initialize_from(&tracker_core_container);
 
-        // UDP Tracker Core Services
-        let (udp_core_stats_event_sender, udp_core_stats_repository) =
-            bittorrent_udp_tracker_core::statistics::setup::factory(configuration.core.tracker_usage_statistics);
-        let udp_core_stats_event_sender = Arc::new(udp_core_stats_event_sender);
-        let udp_core_stats_repository = Arc::new(udp_core_stats_repository);
-        let udp_ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
-        let udp_connect_service = Arc::new(bittorrent_udp_tracker_core::services::connect::ConnectService::new(
-            udp_core_stats_event_sender.clone(),
-        ));
-        let udp_announce_service = Arc::new(bittorrent_udp_tracker_core::services::announce::AnnounceService::new(
-            tracker_core_container.announce_handler.clone(),
-            tracker_core_container.whitelist_authorization.clone(),
-            udp_core_stats_event_sender.clone(),
-        ));
-        let udp_scrape_service = Arc::new(bittorrent_udp_tracker_core::services::scrape::ScrapeService::new(
-            tracker_core_container.scrape_handler.clone(),
-            udp_core_stats_event_sender.clone(),
-        ));
+        let udp_tracker_core_services = UdpTrackerCoreServices::initialize_from(&tracker_core_container);
 
         // UDP Tracker Server Services
         let (udp_server_stats_event_sender, udp_server_stats_repository) =
@@ -114,16 +88,11 @@ impl AppContainer {
             for udp_tracker_config in udp_trackers {
                 udp_tracker_containers.insert(
                     udp_tracker_config.bind_address,
-                    Arc::new(UdpTrackerCoreContainer {
-                        tracker_core_container: tracker_core_container.clone(),
-                        udp_tracker_config: Arc::new(udp_tracker_config.clone()),
-                        udp_core_stats_event_sender: udp_core_stats_event_sender.clone(),
-                        udp_core_stats_repository: udp_core_stats_repository.clone(),
-                        ban_service: udp_ban_service.clone(),
-                        connect_service: udp_connect_service.clone(),
-                        announce_service: udp_announce_service.clone(),
-                        scrape_service: udp_scrape_service.clone(),
-                    }),
+                    UdpTrackerCoreContainer::initialize_from_services(
+                        &tracker_core_container,
+                        &udp_tracker_core_services,
+                        &Arc::new(udp_tracker_config.clone()),
+                    ),
                 );
             }
         }
@@ -134,14 +103,7 @@ impl AppContainer {
             tracker_core_container,
             http_api_config,
             http_tracker_core_services,
-
-            // UDP Tracker Core Services
-            udp_core_stats_event_sender,
-            udp_core_stats_repository,
-            udp_ban_service,
-            udp_connect_service,
-            udp_announce_service,
-            udp_scrape_service,
+            udp_tracker_core_services,
 
             // UDP Tracker Server Services
             udp_server_stats_event_sender,
@@ -188,9 +150,9 @@ impl AppContainer {
         TrackerHttpApiCoreContainer {
             tracker_core_container: self.tracker_core_container.clone(),
             http_api_config: http_api_config.clone(),
-            ban_service: self.udp_ban_service.clone(),
+            ban_service: self.udp_tracker_core_services.udp_ban_service.clone(),
             http_stats_repository: self.http_tracker_core_services.http_stats_repository.clone(),
-            udp_core_stats_repository: self.udp_core_stats_repository.clone(),
+            udp_core_stats_repository: self.udp_tracker_core_services.udp_core_stats_repository.clone(),
             udp_server_stats_repository: self.udp_server_stats_repository.clone(),
         }
         .into()

--- a/src/container.rs
+++ b/src/container.rs
@@ -2,9 +2,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use bittorrent_http_tracker_core::container::HttpTrackerCoreContainer;
-use bittorrent_http_tracker_core::services::announce::AnnounceService;
-use bittorrent_http_tracker_core::services::scrape::ScrapeService;
+use bittorrent_http_tracker_core::container::{HttpTrackerCoreContainer, HttpTrackerCoreServices};
 use bittorrent_tracker_core::container::TrackerCoreContainer;
 use bittorrent_udp_tracker_core::container::UdpTrackerCoreContainer;
 use bittorrent_udp_tracker_core::services::banning::BanService;
@@ -27,6 +25,7 @@ pub enum Error {
 pub struct AppContainer {
     pub tracker_core_container: Arc<TrackerCoreContainer>,
     pub http_api_config: Arc<Option<HttpApi>>,
+    pub http_tracker_core_services: Arc<HttpTrackerCoreServices>,
 
     // UDP Tracker Core Services
     pub udp_core_stats_event_sender: Arc<Option<Box<dyn bittorrent_udp_tracker_core::event::sender::Sender>>>,
@@ -35,12 +34,6 @@ pub struct AppContainer {
     pub udp_connect_service: Arc<bittorrent_udp_tracker_core::services::connect::ConnectService>,
     pub udp_announce_service: Arc<bittorrent_udp_tracker_core::services::announce::AnnounceService>,
     pub udp_scrape_service: Arc<bittorrent_udp_tracker_core::services::scrape::ScrapeService>,
-
-    // HTTP Tracker Core Services
-    pub http_stats_event_sender: Arc<Option<Box<dyn bittorrent_http_tracker_core::event::sender::Sender>>>,
-    pub http_stats_repository: Arc<bittorrent_http_tracker_core::statistics::repository::Repository>,
-    pub http_announce_service: Arc<bittorrent_http_tracker_core::services::announce::AnnounceService>,
-    pub http_scrape_service: Arc<bittorrent_http_tracker_core::services::scrape::ScrapeService>,
 
     // UDP Tracker Server Services
     pub udp_server_stats_event_sender: Arc<Option<Box<dyn torrust_udp_tracker_server::event::sender::Sender>>>,
@@ -63,24 +56,7 @@ impl AppContainer {
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
 
-        // HTTP Tracker Core Services
-        let (http_stats_event_sender, http_stats_repository) =
-            bittorrent_http_tracker_core::statistics::setup::factory(configuration.core.tracker_usage_statistics);
-        let http_stats_event_sender = Arc::new(http_stats_event_sender);
-        let http_stats_repository = Arc::new(http_stats_repository);
-        let http_announce_service = Arc::new(AnnounceService::new(
-            tracker_core_container.core_config.clone(),
-            tracker_core_container.announce_handler.clone(),
-            tracker_core_container.authentication_service.clone(),
-            tracker_core_container.whitelist_authorization.clone(),
-            http_stats_event_sender.clone(),
-        ));
-        let http_scrape_service = Arc::new(ScrapeService::new(
-            tracker_core_container.core_config.clone(),
-            tracker_core_container.scrape_handler.clone(),
-            tracker_core_container.authentication_service.clone(),
-            http_stats_event_sender.clone(),
-        ));
+        let http_tracker_core_services = HttpTrackerCoreServices::initialize_from(&tracker_core_container);
 
         // UDP Tracker Core Services
         let (udp_core_stats_event_sender, udp_core_stats_repository) =
@@ -121,14 +97,11 @@ impl AppContainer {
             for http_tracker_config in http_trackers {
                 http_tracker_containers.insert(
                     http_tracker_config.bind_address,
-                    Arc::new(HttpTrackerCoreContainer {
-                        tracker_core_container: tracker_core_container.clone(),
-                        http_tracker_config: Arc::new(http_tracker_config.clone()),
-                        http_stats_event_sender: http_stats_event_sender.clone(),
-                        http_stats_repository: http_stats_repository.clone(),
-                        announce_service: http_announce_service.clone(),
-                        scrape_service: http_scrape_service.clone(),
-                    }),
+                    HttpTrackerCoreContainer::initialize_from_services(
+                        &tracker_core_container,
+                        &http_tracker_core_services,
+                        &Arc::new(http_tracker_config.clone()),
+                    ),
                 );
             }
         }
@@ -160,6 +133,7 @@ impl AppContainer {
         AppContainer {
             tracker_core_container,
             http_api_config,
+            http_tracker_core_services,
 
             // UDP Tracker Core Services
             udp_core_stats_event_sender,
@@ -168,12 +142,6 @@ impl AppContainer {
             udp_connect_service,
             udp_announce_service,
             udp_scrape_service,
-
-            // HTTP Tracker Core Services
-            http_stats_event_sender,
-            http_stats_repository,
-            http_announce_service,
-            http_scrape_service,
 
             // UDP Tracker Server Services
             udp_server_stats_event_sender,
@@ -221,7 +189,7 @@ impl AppContainer {
             tracker_core_container: self.tracker_core_container.clone(),
             http_api_config: http_api_config.clone(),
             ban_service: self.udp_ban_service.clone(),
-            http_stats_repository: self.http_stats_repository.clone(),
+            http_stats_repository: self.http_tracker_core_services.http_stats_repository.clone(),
             udp_core_stats_repository: self.udp_core_stats_repository.clone(),
             udp_server_stats_repository: self.udp_server_stats_repository.clone(),
         }

--- a/src/container.rs
+++ b/src/container.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use bittorrent_http_tracker_core::container::HttpTrackerCoreContainer;
@@ -9,12 +11,22 @@ use bittorrent_udp_tracker_core::services::banning::BanService;
 use bittorrent_udp_tracker_core::{self, MAX_CONNECTION_ID_ERRORS_PER_IP};
 use tokio::sync::RwLock;
 use torrust_rest_tracker_api_core::container::TrackerHttpApiCoreContainer;
-use torrust_tracker_configuration::{Configuration, HttpApi, HttpTracker, UdpTracker};
+use torrust_tracker_configuration::{Configuration, HttpApi};
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 use tracing::instrument;
 
+#[derive(thiserror::Error, Debug, Clone)]
+pub enum Error {
+    #[error("There is not a HTTP tracker server instance bound to the socket address: {bind_address}")]
+    MissingHttpTrackerCoreContainer { bind_address: SocketAddr },
+
+    #[error("There is not a UDP tracker server instance bound to the socket address: {bind_address}")]
+    MissingUdpTrackerCoreContainer { bind_address: SocketAddr },
+}
+
 pub struct AppContainer {
     pub tracker_core_container: Arc<TrackerCoreContainer>,
+    pub http_api_config: Arc<Option<HttpApi>>,
 
     // UDP Tracker Core Services
     pub udp_core_stats_event_sender: Arc<Option<Box<dyn bittorrent_udp_tracker_core::event::sender::Sender>>>,
@@ -33,12 +45,21 @@ pub struct AppContainer {
     // UDP Tracker Server Services
     pub udp_server_stats_event_sender: Arc<Option<Box<dyn torrust_udp_tracker_server::event::sender::Sender>>>,
     pub udp_server_stats_repository: Arc<torrust_udp_tracker_server::statistics::repository::Repository>,
+
+    // UDP Tracker Server Container
+    pub udp_tracker_server_container: Arc<UdpTrackerServerContainer>,
+
+    // Tracker Instance Containers
+    pub http_tracker_containers: Arc<HashMap<SocketAddr, Arc<HttpTrackerCoreContainer>>>,
+    pub udp_tracker_containers: Arc<HashMap<SocketAddr, Arc<UdpTrackerCoreContainer>>>,
 }
 
 impl AppContainer {
     #[instrument(skip())]
     pub fn initialize(configuration: &Configuration) -> AppContainer {
         let core_config = Arc::new(configuration.core.clone());
+
+        let http_api_config = Arc::new(configuration.http_api.clone());
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize(&core_config));
 
@@ -86,8 +107,59 @@ impl AppContainer {
         let udp_server_stats_event_sender = Arc::new(udp_server_stats_event_sender);
         let udp_server_stats_repository = Arc::new(udp_server_stats_repository);
 
+        // UDP Tracker Server Container
+        let udp_tracker_server_container = Arc::new(UdpTrackerServerContainer {
+            udp_server_stats_event_sender: udp_server_stats_event_sender.clone(),
+            udp_server_stats_repository: udp_server_stats_repository.clone(),
+        });
+
+        // Tracker Instance Containers
+
+        let mut http_tracker_containers = HashMap::new();
+
+        if let Some(http_trackers) = &configuration.http_trackers {
+            for http_tracker_config in http_trackers {
+                http_tracker_containers.insert(
+                    http_tracker_config.bind_address,
+                    Arc::new(HttpTrackerCoreContainer {
+                        tracker_core_container: tracker_core_container.clone(),
+                        http_tracker_config: Arc::new(http_tracker_config.clone()),
+                        http_stats_event_sender: http_stats_event_sender.clone(),
+                        http_stats_repository: http_stats_repository.clone(),
+                        announce_service: http_announce_service.clone(),
+                        scrape_service: http_scrape_service.clone(),
+                    }),
+                );
+            }
+        }
+
+        let http_tracker_containers = Arc::new(http_tracker_containers);
+
+        let mut udp_tracker_containers = HashMap::new();
+
+        if let Some(udp_trackers) = &configuration.udp_trackers {
+            for udp_tracker_config in udp_trackers {
+                udp_tracker_containers.insert(
+                    udp_tracker_config.bind_address,
+                    Arc::new(UdpTrackerCoreContainer {
+                        tracker_core_container: tracker_core_container.clone(),
+                        udp_tracker_config: Arc::new(udp_tracker_config.clone()),
+                        udp_core_stats_event_sender: udp_core_stats_event_sender.clone(),
+                        udp_core_stats_repository: udp_core_stats_repository.clone(),
+                        ban_service: udp_ban_service.clone(),
+                        connect_service: udp_connect_service.clone(),
+                        announce_service: udp_announce_service.clone(),
+                        scrape_service: udp_scrape_service.clone(),
+                    }),
+                );
+            }
+        }
+
+        let udp_tracker_containers = Arc::new(udp_tracker_containers);
+
         AppContainer {
             tracker_core_container,
+            http_api_config,
 
             // UDP Tracker Core Services
             udp_core_stats_event_sender,
@@ -106,37 +178,45 @@ impl AppContainer {
             // UDP Tracker Server Services
             udp_server_stats_event_sender,
             udp_server_stats_repository,
+
+            // UDP Tracker Server Container
+            udp_tracker_server_container,
+
+            // Tracker Instance Containers
+            http_tracker_containers,
+            udp_tracker_containers,
         }
     }
 
     #[must_use]
-    pub fn http_tracker_container(&self, http_tracker_config: &Arc<HttpTracker>) -> HttpTrackerCoreContainer {
-        HttpTrackerCoreContainer {
-            tracker_core_container: self.tracker_core_container.clone(),
-            http_tracker_config: http_tracker_config.clone(),
-            http_stats_event_sender: self.http_stats_event_sender.clone(),
-            http_stats_repository: self.http_stats_repository.clone(),
-            announce_service: self.http_announce_service.clone(),
-            scrape_service: self.http_scrape_service.clone(),
+    pub fn udp_tracker_server_container(&self) -> Arc<UdpTrackerServerContainer> {
+        self.udp_tracker_server_container.clone()
+    }
+
+    /// # Errors
+    ///
+    /// Return an error if there is no HTTP tracker server instance bound to the
+    /// socket address.
+    pub fn http_tracker_container(&self, bind_address: SocketAddr) -> Result<Arc<HttpTrackerCoreContainer>, Error> {
+        match self.http_tracker_containers.get(&bind_address) {
+            Some(http_tracker_container) => Ok(http_tracker_container.clone()),
+            None => Err(Error::MissingHttpTrackerCoreContainer { bind_address }),
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Return an error if there is no UDP tracker server instance bound to the
+    /// socket address.
+    pub fn udp_tracker_container(&self, bind_address: SocketAddr) -> Result<Arc<UdpTrackerCoreContainer>, Error> {
+        match self.udp_tracker_containers.get(&bind_address) {
+            Some(udp_tracker_container) => Ok(udp_tracker_container.clone()),
+            None => Err(Error::MissingUdpTrackerCoreContainer { bind_address }),
         }
     }
 
     #[must_use]
-    pub fn udp_tracker_container(&self, udp_tracker_config: &Arc<UdpTracker>) -> UdpTrackerCoreContainer {
-        UdpTrackerCoreContainer {
-            tracker_core_container: self.tracker_core_container.clone(),
-            udp_tracker_config: udp_tracker_config.clone(),
-            udp_core_stats_event_sender: self.udp_core_stats_event_sender.clone(),
-            udp_core_stats_repository: self.udp_core_stats_repository.clone(),
-            ban_service: self.udp_ban_service.clone(),
-            connect_service: self.udp_connect_service.clone(),
-            announce_service: self.udp_announce_service.clone(),
-            scrape_service: self.udp_scrape_service.clone(),
-        }
-    }
-
-    #[must_use]
-    pub fn tracker_http_api_container(&self, http_api_config: &Arc<HttpApi>) -> TrackerHttpApiCoreContainer {
+    pub fn tracker_http_api_container(&self, http_api_config: &Arc<HttpApi>) -> Arc<TrackerHttpApiCoreContainer> {
         TrackerHttpApiCoreContainer {
             tracker_core_container: self.tracker_core_container.clone(),
             http_api_config: http_api_config.clone(),
@@ -145,13 +225,6 @@ impl AppContainer {
             udp_core_stats_repository: self.udp_core_stats_repository.clone(),
             udp_server_stats_repository: self.udp_server_stats_repository.clone(),
         }
-    }
-
-    #[must_use]
-    pub fn udp_tracker_server_container(&self) -> UdpTrackerServerContainer {
-        UdpTrackerServerContainer {
-            udp_server_stats_event_sender: self.udp_server_stats_event_sender.clone(),
-            udp_server_stats_repository: self.udp_server_stats_repository.clone(),
-        }
+        .into()
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -54,22 +54,11 @@ impl AppContainer {
 
         let http_tracker_core_services = HttpTrackerCoreServices::initialize_from(&tracker_core_container);
 
-        let mut http_tracker_instance_containers = HashMap::new();
-
-        if let Some(http_trackers) = &configuration.http_trackers {
-            for http_tracker_config in http_trackers {
-                http_tracker_instance_containers.insert(
-                    http_tracker_config.bind_address,
-                    HttpTrackerCoreContainer::initialize_from_services(
-                        &tracker_core_container,
-                        &http_tracker_core_services,
-                        &Arc::new(http_tracker_config.clone()),
-                    ),
-                );
-            }
-        }
-
-        let http_tracker_instance_containers = Arc::new(http_tracker_instance_containers);
+        let http_tracker_instance_containers = Self::initialize_http_tracker_instance_containers(
+            configuration,
+            &tracker_core_container,
+            &http_tracker_core_services,
+        );
 
         // UDP
 
@@ -77,22 +66,8 @@ impl AppContainer {
 
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 
-        let mut udp_tracker_instance_containers = HashMap::new();
-
-        if let Some(udp_trackers) = &configuration.udp_trackers {
-            for udp_tracker_config in udp_trackers {
-                udp_tracker_instance_containers.insert(
-                    udp_tracker_config.bind_address,
-                    UdpTrackerCoreContainer::initialize_from_services(
-                        &tracker_core_container,
-                        &udp_tracker_core_services,
-                        &Arc::new(udp_tracker_config.clone()),
-                    ),
-                );
-            }
-        }
-
-        let udp_tracker_instance_containers = Arc::new(udp_tracker_instance_containers);
+        let udp_tracker_instance_containers =
+            Self::initialize_udp_tracker_instance_containers(configuration, &tracker_core_container, &udp_tracker_core_services);
 
         AppContainer {
             // Configuration
@@ -150,5 +125,53 @@ impl AppContainer {
             udp_server_stats_repository: self.udp_tracker_server_container.udp_server_stats_repository.clone(),
         }
         .into()
+    }
+
+    #[must_use]
+    fn initialize_http_tracker_instance_containers(
+        configuration: &Configuration,
+        tracker_core_container: &Arc<TrackerCoreContainer>,
+        http_tracker_core_services: &Arc<HttpTrackerCoreServices>,
+    ) -> Arc<HashMap<SocketAddr, Arc<HttpTrackerCoreContainer>>> {
+        let mut http_tracker_instance_containers = HashMap::new();
+
+        if let Some(http_trackers) = &configuration.http_trackers {
+            for http_tracker_config in http_trackers {
+                http_tracker_instance_containers.insert(
+                    http_tracker_config.bind_address,
+                    HttpTrackerCoreContainer::initialize_from_services(
+                        tracker_core_container,
+                        http_tracker_core_services,
+                        &Arc::new(http_tracker_config.clone()),
+                    ),
+                );
+            }
+        }
+
+        Arc::new(http_tracker_instance_containers)
+    }
+
+    #[must_use]
+    fn initialize_udp_tracker_instance_containers(
+        configuration: &Configuration,
+        tracker_core_container: &Arc<TrackerCoreContainer>,
+        udp_tracker_core_services: &Arc<UdpTrackerCoreServices>,
+    ) -> Arc<HashMap<SocketAddr, Arc<UdpTrackerCoreContainer>>> {
+        let mut udp_tracker_instance_containers = HashMap::new();
+
+        if let Some(udp_trackers) = &configuration.udp_trackers {
+            for udp_tracker_config in udp_trackers {
+                udp_tracker_instance_containers.insert(
+                    udp_tracker_config.bind_address,
+                    UdpTrackerCoreContainer::initialize_from_services(
+                        tracker_core_container,
+                        udp_tracker_core_services,
+                        &Arc::new(udp_tracker_config.clone()),
+                    ),
+                );
+            }
+        }
+
+        Arc::new(udp_tracker_instance_containers)
     }
 }


### PR DESCRIPTION
Refactor `AppContainer` to initialize all services in the setup phase.

I've also removed duplicate code for services initialization.

The REST API container is still initialized in the "start" phase because requires more changes to handle the optional value. We don't need it at the root level for now.