### PR TITLE
Overhaul stats: Refactor metrics in Prometheus format

### DIFF
--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -1,11 +1,12 @@
 use std::net::IpAddr;
 
-use torrust_tracker_metrics::label::LabelSet;
+use torrust_tracker_metrics::label::{LabelName, LabelSet, LabelValue};
 use torrust_tracker_metrics::metric::MetricName;
 use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
 use crate::event::Event;
 use crate::statistics::repository::Repository;
+use crate::statistics::HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
 
 /// # Panics
 ///
@@ -27,12 +28,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 
             // Extendable metrics
 
+            let mut label_set = LabelSet::from(connection);
+            label_set.upsert(LabelName::new("request_kind"), LabelValue::new("announce"));
+
             stats_repository
-                .increase_counter(
-                    &MetricName::new("http_tracker_core_announce_requests_received_total"),
-                    &LabelSet::from(connection),
-                    now,
-                )
+                .increase_counter(&MetricName::new(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
                 .await;
         }
         Event::TcpScrape { connection } => {
@@ -49,12 +49,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 
             // Extendable metrics
 
+            let mut label_set = LabelSet::from(connection);
+            label_set.upsert(LabelName::new("request_kind"), LabelValue::new("scrape"));
+
             stats_repository
-                .increase_counter(
-                    &MetricName::new("http_tracker_core_scrape_requests_received_total"),
-                    &LabelSet::from(connection),
-                    now,
-                )
+                .increase_counter(&MetricName::new(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
                 .await;
         }
     }

--- a/packages/http-tracker-core/src/statistics/mod.rs
+++ b/packages/http-tracker-core/src/statistics/mod.rs
@@ -10,20 +10,16 @@ use torrust_tracker_metrics::metric::description::MetricDescription;
 use torrust_tracker_metrics::metric::MetricName;
 use torrust_tracker_metrics::unit::Unit;
 
+const HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL: &str = "http_tracker_core_requests_received_total";
+
 #[must_use]
 pub fn describe_metrics() -> Metrics {
     let mut metrics = Metrics::default();
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("http_tracker_core_announce_requests_received_total"),
+        &MetricName::new(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL),
         Some(Unit::Count),
-        Some(MetricDescription::new("Total number of HTTP announce requests received")),
-    );
-
-    metrics.metric_collection.describe_counter(
-        &MetricName::new("http_tracker_core_scrape_requests_received_total"),
-        Some(Unit::Count),
-        Some(MetricDescription::new("Total number of HTTP scrape requests received")),
+        Some(MetricDescription::new("Total number of HTTP requests received")),
     );
 
     metrics

--- a/packages/udp-tracker-core/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-core/src/statistics/event/handler.rs
@@ -1,9 +1,10 @@
-use torrust_tracker_metrics::label::LabelSet;
+use torrust_tracker_metrics::label::{LabelName, LabelSet, LabelValue};
 use torrust_tracker_metrics::metric::MetricName;
 use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
 use crate::event::Event;
 use crate::statistics::repository::Repository;
+use crate::statistics::UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
 
 /// # Panics
 ///
@@ -24,12 +25,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 
             // Extendable metrics
 
+            let mut label_set = LabelSet::from(context);
+            label_set.upsert(LabelName::new("request_kind"), LabelValue::new("connect"));
+
             stats_repository
-                .increase_counter(
-                    &MetricName::new("udp_tracker_core_connect_requests_received_total"),
-                    &LabelSet::from(context),
-                    now,
-                )
+                .increase_counter(&MetricName::new(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
                 .await;
         }
         Event::UdpAnnounce { context } => {
@@ -46,12 +46,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 
             // Extendable metrics
 
+            let mut label_set = LabelSet::from(context);
+            label_set.upsert(LabelName::new("request_kind"), LabelValue::new("announce"));
+
             stats_repository
-                .increase_counter(
-                    &MetricName::new("udp_tracker_core_announce_requests_received_total"),
-                    &LabelSet::from(context),
-                    now,
-                )
+                .increase_counter(&MetricName::new(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
                 .await;
         }
         Event::UdpScrape { context } => {
@@ -68,12 +67,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 
             // Extendable metrics
 
+            let mut label_set = LabelSet::from(context);
+            label_set.upsert(LabelName::new("request_kind"), LabelValue::new("scrape"));
+
             stats_repository
-                .increase_counter(
-                    &MetricName::new("udp_tracker_core_scrape_requests_received_total"),
-                    &LabelSet::from(context),
-                    now,
-                )
+                .increase_counter(&MetricName::new(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
                 .await;
         }
     }

--- a/packages/udp-tracker-core/src/statistics/mod.rs
+++ b/packages/udp-tracker-core/src/statistics/mod.rs
@@ -10,26 +10,16 @@ use torrust_tracker_metrics::metric::description::MetricDescription;
 use torrust_tracker_metrics::metric::MetricName;
 use torrust_tracker_metrics::unit::Unit;
 
+const UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL: &str = "udp_tracker_core_requests_received_total";
+
 #[must_use]
 pub fn describe_metrics() -> Metrics {
     let mut metrics = Metrics::default();
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_core_connect_requests_received_total"),
+        &MetricName::new(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL),
         Some(Unit::Count),
-        Some(MetricDescription::new("Total number of UDP connect requests received")),
-    );
-
-    metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_core_announce_requests_received_total"),
-        Some(Unit::Count),
-        Some(MetricDescription::new("Total number of UDP announce requests received")),
-    );
-
-    metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_core_scrape_requests_received_total"),
-        Some(Unit::Count),
-        Some(MetricDescription::new("Total number of UDP scrape requests received")),
+        Some(MetricDescription::new("Total number of UDP requests received")),
     );
 
     metrics

--- a/packages/udp-tracker-server/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-server/src/statistics/event/handler.rs
@@ -4,6 +4,12 @@ use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
 use crate::event::{Event, UdpRequestKind, UdpResponseKind};
 use crate::statistics::repository::Repository;
+use crate::statistics::{
+    UDP_TRACKER_SERVER_ERRORS_TOTAL, UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS,
+    UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL, UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL,
+    UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL, UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL,
+    UDP_TRACKER_SERVER_RESPONSES_SENT_TOTAL,
+};
 
 /// # Panics
 ///
@@ -19,7 +25,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
             // Extendable metrics
             stats_repository
                 .increase_counter(
-                    &MetricName::new("udp_tracker_server_requests_aborted_total"),
+                    &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL),
                     &LabelSet::from(context),
                     now,
                 )
@@ -32,7 +38,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
             // Extendable metrics
             stats_repository
                 .increase_counter(
-                    &MetricName::new("udp_tracker_server_requests_banned_total"),
+                    &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL),
                     &LabelSet::from(context),
                     now,
                 )
@@ -52,7 +58,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
             // Extendable metrics
             stats_repository
                 .increase_counter(
-                    &MetricName::new("udp_tracker_server_requests_received_total"),
+                    &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL),
                     &LabelSet::from(context),
                     now,
                 )
@@ -94,11 +100,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
             label_set.upsert(LabelName::new("kind"), LabelValue::new(&kind.to_string()));
 
             stats_repository
-                .increase_counter(
-                    &MetricName::new("udp_tracker_server_requests_accepted_total"),
-                    &label_set,
-                    now,
-                )
+                .increase_counter(&MetricName::new(UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL), &label_set, now)
                 .await;
         }
         Event::UdpResponseSent {
@@ -124,10 +126,14 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                             .await;
 
                         // Extendable metrics
+
+                        let mut label_set = LabelSet::from(context.clone());
+                        label_set.upsert(LabelName::new("request_kind"), LabelValue::new(&req_kind.to_string()));
+
                         stats_repository
                             .set_gauge(
-                                &MetricName::new("udp_tracker_server_performance_avg_connect_processing_time_ns"),
-                                &LabelSet::from(context.clone()),
+                                &MetricName::new(UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS),
+                                &label_set,
                                 new_avg,
                                 now,
                             )
@@ -141,16 +147,20 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                             .await;
 
                         // Extendable metrics
+
+                        let mut label_set = LabelSet::from(context.clone());
+                        label_set.upsert(LabelName::new("request_kind"), LabelValue::new(&req_kind.to_string()));
+
                         stats_repository
                             .set_gauge(
-                                &MetricName::new("udp_tracker_server_performance_avg_announce_processing_time_ns"),
-                                &LabelSet::from(context.clone()),
+                                &MetricName::new(UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS),
+                                &label_set,
                                 new_avg,
                                 now,
                             )
                             .await;
 
-                        (LabelValue::new("ok"), LabelValue::new(&UdpRequestKind::Connect.to_string()))
+                        (LabelValue::new("ok"), LabelValue::new(&UdpRequestKind::Announce.to_string()))
                     }
                     UdpRequestKind::Scrape => {
                         let new_avg = stats_repository
@@ -158,30 +168,36 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                             .await;
 
                         // Extendable metrics
+
+                        let mut label_set = LabelSet::from(context.clone());
+                        label_set.upsert(LabelName::new("request_kind"), LabelValue::new(&req_kind.to_string()));
+
                         stats_repository
                             .set_gauge(
-                                &MetricName::new("udp_tracker_server_performance_avg_scrape_processing_time_ns"),
-                                &LabelSet::from(context.clone()),
+                                &MetricName::new(UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS),
+                                &label_set,
                                 new_avg,
                                 now,
                             )
                             .await;
 
-                        (LabelValue::new("ok"), LabelValue::new(&UdpRequestKind::Connect.to_string()))
+                        (LabelValue::new("ok"), LabelValue::new(&UdpRequestKind::Scrape.to_string()))
                     }
                 },
-                UdpResponseKind::Error { opt_req_kind: _ } => (LabelValue::new("ok"), LabelValue::ignore()),
+                UdpResponseKind::Error { opt_req_kind: _ } => (LabelValue::new("error"), LabelValue::ignore()),
             };
 
             // Extendable metrics
 
             let mut label_set = LabelSet::from(context);
 
+            if result_label_value == LabelValue::new("ok") {
+                label_set.upsert(LabelName::new("request_kind"), kind_label_value);
+            }
             label_set.upsert(LabelName::new("result"), result_label_value);
-            label_set.upsert(LabelName::new("kind"), kind_label_value);
 
             stats_repository
-                .increase_counter(&MetricName::new("udp_tracker_server_responses_sent_total"), &label_set, now)
+                .increase_counter(&MetricName::new(UDP_TRACKER_SERVER_RESPONSES_SENT_TOTAL), &label_set, now)
                 .await;
         }
         Event::UdpError { context } => {
@@ -198,7 +214,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
             // Extendable metrics
             stats_repository
                 .increase_counter(
-                    &MetricName::new("udp_tracker_server_errors_total"),
+                    &MetricName::new(UDP_TRACKER_SERVER_ERRORS_TOTAL),
                     &LabelSet::from(context),
                     now,
                 )

--- a/packages/udp-tracker-server/src/statistics/mod.rs
+++ b/packages/udp-tracker-server/src/statistics/mod.rs
@@ -10,67 +10,59 @@ use torrust_tracker_metrics::metric::description::MetricDescription;
 use torrust_tracker_metrics::metric::MetricName;
 use torrust_tracker_metrics::unit::Unit;
 
+const UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL: &str = "udp_tracker_server_requests_aborted_total";
+const UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL: &str = "udp_tracker_server_requests_banned_total";
+const UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL: &str = "udp_tracker_server_requests_received_total";
+const UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL: &str = "udp_tracker_server_requests_accepted_total";
+const UDP_TRACKER_SERVER_RESPONSES_SENT_TOTAL: &str = "udp_tracker_server_responses_sent_total";
+const UDP_TRACKER_SERVER_ERRORS_TOTAL: &str = "udp_tracker_server_errors_total";
+const UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS: &str = "udp_tracker_server_performance_avg_processing_time_ns";
+
 #[must_use]
 pub fn describe_metrics() -> Metrics {
     let mut metrics = Metrics::default();
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_requests_aborted_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP requests aborted")),
     );
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_requests_banned_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP requests banned")),
     );
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_requests_received_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP requests received")),
     );
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_requests_accepted_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP requests accepted")),
     );
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_responses_sent_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_RESPONSES_SENT_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP responses sent")),
     );
 
     metrics.metric_collection.describe_counter(
-        &MetricName::new("udp_tracker_server_errors_total"),
+        &MetricName::new(UDP_TRACKER_SERVER_ERRORS_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of errors processing UDP requests")),
     );
 
     metrics.metric_collection.describe_gauge(
-        &MetricName::new("udp_tracker_server_performance_avg_connect_processing_time_ns"),
+        &MetricName::new(UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS),
         Some(Unit::Nanoseconds),
         Some(MetricDescription::new(
             "Average time to process a UDP connect request in nanoseconds",
-        )),
-    );
-
-    metrics.metric_collection.describe_gauge(
-        &MetricName::new("udp_tracker_server_performance_avg_announce_processing_time_ns"),
-        Some(Unit::Nanoseconds),
-        Some(MetricDescription::new(
-            "Average time to process a UDP announce request in nanoseconds",
-        )),
-    );
-
-    metrics.metric_collection.describe_gauge(
-        &MetricName::new("udp_tracker_server_performance_avg_scrape_processing_time_ns"),
-        Some(Unit::Nanoseconds),
-        Some(MetricDescription::new(
-            "Average time to process a UDP scrape request in nanoseconds",
         )),
     );
 


### PR DESCRIPTION
Some fixes for the UDP metrics.

The new version is:

```output
http_tracker_core_requests_received_total{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="7070",server_binding_protocol="http"} 1
http_tracker_core_requests_received_total{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="7070",server_binding_protocol="http"} 1
udp_tracker_core_requests_received_total{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_core_requests_received_total{request_kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_core_requests_received_total{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_performance_avg_processing_time_ns{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 53430
udp_tracker_server_performance_avg_processing_time_ns{request_kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 43320.5
udp_tracker_server_performance_avg_processing_time_ns{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 45595
udp_tracker_server_requests_accepted_total{kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_requests_accepted_total{kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_server_requests_accepted_total{kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_requests_received_total{server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 4
udp_tracker_server_responses_sent_total{request_kind="announce",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_responses_sent_total{request_kind="connect",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_server_responses_sent_total{request_kind="scrape",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
```

You get those metrics running the tracker and the following command:

```console
cargo run -p torrust-tracker-client --bin http_tracker_client announce http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6 | jq
cargo run -p torrust-tracker-client --bin http_tracker_client scrape http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6 | jq
cargo run -p torrust-tracker-client --bin udp_tracker_client announce udp://127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 | jq
cargo run -p torrust-tracker-client --bin udp_tracker_client scrape udp://127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 | jq
curl "http://127.0.0.1:1212/api/v1/metrics?token=MyAccessToken&format=prometheus" | sort
```

Metrics explained:

```
# each tracker client request makes also a connect requests so there are 4 requests in total

# http tracker core
http_tracker_core_requests_received_total{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="7070",server_binding_protocol="http"} 1
http_tracker_core_requests_received_total{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="7070",server_binding_protocol="http"} 1

# udp tracker core (4 received)
udp_tracker_core_requests_received_total{request_kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_core_requests_received_total{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_core_requests_received_total{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1

# udp tracker server

# request received (passed the ban filter)
udp_tracker_server_requests_received_total{server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 4

# request accepted
udp_tracker_server_requests_accepted_total{kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_server_requests_accepted_total{kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_requests_accepted_total{kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1

udp_tracker_server_responses_sent_total{request_kind="connect",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 2
udp_tracker_server_responses_sent_total{request_kind="announce",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1
udp_tracker_server_responses_sent_total{request_kind="scrape",result="ok",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 1

udp_tracker_server_performance_avg_processing_time_ns{request_kind="connect",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 43320.5
udp_tracker_server_performance_avg_processing_time_ns{request_kind="announce",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 53430
udp_tracker_server_performance_avg_processing_time_ns{request_kind="scrape",server_binding_ip="0.0.0.0",server_binding_port="6969",server_binding_protocol="udp"} 45595

```