### PR TITLE
Fix shutdown message and improve it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4684,7 +4684,6 @@ dependencies = [
  "bittorrent-udp-tracker-core",
  "chrono",
  "clap",
- "futures",
  "local-ip-address",
  "mockall",
  "rand 0.9.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ bittorrent-tracker-core = { version = "3.0.0-develop", path = "packages/tracker-
 bittorrent-udp-tracker-core = { version = "3.0.0-develop", path = "packages/udp-tracker-core" }
 chrono = { version = "0", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
-futures = "0"
 rand = "0"
 regex = "1"
 reqwest = { version = "0", features = ["json"] }

--- a/packages/axum-health-check-api-server/src/server.rs
+++ b/packages/axum-health-check-api-server/src/server.rs
@@ -113,6 +113,7 @@ pub fn start(
         handle.clone(),
         rx_halt,
         format!("Shutting down http server on socket address: {address}"),
+        address,
     ));
 
     let running = axum_server::from_tcp(socket)

--- a/packages/axum-http-tracker-server/src/server.rs
+++ b/packages/axum-http-tracker-server/src/server.rs
@@ -60,6 +60,7 @@ impl Launcher {
             handle.clone(),
             rx_halt,
             format!("Shutting down HTTP server on socket address: {address}"),
+            address,
         ));
 
         let tls = self.tls.clone();

--- a/packages/axum-rest-tracker-api-server/src/server.rs
+++ b/packages/axum-rest-tracker-api-server/src/server.rs
@@ -257,6 +257,7 @@ impl Launcher {
             handle.clone(),
             rx_halt,
             format!("Shutting down tracker API server on socket address: {address}"),
+            address,
         ));
 
         let tls = self.tls.clone();

--- a/packages/axum-server/src/signals.rs
+++ b/packages/axum-server/src/signals.rs
@@ -8,14 +8,20 @@ use tracing::instrument;
 pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync::oneshot::Receiver<Halted>, message: String) {
     shutdown_signal_with_message(rx_halt, message).await;
 
-    tracing::debug!("Sending graceful shutdown signal");
+    let duration = Duration::from_secs(90);
+
+    tracing::info!(
+        "Http server received shutdown signal, shutting down server listening on: {:?}",
+        handle.listening().await
+    );
+
     handle.graceful_shutdown(Some(Duration::from_secs(90)));
 
-    println!("!! shuting down in 90 seconds !!");
+    tracing::info!("!! Shuting down in {} seconds !!", duration.as_secs());
 
     loop {
         sleep(Duration::from_secs(1)).await;
 
-        tracing::info!("remaining alive connections: {}", handle.connection_count());
+        tracing::info!("Remaining alive connections: {}", handle.connection_count());
     }
 }

--- a/packages/axum-server/src/signals.rs
+++ b/packages/axum-server/src/signals.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::time::Duration;
 
 use tokio::time::{sleep, Instant};
@@ -5,8 +6,13 @@ use torrust_server_lib::signals::{shutdown_signal_with_message, Halted};
 use tracing::instrument;
 
 #[instrument(skip(handle, rx_halt, message))]
-pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync::oneshot::Receiver<Halted>, message: String) {
-    shutdown_signal_with_message(rx_halt, message).await;
+pub async fn graceful_shutdown(
+    handle: axum_server::Handle,
+    rx_halt: tokio::sync::oneshot::Receiver<Halted>,
+    message: String,
+    address: SocketAddr,
+) {
+    shutdown_signal_with_message(rx_halt, message.clone()).await;
 
     let grace_period = Duration::from_secs(90);
     let max_wait = Duration::from_secs(95);
@@ -14,18 +20,19 @@ pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync
 
     handle.graceful_shutdown(Some(grace_period));
 
-    tracing::info!("!! Shutting down http server in {} seconds !!", grace_period.as_secs());
+    tracing::info!("!! {} in {} seconds !!", message, grace_period.as_secs());
 
     loop {
         if handle.connection_count() == 0 {
-            tracing::info!("All connections closed, shutting down server");
+            tracing::info!("All connections closed, shutting down server in address {}", address);
             break;
         }
 
         if start.elapsed() >= max_wait {
             tracing::warn!(
-                "Shutdown timeout of {} seconds reached. Forcing shutdown with {} active connections.",
+                "Shutdown timeout of {} seconds reached. Forcing shutdown in address {} with {} active connections.",
                 max_wait.as_secs(),
+                address,
                 handle.connection_count()
             );
             break;

--- a/packages/axum-server/src/signals.rs
+++ b/packages/axum-server/src/signals.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tokio::time::sleep;
+use tokio::time::{sleep, Instant};
 use torrust_server_lib::signals::{shutdown_signal_with_message, Halted};
 use tracing::instrument;
 
@@ -8,16 +8,13 @@ use tracing::instrument;
 pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync::oneshot::Receiver<Halted>, message: String) {
     shutdown_signal_with_message(rx_halt, message).await;
 
-    let duration = Duration::from_secs(90);
+    let grace_period = Duration::from_secs(90);
+    let max_wait = Duration::from_secs(95);
+    let start = Instant::now();
 
-    tracing::info!(
-        "Http server received shutdown signal, shutting down server listening on: {:?}",
-        handle.listening().await
-    );
+    handle.graceful_shutdown(Some(grace_period));
 
-    handle.graceful_shutdown(Some(Duration::from_secs(90)));
-
-    tracing::info!("!! Shuting down in {} seconds !!", duration.as_secs());
+    tracing::info!("!! Shutting down http server in {} seconds !!", grace_period.as_secs());
 
     loop {
         if handle.connection_count() == 0 {
@@ -25,8 +22,21 @@ pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync
             break;
         }
 
-        sleep(Duration::from_secs(1)).await;
+        if start.elapsed() >= max_wait {
+            tracing::warn!(
+                "Shutdown timeout of {} seconds reached. Forcing shutdown with {} active connections.",
+                max_wait.as_secs(),
+                handle.connection_count()
+            );
+            break;
+        }
 
-        tracing::info!("Remaining alive connections: {}", handle.connection_count());
+        tracing::info!(
+            "Remaining alive connections: {} ({}s elapsed)",
+            handle.connection_count(),
+            start.elapsed().as_secs()
+        );
+
+        sleep(Duration::from_secs(1)).await;
     }
 }

--- a/packages/axum-server/src/signals.rs
+++ b/packages/axum-server/src/signals.rs
@@ -20,6 +20,11 @@ pub async fn graceful_shutdown(handle: axum_server::Handle, rx_halt: tokio::sync
     tracing::info!("!! Shuting down in {} seconds !!", duration.as_secs());
 
     loop {
+        if handle.connection_count() == 0 {
+            tracing::info!("All connections closed, shutting down server");
+            break;
+        }
+
         sleep(Duration::from_secs(1)).await;
 
         tracing::info!("Remaining alive connections: {}", handle.connection_count());

--- a/packages/http-tracker-core/src/statistics/event/listener.rs
+++ b/packages/http-tracker-core/src/statistics/event/listener.rs
@@ -23,18 +23,32 @@ pub fn run_event_listener(receiver: Receiver, repository: &Arc<Repository>) -> J
 }
 
 async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repository>) {
+    let shutdown_signal = tokio::signal::ctrl_c();
+
+    tokio::pin!(shutdown_signal);
+
     loop {
-        match receiver.recv().await {
-            Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
-            Err(e) => {
-                match e {
-                    RecvError::Closed => {
-                        tracing::info!(target: HTTP_TRACKER_LOG_TARGET, "Http core statistics receiver closed.");
-                        break;
-                    }
-                    RecvError::Lagged(n) => {
-                        // From now on, metrics will be imprecise
-                        tracing::warn!(target: HTTP_TRACKER_LOG_TARGET, "Http core statistics receiver lagged by {} events.", n);
+        tokio::select! {
+            biased;
+
+            _ = &mut shutdown_signal => {
+                tracing::info!(target: HTTP_TRACKER_LOG_TARGET, "Received Ctrl+C, shutting down HTTP tracker core event listener.");
+                break;
+            }
+
+            result = receiver.recv() => {
+                match result {
+                    Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
+                    Err(e) => {
+                        match e {
+                            RecvError::Closed => {
+                                tracing::info!(target: HTTP_TRACKER_LOG_TARGET, "Http core statistics receiver closed.");
+                                break;
+                            }
+                            RecvError::Lagged(n) => {
+                                tracing::warn!(target: HTTP_TRACKER_LOG_TARGET, "Http core statistics receiver lagged by {} events.", n);
+                            }
+                        }
                     }
                 }
             }

--- a/packages/udp-tracker-core/src/statistics/event/listener.rs
+++ b/packages/udp-tracker-core/src/statistics/event/listener.rs
@@ -23,18 +23,31 @@ pub fn run_event_listener(receiver: Receiver, repository: &Arc<Repository>) -> J
 }
 
 async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repository>) {
+    let shutdown_signal = tokio::signal::ctrl_c();
+    tokio::pin!(shutdown_signal);
+
     loop {
-        match receiver.recv().await {
-            Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
-            Err(e) => {
-                match e {
-                    RecvError::Closed => {
-                        tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp core statistics receiver closed.");
-                        break;
-                    }
-                    RecvError::Lagged(n) => {
-                        // From now on, metrics will be imprecise
-                        tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp core statistics receiver lagged by {} events.", n);
+        tokio::select! {
+            biased;
+
+            _ = &mut shutdown_signal => {
+                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received Ctrl+C, shutting down UDP tracker core event listener.");
+                break;
+            }
+
+            result = receiver.recv() => {
+                match result {
+                    Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
+                    Err(e) => {
+                        match e {
+                            RecvError::Closed => {
+                                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp core statistics receiver closed.");
+                                break;
+                            }
+                            RecvError::Lagged(n) => {
+                                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp core statistics receiver lagged by {} events.", n);
+                            }
+                        }
                     }
                 }
             }

--- a/packages/udp-tracker-server/src/statistics/event/listener.rs
+++ b/packages/udp-tracker-server/src/statistics/event/listener.rs
@@ -19,23 +19,36 @@ pub fn run_event_listener(receiver: Receiver, repository: &Arc<Repository>) -> J
     tokio::spawn(async move {
         dispatch_events(receiver, stats_repository).await;
 
-        tracing::info!(target: UDP_TRACKER_LOG_TARGET, "DP tracker server event listener finished");
+        tracing::info!(target: UDP_TRACKER_LOG_TARGET, "UDP tracker server event listener finished");
     })
 }
 
 async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repository>) {
+    let shutdown_signal = tokio::signal::ctrl_c();
+    tokio::pin!(shutdown_signal);
+
     loop {
-        match receiver.recv().await {
-            Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
-            Err(e) => {
-                match e {
-                    RecvError::Closed => {
-                        tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp server statistics receiver closed.");
-                        break;
-                    }
-                    RecvError::Lagged(n) => {
-                        // From now on, metrics will be imprecise
-                        tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp server statistics receiver lagged by {} events.", n);
+        tokio::select! {
+            biased;
+
+            _ = &mut shutdown_signal => {
+                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received Ctrl+C, shutting down UDP tracker server event listener.");
+                break;
+            }
+
+            result = receiver.recv() => {
+                match result {
+                    Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
+                    Err(e) => {
+                        match e {
+                            RecvError::Closed => {
+                                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp server statistics receiver closed.");
+                                break;
+                            }
+                            RecvError::Lagged(n) => {
+                                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp server statistics receiver lagged by {} events.", n);
+                            }
+                        }
                     }
                 }
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,9 +66,9 @@ async fn load_data_from_database(config: &Configuration, app_container: &Arc<App
 async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> Vec<JoinHandle<()>> {
     let mut jobs: Vec<JoinHandle<()>> = Vec::new();
 
-    start_http_core_event_listener(config, app_container);
-    start_udp_core_event_listener(config, app_container);
-    start_udp_server_event_listener(config, app_container);
+    start_http_core_event_listener(config, app_container, &mut jobs);
+    start_udp_core_event_listener(config, app_container, &mut jobs);
+    start_udp_server_event_listener(config, app_container, &mut jobs);
     start_the_udp_instances(config, app_container, &mut jobs).await;
     start_the_http_instances(config, app_container, &mut jobs).await;
     start_the_http_api(config, app_container, &mut jobs).await;
@@ -109,43 +109,28 @@ async fn load_whitelisted_torrents(config: &Configuration, app_container: &Arc<A
     }
 }
 
-fn start_http_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    let _job = jobs::http_tracker_core::start_event_listener(config, app_container);
+fn start_http_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+    let opt_job = jobs::http_tracker_core::start_event_listener(config, app_container);
 
-    // todo: this cannot be enabled otherwise the application never ends
-    // because the event listener never stops. You see this console message
-    // forever:
-    //
-    // !! shuting down in 90 seconds !!
-    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-    //
-    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
+    if let Some(job) = opt_job {
+        jobs.push(job);
+    }
 }
 
-fn start_udp_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    let _job = jobs::udp_tracker_core::start_event_listener(config, app_container);
+fn start_udp_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+    let opt_job = jobs::udp_tracker_core::start_event_listener(config, app_container);
 
-    // todo: the job cannot be added in the jobs vector otherwise the application never ends
-    // because the event listener never stops. You see this console message
-    // forever:
-    //
-    // !! shuting down in 90 seconds !!
-    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-    //
-    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
+    if let Some(job) = opt_job {
+        jobs.push(job);
+    }
 }
 
-fn start_udp_server_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    let _job = jobs::udp_tracker_server::start_event_listener(config, app_container);
+fn start_udp_server_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+    let opt_job = jobs::udp_tracker_server::start_event_listener(config, app_container);
 
-    // todo: the job cannot be added in the jobs vector otherwise the application never ends
-    // because the event listener never stops. You see this console message
-    // forever:
-    //
-    // !! shuting down in 90 seconds !!
-    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-    //
-    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
+    if let Some(job) = opt_job {
+        jobs.push(job);
+    }
 }
 
 async fn start_the_udp_instances(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,7 +27,7 @@ use tokio::task::JoinHandle;
 use torrust_tracker_configuration::{Configuration, HttpTracker, UdpTracker};
 use tracing::instrument;
 
-use crate::bootstrap::jobs::{health_check_api, http_tracker, torrent_cleanup, tracker_apis, udp_tracker};
+use crate::bootstrap::jobs::{self, health_check_api, http_tracker, torrent_cleanup, tracker_apis, udp_tracker};
 use crate::bootstrap::{self};
 use crate::container::AppContainer;
 
@@ -110,63 +110,42 @@ async fn load_whitelisted_torrents(config: &Configuration, app_container: &Arc<A
 }
 
 fn start_http_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    if config.core.tracker_usage_statistics {
-        let _job = bittorrent_http_tracker_core::statistics::event::listener::run_event_listener(
-            app_container.http_tracker_core_services.event_bus.receiver(),
-            &app_container.http_tracker_core_services.stats_repository,
-        );
+    let _job = jobs::http_tracker_core::start_event_listener(config, app_container);
 
-        // todo: this cannot be enabled otherwise the application never ends
-        // because the event listener never stops. You see this console message
-        // forever:
-        //
-        // !! shuting down in 90 seconds !!
-        // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-        //
-        // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
-
-        //jobs.push(job);
-    }
+    // todo: this cannot be enabled otherwise the application never ends
+    // because the event listener never stops. You see this console message
+    // forever:
+    //
+    // !! shuting down in 90 seconds !!
+    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
+    //
+    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
 }
 
 fn start_udp_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    if config.core.tracker_usage_statistics {
-        let _job = bittorrent_udp_tracker_core::statistics::event::listener::run_event_listener(
-            app_container.udp_tracker_core_services.event_bus.receiver(),
-            &app_container.udp_tracker_core_services.stats_repository,
-        );
+    let _job = jobs::udp_tracker_core::start_event_listener(config, app_container);
 
-        // todo: this cannot be enabled otherwise the application never ends
-        // because the event listener never stops. You see this console message
-        // forever:
-        //
-        // !! shuting down in 90 seconds !!
-        // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-        //
-        // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
-
-        //jobs.push(job);
-    }
+    // todo: the job cannot be added in the jobs vector otherwise the application never ends
+    // because the event listener never stops. You see this console message
+    // forever:
+    //
+    // !! shuting down in 90 seconds !!
+    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
+    //
+    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
 }
 
 fn start_udp_server_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) {
-    if config.core.tracker_usage_statistics {
-        let _job = torrust_udp_tracker_server::statistics::event::listener::run_event_listener(
-            app_container.udp_tracker_server_container.event_bus.receiver(),
-            &app_container.udp_tracker_server_container.stats_repository,
-        );
+    let _job = jobs::udp_tracker_server::start_event_listener(config, app_container);
 
-        // todo: this cannot be enabled otherwise the application never ends
-        // because the event listener never stops. You see this console message
-        // forever:
-        //
-        // !! shuting down in 90 seconds !!
-        // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
-        //
-        // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
-
-        //jobs.push(job);
-    }
+    // todo: the job cannot be added in the jobs vector otherwise the application never ends
+    // because the event listener never stops. You see this console message
+    // forever:
+    //
+    // !! shuting down in 90 seconds !!
+    // 2025-04-24T15:27:45.454101Z  INFO graceful_shutdown: torrust_axum_server::signals: remaining alive connections: 0
+    //
+    // Depends on: https://github.com/torrust/torrust-tracker/issues/1405
 }
 
 async fn start_the_udp_instances(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,15 +23,15 @@
 //! - Tracker REST API: the tracker API can be enabled/disabled.
 use std::sync::Arc;
 
-use tokio::task::JoinHandle;
 use torrust_tracker_configuration::{Configuration, HttpTracker, UdpTracker};
 use tracing::instrument;
 
+use crate::bootstrap::jobs::manager::JobManager;
 use crate::bootstrap::jobs::{self, health_check_api, http_tracker, torrent_cleanup, tracker_apis, udp_tracker};
 use crate::bootstrap::{self};
 use crate::container::AppContainer;
 
-pub async fn run() -> (Arc<AppContainer>, Vec<JoinHandle<()>>) {
+pub async fn run() -> (Arc<AppContainer>, JobManager) {
     let (config, app_container) = bootstrap::app::setup();
 
     let app_container = Arc::new(app_container);
@@ -50,7 +50,7 @@ pub async fn run() -> (Arc<AppContainer>, Vec<JoinHandle<()>>) {
 /// - Can't retrieve tracker keys from database.
 /// - Can't load whitelist from database.
 #[instrument(skip(config, app_container))]
-pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) -> Vec<JoinHandle<()>> {
+pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) -> JobManager {
     warn_if_no_services_enabled(config);
 
     load_data_from_database(config, app_container).await;
@@ -63,19 +63,19 @@ async fn load_data_from_database(config: &Configuration, app_container: &Arc<App
     load_whitelisted_torrents(config, app_container).await;
 }
 
-async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> Vec<JoinHandle<()>> {
-    let mut jobs: Vec<JoinHandle<()>> = Vec::new();
+async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> JobManager {
+    let mut job_manager = JobManager::new();
 
-    start_http_core_event_listener(config, app_container, &mut jobs);
-    start_udp_core_event_listener(config, app_container, &mut jobs);
-    start_udp_server_event_listener(config, app_container, &mut jobs);
-    start_the_udp_instances(config, app_container, &mut jobs).await;
-    start_the_http_instances(config, app_container, &mut jobs).await;
-    start_the_http_api(config, app_container, &mut jobs).await;
-    start_torrent_cleanup(config, app_container, &mut jobs);
-    start_health_check_api(config, app_container, &mut jobs).await;
+    start_http_core_event_listener(config, app_container, &mut job_manager);
+    start_udp_core_event_listener(config, app_container, &mut job_manager);
+    start_udp_server_event_listener(config, app_container, &mut job_manager);
+    start_the_udp_instances(config, app_container, &mut job_manager).await;
+    start_the_http_instances(config, app_container, &mut job_manager).await;
+    start_the_http_api(config, app_container, &mut job_manager).await;
+    start_torrent_cleanup(config, app_container, &mut job_manager);
+    start_health_check_api(config, app_container, &mut job_manager).await;
 
-    jobs
+    job_manager
 }
 
 fn warn_if_no_services_enabled(config: &Configuration) {
@@ -109,40 +109,40 @@ async fn load_whitelisted_torrents(config: &Configuration, app_container: &Arc<A
     }
 }
 
-fn start_http_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
-    let opt_job = jobs::http_tracker_core::start_event_listener(config, app_container);
+fn start_http_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
+    let opt_handle = jobs::http_tracker_core::start_event_listener(config, app_container);
 
-    if let Some(job) = opt_job {
-        jobs.push(job);
+    if let Some(handle) = opt_handle {
+        job_manager.push("http_core_event_listener", handle);
     }
 }
 
-fn start_udp_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
-    let opt_job = jobs::udp_tracker_core::start_event_listener(config, app_container);
+fn start_udp_core_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
+    let opt_handle = jobs::udp_tracker_core::start_event_listener(config, app_container);
 
-    if let Some(job) = opt_job {
-        jobs.push(job);
+    if let Some(handle) = opt_handle {
+        job_manager.push("udp_core_event_listener", handle);
     }
 }
 
-fn start_udp_server_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
-    let opt_job = jobs::udp_tracker_server::start_event_listener(config, app_container);
+fn start_udp_server_event_listener(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
+    let opt_handle = jobs::udp_tracker_server::start_event_listener(config, app_container);
 
-    if let Some(job) = opt_job {
-        jobs.push(job);
+    if let Some(handle) = opt_handle {
+        job_manager.push("udp_server_event_listener", handle);
     }
 }
 
-async fn start_the_udp_instances(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+async fn start_the_udp_instances(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
     if let Some(udp_trackers) = &config.udp_trackers {
-        for udp_tracker_config in udp_trackers {
+        for (idx, udp_tracker_config) in udp_trackers.iter().enumerate() {
             if config.core.private {
                 tracing::warn!(
                     "Could not start UDP tracker on: {} while in private mode. UDP is not safe for private trackers!",
                     udp_tracker_config.bind_address
                 );
             } else {
-                start_udp_instance(udp_tracker_config, app_container, jobs).await;
+                start_udp_instance(idx, udp_tracker_config, app_container, job_manager).await;
             }
         }
     } else {
@@ -150,26 +150,31 @@ async fn start_the_udp_instances(config: &Configuration, app_container: &Arc<App
     }
 }
 
-async fn start_udp_instance(udp_tracker_config: &UdpTracker, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+async fn start_udp_instance(
+    idx: usize,
+    udp_tracker_config: &UdpTracker,
+    app_container: &Arc<AppContainer>,
+    job_manager: &mut JobManager,
+) {
     let udp_tracker_container = app_container
         .udp_tracker_container(udp_tracker_config.bind_address)
         .expect("Could not create UDP tracker container");
     let udp_tracker_server_container = app_container.udp_tracker_server_container();
 
-    jobs.push(
-        udp_tracker::start_job(
-            udp_tracker_container,
-            udp_tracker_server_container,
-            app_container.registar.give_form(),
-        )
-        .await,
-    );
+    let handle = udp_tracker::start_job(
+        udp_tracker_container,
+        udp_tracker_server_container,
+        app_container.registar.give_form(),
+    )
+    .await;
+
+    job_manager.push(format!("udp_instance_{}_{}", idx, udp_tracker_config.bind_address), handle);
 }
 
-async fn start_the_http_instances(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+async fn start_the_http_instances(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
     if let Some(http_trackers) = &config.http_trackers {
-        for http_tracker_config in http_trackers {
-            start_http_instance(http_tracker_config, app_container, jobs).await;
+        for (idx, http_tracker_config) in http_trackers.iter().enumerate() {
+            start_http_instance(idx, http_tracker_config, app_container, job_manager).await;
         }
     } else {
         tracing::info!("No HTTP blocks in configuration");
@@ -177,26 +182,27 @@ async fn start_the_http_instances(config: &Configuration, app_container: &Arc<Ap
 }
 
 async fn start_http_instance(
+    idx: usize,
     http_tracker_config: &HttpTracker,
     app_container: &Arc<AppContainer>,
-    jobs: &mut Vec<JoinHandle<()>>,
+    job_manager: &mut JobManager,
 ) {
     let http_tracker_container = app_container
         .http_tracker_container(http_tracker_config.bind_address)
         .expect("Could not create HTTP tracker container");
 
-    if let Some(job) = http_tracker::start_job(
+    if let Some(handle) = http_tracker::start_job(
         http_tracker_container,
         app_container.registar.give_form(),
         torrust_axum_http_tracker_server::Version::V1,
     )
     .await
     {
-        jobs.push(job);
+        job_manager.push(format!("http_instance_{}_{}", idx, http_tracker_config.bind_address), handle);
     }
 }
 
-async fn start_the_http_api(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+async fn start_the_http_api(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
     if let Some(http_api_config) = &config.http_api {
         let http_api_config = Arc::new(http_api_config.clone());
         let http_api_container = app_container.tracker_http_api_container(&http_api_config);
@@ -208,22 +214,23 @@ async fn start_the_http_api(config: &Configuration, app_container: &Arc<AppConta
         )
         .await
         {
-            jobs.push(job);
+            job_manager.push("http_api", job);
         }
     } else {
         tracing::info!("No API block in configuration");
     }
 }
 
-fn start_torrent_cleanup(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
+fn start_torrent_cleanup(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
     if config.core.inactive_peer_cleanup_interval > 0 {
-        jobs.push(torrent_cleanup::start_job(
-            &config.core,
-            &app_container.tracker_core_container.torrents_manager,
-        ));
+        let handle = torrent_cleanup::start_job(&config.core, &app_container.tracker_core_container.torrents_manager);
+
+        job_manager.push("torrent_cleanup", handle);
     }
 }
 
-async fn start_health_check_api(config: &Configuration, app_container: &Arc<AppContainer>, jobs: &mut Vec<JoinHandle<()>>) {
-    jobs.push(health_check_api::start_job(&config.health_check_api, app_container.registar.entries()).await);
+async fn start_health_check_api(config: &Configuration, app_container: &Arc<AppContainer>, job_manager: &mut JobManager) {
+    let handle = health_check_api::start_job(&config.health_check_api, app_container.registar.entries()).await;
+
+    job_manager.push("health_check_api", handle);
 }

--- a/src/bootstrap/jobs/http_tracker_core.rs
+++ b/src/bootstrap/jobs/http_tracker_core.rs
@@ -1,0 +1,20 @@
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use torrust_tracker_configuration::Configuration;
+
+use crate::container::AppContainer;
+
+pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) -> Option<JoinHandle<()>> {
+    if config.core.tracker_usage_statistics {
+        let job = bittorrent_http_tracker_core::statistics::event::listener::run_event_listener(
+            app_container.http_tracker_core_services.event_bus.receiver(),
+            &app_container.http_tracker_core_services.stats_repository,
+        );
+
+        Some(job)
+    } else {
+        tracing::info!("HTTP tracker core event listener job is disabled.");
+        None
+    }
+}

--- a/src/bootstrap/jobs/manager.rs
+++ b/src/bootstrap/jobs/manager.rs
@@ -1,0 +1,89 @@
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tracing::{info, warn};
+
+/// Represents a named background job.
+#[derive(Debug)]
+pub struct Job {
+    pub name: String,
+    pub handle: JoinHandle<()>,
+}
+
+impl Job {
+    pub fn new<N: Into<String>>(name: N, handle: JoinHandle<()>) -> Self {
+        Self {
+            name: name.into(),
+            handle,
+        }
+    }
+}
+
+/// Manages multiple background jobs.
+#[derive(Debug, Default)]
+pub struct JobManager {
+    jobs: Vec<Job>,
+}
+
+impl JobManager {
+    #[must_use]
+    pub fn new() -> Self {
+        Self { jobs: Vec::new() }
+    }
+
+    pub fn push<N: Into<String>>(&mut self, name: N, handle: JoinHandle<()>) {
+        self.jobs.push(Job::new(name, handle));
+    }
+
+    /// Waits sequentially for all jobs to complete, with a graceful timeout per
+    /// job.
+    pub async fn wait_for_all(mut self, grace_period: Duration) {
+        for job in self.jobs.drain(..) {
+            let name = job.name.clone();
+
+            info!(job = %name, "Waiting for job to finish (timeout of {} seconds) ...", grace_period.as_secs());
+
+            if let Ok(result) = timeout(grace_period, job.handle).await {
+                if let Err(e) = result {
+                    warn!(job = %name, "Job return an error: {:?}", e);
+                } else {
+                    info!(job = %name, "Job completed gracefully");
+                }
+            } else {
+                warn!(job = %name, "Job did not complete in time");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::time::Duration;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_should_wait_for_all_jobs_to_finish() {
+        let mut manager = JobManager::new();
+
+        manager.push("job1", tokio::spawn(async {}));
+        manager.push("job2", tokio::spawn(async {}));
+
+        manager.wait_for_all(Duration::from_secs(1)).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_log_when_a_job_panics() {
+        let mut manager = JobManager::new();
+
+        manager.push(
+            "panic_job",
+            tokio::spawn(async {
+                panic!("expected panic");
+            }),
+        );
+
+        manager.wait_for_all(Duration::from_secs(1)).await;
+    }
+}

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -9,6 +9,7 @@
 pub mod health_check_api;
 pub mod http_tracker;
 pub mod http_tracker_core;
+pub mod manager;
 pub mod torrent_cleanup;
 pub mod tracker_apis;
 pub mod udp_tracker;

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -7,7 +7,10 @@
 //!
 //! This modules contains all the functions needed to start those jobs.
 pub mod health_check_api;
+pub mod http_tracker_core;
 pub mod http_tracker;
 pub mod torrent_cleanup;
 pub mod tracker_apis;
+pub mod udp_tracker_core;
+pub mod udp_tracker_server;
 pub mod udp_tracker;

--- a/src/bootstrap/jobs/mod.rs
+++ b/src/bootstrap/jobs/mod.rs
@@ -7,10 +7,10 @@
 //!
 //! This modules contains all the functions needed to start those jobs.
 pub mod health_check_api;
-pub mod http_tracker_core;
 pub mod http_tracker;
+pub mod http_tracker_core;
 pub mod torrent_cleanup;
 pub mod tracker_apis;
+pub mod udp_tracker;
 pub mod udp_tracker_core;
 pub mod udp_tracker_server;
-pub mod udp_tracker;

--- a/src/bootstrap/jobs/udp_tracker_core.rs
+++ b/src/bootstrap/jobs/udp_tracker_core.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use torrust_tracker_configuration::Configuration;
+
+use crate::container::AppContainer;
+
+pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) -> Option<JoinHandle<()>> {
+    if config.core.tracker_usage_statistics {
+        let job = bittorrent_udp_tracker_core::statistics::event::listener::run_event_listener(
+            app_container.udp_tracker_core_services.event_bus.receiver(),
+            &app_container.udp_tracker_core_services.stats_repository,
+        );
+        Some(job)
+    } else {
+        tracing::info!("UDP tracker core event listener job is disabled.");
+        None
+    }
+}

--- a/src/bootstrap/jobs/udp_tracker_server.rs
+++ b/src/bootstrap/jobs/udp_tracker_server.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use tokio::task::JoinHandle;
+use torrust_tracker_configuration::Configuration;
+
+use crate::container::AppContainer;
+
+pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) -> Option<JoinHandle<()>> {
+    if config.core.tracker_usage_statistics {
+        let job = torrust_udp_tracker_server::statistics::event::listener::run_event_listener(
+            app_container.udp_tracker_server_container.event_bus.receiver(),
+            &app_container.udp_tracker_server_container.stats_repository,
+        );
+        Some(job)
+    } else {
+        tracing::info!("UDP tracker server event listener job is disabled.");
+        None
+    }
+}

--- a/src/console/profiling.rs
+++ b/src/console/profiling.rs
@@ -191,8 +191,7 @@ pub async fn run() {
         _ = tokio::signal::ctrl_c() => {
             tracing::info!("Torrust tracker shutting down via Ctrl+C ...");
 
-            // Await for all jobs to shutdown
-            futures::future::join_all(jobs).await;
+            jobs.wait_for_all(Duration::from_secs(10)).await;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,16 @@
+use std::time::Duration;
+
 use torrust_tracker_lib::app;
 
 #[tokio::main]
 async fn main() {
     let (_app_container, jobs) = app::run().await;
 
-    // handle the signals
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
             tracing::info!("Torrust tracker shutting down ...");
 
-            // Await for all jobs to shutdown
-            futures::future::join_all(jobs).await;
+            jobs.wait_for_all(Duration::from_secs(10)).await;
 
             tracing::info!("Torrust tracker successfully shutdown.");
         }


### PR DESCRIPTION
Fix shutdown message and improve it for HTTP servers (they all use Axum).

### Subtasks

- [x] Hard timeout for shutdown. Stop the loop even when there are alive connections after the grace period.
- [x] Show socket-bound address in logs.
- [x] Fix bug, not showing the message passed as a parameter.
- [x] Event listeners should listen to `CRTL+c` signal. Temporary solution until we implement:
  - https://github.com/torrust/torrust-tracker/issues/1405.
- [x] Add a job manager to give a name to all jobs and identify them when the app shuts down.
