### PR TITLE
Disable torrent stats importation at start

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -61,7 +61,12 @@ pub async fn start(config: &Configuration, app_container: &Arc<AppContainer>) ->
 async fn load_data_from_database(config: &Configuration, app_container: &Arc<AppContainer>) {
     load_peer_keys(config, app_container).await;
     load_whitelisted_torrents(config, app_container).await;
-    load_torrents_from_database(config, app_container);
+    // todo: disabled because of performance issues.
+    // The tracker demo has a lot of torrents and loading them all at once is not
+    // efficient. We also load them on demand but the total number of downloads
+    // metric is not accurate because not all torrents are loaded.
+    // See: https://github.com/torrust/torrust-tracker/issues/1510
+    //load_torrents_from_database(config, app_container);
 }
 
 async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> JobManager {
@@ -110,6 +115,7 @@ async fn load_whitelisted_torrents(config: &Configuration, app_container: &Arc<A
     }
 }
 
+#[allow(dead_code)]
 fn load_torrents_from_database(config: &Configuration, app_container: &Arc<AppContainer>) {
     if config.core.tracker_policy.persistent_torrent_completed_stat {
         app_container


### PR DESCRIPTION
When the tracker starts, if stats persistence is enabled, all torrents that have ever been downloaded are loaded into memory (`Swarms` type) with their download counter.

That's the current way to count all downloads and expose that metric.

However, it does not work with **millions of torrents** (like in the tracker demo) becuase:

- It's too slow.
- It consumes too much memory (all torrents that have ever been downloaded have to be loaded).

A new solution is needed to keep that metric, but in the meantime, this disables that feature, producing these effects:

- Non-accurate value for downloads when the tracker is restarted.
- Increasing indefinitely the number of torrents in memory even if the "remove peerless torrents" policy is enabled (becuase this feature overrides that policy and peerless torrents are kept in memory).