### PR TITLE
Change rustdoc docs to only compile+run in release mode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,6 @@
 //! ```text
 //! git clone https://github.com/torrust/torrust-tracker.git \
 //!   && cd torrust-tracker \
-//!   && cargo build --release \
 //!   && mkdir -p ./storage/tracker/etc \
 //!   && mkdir -p ./storage/tracker/lib/database \
 //!   && mkdir -p ./storage/tracker/lib/tls \
@@ -149,7 +148,7 @@
 //! compile and after being compiled it will start running the tracker.
 //!
 //! ```text
-//! cargo run
+//! cargo run --release
 //! ```
 //!
 //! ## Run with docker


### PR DESCRIPTION
As-is, it asks the user to do a release mode build first, then after creating the directories, then do a debug mode build + run.

This commit simplifies it and avoids compiling the tracker in both debug and release mode, and instead only compiles+run with release mode