### PR TITLE
Enrich UDP core `Event::UdpAnnounce` event

### DIFF
--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -124,7 +124,17 @@ pub mod test {
             ) => {
                 *connection == *expected_connection
                     && *info_hash == *expected_info_hash
+                    && announcement.peer_id == expected_announcement.peer_id
                     && announcement.peer_addr == expected_announcement.peer_addr
+                    // Events can't be compared due to the `updated` field.
+                    // The `announcement.uploaded` contains the current time
+                    // when the test is executed.
+                    // todo: mock time
+                    //&& announcement.updated == expected_announcement.updated
+                    && announcement.uploaded == expected_announcement.uploaded
+                    && announcement.downloaded == expected_announcement.downloaded
+                    && announcement.left == expected_announcement.left
+                    && announcement.event == expected_announcement.event
             }
             _ => false,
         }

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -108,7 +108,7 @@ pub mod test {
     use crate::tests::sample_info_hash;
 
     #[must_use]
-    pub fn events_match(event: &Event, expected_event: &Event) -> bool {
+    pub fn announce_events_match(event: &Event, expected_event: &Event) -> bool {
         match (event, expected_event) {
             (
                 Event::TcpAnnounce {

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -312,7 +312,7 @@ mod tests {
         use torrust_tracker_test_helpers::configuration;
 
         use crate::event;
-        use crate::event::test::events_match;
+        use crate::event::test::announce_events_match;
         use crate::event::{ConnectionContext, Event};
         use crate::services::announce::tests::{
             initialize_core_tracker_services, initialize_core_tracker_services_with_config, sample_announce_request_for_peer,
@@ -388,7 +388,7 @@ mod tests {
                         announcement,
                     };
 
-                    events_match(event, &expected_event)
+                    announce_events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -465,7 +465,7 @@ mod tests {
                         announcement: peer_announcement,
                     };
 
-                    events_match(event, &expected_event)
+                    announce_events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -514,7 +514,7 @@ mod tests {
                         info_hash: sample_info_hash(),
                         announcement: peer,
                     };
-                    events_match(event, &expected_event)
+                    announce_events_match(event, &expected_event)
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));

--- a/packages/udp-tracker-core/src/event/mod.rs
+++ b/packages/udp-tracker-core/src/event/mod.rs
@@ -9,9 +9,9 @@ pub mod sender;
 /// A UDP core event.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Event {
-    UdpConnect { context: ConnectionContext },
-    UdpAnnounce { context: ConnectionContext },
-    UdpScrape { context: ConnectionContext },
+    UdpConnect { connection: ConnectionContext },
+    UdpAnnounce { connection: ConnectionContext },
+    UdpScrape { connection: ConnectionContext },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/packages/udp-tracker-core/src/event/mod.rs
+++ b/packages/udp-tracker-core/src/event/mod.rs
@@ -1,7 +1,9 @@
 use std::net::SocketAddr;
 
+use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
+use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 pub mod sender;
@@ -9,9 +11,17 @@ pub mod sender;
 /// A UDP core event.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Event {
-    UdpConnect { connection: ConnectionContext },
-    UdpAnnounce { connection: ConnectionContext },
-    UdpScrape { connection: ConnectionContext },
+    UdpConnect {
+        connection: ConnectionContext,
+    },
+    UdpAnnounce {
+        connection: ConnectionContext,
+        info_hash: InfoHash,
+        announcement: PeerAnnouncement,
+    },
+    UdpScrape {
+        connection: ConnectionContext,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/packages/udp-tracker-core/src/lib.rs
+++ b/packages/udp-tracker-core/src/lib.rs
@@ -42,3 +42,18 @@ pub fn initialize_static() {
     // Initialize the Zeroed Cipher
     lazy_static::initialize(&ephemeral_instance_keys::ZEROED_TEST_CIPHER_BLOWFISH);
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use bittorrent_primitives::info_hash::InfoHash;
+
+    /// # Panics
+    ///
+    /// Will panic if the string representation of the info hash is not a valid info hash.
+    #[must_use]
+    pub fn sample_info_hash() -> InfoHash {
+        "3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0" // DevSkim: ignore DS173237
+            .parse::<InfoHash>()
+            .expect("String should be a valid info hash")
+    }
+}

--- a/packages/udp-tracker-core/src/services/announce.rs
+++ b/packages/udp-tracker-core/src/services/announce.rs
@@ -105,7 +105,7 @@ impl AnnounceService {
         if let Some(udp_stats_event_sender) = self.opt_udp_core_stats_event_sender.as_deref() {
             udp_stats_event_sender
                 .send_event(Event::UdpAnnounce {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding),
+                    connection: ConnectionContext::new(client_socket_addr, server_service_binding),
                 })
                 .await;
         }

--- a/packages/udp-tracker-core/src/services/announce.rs
+++ b/packages/udp-tracker-core/src/services/announce.rs
@@ -18,6 +18,7 @@ use bittorrent_tracker_core::error::{AnnounceError, WhitelistError};
 use bittorrent_tracker_core::whitelist;
 use bittorrent_udp_tracker_protocol::peer_builder;
 use torrust_tracker_primitives::core::AnnounceData;
+use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
 use crate::connection_cookie::{check, gen_remote_fingerprint, ConnectionCookieError};
@@ -80,7 +81,8 @@ impl AnnounceService {
             .announce(&info_hash, &mut peer, &remote_client_ip, &peers_wanted)
             .await?;
 
-        self.send_event(client_socket_addr, server_service_binding).await;
+        self.send_event(info_hash, peer, client_socket_addr, server_service_binding)
+            .await;
 
         Ok(announce_data)
     }
@@ -101,13 +103,25 @@ impl AnnounceService {
         self.whitelist_authorization.authorize(info_hash).await
     }
 
-    async fn send_event(&self, client_socket_addr: SocketAddr, server_service_binding: ServiceBinding) {
+    async fn send_event(
+        &self,
+        info_hash: InfoHash,
+        announcement: PeerAnnouncement,
+        client_socket_addr: SocketAddr,
+        server_service_binding: ServiceBinding,
+    ) {
         if let Some(udp_stats_event_sender) = self.opt_udp_core_stats_event_sender.as_deref() {
-            udp_stats_event_sender
-                .send_event(Event::UdpAnnounce {
-                    connection: ConnectionContext::new(client_socket_addr, server_service_binding),
-                })
-                .await;
+            let event = Event::UdpAnnounce {
+                connection: ConnectionContext::new(client_socket_addr, server_service_binding),
+                info_hash,
+                announcement,
+            };
+
+            tracing::debug!(target = crate::UDP_TRACKER_LOG_TARGET, "Sending UdpAnnounce event: {event:?}");
+
+            println!("Sending UdpAnnounce event: {event:?}");
+
+            udp_stats_event_sender.send_event(event).await;
         }
     }
 }

--- a/packages/udp-tracker-core/src/services/connect.rs
+++ b/packages/udp-tracker-core/src/services/connect.rs
@@ -43,7 +43,7 @@ impl ConnectService {
         if let Some(udp_stats_event_sender) = self.opt_udp_core_stats_event_sender.as_deref() {
             udp_stats_event_sender
                 .send_event(Event::UdpConnect {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding),
+                    connection: ConnectionContext::new(client_socket_addr, server_service_binding),
                 })
                 .await;
         }
@@ -144,7 +144,7 @@ mod tests {
             udp_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(Event::UdpConnect {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                    connection: ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -168,7 +168,7 @@ mod tests {
             udp_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(Event::UdpConnect {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                    connection: ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));

--- a/packages/udp-tracker-core/src/services/scrape.rs
+++ b/packages/udp-tracker-core/src/services/scrape.rs
@@ -87,7 +87,7 @@ impl ScrapeService {
         if let Some(udp_stats_event_sender) = self.opt_udp_stats_event_sender.as_deref() {
             udp_stats_event_sender
                 .send_event(Event::UdpScrape {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding),
+                    connection: ConnectionContext::new(client_socket_addr, server_service_binding),
                 })
                 .await;
         }

--- a/packages/udp-tracker-core/src/services/scrape.rs
+++ b/packages/udp-tracker-core/src/services/scrape.rs
@@ -85,11 +85,13 @@ impl ScrapeService {
 
     async fn send_event(&self, client_socket_addr: SocketAddr, server_service_binding: ServiceBinding) {
         if let Some(udp_stats_event_sender) = self.opt_udp_stats_event_sender.as_deref() {
-            udp_stats_event_sender
-                .send_event(Event::UdpScrape {
-                    connection: ConnectionContext::new(client_socket_addr, server_service_binding),
-                })
-                .await;
+            let event = Event::UdpScrape {
+                connection: ConnectionContext::new(client_socket_addr, server_service_binding),
+            };
+
+            tracing::debug!(target = crate::UDP_TRACKER_LOG_TARGET, "Sending UdpScrape event: {event:?}");
+
+            udp_stats_event_sender.send_event(event).await;
         }
     }
 }

--- a/packages/udp-tracker-core/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-core/src/statistics/event/handler.rs
@@ -11,7 +11,7 @@ use crate::statistics::UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
 /// This function panics if the IP version does not match the event type.
 pub async fn handle_event(event: Event, stats_repository: &Repository, now: DurationSinceUnixEpoch) {
     match event {
-        Event::UdpConnect { context } => {
+        Event::UdpConnect { connection: context } => {
             // Global fixed metrics
 
             match context.client_socket_addr.ip() {
@@ -36,7 +36,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                 Err(err) => tracing::error!("Failed to increase the counter: {}", err),
             };
         }
-        Event::UdpAnnounce { context } => {
+        Event::UdpAnnounce { connection: context } => {
             // Global fixed metrics
 
             match context.client_socket_addr.ip() {
@@ -61,7 +61,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                 Err(err) => tracing::error!("Failed to increase the counter: {}", err),
             };
         }
-        Event::UdpScrape { context } => {
+        Event::UdpScrape { connection: context } => {
             // Global fixed metrics
 
             match context.client_socket_addr.ip() {
@@ -109,7 +109,7 @@ mod tests {
 
         handle_event(
             Event::UdpConnect {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,
@@ -134,7 +134,7 @@ mod tests {
 
         handle_event(
             Event::UdpAnnounce {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,
@@ -159,7 +159,7 @@ mod tests {
 
         handle_event(
             Event::UdpScrape {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,
@@ -184,7 +184,7 @@ mod tests {
 
         handle_event(
             Event::UdpConnect {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,
@@ -209,7 +209,7 @@ mod tests {
 
         handle_event(
             Event::UdpAnnounce {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,
@@ -234,7 +234,7 @@ mod tests {
 
         handle_event(
             Event::UdpScrape {
-                context: ConnectionContext::new(
+                connection: ConnectionContext::new(
                     SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 203, 0, 113, 195)), 8080),
                     ServiceBinding::new(
                         Protocol::UDP,

--- a/packages/udp-tracker-core/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-core/src/statistics/event/handler.rs
@@ -36,7 +36,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                 Err(err) => tracing::error!("Failed to increase the counter: {}", err),
             };
         }
-        Event::UdpAnnounce { connection: context } => {
+        Event::UdpAnnounce { connection: context, .. } => {
             // Global fixed metrics
 
             match context.client_socket_addr.ip() {
@@ -96,11 +96,13 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use torrust_tracker_clock::clock::Time;
+    use torrust_tracker_primitives::peer::PeerAnnouncement;
     use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
     use crate::event::{ConnectionContext, Event};
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
+    use crate::tests::sample_info_hash;
     use crate::CurrentClock;
 
     #[tokio::test]
@@ -142,6 +144,8 @@ mod tests {
                     )
                     .unwrap(),
                 ),
+                info_hash: sample_info_hash(),
+                announcement: PeerAnnouncement::default(),
             },
             &stats_repository,
             CurrentClock::now(),
@@ -217,6 +221,8 @@ mod tests {
                     )
                     .unwrap(),
                 ),
+                info_hash: sample_info_hash(),
+                announcement: PeerAnnouncement::default(),
             },
             &stats_repository,
             CurrentClock::now(),

--- a/packages/udp-tracker-server/src/handlers/announce.rs
+++ b/packages/udp-tracker-server/src/handlers/announce.rs
@@ -868,7 +868,7 @@ mod tests {
                     udp_core_stats_event_sender_mock
                         .expect_send_event()
                         .with(eq(core_event::Event::UdpAnnounce {
-                            context: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                            connection: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
                         }))
                         .times(1)
                         .returning(|_| Box::pin(future::ready(Some(Ok(1)))));

--- a/packages/udp-tracker-server/src/handlers/announce.rs
+++ b/packages/udp-tracker-server/src/handlers/announce.rs
@@ -824,7 +824,7 @@ mod tests {
                 use bittorrent_udp_tracker_core::connection_cookie::{gen_remote_fingerprint, make};
                 use bittorrent_udp_tracker_core::services::announce::AnnounceService;
                 use bittorrent_udp_tracker_core::{self, event as core_event};
-                use mockall::predicate::eq;
+                use mockall::predicate::{self, eq};
                 use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
                 use crate::event::{self, ConnectionContext, Event, UdpRequestKind};
@@ -834,6 +834,7 @@ mod tests {
                     sample_cookie_valid_range, sample_issue_time, MockUdpCoreStatsEventSender, MockUdpServerStatsEventSender,
                     TrackerConfigurationBuilder,
                 };
+                use crate::tests::{announce_events_match, sample_peer};
 
                 #[tokio::test]
                 async fn the_peer_ip_should_be_changed_to_the_external_ip_in_the_tracker_configuration() {
@@ -848,6 +849,11 @@ mod tests {
 
                     let info_hash = AquaticInfoHash([0u8; 20]);
                     let peer_id = AquaticPeerId([255u8; 20]);
+                    let mut announcement = sample_peer();
+                    announcement.peer_id = peer_id;
+                    announcement.peer_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x7e00, 1)), client_port);
+
+                    println!("announcement.peer_addr: {}", announcement.peer_addr);
 
                     let client_socket_addr = SocketAddr::new(IpAddr::V6(client_ip_v6), client_port);
                     let mut server_socket_addr = config.udp_trackers.clone().unwrap()[0].bind_address;
@@ -856,6 +862,7 @@ mod tests {
                         server_socket_addr.set_port(6969);
                     }
                     let server_service_binding = ServiceBinding::new(Protocol::UDP, server_socket_addr).unwrap();
+                    let server_service_binding_clone = server_service_binding.clone();
 
                     let database = initialize_database(&config.core);
                     let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
@@ -867,8 +874,17 @@ mod tests {
                     let mut udp_core_stats_event_sender_mock = MockUdpCoreStatsEventSender::new();
                     udp_core_stats_event_sender_mock
                         .expect_send_event()
-                        .with(eq(core_event::Event::UdpAnnounce {
-                            connection: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                        .with(predicate::function(move |event| {
+                            let expected_event = core_event::Event::UdpAnnounce {
+                                connection: core_event::ConnectionContext::new(
+                                    client_socket_addr,
+                                    server_service_binding.clone(),
+                                ),
+                                info_hash: info_hash.into(),
+                                announcement,
+                            };
+
+                            announce_events_match(event, &expected_event)
                         }))
                         .times(1)
                         .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -879,7 +895,7 @@ mod tests {
                     udp_server_stats_event_sender_mock
                         .expect_send_event()
                         .with(eq(Event::UdpRequestAccepted {
-                            context: ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                            context: ConnectionContext::new(client_socket_addr, server_service_binding_clone.clone()),
                             kind: UdpRequestKind::Announce,
                         }))
                         .times(1)
@@ -913,7 +929,7 @@ mod tests {
                     handle_announce(
                         &announce_service,
                         client_socket_addr,
-                        server_service_binding,
+                        server_service_binding_clone,
                         &request,
                         &core_config,
                         &udp_server_stats_event_sender,
@@ -927,6 +943,8 @@ mod tests {
                     let external_ip_in_tracker_configuration = core_config.net.external_ip.unwrap();
 
                     assert!(external_ip_in_tracker_configuration.is_ipv6());
+
+                    println!("Peer addr: {}", peers[0].peer_addr.ip());
 
                     // There's a special type of IPv6 addresses that provide compatibility with IPv4.
                     // The last 32 bits of these addresses represent an IPv4, and are represented like this:

--- a/packages/udp-tracker-server/src/handlers/announce.rs
+++ b/packages/udp-tracker-server/src/handlers/announce.rs
@@ -853,8 +853,6 @@ mod tests {
                     announcement.peer_id = peer_id;
                     announcement.peer_addr = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0x7e00, 1)), client_port);
 
-                    println!("announcement.peer_addr: {}", announcement.peer_addr);
-
                     let client_socket_addr = SocketAddr::new(IpAddr::V6(client_ip_v6), client_port);
                     let mut server_socket_addr = config.udp_trackers.clone().unwrap()[0].bind_address;
                     if server_socket_addr.port() == 0 {
@@ -943,8 +941,6 @@ mod tests {
                     let external_ip_in_tracker_configuration = core_config.net.external_ip.unwrap();
 
                     assert!(external_ip_in_tracker_configuration.is_ipv6());
-
-                    println!("Peer addr: {}", peers[0].peer_addr.ip());
 
                     // There's a special type of IPv6 addresses that provide compatibility with IPv4.
                     // The last 32 bits of these addresses represent an IPv4, and are represented like this:

--- a/packages/udp-tracker-server/src/handlers/connect.rs
+++ b/packages/udp-tracker-server/src/handlers/connect.rs
@@ -197,7 +197,7 @@ mod tests {
             udp_core_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(core_event::Event::UdpConnect {
-                    context: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                    connection: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));
@@ -239,7 +239,7 @@ mod tests {
             udp_core_stats_event_sender_mock
                 .expect_send_event()
                 .with(eq(core_event::Event::UdpConnect {
-                    context: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
+                    connection: core_event::ConnectionContext::new(client_socket_addr, server_service_binding.clone()),
                 }))
                 .times(1)
                 .returning(|_| Box::pin(future::ready(Some(Ok(1)))));

--- a/packages/udp-tracker-server/src/lib.rs
+++ b/packages/udp-tracker-server/src/lib.rs
@@ -711,7 +711,17 @@ pub(crate) mod tests {
             ) => {
                 *connection == *expected_connection
                     && *info_hash == *expected_info_hash
+                    && announcement.peer_id == expected_announcement.peer_id
                     && announcement.peer_addr == expected_announcement.peer_addr
+                    // Events can't be compared due to the `updated` field.
+                    // The `announcement.uploaded` contains the current time
+                    // when the test is executed.
+                    // todo: mock time
+                    //&& announcement.updated == expected_announcement.updated
+                    && announcement.uploaded == expected_announcement.uploaded
+                    && announcement.downloaded == expected_announcement.downloaded
+                    && announcement.left == expected_announcement.left
+                    && announcement.event == expected_announcement.event
             }
             _ => false,
         }

--- a/packages/udp-tracker-server/src/lib.rs
+++ b/packages/udp-tracker-server/src/lib.rs
@@ -673,3 +673,47 @@ pub struct RawRequest {
     payload: Vec<u8>,
     from: SocketAddr,
 }
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use aquatic_udp_protocol::{AnnounceEvent, NumberOfBytes, PeerId};
+    use bittorrent_udp_tracker_core::event::Event;
+    use torrust_tracker_primitives::{peer, DurationSinceUnixEpoch};
+
+    pub fn sample_peer() -> peer::Peer {
+        peer::Peer {
+            peer_id: PeerId(*b"-qB00000000000000000"),
+            peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),
+            updated: DurationSinceUnixEpoch::new(1_669_397_478_934, 0),
+            uploaded: NumberOfBytes::new(0),
+            downloaded: NumberOfBytes::new(0),
+            left: NumberOfBytes::new(0),
+            event: AnnounceEvent::Started,
+        }
+    }
+
+    #[must_use]
+    pub fn announce_events_match(event: &Event, expected_event: &Event) -> bool {
+        match (event, expected_event) {
+            (
+                Event::UdpAnnounce {
+                    connection,
+                    info_hash,
+                    announcement,
+                },
+                Event::UdpAnnounce {
+                    connection: expected_connection,
+                    info_hash: expected_info_hash,
+                    announcement: expected_announcement,
+                },
+            ) => {
+                *connection == *expected_connection
+                    && *info_hash == *expected_info_hash
+                    && announcement.peer_addr == expected_announcement.peer_addr
+            }
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
Enrich UDP core `Event::UdpAnnounce` event.

```rust
pub enum Event {
    UdpConnect {
        connection: ConnectionContext,
    },
    UdpAnnounce {
        connection: ConnectionContext,
        info_hash: InfoHash,               // New field
        announcement: PeerAnnouncement,    // New field
    },
    UdpScrape {
        connection: ConnectionContext,
    },
}
```
