### PR TITLE
Enrich HTTP core `Event::TcpAnnounce` event

### DIFF
--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -94,3 +94,44 @@ impl From<ConnectionContext> for LabelSet {
         ])
     }
 }
+
+#[cfg(test)]
+pub mod test {
+
+    use torrust_tracker_primitives::peer::Peer;
+    use torrust_tracker_primitives::service_binding::Protocol;
+
+    #[test]
+    fn events_should_be_comparable() {
+        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+        use torrust_tracker_primitives::service_binding::ServiceBinding;
+
+        use crate::event::{ConnectionContext, Event};
+
+        let event1 = Event::TcpAnnounce {
+            connection: ConnectionContext::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                Some(8080),
+                ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
+            ),
+            announced_peer: Peer::default(),
+            added_peer: Peer::default(),
+        };
+
+        let event2 = Event::TcpAnnounce {
+            connection: ConnectionContext::new(
+                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                Some(8080),
+                ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
+            ),
+            announced_peer: Peer::default(),
+            added_peer: Peer::default(),
+        };
+
+        let event1_clone = event1.clone();
+
+        assert!(event1 == event1_clone);
+        assert!(event1 != event2);
+    }
+}

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -1,5 +1,6 @@
 use std::net::{IpAddr, SocketAddr};
 
+use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
@@ -12,6 +13,7 @@ pub mod sender;
 pub enum Event {
     TcpAnnounce {
         connection: ConnectionContext,
+        info_hash: InfoHash,
         announcement: PeerAnnouncement,
     },
     TcpScrape {
@@ -93,6 +95,32 @@ pub mod test {
     use torrust_tracker_primitives::peer::Peer;
     use torrust_tracker_primitives::service_binding::Protocol;
 
+    use super::Event;
+    use crate::tests::sample_info_hash;
+
+    #[must_use]
+    pub fn events_match(event: &Event, expected_event: &Event) -> bool {
+        match (event, expected_event) {
+            (
+                Event::TcpAnnounce {
+                    connection,
+                    info_hash,
+                    announcement,
+                },
+                Event::TcpAnnounce {
+                    connection: expected_connection,
+                    info_hash: expected_info_hash,
+                    announcement: expected_announcement,
+                },
+            ) => {
+                *connection == *expected_connection
+                    && *info_hash == *expected_info_hash
+                    && announcement.peer_addr == expected_announcement.peer_addr
+            }
+            _ => false,
+        }
+    }
+
     #[test]
     fn events_should_be_comparable() {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -102,6 +130,7 @@ pub mod test {
         use crate::event::{ConnectionContext, Event};
 
         let remote_client_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let info_hash = sample_info_hash();
 
         let event1 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
@@ -109,6 +138,7 @@ pub mod test {
                 Some(8080),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
+            info_hash,
             announcement: Peer::default(),
         };
 
@@ -118,6 +148,7 @@ pub mod test {
                 Some(8080),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
+            info_hash,
             announcement: Peer::default(),
         };
 

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -2,6 +2,7 @@ use std::net::{IpAddr, SocketAddr};
 
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
+use torrust_tracker_primitives::peer::Peer;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 pub mod sender;
@@ -9,8 +10,21 @@ pub mod sender;
 /// A HTTP core event.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Event {
-    TcpAnnounce { connection: ConnectionContext },
-    TcpScrape { connection: ConnectionContext },
+    TcpAnnounce {
+        connection: ConnectionContext,
+
+        /// The peer that is announcing itself to the tracker.
+        announced_peer: Peer,
+
+        /// The peer that is added to the tracker.
+        ///
+        /// It might not be the same as the `announced_peer` because the tracker
+        /// can change the peer's IP address.
+        added_peer: Peer,
+    },
+    TcpScrape {
+        connection: ConnectionContext,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -2,7 +2,7 @@ use std::net::{IpAddr, SocketAddr};
 
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
-use torrust_tracker_primitives::peer::Peer;
+use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 pub mod sender;
@@ -12,15 +12,7 @@ pub mod sender;
 pub enum Event {
     TcpAnnounce {
         connection: ConnectionContext,
-
-        /// The peer that is announcing itself to the tracker.
-        announced_peer: Peer,
-
-        /// The peer that is added to the tracker.
-        ///
-        /// It might not be the same as the `announced_peer` because the tracker
-        /// can change the peer's IP address.
-        added_peer: Peer,
+        announcement: PeerAnnouncement,
     },
     TcpScrape {
         connection: ConnectionContext,
@@ -109,14 +101,15 @@ pub mod test {
 
         use crate::event::{ConnectionContext, Event};
 
+        let remote_client_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
         let event1 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                remote_client_ip,
                 Some(8080),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
-            announced_peer: Peer::default(),
-            added_peer: Peer::default(),
+            announcement: Peer::default(),
         };
 
         let event2 = Event::TcpAnnounce {
@@ -125,8 +118,7 @@ pub mod test {
                 Some(8080),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
-            announced_peer: Peer::default(),
-            added_peer: Peer::default(),
+            announcement: Peer::default(),
         };
 
         let event1_clone = event1.clone();

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -6,6 +6,8 @@ use torrust_tracker_metrics::label_name;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
+use crate::services::RemoteClientAddr;
+
 pub mod sender;
 
 /// A HTTP core event.
@@ -29,12 +31,9 @@ pub struct ConnectionContext {
 
 impl ConnectionContext {
     #[must_use]
-    pub fn new(client_ip_addr: IpAddr, opt_client_port: Option<u16>, server_service_binding: ServiceBinding) -> Self {
+    pub fn new(remote_client_addr: RemoteClientAddr, server_service_binding: ServiceBinding) -> Self {
         Self {
-            client: ClientConnectionContext {
-                ip_addr: client_ip_addr,
-                port: opt_client_port,
-            },
+            client: ClientConnectionContext { remote_client_addr },
             server: ServerConnectionContext {
                 service_binding: server_service_binding,
             },
@@ -43,12 +42,12 @@ impl ConnectionContext {
 
     #[must_use]
     pub fn client_ip_addr(&self) -> IpAddr {
-        self.client.ip_addr
+        self.client.ip_addr()
     }
 
     #[must_use]
     pub fn client_port(&self) -> Option<u16> {
-        self.client.port
+        self.client.port()
     }
 
     #[must_use]
@@ -59,10 +58,19 @@ impl ConnectionContext {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ClientConnectionContext {
-    ip_addr: IpAddr,
+    remote_client_addr: RemoteClientAddr,
+}
 
-    /// It's provided if you use the `torrust-axum-http-tracker-server` crate.
-    port: Option<u16>,
+impl ClientConnectionContext {
+    #[must_use]
+    pub fn ip_addr(&self) -> IpAddr {
+        self.remote_client_addr.ip
+    }
+
+    #[must_use]
+    pub fn port(&self) -> Option<u16> {
+        self.remote_client_addr.port
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -96,6 +104,7 @@ pub mod test {
     use torrust_tracker_primitives::service_binding::Protocol;
 
     use super::Event;
+    use crate::services::RemoteClientAddr;
     use crate::tests::sample_info_hash;
 
     #[must_use]
@@ -134,8 +143,7 @@ pub mod test {
 
         let event1 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
-                remote_client_ip,
-                Some(8080),
+                RemoteClientAddr::new(remote_client_ip, Some(8080)),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
             info_hash,
@@ -144,8 +152,7 @@ pub mod test {
 
         let event2 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
-                IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                Some(8080),
+                RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), Some(8080)),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
             info_hash,

--- a/packages/http-tracker-core/src/lib.rs
+++ b/packages/http-tracker-core/src/lib.rs
@@ -20,7 +20,11 @@ pub const HTTP_TRACKER_LOG_TARGET: &str = "HTTP TRACKER";
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes, PeerId};
     use bittorrent_primitives::info_hash::InfoHash;
+    use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
 
     /// # Panics
     ///
@@ -30,5 +34,30 @@ pub(crate) mod tests {
         "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0" // DevSkim: ignore DS173237
             .parse::<InfoHash>()
             .expect("String should be a valid info hash")
+    }
+
+    pub fn sample_peer_using_ipv4() -> peer::Peer {
+        sample_peer()
+    }
+
+    pub fn sample_peer_using_ipv6() -> peer::Peer {
+        let mut peer = sample_peer();
+        peer.peer_addr = SocketAddr::new(
+            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+            8080,
+        );
+        peer
+    }
+
+    pub fn sample_peer() -> peer::Peer {
+        peer::Peer {
+            peer_id: PeerId(*b"-qB00000000000000000"),
+            peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),
+            updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+            uploaded: NumberOfBytes::new(0),
+            downloaded: NumberOfBytes::new(0),
+            left: NumberOfBytes::new(0),
+            event: AnnounceEvent::Started,
+        }
     }
 }

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -21,7 +21,7 @@ use bittorrent_tracker_core::error::{AnnounceError, TrackerCoreError, WhitelistE
 use bittorrent_tracker_core::whitelist;
 use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::AnnounceData;
-use torrust_tracker_primitives::peer::Peer;
+use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 use crate::event;
@@ -78,11 +78,9 @@ impl AnnounceService {
 
         self.authorize(announce_request.info_hash).await?;
 
-        let (remote_client_ip, opt_remote_client_port) = self.resolve_remote_client_address(client_ip_sources)?;
+        let (remote_client_ip, opt_remote_client_port) = self.resolve_remote_client_ip(client_ip_sources)?;
 
         let mut peer = peer_from_request(announce_request, &remote_client_ip);
-
-        let announced_peer = peer;
 
         let peers_wanted = Self::peers_wanted(announce_request);
 
@@ -91,16 +89,8 @@ impl AnnounceService {
             .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        let added_peer = peer;
-
-        self.send_event(
-            remote_client_ip,
-            opt_remote_client_port,
-            server_service_binding.clone(),
-            announced_peer,
-            added_peer,
-        )
-        .await;
+        self.send_event(remote_client_ip, opt_remote_client_port, server_service_binding.clone(), peer)
+            .await;
 
         Ok(announce_data)
     }
@@ -122,7 +112,7 @@ impl AnnounceService {
     }
 
     /// Resolves the client's real IP address considering proxy headers
-    fn resolve_remote_client_address(
+    fn resolve_remote_client_ip(
         &self,
         client_ip_sources: &ClientIpSources,
     ) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
@@ -152,17 +142,15 @@ impl AnnounceService {
 
     async fn send_event(
         &self,
-        peer_ip: IpAddr,
+        remote_client_ip: IpAddr,
         opt_peer_ip_port: Option<u16>,
         server_service_binding: ServiceBinding,
-        announced_peer: Peer,
-        added_peer: Peer,
+        announcement: PeerAnnouncement,
     ) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             let event = Event::TcpAnnounce {
-                connection: event::ConnectionContext::new(peer_ip, opt_peer_ip_port, server_service_binding),
-                announced_peer,
-                added_peer,
+                connection: event::ConnectionContext::new(remote_client_ip, opt_peer_ip_port, server_service_binding),
+                announcement,
             };
 
             tracing::debug!("Sending TcpAnnounce event: {:?}", event);
@@ -389,6 +377,7 @@ mod tests {
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
             let peer = sample_peer_using_ipv4();
+            let remote_client_ip = IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1));
 
             let server_service_binding_clone = server_service_binding.clone();
             let peer_copy = peer;
@@ -400,32 +389,25 @@ mod tests {
                     let mut announced_peer = peer_copy;
                     announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
 
-                    let mut added_peer = peer;
-                    added_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
+                    let mut announcement = peer;
+                    announcement.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
 
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(
-                            IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                            Some(8080),
-                            server_service_binding.clone(),
-                        ),
-                        announced_peer,
-                        added_peer,
+                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        announcement,
                     };
 
                     match (event, expected_event) {
                         (
                             Event::TcpAnnounce {
                                 connection: a_conn,
-                                announced_peer: a1,
-                                added_peer: a2,
+                                announcement: a2,
                             },
                             Event::TcpAnnounce {
                                 connection: b_conn,
-                                announced_peer: b1,
-                                added_peer: b2,
+                                announcement: b2,
                             },
-                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
                         _ => false,
                     }
                 }))
@@ -477,6 +459,7 @@ mod tests {
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
             let peer = peer_with_the_ipv4_loopback_ip();
+            let remote_client_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
 
             let server_service_binding_clone = server_service_binding.clone();
             let peer_copy = peer;
@@ -488,35 +471,28 @@ mod tests {
                     let mut announced_peer = peer_copy;
                     announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
 
-                    let mut added_peer = peer;
-                    added_peer.peer_addr = SocketAddr::new(
+                    let mut peer_announcement = peer;
+                    peer_announcement.peer_addr = SocketAddr::new(
                         IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
                         8080,
                     );
 
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(
-                            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                            Some(8080),
-                            server_service_binding.clone(),
-                        ),
-                        announced_peer,
-                        added_peer,
+                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        announcement: peer_announcement,
                     };
 
                     match (event, expected_event) {
                         (
                             Event::TcpAnnounce {
                                 connection: a_conn,
-                                announced_peer: a1,
-                                added_peer: a2,
+                                announcement: a2,
                             },
                             Event::TcpAnnounce {
                                 connection: b_conn,
-                                announced_peer: b1,
-                                added_peer: b2,
+                                announcement: b2,
                             },
-                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
                         _ => false,
                     }
                 }))
@@ -553,42 +529,28 @@ mod tests {
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
             let peer = sample_peer_using_ipv6();
-
-            let peer_copy = peer;
+            let remote_client_ip = IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969));
 
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
                 .with(predicate::function(move |event| {
-                    let announced_peer = peer_copy;
-                    //announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
-
-                    let added_peer = peer;
-                    //added_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
-
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(
-                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                            Some(8080),
-                            server_service_binding.clone(),
-                        ),
-                        announced_peer,
-                        added_peer,
+                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        announcement: peer,
                     };
 
                     match (event, expected_event) {
                         (
                             Event::TcpAnnounce {
                                 connection: a_conn,
-                                announced_peer: a1,
-                                added_peer: a2,
+                                announcement: a2,
                             },
                             Event::TcpAnnounce {
                                 connection: b_conn,
-                                announced_peer: b1,
-                                added_peer: b2,
+                                announcement: b2,
                             },
-                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
                         _ => false,
                     }
                 }))

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -7,7 +7,6 @@
 //!
 //! It also sends an [`http_tracker_core::event::Event`]
 //! because events are specific for the HTTP tracker.
-use std::net::IpAddr;
 use std::panic::Location;
 use std::sync::Arc;
 
@@ -24,7 +23,7 @@ use torrust_tracker_primitives::core::AnnounceData;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
-use super::resolve_remote_client_ip;
+use super::{resolve_remote_client_addr, RemoteClientAddr};
 use crate::event;
 use crate::event::Event;
 
@@ -79,22 +78,20 @@ impl AnnounceService {
 
         self.authorize(announce_request.info_hash).await?;
 
-        let (remote_client_ip, opt_remote_client_port) =
-            resolve_remote_client_ip(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
+        let remote_client_addr = resolve_remote_client_addr(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
 
-        let mut peer = peer_from_request(announce_request, &remote_client_ip);
+        let mut peer = peer_from_request(announce_request, &remote_client_addr.ip);
 
         let peers_wanted = Self::peers_wanted(announce_request);
 
         let announce_data = self
             .announce_handler
-            .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
+            .announce(&announce_request.info_hash, &mut peer, &remote_client_addr.ip, &peers_wanted)
             .await?;
 
         self.send_event(
             announce_request.info_hash,
-            remote_client_ip,
-            opt_remote_client_port,
+            remote_client_addr,
             server_service_binding.clone(),
             peer,
         )
@@ -130,14 +127,13 @@ impl AnnounceService {
     async fn send_event(
         &self,
         info_hash: InfoHash,
-        remote_client_ip: IpAddr,
-        opt_peer_ip_port: Option<u16>,
+        remote_client_addr: RemoteClientAddr,
         server_service_binding: ServiceBinding,
         announcement: PeerAnnouncement,
     ) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             let event = Event::TcpAnnounce {
-                connection: event::ConnectionContext::new(remote_client_ip, opt_peer_ip_port, server_service_binding),
+                connection: event::ConnectionContext::new(remote_client_addr, server_service_binding),
                 info_hash,
                 announcement,
             };
@@ -323,6 +319,7 @@ mod tests {
             MockHttpStatsEventSender,
         };
         use crate::services::announce::AnnounceService;
+        use crate::services::RemoteClientAddr;
         use crate::tests::{sample_info_hash, sample_peer, sample_peer_using_ipv4, sample_peer_using_ipv6};
 
         #[tokio::test]
@@ -383,7 +380,10 @@ mod tests {
                     announcement.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
 
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        connection: ConnectionContext::new(
+                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            server_service_binding.clone(),
+                        ),
                         info_hash: sample_info_hash(),
                         announcement,
                     };
@@ -457,7 +457,10 @@ mod tests {
                     );
 
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        connection: ConnectionContext::new(
+                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            server_service_binding.clone(),
+                        ),
                         info_hash: sample_info_hash(),
                         announcement: peer_announcement,
                     };
@@ -504,7 +507,10 @@ mod tests {
                 .expect_send_event()
                 .with(predicate::function(move |event| {
                     let expected_event = Event::TcpAnnounce {
-                        connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        connection: ConnectionContext::new(
+                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            server_service_binding.clone(),
+                        ),
                         info_hash: sample_info_hash(),
                         announcement: peer,
                     };

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -89,8 +89,14 @@ impl AnnounceService {
             .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        self.send_event(remote_client_ip, opt_remote_client_port, server_service_binding.clone(), peer)
-            .await;
+        self.send_event(
+            announce_request.info_hash,
+            remote_client_ip,
+            opt_remote_client_port,
+            server_service_binding.clone(),
+            peer,
+        )
+        .await;
 
         Ok(announce_data)
     }
@@ -142,6 +148,7 @@ impl AnnounceService {
 
     async fn send_event(
         &self,
+        info_hash: InfoHash,
         remote_client_ip: IpAddr,
         opt_peer_ip_port: Option<u16>,
         server_service_binding: ServiceBinding,
@@ -150,6 +157,7 @@ impl AnnounceService {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             let event = Event::TcpAnnounce {
                 connection: event::ConnectionContext::new(remote_client_ip, opt_peer_ip_port, server_service_binding),
+                info_hash,
                 announcement,
             };
 
@@ -327,13 +335,14 @@ mod tests {
         use torrust_tracker_test_helpers::configuration;
 
         use crate::event;
+        use crate::event::test::events_match;
         use crate::event::{ConnectionContext, Event};
         use crate::services::announce::tests::{
             initialize_core_tracker_services, initialize_core_tracker_services_with_config, sample_announce_request_for_peer,
             MockHttpStatsEventSender,
         };
         use crate::services::announce::AnnounceService;
-        use crate::tests::{sample_peer, sample_peer_using_ipv4, sample_peer_using_ipv6};
+        use crate::tests::{sample_info_hash, sample_peer, sample_peer_using_ipv4, sample_peer_using_ipv6};
 
         #[tokio::test]
         async fn it_should_return_the_announce_data() {
@@ -394,22 +403,11 @@ mod tests {
 
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        info_hash: sample_info_hash(),
                         announcement,
                     };
 
-                    match (event, expected_event) {
-                        (
-                            Event::TcpAnnounce {
-                                connection: a_conn,
-                                announcement: a2,
-                            },
-                            Event::TcpAnnounce {
-                                connection: b_conn,
-                                announcement: b2,
-                            },
-                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
-                        _ => false,
-                    }
+                    events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -479,22 +477,11 @@ mod tests {
 
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        info_hash: sample_info_hash(),
                         announcement: peer_announcement,
                     };
 
-                    match (event, expected_event) {
-                        (
-                            Event::TcpAnnounce {
-                                connection: a_conn,
-                                announcement: a2,
-                            },
-                            Event::TcpAnnounce {
-                                connection: b_conn,
-                                announcement: b2,
-                            },
-                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
-                        _ => false,
-                    }
+                    events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -537,22 +524,10 @@ mod tests {
                 .with(predicate::function(move |event| {
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(remote_client_ip, Some(8080), server_service_binding.clone()),
+                        info_hash: sample_info_hash(),
                         announcement: peer,
                     };
-
-                    match (event, expected_event) {
-                        (
-                            Event::TcpAnnounce {
-                                connection: a_conn,
-                                announcement: a2,
-                            },
-                            Event::TcpAnnounce {
-                                connection: b_conn,
-                                announcement: b2,
-                            },
-                        ) => *a_conn == b_conn && a2.peer_addr == b2.peer_addr,
-                        _ => false,
-                    }
+                    events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -21,6 +21,7 @@ use bittorrent_tracker_core::error::{AnnounceError, TrackerCoreError, WhitelistE
 use bittorrent_tracker_core::whitelist;
 use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::AnnounceData;
+use torrust_tracker_primitives::peer::Peer;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 use crate::event;
@@ -81,6 +82,8 @@ impl AnnounceService {
 
         let mut peer = peer_from_request(announce_request, &remote_client_ip);
 
+        let announced_peer = peer;
+
         let peers_wanted = Self::peers_wanted(announce_request);
 
         let announce_data = self
@@ -88,8 +91,16 @@ impl AnnounceService {
             .announce(&announce_request.info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        self.send_event(remote_client_ip, opt_remote_client_port, server_service_binding.clone())
-            .await;
+        let added_peer = peer;
+
+        self.send_event(
+            remote_client_ip,
+            opt_remote_client_port,
+            server_service_binding.clone(),
+            announced_peer,
+            added_peer,
+        )
+        .await;
 
         Ok(announce_data)
     }
@@ -139,13 +150,24 @@ impl AnnounceService {
         }
     }
 
-    async fn send_event(&self, peer_ip: IpAddr, opt_peer_ip_port: Option<u16>, server_service_binding: ServiceBinding) {
+    async fn send_event(
+        &self,
+        peer_ip: IpAddr,
+        opt_peer_ip_port: Option<u16>,
+        server_service_binding: ServiceBinding,
+        announced_peer: Peer,
+        added_peer: Peer,
+    ) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
-            http_stats_event_sender
-                .send_event(Event::TcpAnnounce {
-                    connection: event::ConnectionContext::new(peer_ip, opt_peer_ip_port, server_service_binding),
-                })
-                .await;
+            let event = Event::TcpAnnounce {
+                connection: event::ConnectionContext::new(peer_ip, opt_peer_ip_port, server_service_binding),
+                announced_peer,
+                added_peer,
+            };
+
+            tracing::debug!("Sending TcpAnnounce event: {:?}", event);
+
+            http_stats_event_sender.send_event(event).await;
         }
     }
 }
@@ -202,10 +224,9 @@ impl From<authentication::key::Error> for HttpAnnounceError {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::net::SocketAddr;
     use std::sync::Arc;
 
-    use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes, PeerId};
     use bittorrent_http_tracker_protocol::v1::requests::announce::Announce;
     use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
     use bittorrent_tracker_core::announce_handler::AnnounceHandler;
@@ -218,7 +239,6 @@ mod tests {
     use bittorrent_tracker_core::whitelist::repository::in_memory::InMemoryWhitelist;
     use torrust_tracker_configuration::{Configuration, Core};
     use torrust_tracker_primitives::peer::Peer;
-    use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
     use torrust_tracker_test_helpers::configuration;
 
     struct CoreTrackerServices {
@@ -269,31 +289,6 @@ mod tests {
         )
     }
 
-    fn sample_peer_using_ipv4() -> peer::Peer {
-        sample_peer()
-    }
-
-    fn sample_peer_using_ipv6() -> peer::Peer {
-        let mut peer = sample_peer();
-        peer.peer_addr = SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-            8080,
-        );
-        peer
-    }
-
-    fn sample_peer() -> peer::Peer {
-        peer::Peer {
-            peer_id: PeerId(*b"-qB00000000000000000"),
-            peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),
-            updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
-            uploaded: NumberOfBytes::new(0),
-            downloaded: NumberOfBytes::new(0),
-            left: NumberOfBytes::new(0),
-            event: AnnounceEvent::Started,
-        }
-    }
-
     fn sample_announce_request_for_peer(peer: Peer) -> (Announce, ClientIpSources) {
         let announce_request = Announce {
             info_hash: sample_info_hash(),
@@ -335,7 +330,7 @@ mod tests {
         use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
         use std::sync::Arc;
 
-        use mockall::predicate::eq;
+        use mockall::predicate::{self};
         use torrust_tracker_configuration::Configuration;
         use torrust_tracker_primitives::core::AnnounceData;
         use torrust_tracker_primitives::peer;
@@ -343,14 +338,14 @@ mod tests {
         use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
         use torrust_tracker_test_helpers::configuration;
 
-        use super::{sample_peer_using_ipv4, sample_peer_using_ipv6};
         use crate::event;
         use crate::event::{ConnectionContext, Event};
         use crate::services::announce::tests::{
             initialize_core_tracker_services, initialize_core_tracker_services_with_config, sample_announce_request_for_peer,
-            sample_peer, MockHttpStatsEventSender,
+            MockHttpStatsEventSender,
         };
         use crate::services::announce::AnnounceService;
+        use crate::tests::{sample_peer, sample_peer_using_ipv4, sample_peer_using_ipv6};
 
         #[tokio::test]
         async fn it_should_return_the_announce_data() {
@@ -393,16 +388,46 @@ mod tests {
         async fn it_should_send_the_tcp_4_announce_event_when_the_peer_uses_ipv4() {
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
+            let peer = sample_peer_using_ipv4();
+
+            let server_service_binding_clone = server_service_binding.clone();
+            let peer_copy = peer;
 
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(Event::TcpAnnounce {
-                    connection: ConnectionContext::new(
-                        IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        Some(8080),
-                        server_service_binding.clone(),
-                    ),
+                .with(predicate::function(move |event| {
+                    let mut announced_peer = peer_copy;
+                    announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
+
+                    let mut added_peer = peer;
+                    added_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
+
+                    let expected_event = Event::TcpAnnounce {
+                        connection: ConnectionContext::new(
+                            IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
+                            Some(8080),
+                            server_service_binding.clone(),
+                        ),
+                        announced_peer,
+                        added_peer,
+                    };
+
+                    match (event, expected_event) {
+                        (
+                            Event::TcpAnnounce {
+                                connection: a_conn,
+                                announced_peer: a1,
+                                added_peer: a2,
+                            },
+                            Event::TcpAnnounce {
+                                connection: b_conn,
+                                announced_peer: b1,
+                                added_peer: b2,
+                            },
+                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        _ => false,
+                    }
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -412,8 +437,6 @@ mod tests {
             let (core_tracker_services, mut core_http_tracker_services) = initialize_core_tracker_services();
 
             core_http_tracker_services.http_stats_event_sender = http_stats_event_sender;
-
-            let peer = sample_peer_using_ipv4();
 
             let (announce_request, client_ip_sources) = sample_announce_request_for_peer(peer);
 
@@ -426,7 +449,7 @@ mod tests {
             );
 
             let _announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, &server_service_binding, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_service_binding_clone, None)
                 .await
                 .unwrap();
         }
@@ -453,20 +476,53 @@ mod tests {
 
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
+            let peer = peer_with_the_ipv4_loopback_ip();
 
-            // Assert that the event sent is a TCP4 event
+            let server_service_binding_clone = server_service_binding.clone();
+            let peer_copy = peer;
+
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(Event::TcpAnnounce {
-                    connection: ConnectionContext::new(
-                        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                        Some(8080),
-                        server_service_binding.clone(),
-                    ),
+                .with(predicate::function(move |event| {
+                    let mut announced_peer = peer_copy;
+                    announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+
+                    let mut added_peer = peer;
+                    added_peer.peer_addr = SocketAddr::new(
+                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        8080,
+                    );
+
+                    let expected_event = Event::TcpAnnounce {
+                        connection: ConnectionContext::new(
+                            IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                            Some(8080),
+                            server_service_binding.clone(),
+                        ),
+                        announced_peer,
+                        added_peer,
+                    };
+
+                    match (event, expected_event) {
+                        (
+                            Event::TcpAnnounce {
+                                connection: a_conn,
+                                announced_peer: a1,
+                                added_peer: a2,
+                            },
+                            Event::TcpAnnounce {
+                                connection: b_conn,
+                                announced_peer: b1,
+                                added_peer: b2,
+                            },
+                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        _ => false,
+                    }
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
+
             let http_stats_event_sender: Arc<Option<Box<dyn event::sender::Sender>>> =
                 Arc::new(Some(Box::new(http_stats_event_sender_mock)));
 
@@ -474,8 +530,6 @@ mod tests {
                 initialize_core_tracker_services_with_config(&tracker_with_an_ipv6_external_ip());
 
             core_http_tracker_services.http_stats_event_sender = http_stats_event_sender;
-
-            let peer = peer_with_the_ipv4_loopback_ip();
 
             let (announce_request, client_ip_sources) = sample_announce_request_for_peer(peer);
 
@@ -488,7 +542,7 @@ mod tests {
             );
 
             let _announce_data = announce_service
-                .handle_announce(&announce_request, &client_ip_sources, &server_service_binding, None)
+                .handle_announce(&announce_request, &client_ip_sources, &server_service_binding_clone, None)
                 .await
                 .unwrap();
         }
@@ -498,16 +552,45 @@ mod tests {
         {
             let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070);
             let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
+            let peer = sample_peer_using_ipv6();
+
+            let peer_copy = peer;
 
             let mut http_stats_event_sender_mock = MockHttpStatsEventSender::new();
             http_stats_event_sender_mock
                 .expect_send_event()
-                .with(eq(Event::TcpAnnounce {
-                    connection: ConnectionContext::new(
-                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                        Some(8080),
-                        server_service_binding,
-                    ),
+                .with(predicate::function(move |event| {
+                    let announced_peer = peer_copy;
+                    //announced_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
+
+                    let added_peer = peer;
+                    //added_peer.peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080);
+
+                    let expected_event = Event::TcpAnnounce {
+                        connection: ConnectionContext::new(
+                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                            Some(8080),
+                            server_service_binding.clone(),
+                        ),
+                        announced_peer,
+                        added_peer,
+                    };
+
+                    match (event, expected_event) {
+                        (
+                            Event::TcpAnnounce {
+                                connection: a_conn,
+                                announced_peer: a1,
+                                added_peer: a2,
+                            },
+                            Event::TcpAnnounce {
+                                connection: b_conn,
+                                announced_peer: b1,
+                                added_peer: b2,
+                            },
+                        ) => *a_conn == b_conn && a1.peer_addr == b1.peer_addr && a2.peer_addr == b2.peer_addr,
+                        _ => false,
+                    }
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -516,8 +599,6 @@ mod tests {
 
             let (core_tracker_services, mut core_http_tracker_services) = initialize_core_tracker_services();
             core_http_tracker_services.http_stats_event_sender = http_stats_event_sender;
-
-            let peer = sample_peer_using_ipv6();
 
             let (announce_request, client_ip_sources) = sample_announce_request_for_peer(peer);
 

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -12,7 +12,7 @@ use std::panic::Location;
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::announce::{peer_from_request, Announce};
-use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{self, ClientIpSources, PeerIpResolutionError};
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, PeerIpResolutionError};
 use bittorrent_primitives::info_hash::InfoHash;
 use bittorrent_tracker_core::announce_handler::{AnnounceHandler, PeersWanted};
 use bittorrent_tracker_core::authentication::service::AuthenticationService;
@@ -24,6 +24,7 @@ use torrust_tracker_primitives::core::AnnounceData;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
+use super::resolve_remote_client_ip;
 use crate::event;
 use crate::event::Event;
 
@@ -78,7 +79,8 @@ impl AnnounceService {
 
         self.authorize(announce_request.info_hash).await?;
 
-        let (remote_client_ip, opt_remote_client_port) = self.resolve_remote_client_ip(client_ip_sources)?;
+        let (remote_client_ip, opt_remote_client_port) =
+            resolve_remote_client_ip(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
 
         let mut peer = peer_from_request(announce_request, &remote_client_ip);
 
@@ -115,27 +117,6 @@ impl AnnounceService {
 
     async fn authorize(&self, info_hash: InfoHash) -> Result<(), WhitelistError> {
         self.whitelist_authorization.authorize(&info_hash).await
-    }
-
-    /// Resolves the client's real IP address considering proxy headers
-    fn resolve_remote_client_ip(
-        &self,
-        client_ip_sources: &ClientIpSources,
-    ) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
-        let ip = match peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources) {
-            Ok(peer_ip) => Ok(peer_ip),
-            Err(error) => Err(error),
-        }?;
-
-        let port = if client_ip_sources.connection_info_socket_address.is_some() {
-            client_ip_sources
-                .connection_info_socket_address
-                .map(|socket_addr| socket_addr.port())
-        } else {
-            None
-        };
-
-        Ok((ip, port))
     }
 
     /// Determines how many peers the client wants in the response

--- a/packages/http-tracker-core/src/services/mod.rs
+++ b/packages/http-tracker-core/src/services/mod.rs
@@ -12,15 +12,28 @@ use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{self, Cli
 pub mod announce;
 pub mod scrape;
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RemoteClientAddr {
+    pub ip: IpAddr,
+    pub port: Option<u16>,
+}
+
+impl RemoteClientAddr {
+    #[must_use]
+    pub fn new(ip: IpAddr, port: Option<u16>) -> Self {
+        Self { ip, port }
+    }
+}
+
 /// Resolves the client's real IP address considering proxy headers
 ///
 /// # Errors
 ///
 /// This function returns an error if the IP address cannot be resolved.
-pub fn resolve_remote_client_ip(
+pub fn resolve_remote_client_addr(
     on_reverse_proxy: bool,
     client_ip_sources: &ClientIpSources,
-) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
+) -> Result<RemoteClientAddr, PeerIpResolutionError> {
     let ip = match peer_ip_resolver::invoke(on_reverse_proxy, client_ip_sources) {
         Ok(peer_ip) => Ok(peer_ip),
         Err(error) => Err(error),
@@ -34,5 +47,5 @@ pub fn resolve_remote_client_ip(
         None
     };
 
-    Ok((ip, port))
+    Ok(RemoteClientAddr { ip, port })
 }

--- a/packages/http-tracker-core/src/services/mod.rs
+++ b/packages/http-tracker-core/src/services/mod.rs
@@ -5,5 +5,34 @@
 //! servers.
 //!
 //! Refer to [`torrust_tracker`](crate) documentation.
+
+use std::net::IpAddr;
+
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{self, ClientIpSources, PeerIpResolutionError};
 pub mod announce;
 pub mod scrape;
+
+/// Resolves the client's real IP address considering proxy headers
+///
+/// # Errors
+///
+/// This function returns an error if the IP address cannot be resolved.
+pub fn resolve_remote_client_ip(
+    on_reverse_proxy: bool,
+    client_ip_sources: &ClientIpSources,
+) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
+    let ip = match peer_ip_resolver::invoke(on_reverse_proxy, client_ip_sources) {
+        Ok(peer_ip) => Ok(peer_ip),
+        Err(error) => Err(error),
+    }?;
+
+    let port = if client_ip_sources.connection_info_socket_address.is_some() {
+        client_ip_sources
+            .connection_info_socket_address
+            .map(|socket_addr| socket_addr.port())
+    } else {
+        None
+    };
+
+    Ok((ip, port))
+}

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -11,7 +11,7 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
-use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{self, ClientIpSources, PeerIpResolutionError};
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, PeerIpResolutionError};
 use bittorrent_tracker_core::authentication::service::AuthenticationService;
 use bittorrent_tracker_core::authentication::{self, Key};
 use bittorrent_tracker_core::error::{ScrapeError, TrackerCoreError, WhitelistError};
@@ -20,6 +20,7 @@ use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::ScrapeData;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
+use super::resolve_remote_client_ip;
 use crate::event;
 use crate::event::{ConnectionContext, Event};
 
@@ -81,7 +82,8 @@ impl ScrapeService {
             self.scrape_handler.scrape(&scrape_request.info_hashes).await?
         };
 
-        let (remote_client_ip, opt_client_port) = self.resolve_remote_client_ip(client_ip_sources)?;
+        let (remote_client_ip, opt_client_port) =
+            resolve_remote_client_ip(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
 
         self.send_event(remote_client_ip, opt_client_port, server_service_binding.clone())
             .await;
@@ -99,24 +101,6 @@ impl ScrapeService {
         }
 
         false
-    }
-
-    /// Resolves the client's real IP address considering proxy headers.
-    fn resolve_remote_client_ip(
-        &self,
-        client_ip_sources: &ClientIpSources,
-    ) -> Result<(IpAddr, Option<u16>), PeerIpResolutionError> {
-        let ip = peer_ip_resolver::invoke(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
-
-        let port = if client_ip_sources.connection_info_socket_address.is_some() {
-            client_ip_sources
-                .connection_info_socket_address
-                .map(|socket_addr| socket_addr.port())
-        } else {
-            None
-        };
-
-        Ok((ip, port))
     }
 
     async fn send_event(

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -126,11 +126,13 @@ impl ScrapeService {
         server_service_binding: ServiceBinding,
     ) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
-            http_stats_event_sender
-                .send_event(Event::TcpScrape {
-                    connection: ConnectionContext::new(original_peer_ip, opt_original_peer_port, server_service_binding),
-                })
-                .await;
+            let event = Event::TcpScrape {
+                connection: ConnectionContext::new(original_peer_ip, opt_original_peer_port, server_service_binding),
+            };
+
+            tracing::debug!("Sending TcpScrape event: {:?}", event);
+
+            http_stats_event_sender.send_event(event).await;
         }
     }
 }

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -7,7 +7,6 @@
 //!
 //! It also sends an [`http_tracker_core::statistics::event::Event`]
 //! because events are specific for the HTTP tracker.
-use std::net::IpAddr;
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
@@ -20,7 +19,7 @@ use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::ScrapeData;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
-use super::resolve_remote_client_ip;
+use super::{resolve_remote_client_addr, RemoteClientAddr};
 use crate::event;
 use crate::event::{ConnectionContext, Event};
 
@@ -82,11 +81,9 @@ impl ScrapeService {
             self.scrape_handler.scrape(&scrape_request.info_hashes).await?
         };
 
-        let (remote_client_ip, opt_client_port) =
-            resolve_remote_client_ip(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
+        let remote_client_addr = resolve_remote_client_addr(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
 
-        self.send_event(remote_client_ip, opt_client_port, server_service_binding.clone())
-            .await;
+        self.send_event(remote_client_addr, server_service_binding.clone()).await;
 
         Ok(scrape_data)
     }
@@ -103,15 +100,10 @@ impl ScrapeService {
         false
     }
 
-    async fn send_event(
-        &self,
-        original_peer_ip: IpAddr,
-        opt_original_peer_port: Option<u16>,
-        server_service_binding: ServiceBinding,
-    ) {
+    async fn send_event(&self, remote_client_addr: RemoteClientAddr, server_service_binding: ServiceBinding) {
         if let Some(http_stats_event_sender) = self.opt_http_stats_event_sender.as_deref() {
             let event = Event::TcpScrape {
-                connection: ConnectionContext::new(original_peer_ip, opt_original_peer_port, server_service_binding),
+                connection: ConnectionContext::new(remote_client_addr, server_service_binding),
             };
 
             tracing::debug!("Sending TcpScrape event: {:?}", event);
@@ -271,6 +263,7 @@ mod tests {
             initialize_services_with_configuration, sample_info_hashes, sample_peer, MockHttpStatsEventSender,
         };
         use crate::services::scrape::ScrapeService;
+        use crate::services::RemoteClientAddr;
         use crate::tests::sample_info_hash;
         use crate::{event, statistics};
 
@@ -342,8 +335,7 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        Some(8080),
+                        RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), Some(8080)),
                         ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070))
                             .unwrap(),
                     ),
@@ -394,8 +386,10 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                        Some(8080),
+                        RemoteClientAddr::new(
+                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                            Some(8080),
+                        ),
                         server_service_binding,
                     ),
                 }))
@@ -453,6 +447,7 @@ mod tests {
             initialize_services_with_configuration, sample_info_hashes, sample_peer, MockHttpStatsEventSender,
         };
         use crate::services::scrape::ScrapeService;
+        use crate::services::RemoteClientAddr;
         use crate::tests::sample_info_hash;
         use crate::{event, statistics};
 
@@ -518,8 +513,7 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)),
-                        Some(8080),
+                        RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), Some(8080)),
                         ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070))
                             .unwrap(),
                     ),
@@ -570,8 +564,10 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                        Some(8080),
+                        RemoteClientAddr::new(
+                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                            Some(8080),
+                        ),
                         server_service_binding,
                     ),
                 }))

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -77,6 +77,7 @@ mod tests {
     use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
     use crate::event::{ConnectionContext, Event};
+    use crate::services::RemoteClientAddr;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
     use crate::tests::{sample_info_hash, sample_peer_using_ipv4, sample_peer_using_ipv6};
@@ -91,8 +92,7 @@ mod tests {
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    remote_client_ip,
-                    Some(8080),
+                    RemoteClientAddr::new(remote_client_ip, Some(8080)),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
                 info_hash: sample_info_hash(),
@@ -115,8 +115,7 @@ mod tests {
         handle_event(
             Event::TcpScrape {
                 connection: ConnectionContext::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
-                    Some(8080),
+                    RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), Some(8080)),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
             },
@@ -139,8 +138,7 @@ mod tests {
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    remote_client_ip,
-                    Some(8080),
+                    RemoteClientAddr::new(remote_client_ip, Some(8080)),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
                 info_hash: sample_info_hash(),
@@ -163,8 +161,10 @@ mod tests {
         handle_event(
             Event::TcpScrape {
                 connection: ConnectionContext::new(
-                    IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
-                    Some(8080),
+                    RemoteClientAddr::new(
+                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        Some(8080),
+                    ),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
             },

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -14,7 +14,7 @@ use crate::statistics::HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
 /// version of the event.
 pub async fn handle_event(event: Event, stats_repository: &Repository, now: DurationSinceUnixEpoch) {
     match event {
-        Event::TcpAnnounce { connection } => {
+        Event::TcpAnnounce { connection, .. } => {
             // Global fixed metrics
 
             match connection.client_ip_addr() {
@@ -79,11 +79,13 @@ mod tests {
     use crate::event::{ConnectionContext, Event};
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
+    use crate::tests::{sample_peer_using_ipv4, sample_peer_using_ipv6};
     use crate::CurrentClock;
 
     #[tokio::test]
     async fn should_increase_the_tcp4_announces_counter_when_it_receives_a_tcp4_announce_event() {
         let stats_repository = Repository::new();
+        let peer = sample_peer_using_ipv4();
 
         handle_event(
             Event::TcpAnnounce {
@@ -92,6 +94,8 @@ mod tests {
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
+                announced_peer: peer,
+                added_peer: peer,
             },
             &stats_repository,
             CurrentClock::now(),
@@ -128,6 +132,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_tcp6_announces_counter_when_it_receives_a_tcp6_announce_event() {
         let stats_repository = Repository::new();
+        let peer = sample_peer_using_ipv6();
 
         handle_event(
             Event::TcpAnnounce {
@@ -136,6 +141,8 @@ mod tests {
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
+                announced_peer: peer,
+                added_peer: peer,
             },
             &stats_repository,
             CurrentClock::now(),

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -79,7 +79,7 @@ mod tests {
     use crate::event::{ConnectionContext, Event};
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
-    use crate::tests::{sample_peer_using_ipv4, sample_peer_using_ipv6};
+    use crate::tests::{sample_info_hash, sample_peer_using_ipv4, sample_peer_using_ipv6};
     use crate::CurrentClock;
 
     #[tokio::test]
@@ -95,6 +95,7 @@ mod tests {
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
+                info_hash: sample_info_hash(),
                 announcement: peer,
             },
             &stats_repository,
@@ -142,6 +143,7 @@ mod tests {
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
+                info_hash: sample_info_hash(),
                 announcement: peer,
             },
             &stats_repository,

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -86,16 +86,16 @@ mod tests {
     async fn should_increase_the_tcp4_announces_counter_when_it_receives_a_tcp4_announce_event() {
         let stats_repository = Repository::new();
         let peer = sample_peer_using_ipv4();
+        let remote_client_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2));
 
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)),
+                    remote_client_ip,
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
-                announced_peer: peer,
-                added_peer: peer,
+                announcement: peer,
             },
             &stats_repository,
             CurrentClock::now(),
@@ -133,16 +133,16 @@ mod tests {
     async fn should_increase_the_tcp6_announces_counter_when_it_receives_a_tcp6_announce_event() {
         let stats_repository = Repository::new();
         let peer = sample_peer_using_ipv6();
+        let remote_client_ip = IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969));
 
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                    remote_client_ip,
                     Some(8080),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
-                announced_peer: peer,
-                added_peer: peer,
+                announcement: peer,
             },
             &stats_repository,
             CurrentClock::now(),

--- a/packages/primitives/src/peer.rs
+++ b/packages/primitives/src/peer.rs
@@ -513,6 +513,22 @@ pub mod fixture {
 
 #[cfg(test)]
 pub mod test {
+
+    mod peer {
+        use crate::peer::fixture::PeerBuilder;
+
+        #[test]
+        fn should_be_comparable() {
+            let seeder1 = PeerBuilder::seeder().build();
+            let seeder2 = PeerBuilder::seeder().build();
+
+            let leecher1 = PeerBuilder::leecher().build();
+
+            assert!(seeder1 == seeder2);
+            assert!(seeder1 != leecher1);
+        }
+    }
+
     mod torrent_peer_id {
         use aquatic_udp_protocol::PeerId;
 

--- a/packages/primitives/src/peer.rs
+++ b/packages/primitives/src/peer.rs
@@ -32,6 +32,8 @@ use zerocopy::FromBytes as _;
 
 use crate::DurationSinceUnixEpoch;
 
+pub type PeerAnnouncement = Peer;
+
 /// Peer struct used by the core `Tracker`.
 ///
 /// A sample peer:


### PR DESCRIPTION
Added `info_hash` and `announcement` (peer announce request data):

```rust
pub enum Event {
    TcpAnnounce {
        connection: ConnectionContext,
        info_hash: InfoHash,
        announcement: PeerAnnouncement,
    },
    TcpScrape {
        connection: ConnectionContext,
    },
}
```