### PR TITLE
Do not reveal the API token in logs

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -38,7 +38,7 @@ pub struct AppContainer {
 }
 
 impl AppContainer {
-    #[instrument(skip())]
+    #[instrument(skip(configuration))]
     pub fn initialize(configuration: &Configuration) -> AppContainer {
         // Configuration
 


### PR DESCRIPTION
Do not reveal the API token in logs.