### PR TITLE
Fix wrong number of downloads when the tracker starts

### DIFF
--- a/packages/torrent-repository/src/swarms.rs
+++ b/packages/torrent-repository/src/swarms.rs
@@ -231,7 +231,7 @@ impl Swarms {
             inactive_peers_removed += removed;
         }
 
-        tracing::info!("Inactive peers removed: {inactive_peers_removed}");
+        tracing::info!(inactive_peers_removed = inactive_peers_removed);
 
         Ok(inactive_peers_removed)
     }
@@ -262,7 +262,7 @@ impl Swarms {
             peerless_torrents_removed += 1;
         }
 
-        tracing::info!("Peerless torrents removed: {peerless_torrents_removed}");
+        tracing::info!(peerless_torrents_removed = peerless_torrents_removed);
 
         Ok(peerless_torrents_removed)
     }
@@ -291,7 +291,7 @@ impl Swarms {
             torrents_imported += 1;
         }
 
-        tracing::info!("Imported torrents: {torrents_imported}");
+        tracing::info!(imported_torrents = torrents_imported);
 
         torrents_imported
     }

--- a/packages/tracker-core/src/torrent/manager.rs
+++ b/packages/tracker-core/src/torrent/manager.rs
@@ -60,7 +60,7 @@ impl TorrentsManager {
         }
     }
 
-    /// Loads torrents from the persistent database into the in-memory repository.
+    /// Loads torrents from the database into the in-memory repository.
     ///
     /// This function retrieves the list of persistent torrent entries (which
     /// include only the aggregate metrics, not the detailed peer lists) from
@@ -70,8 +70,7 @@ impl TorrentsManager {
     ///
     /// Returns a `databases::error::Error` if unable to load the persistent
     /// torrent data.
-    #[allow(dead_code)]
-    pub(crate) fn load_torrents_from_database(&self) -> Result<(), databases::error::Error> {
+    pub fn load_torrents_from_database(&self) -> Result<(), databases::error::Error> {
         let persistent_torrents = self.db_torrent_repository.load_all()?;
 
         self.in_memory_torrent_repository.import_persistent(&persistent_torrents);

--- a/share/default/config/tracker.development.sqlite3.toml
+++ b/share/default/config/tracker.development.sqlite3.toml
@@ -11,9 +11,9 @@ threshold = "info"
 listed = false
 private = false
 
-#[core.tracker_policy]
+[core.tracker_policy]
 #max_peer_timeout = 30
-#persistent_torrent_completed_stat = true
+persistent_torrent_completed_stat = true
 #remove_peerless_torrents = true
 
 [[udp_trackers]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -61,6 +61,7 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
 async fn load_data_from_database(config: &Configuration, app_container: &Arc<AppContainer>) {
     load_peer_keys(config, app_container).await;
     load_whitelisted_torrents(config, app_container).await;
+    load_torrents_from_database(config, app_container);
 }
 
 async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> JobManager {
@@ -106,6 +107,16 @@ async fn load_whitelisted_torrents(config: &Configuration, app_container: &Arc<A
             .load_whitelist_from_database()
             .await
             .expect("Could not load whitelist from database.");
+    }
+}
+
+fn load_torrents_from_database(config: &Configuration, app_container: &Arc<AppContainer>) {
+    if config.core.tracker_policy.persistent_torrent_completed_stat {
+        app_container
+            .tracker_core_container
+            .torrents_manager
+            .load_torrents_from_database()
+            .expect("Could not load torrents from database.");
     }
 }
 


### PR DESCRIPTION
Relates to: https://github.com/torrust/torrust-tracker/issues/1502

As described [here](https://github.com/torrust/torrust-tracker/issues/1502#issuecomment-2863479464), when you start the tracker and stats persistence is enabled, you should see the last value for the number of downloads. Instead, you see something like this:

![image](https://github.com/user-attachments/assets/9fffeb7f-5666-41f0-ac64-7049a6225a17)

This PR fixes that problem.

It fixes the bug described in https://github.com/torrust/torrust-tracker/issues/1502. However, it does not fix other problems described in the issue (problem 3). I will open a new PR to fix problem 3.