### PR TITLE
Refactor remote client IP resolution code

### DIFF
--- a/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
+++ b/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
@@ -1,4 +1,4 @@
-//! This service resolves the peer IP from the request.
+//! This service resolves the remote client address.
 //!
 //! The peer IP is used to identify the peer in the tracker. It's the peer IP
 //! that is used in the `announce` responses (peer list). And it's also used to
@@ -12,20 +12,65 @@
 //!                     X-Forwarded-For: 126.0.0.1       X-Forwarded-For: 126.0.0.1,126.0.0.2
 //! ```
 //!
-//! This service returns two options for the peer IP:
+//! This `ClientIpSources` contains two options for the peer IP:
 //!
 //! ```text
 //! right_most_x_forwarded_for = 126.0.0.2
 //! connection_info_ip         = 126.0.0.3
 //! ```
 //!
-//! Depending on the tracker configuration.
+//! Which one to use depends on the `ReverseProxyMode`.
 use std::net::{IpAddr, SocketAddr};
 use std::panic::Location;
 
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+/// Resolves the client's real address considering proxy headers. Port is also
+/// included when available.
+///
+/// # Errors
+///
+/// This function returns an error if the IP address cannot be resolved.
+pub fn resolve_remote_client_addr(
+    reverse_proxy_mode: &ReverseProxyMode,
+    client_ip_sources: &ClientIpSources,
+) -> Result<RemoteClientAddr, PeerIpResolutionError> {
+    let ip = match reverse_proxy_mode {
+        ReverseProxyMode::Enabled => ResolvedIp::FromXForwardedFor(client_ip_sources.try_client_ip_from_proxy_header()?),
+        ReverseProxyMode::Disabled => ResolvedIp::FromSocketAddr(client_ip_sources.try_client_ip_from_connection_info()?),
+    };
+
+    let port = client_ip_sources.client_port_from_connection_info();
+
+    Ok(RemoteClientAddr::new(ip, port))
+}
+
+/// This struct indicates whether the tracker is running on reverse proxy mode.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ReverseProxyMode {
+    Enabled,
+    Disabled,
+}
+
+impl From<ReverseProxyMode> for bool {
+    fn from(reverse_proxy_mode: ReverseProxyMode) -> Self {
+        match reverse_proxy_mode {
+            ReverseProxyMode::Enabled => true,
+            ReverseProxyMode::Disabled => false,
+        }
+    }
+}
+
+impl From<bool> for ReverseProxyMode {
+    fn from(reverse_proxy_mode: bool) -> Self {
+        if reverse_proxy_mode {
+            ReverseProxyMode::Enabled
+        } else {
+            ReverseProxyMode::Disabled
+        }
+    }
+}
 /// This struct contains the sources from which the peer IP can be obtained.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ClientIpSources {
@@ -34,6 +79,36 @@ pub struct ClientIpSources {
 
     /// The client's socket address from the connection info.
     pub connection_info_socket_address: Option<SocketAddr>,
+}
+
+impl ClientIpSources {
+    fn try_client_ip_from_connection_info(&self) -> Result<IpAddr, PeerIpResolutionError> {
+        if let Some(socket_addr) = self.connection_info_socket_address {
+            Ok(socket_addr.ip())
+        } else {
+            Err(PeerIpResolutionError::MissingClientIp {
+                location: Location::caller(),
+            })
+        }
+    }
+
+    fn try_client_ip_from_proxy_header(&self) -> Result<IpAddr, PeerIpResolutionError> {
+        if let Some(ip) = self.right_most_x_forwarded_for {
+            Ok(ip)
+        } else {
+            Err(PeerIpResolutionError::MissingRightMostXForwardedForIp {
+                location: Location::caller(),
+            })
+        }
+    }
+
+    fn client_port_from_connection_info(&self) -> Option<u16> {
+        if self.connection_info_socket_address.is_some() {
+            self.connection_info_socket_address.map(|socket_addr| socket_addr.port())
+        } else {
+            None
+        }
+    }
 }
 
 /// The error that can occur when resolving the peer IP.
@@ -54,104 +129,57 @@ pub enum PeerIpResolutionError {
     MissingClientIp { location: &'static Location<'static> },
 }
 
-/// Resolves the peer IP from the request.
-///
-/// Given the sources from which the peer IP can be obtained, this function
-/// resolves the peer IP according to the tracker configuration.
-///
-/// With the tracker running on reverse proxy mode:
-///
-/// ```rust
-/// use std::net::IpAddr;
-/// use std::str::FromStr;
-///
-/// use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
-///
-/// let on_reverse_proxy = true;
-///
-/// let ip = invoke(
-///     on_reverse_proxy,
-///     &ClientIpSources {
-///         right_most_x_forwarded_for: Some(IpAddr::from_str("203.0.113.195").unwrap()),
-///         connection_info_socket_address: None,
-///     },
-/// )
-/// .unwrap();
-///
-/// assert_eq!(ip, IpAddr::from_str("203.0.113.195").unwrap());
-/// ```
-///
-/// With the tracker non running on reverse proxy mode:
-///
-/// ```rust
-/// use std::net::{IpAddr,Ipv4Addr,SocketAddr};
-/// use std::str::FromStr;
-///
-/// use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
-///
-/// let on_reverse_proxy = false;
-///
-/// let ip = invoke(
-///     on_reverse_proxy,
-///     &ClientIpSources {
-///         right_most_x_forwarded_for: None,
-///         connection_info_socket_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080))
-///     },
-/// )
-/// .unwrap();
-///
-/// assert_eq!(ip, IpAddr::from_str("203.0.113.195").unwrap());
-/// ```
-///
-/// # Errors
-///
-/// Will return an error if the peer IP cannot be obtained according to the configuration.
-/// For example, if the IP is extracted from an HTTP header which is missing in the request.
-pub fn invoke(on_reverse_proxy: bool, client_ip_sources: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-    if on_reverse_proxy {
-        resolve_peer_ip_on_reverse_proxy(client_ip_sources)
-    } else {
-        resolve_peer_ip_without_reverse_proxy(client_ip_sources)
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub struct RemoteClientAddr {
+    ip: ResolvedIp,
+    port: Option<u16>,
+}
+
+impl RemoteClientAddr {
+    #[must_use]
+    pub fn new(ip: ResolvedIp, port: Option<u16>) -> Self {
+        Self { ip, port }
+    }
+
+    #[must_use]
+    pub fn ip(&self) -> IpAddr {
+        match self.ip {
+            ResolvedIp::FromSocketAddr(ip) | ResolvedIp::FromXForwardedFor(ip) => ip,
+        }
+    }
+
+    #[must_use]
+    pub fn port(&self) -> Option<u16> {
+        self.port
     }
 }
 
-fn resolve_peer_ip_without_reverse_proxy(remote_client_ip: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-    if let Some(socket_addr) = remote_client_ip.connection_info_socket_address {
-        Ok(socket_addr.ip())
-    } else {
-        Err(PeerIpResolutionError::MissingClientIp {
-            location: Location::caller(),
-        })
-    }
-}
-
-fn resolve_peer_ip_on_reverse_proxy(remote_client_ip: &ClientIpSources) -> Result<IpAddr, PeerIpResolutionError> {
-    if let Some(ip) = remote_client_ip.right_most_x_forwarded_for {
-        Ok(ip)
-    } else {
-        Err(PeerIpResolutionError::MissingRightMostXForwardedForIp {
-            location: Location::caller(),
-        })
-    }
+/// This enum indicates the source of the resolved IP address.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ResolvedIp {
+    FromXForwardedFor(IpAddr),
+    FromSocketAddr(IpAddr),
 }
 
 #[cfg(test)]
 mod tests {
-    use super::invoke;
+    use super::resolve_remote_client_addr;
 
     mod working_without_reverse_proxy {
         use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
-        use super::invoke;
-        use crate::v1::services::peer_ip_resolver::{ClientIpSources, PeerIpResolutionError};
+        use super::resolve_remote_client_addr;
+        use crate::v1::services::peer_ip_resolver::{
+            ClientIpSources, PeerIpResolutionError, RemoteClientAddr, ResolvedIp, ReverseProxyMode,
+        };
 
         #[test]
-        fn it_should_get_the_peer_ip_from_the_connection_info() {
-            let on_reverse_proxy = false;
+        fn it_should_get_the_remote_client_address_from_the_connection_info() {
+            let reverse_proxy_mode = ReverseProxyMode::Disabled;
 
-            let ip = invoke(
-                on_reverse_proxy,
+            let ip = resolve_remote_client_addr(
+                &reverse_proxy_mode,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
                     connection_info_socket_address: Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 195)), 8080)),
@@ -159,15 +187,21 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(ip, IpAddr::from_str("203.0.113.195").unwrap());
+            assert_eq!(
+                ip,
+                RemoteClientAddr::new(
+                    ResolvedIp::FromSocketAddr(IpAddr::from_str("203.0.113.195").unwrap()),
+                    Some(8080)
+                )
+            );
         }
 
         #[test]
-        fn it_should_return_an_error_if_it_cannot_get_the_peer_ip_from_the_connection_info() {
-            let on_reverse_proxy = false;
+        fn it_should_return_an_error_if_it_cannot_get_the_remote_client_ip_from_the_connection_info() {
+            let reverse_proxy_mode = ReverseProxyMode::Disabled;
 
-            let error = invoke(
-                on_reverse_proxy,
+            let error = resolve_remote_client_addr(
+                &reverse_proxy_mode,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
                     connection_info_socket_address: None,
@@ -179,18 +213,20 @@ mod tests {
         }
     }
 
-    mod working_on_reverse_proxy {
+    mod working_on_reverse_proxy_mode {
         use std::net::IpAddr;
         use std::str::FromStr;
 
-        use crate::v1::services::peer_ip_resolver::{invoke, ClientIpSources, PeerIpResolutionError};
+        use crate::v1::services::peer_ip_resolver::{
+            resolve_remote_client_addr, ClientIpSources, PeerIpResolutionError, RemoteClientAddr, ResolvedIp, ReverseProxyMode,
+        };
 
         #[test]
-        fn it_should_get_the_peer_ip_from_the_right_most_ip_in_the_x_forwarded_for_header() {
-            let on_reverse_proxy = true;
+        fn it_should_get_the_remote_client_ip_from_the_right_most_ip_in_the_x_forwarded_for_header() {
+            let reverse_proxy_mode = ReverseProxyMode::Enabled;
 
-            let ip = invoke(
-                on_reverse_proxy,
+            let ip = resolve_remote_client_addr(
+                &reverse_proxy_mode,
                 &ClientIpSources {
                     right_most_x_forwarded_for: Some(IpAddr::from_str("203.0.113.195").unwrap()),
                     connection_info_socket_address: None,
@@ -198,15 +234,21 @@ mod tests {
             )
             .unwrap();
 
-            assert_eq!(ip, IpAddr::from_str("203.0.113.195").unwrap());
+            assert_eq!(
+                ip,
+                RemoteClientAddr::new(
+                    ResolvedIp::FromXForwardedFor(IpAddr::from_str("203.0.113.195").unwrap()),
+                    None
+                )
+            );
         }
 
         #[test]
         fn it_should_return_an_error_if_it_cannot_get_the_right_most_ip_from_the_x_forwarded_for_header() {
-            let on_reverse_proxy = true;
+            let reverse_proxy_mode = ReverseProxyMode::Enabled;
 
-            let error = invoke(
-                on_reverse_proxy,
+            let error = resolve_remote_client_addr(
+                &reverse_proxy_mode,
                 &ClientIpSources {
                     right_most_x_forwarded_for: None,
                     connection_info_socket_address: None,

--- a/packages/http-tracker-core/src/event/mod.rs
+++ b/packages/http-tracker-core/src/event/mod.rs
@@ -1,12 +1,11 @@
 use std::net::{IpAddr, SocketAddr};
 
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::RemoteClientAddr;
 use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
-
-use crate::services::RemoteClientAddr;
 
 pub mod sender;
 
@@ -64,12 +63,12 @@ pub struct ClientConnectionContext {
 impl ClientConnectionContext {
     #[must_use]
     pub fn ip_addr(&self) -> IpAddr {
-        self.remote_client_addr.ip
+        self.remote_client_addr.ip()
     }
 
     #[must_use]
     pub fn port(&self) -> Option<u16> {
-        self.remote_client_addr.port
+        self.remote_client_addr.port()
     }
 }
 
@@ -100,11 +99,11 @@ impl From<ConnectionContext> for LabelSet {
 #[cfg(test)]
 pub mod test {
 
+    use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{RemoteClientAddr, ResolvedIp};
     use torrust_tracker_primitives::peer::Peer;
     use torrust_tracker_primitives::service_binding::Protocol;
 
     use super::Event;
-    use crate::services::RemoteClientAddr;
     use crate::tests::sample_info_hash;
 
     #[must_use]
@@ -153,7 +152,7 @@ pub mod test {
 
         let event1 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
-                RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
             info_hash,
@@ -162,7 +161,10 @@ pub mod test {
 
         let event2 = Event::TcpAnnounce {
             connection: ConnectionContext::new(
-                RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), Some(8080)),
+                RemoteClientAddr::new(
+                    ResolvedIp::FromSocketAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))),
+                    Some(8080),
+                ),
                 ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
             ),
             info_hash,

--- a/packages/http-tracker-core/src/services/announce.rs
+++ b/packages/http-tracker-core/src/services/announce.rs
@@ -11,7 +11,9 @@ use std::panic::Location;
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::announce::{peer_from_request, Announce};
-use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, PeerIpResolutionError};
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{
+    resolve_remote_client_addr, ClientIpSources, PeerIpResolutionError, RemoteClientAddr,
+};
 use bittorrent_primitives::info_hash::InfoHash;
 use bittorrent_tracker_core::announce_handler::{AnnounceHandler, PeersWanted};
 use bittorrent_tracker_core::authentication::service::AuthenticationService;
@@ -23,7 +25,6 @@ use torrust_tracker_primitives::core::AnnounceData;
 use torrust_tracker_primitives::peer::PeerAnnouncement;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
-use super::{resolve_remote_client_addr, RemoteClientAddr};
 use crate::event;
 use crate::event::Event;
 
@@ -78,15 +79,20 @@ impl AnnounceService {
 
         self.authorize(announce_request.info_hash).await?;
 
-        let remote_client_addr = resolve_remote_client_addr(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
+        let remote_client_addr = resolve_remote_client_addr(&self.core_config.net.on_reverse_proxy.into(), client_ip_sources)?;
 
-        let mut peer = peer_from_request(announce_request, &remote_client_addr.ip);
+        let mut peer = peer_from_request(announce_request, &remote_client_addr.ip());
 
         let peers_wanted = Self::peers_wanted(announce_request);
 
         let announce_data = self
             .announce_handler
-            .announce(&announce_request.info_hash, &mut peer, &remote_client_addr.ip, &peers_wanted)
+            .announce(
+                &announce_request.info_hash,
+                &mut peer,
+                &remote_client_addr.ip(),
+                &peers_wanted,
+            )
             .await?;
 
         self.send_event(
@@ -303,6 +309,7 @@ mod tests {
         use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
         use std::sync::Arc;
 
+        use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{RemoteClientAddr, ResolvedIp};
         use mockall::predicate::{self};
         use torrust_tracker_configuration::Configuration;
         use torrust_tracker_primitives::core::AnnounceData;
@@ -319,7 +326,6 @@ mod tests {
             MockHttpStatsEventSender,
         };
         use crate::services::announce::AnnounceService;
-        use crate::services::RemoteClientAddr;
         use crate::tests::{sample_info_hash, sample_peer, sample_peer_using_ipv4, sample_peer_using_ipv6};
 
         #[tokio::test]
@@ -381,7 +387,7 @@ mod tests {
 
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(
-                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                             server_service_binding.clone(),
                         ),
                         info_hash: sample_info_hash(),
@@ -458,7 +464,7 @@ mod tests {
 
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(
-                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                             server_service_binding.clone(),
                         ),
                         info_hash: sample_info_hash(),
@@ -508,7 +514,7 @@ mod tests {
                 .with(predicate::function(move |event| {
                     let expected_event = Event::TcpAnnounce {
                         connection: ConnectionContext::new(
-                            RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                            RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                             server_service_binding.clone(),
                         ),
                         info_hash: sample_info_hash(),

--- a/packages/http-tracker-core/src/services/mod.rs
+++ b/packages/http-tracker-core/src/services/mod.rs
@@ -5,47 +5,5 @@
 //! servers.
 //!
 //! Refer to [`torrust_tracker`](crate) documentation.
-
-use std::net::IpAddr;
-
-use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{self, ClientIpSources, PeerIpResolutionError};
 pub mod announce;
 pub mod scrape;
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RemoteClientAddr {
-    pub ip: IpAddr,
-    pub port: Option<u16>,
-}
-
-impl RemoteClientAddr {
-    #[must_use]
-    pub fn new(ip: IpAddr, port: Option<u16>) -> Self {
-        Self { ip, port }
-    }
-}
-
-/// Resolves the client's real IP address considering proxy headers
-///
-/// # Errors
-///
-/// This function returns an error if the IP address cannot be resolved.
-pub fn resolve_remote_client_addr(
-    on_reverse_proxy: bool,
-    client_ip_sources: &ClientIpSources,
-) -> Result<RemoteClientAddr, PeerIpResolutionError> {
-    let ip = match peer_ip_resolver::invoke(on_reverse_proxy, client_ip_sources) {
-        Ok(peer_ip) => Ok(peer_ip),
-        Err(error) => Err(error),
-    }?;
-
-    let port = if client_ip_sources.connection_info_socket_address.is_some() {
-        client_ip_sources
-            .connection_info_socket_address
-            .map(|socket_addr| socket_addr.port())
-    } else {
-        None
-    };
-
-    Ok(RemoteClientAddr { ip, port })
-}

--- a/packages/http-tracker-core/src/services/scrape.rs
+++ b/packages/http-tracker-core/src/services/scrape.rs
@@ -10,7 +10,9 @@
 use std::sync::Arc;
 
 use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
-use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, PeerIpResolutionError};
+use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{
+    resolve_remote_client_addr, ClientIpSources, PeerIpResolutionError, RemoteClientAddr,
+};
 use bittorrent_tracker_core::authentication::service::AuthenticationService;
 use bittorrent_tracker_core::authentication::{self, Key};
 use bittorrent_tracker_core::error::{ScrapeError, TrackerCoreError, WhitelistError};
@@ -19,7 +21,6 @@ use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::core::ScrapeData;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
-use super::{resolve_remote_client_addr, RemoteClientAddr};
 use crate::event;
 use crate::event::{ConnectionContext, Event};
 
@@ -81,7 +82,7 @@ impl ScrapeService {
             self.scrape_handler.scrape(&scrape_request.info_hashes).await?
         };
 
-        let remote_client_addr = resolve_remote_client_addr(self.core_config.net.on_reverse_proxy, client_ip_sources)?;
+        let remote_client_addr = resolve_remote_client_addr(&self.core_config.net.on_reverse_proxy.into(), client_ip_sources)?;
 
         self.send_event(remote_client_addr, server_service_binding.clone()).await;
 
@@ -250,7 +251,7 @@ mod tests {
         use std::sync::Arc;
 
         use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
-        use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
+        use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, RemoteClientAddr, ResolvedIp};
         use bittorrent_tracker_core::announce_handler::PeersWanted;
         use mockall::predicate::eq;
         use torrust_tracker_primitives::core::ScrapeData;
@@ -263,7 +264,6 @@ mod tests {
             initialize_services_with_configuration, sample_info_hashes, sample_peer, MockHttpStatsEventSender,
         };
         use crate::services::scrape::ScrapeService;
-        use crate::services::RemoteClientAddr;
         use crate::tests::sample_info_hash;
         use crate::{event, statistics};
 
@@ -335,7 +335,10 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), Some(8080)),
+                        RemoteClientAddr::new(
+                            ResolvedIp::FromSocketAddr(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1))),
+                            Some(8080),
+                        ),
                         ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070))
                             .unwrap(),
                     ),
@@ -387,7 +390,9 @@ mod tests {
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
                         RemoteClientAddr::new(
-                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                            ResolvedIp::FromSocketAddr(IpAddr::V6(Ipv6Addr::new(
+                                0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
+                            ))),
                             Some(8080),
                         ),
                         server_service_binding,
@@ -435,7 +440,7 @@ mod tests {
         use std::sync::Arc;
 
         use bittorrent_http_tracker_protocol::v1::requests::scrape::Scrape;
-        use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::ClientIpSources;
+        use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{ClientIpSources, RemoteClientAddr, ResolvedIp};
         use bittorrent_tracker_core::announce_handler::PeersWanted;
         use mockall::predicate::eq;
         use torrust_tracker_primitives::core::ScrapeData;
@@ -447,7 +452,6 @@ mod tests {
             initialize_services_with_configuration, sample_info_hashes, sample_peer, MockHttpStatsEventSender,
         };
         use crate::services::scrape::ScrapeService;
-        use crate::services::RemoteClientAddr;
         use crate::tests::sample_info_hash;
         use crate::{event, statistics};
 
@@ -513,7 +517,10 @@ mod tests {
                 .expect_send_event()
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
-                        RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), Some(8080)),
+                        RemoteClientAddr::new(
+                            ResolvedIp::FromSocketAddr(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1))),
+                            Some(8080),
+                        ),
                         ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070))
                             .unwrap(),
                     ),
@@ -565,7 +572,9 @@ mod tests {
                 .with(eq(Event::TcpScrape {
                     connection: ConnectionContext::new(
                         RemoteClientAddr::new(
-                            IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                            ResolvedIp::FromSocketAddr(IpAddr::V6(Ipv6Addr::new(
+                                0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
+                            ))),
                             Some(8080),
                         ),
                         server_service_binding,

--- a/packages/http-tracker-core/src/statistics/event/handler.rs
+++ b/packages/http-tracker-core/src/statistics/event/handler.rs
@@ -73,11 +73,11 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
+    use bittorrent_http_tracker_protocol::v1::services::peer_ip_resolver::{RemoteClientAddr, ResolvedIp};
     use torrust_tracker_clock::clock::Time;
     use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
     use crate::event::{ConnectionContext, Event};
-    use crate::services::RemoteClientAddr;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
     use crate::tests::{sample_info_hash, sample_peer_using_ipv4, sample_peer_using_ipv6};
@@ -92,7 +92,7 @@ mod tests {
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                    RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
                 info_hash: sample_info_hash(),
@@ -115,7 +115,10 @@ mod tests {
         handle_event(
             Event::TcpScrape {
                 connection: ConnectionContext::new(
-                    RemoteClientAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), Some(8080)),
+                    RemoteClientAddr::new(
+                        ResolvedIp::FromSocketAddr(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))),
+                        Some(8080),
+                    ),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
             },
@@ -138,7 +141,7 @@ mod tests {
         handle_event(
             Event::TcpAnnounce {
                 connection: ConnectionContext::new(
-                    RemoteClientAddr::new(remote_client_ip, Some(8080)),
+                    RemoteClientAddr::new(ResolvedIp::FromSocketAddr(remote_client_ip), Some(8080)),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),
                 ),
                 info_hash: sample_info_hash(),
@@ -162,7 +165,9 @@ mod tests {
             Event::TcpScrape {
                 connection: ConnectionContext::new(
                     RemoteClientAddr::new(
-                        IpAddr::V6(Ipv6Addr::new(0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969)),
+                        ResolvedIp::FromSocketAddr(IpAddr::V6(Ipv6Addr::new(
+                            0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969, 0x6969,
+                        ))),
                         Some(8080),
                     ),
                     ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 7070)).unwrap(),


### PR DESCRIPTION
Refactor the remote client IP resolution code.

- [x] Extract `ReverseProxyMode` flag.
- [x] Extract `RemoteClientAddr` type.
- [x] Add IP wrapper `ResolvedIp` to track IP source.
- [x] Move all code to the `http-protocol` package.
- [x] Other improvements.