### PR TITLE
Add metric for UDP client software when the client makes a wrong request.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,6 @@ dependencies = [
  "torrust-tracker-clock",
  "torrust-tracker-configuration",
  "torrust-tracker-events",
- "torrust-tracker-located-error",
  "torrust-tracker-metrics",
  "torrust-tracker-primitives",
  "torrust-tracker-swarm-coordination-registry",

--- a/packages/tracker-core/src/error.rs
+++ b/packages/tracker-core/src/error.rs
@@ -84,7 +84,7 @@ pub enum ScrapeError {
 ///
 /// This error is returned when an operation involves a torrent that is not
 /// present in the whitelist.
-#[derive(thiserror::Error, Debug, Clone)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
 pub enum WhitelistError {
     /// Indicates that the torrent identified by `info_hash` is not whitelisted.
     #[error("The torrent: {info_hash}, is not whitelisted, {location}")]

--- a/packages/udp-tracker-core/src/connection_cookie.rs
+++ b/packages/udp-tracker-core/src/connection_cookie.rs
@@ -86,7 +86,7 @@ use zerocopy::AsBytes;
 use crate::crypto::keys::CipherArrayBlowfish;
 
 /// Error returned when there was an error with the connection cookie.
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum ConnectionCookieError {
     #[error("cookie value is not normal: {not_normal_value}")]
     ValueNotNormal { not_normal_value: f64 },

--- a/packages/udp-tracker-server/Cargo.toml
+++ b/packages/udp-tracker-server/Cargo.toml
@@ -30,7 +30,6 @@ torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
 torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
 torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
 torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }

--- a/packages/udp-tracker-server/src/environment.rs
+++ b/packages/udp-tracker-server/src/environment.rs
@@ -82,6 +82,7 @@ impl Environment<Stopped> {
         let udp_server_event_listener_job = Some(crate::statistics::event::listener::run_event_listener(
             self.container.udp_tracker_server_container.event_bus.receiver(),
             &self.container.udp_tracker_server_container.stats_repository,
+            &self.container.udp_tracker_core_container.ban_service,
         ));
 
         // Start the UDP tracker server

--- a/packages/udp-tracker-server/src/error.rs
+++ b/packages/udp-tracker-server/src/error.rs
@@ -1,4 +1,5 @@
 //! Error types for the UDP server.
+use std::fmt::Display;
 use std::panic::Location;
 
 use aquatic_udp_protocol::{ConnectionId, RequestParseError, TransactionId};
@@ -13,7 +14,7 @@ use torrust_tracker_located_error::LocatedError;
 pub struct ConnectionCookie(pub ConnectionId);
 
 /// Error returned by the UDP server.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     /// Error returned when the request is invalid.
     #[error("error when phrasing request: {request_parse_error:?}")]
@@ -74,6 +75,16 @@ pub struct SendableRequestParseError {
     pub message: String,
     pub opt_connection_id: Option<ConnectionId>,
     pub opt_transaction_id: Option<TransactionId>,
+}
+
+impl Display for SendableRequestParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SendableRequestParseError: message: {}, connection_id: {:?}, transaction_id: {:?}",
+            self.message, self.opt_connection_id, self.opt_transaction_id
+        )
+    }
 }
 
 impl From<RequestParseError> for SendableRequestParseError {

--- a/packages/udp-tracker-server/src/error.rs
+++ b/packages/udp-tracker-server/src/error.rs
@@ -16,7 +16,7 @@ pub struct ConnectionCookie(pub ConnectionId);
 #[derive(Error, Debug, Clone)]
 pub enum Error {
     /// Error returned when the request is invalid.
-    #[error("error when phrasing request: {request_parse_error:?}")]
+    #[error("error parsing request: {request_parse_error:?}")]
     RequestParseError { request_parse_error: SendableRequestParseError },
 
     /// Error returned when the domain tracker returns an announce error.

--- a/packages/udp-tracker-server/src/error.rs
+++ b/packages/udp-tracker-server/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for the UDP server.
 use std::panic::Location;
 
-use aquatic_udp_protocol::{ConnectionId, RequestParseError};
+use aquatic_udp_protocol::{ConnectionId, RequestParseError, TransactionId};
 use bittorrent_udp_tracker_core::services::announce::UdpAnnounceError;
 use bittorrent_udp_tracker_core::services::scrape::UdpScrapeError;
 use derive_more::derive::Display;
@@ -17,7 +17,7 @@ pub struct ConnectionCookie(pub ConnectionId);
 pub enum Error {
     /// Error returned when the request is invalid.
     #[error("error when phrasing request: {request_parse_error:?}")]
-    RequestParseError { request_parse_error: RequestParseError },
+    RequestParseError { request_parse_error: SendableRequestParseError },
 
     /// Error returned when the domain tracker returns an announce error.
     #[error("tracker announce error: {source}")]
@@ -47,7 +47,9 @@ pub enum Error {
 
 impl From<RequestParseError> for Error {
     fn from(request_parse_error: RequestParseError) -> Self {
-        Self::RequestParseError { request_parse_error }
+        Self::RequestParseError {
+            request_parse_error: request_parse_error.into(),
+        }
     }
 }
 
@@ -63,6 +65,32 @@ impl From<UdpScrapeError> for Error {
     fn from(udp_scrape_error: UdpScrapeError) -> Self {
         Self::UdpScrapeError {
             source: udp_scrape_error,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SendableRequestParseError {
+    pub message: String,
+    pub opt_connection_id: Option<ConnectionId>,
+    pub opt_transaction_id: Option<TransactionId>,
+}
+
+impl From<RequestParseError> for SendableRequestParseError {
+    fn from(request_parse_error: RequestParseError) -> Self {
+        let (message, opt_connection_id, opt_transaction_id) = match request_parse_error {
+            RequestParseError::Sendable {
+                connection_id,
+                transaction_id,
+                err,
+            } => ((*err).to_string(), Some(connection_id), Some(transaction_id)),
+            RequestParseError::Unsendable { err } => (err.to_string(), None, None),
+        };
+
+        Self {
+            message,
+            opt_connection_id,
+            opt_transaction_id,
         }
     }
 }

--- a/packages/udp-tracker-server/src/error.rs
+++ b/packages/udp-tracker-server/src/error.rs
@@ -7,7 +7,6 @@ use bittorrent_udp_tracker_core::services::announce::UdpAnnounceError;
 use bittorrent_udp_tracker_core::services::scrape::UdpScrapeError;
 use derive_more::derive::Display;
 use thiserror::Error;
-use torrust_tracker_located_error::LocatedError;
 
 #[derive(Display, Debug)]
 #[display(":?")]
@@ -33,12 +32,6 @@ pub enum Error {
     InternalServer {
         location: &'static Location<'static>,
         message: String,
-    },
-
-    /// Error returned when the request is invalid.
-    #[error("bad request: {source}")]
-    BadRequest {
-        source: LocatedError<'static, dyn std::error::Error + Send + Sync>,
     },
 
     /// Error returned when tracker requires authentication.

--- a/packages/udp-tracker-server/src/event.rs
+++ b/packages/udp-tracker-server/src/event.rs
@@ -2,12 +2,17 @@ use std::fmt;
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use bittorrent_tracker_core::error::{AnnounceError, ScrapeError};
+use bittorrent_udp_tracker_core::services::announce::UdpAnnounceError;
+use bittorrent_udp_tracker_core::services::scrape::UdpScrapeError;
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::label_name;
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 
+use crate::error::Error;
+
 /// A UDP server event.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     UdpRequestReceived {
         context: ConnectionContext,
@@ -30,6 +35,7 @@ pub enum Event {
     UdpError {
         context: ConnectionContext,
         kind: Option<UdpRequestKind>,
+        error: ErrorKind,
     },
 }
 
@@ -106,6 +112,43 @@ impl From<ConnectionContext> for LabelSet {
                 LabelValue::new(&connection_context.server_service_binding.bind_address().port().to_string()),
             ),
         ])
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ErrorKind {
+    RequestParse(String),
+    ConnectionCookie(String),
+    Whitelist(String),
+    Database(String),
+    InternalServer(String),
+    BadRequest(String),
+    TrackerAuthentication(String),
+}
+
+impl From<Error> for ErrorKind {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::RequestParseError { request_parse_error } => Self::RequestParse(request_parse_error.to_string()),
+            Error::UdpAnnounceError { source } => match source {
+                UdpAnnounceError::ConnectionCookieError { source } => Self::ConnectionCookie(source.to_string()),
+                UdpAnnounceError::TrackerCoreAnnounceError { source } => match source {
+                    AnnounceError::Whitelist(whitelist_error) => Self::Whitelist(whitelist_error.to_string()),
+                    AnnounceError::Database(error) => Self::Database(error.to_string()),
+                },
+                UdpAnnounceError::TrackerCoreWhitelistError { source } => Self::Whitelist(source.to_string()),
+            },
+            Error::UdpScrapeError { source } => match source {
+                UdpScrapeError::ConnectionCookieError { source } => Self::ConnectionCookie(source.to_string()),
+                UdpScrapeError::TrackerCoreScrapeError { source } => match source {
+                    ScrapeError::Whitelist(whitelist_error) => Self::Whitelist(whitelist_error.to_string()),
+                },
+                UdpScrapeError::TrackerCoreWhitelistError { source } => Self::Whitelist(source.to_string()),
+            },
+            Error::InternalServer { location: _, message } => Self::InternalServer(message.to_string()),
+            Error::BadRequest { source } => Self::BadRequest(source.to_string()),
+            Error::TrackerAuthenticationRequired { location } => Self::TrackerAuthentication(location.to_string()),
+        }
     }
 }
 

--- a/packages/udp-tracker-server/src/event.rs
+++ b/packages/udp-tracker-server/src/event.rs
@@ -146,7 +146,6 @@ impl From<Error> for ErrorKind {
                 UdpScrapeError::TrackerCoreWhitelistError { source } => Self::Whitelist(source.to_string()),
             },
             Error::InternalServer { location: _, message } => Self::InternalServer(message.to_string()),
-            Error::BadRequest { source } => Self::BadRequest(source.to_string()),
             Error::TrackerAuthenticationRequired { location } => Self::TrackerAuthentication(location.to_string()),
         }
     }

--- a/packages/udp-tracker-server/src/handlers/error.rs
+++ b/packages/udp-tracker-server/src/handlers/error.rs
@@ -31,10 +31,9 @@ pub async fn handle_error(
     log_error(error, client_socket_addr, server_socket_addr, opt_transaction_id, request_id);
 
     trigger_udp_error_event(
-        error.clone(),
+        error,
         client_socket_addr,
         server_service_binding,
-        opt_transaction_id,
         opt_udp_server_stats_event_sender,
         req_kind,
     )
@@ -51,7 +50,6 @@ fn log_error(
     client_socket_addr: SocketAddr,
     server_socket_addr: SocketAddr,
     opt_transaction_id: Option<TransactionId>,
-
     request_id: Uuid,
 ) {
     match opt_transaction_id {
@@ -66,25 +64,19 @@ fn log_error(
 }
 
 async fn trigger_udp_error_event(
-    error: Error,
+    error: &Error,
     client_socket_addr: SocketAddr,
     server_service_binding: ServiceBinding,
-    opt_transaction_id: Option<TransactionId>,
-
     opt_udp_server_stats_event_sender: &crate::event::sender::Sender,
     req_kind: Option<UdpRequestKind>,
 ) {
-    if opt_transaction_id.is_some() {
-        // code-review: why we trigger an event only if transaction_id is present?
-
-        if let Some(udp_server_stats_event_sender) = opt_udp_server_stats_event_sender.as_deref() {
-            udp_server_stats_event_sender
-                .send(Event::UdpError {
-                    context: ConnectionContext::new(client_socket_addr, server_service_binding),
-                    kind: req_kind,
-                    error: error.clone().into(),
-                })
-                .await;
-        }
+    if let Some(udp_server_stats_event_sender) = opt_udp_server_stats_event_sender.as_deref() {
+        udp_server_stats_event_sender
+            .send(Event::UdpError {
+                context: ConnectionContext::new(client_socket_addr, server_service_binding),
+                kind: req_kind,
+                error: error.clone().into(),
+            })
+            .await;
     }
 }

--- a/packages/udp-tracker-server/src/handlers/error.rs
+++ b/packages/udp-tracker-server/src/handlers/error.rs
@@ -28,6 +28,32 @@ pub async fn handle_error(
 
     let server_socket_addr = server_service_binding.bind_address();
 
+    log_error(error, client_socket_addr, server_socket_addr, opt_transaction_id, request_id);
+
+    trigger_udp_error_event(
+        error.clone(),
+        client_socket_addr,
+        server_service_binding,
+        opt_transaction_id,
+        opt_udp_server_stats_event_sender,
+        req_kind,
+    )
+    .await;
+
+    Response::from(ErrorResponse {
+        transaction_id: opt_transaction_id.unwrap_or(TransactionId(I32::new(0))),
+        message: error.to_string().into(),
+    })
+}
+
+fn log_error(
+    error: &Error,
+    client_socket_addr: SocketAddr,
+    server_socket_addr: SocketAddr,
+    opt_transaction_id: Option<TransactionId>,
+
+    request_id: Uuid,
+) {
     match opt_transaction_id {
         Some(transaction_id) => {
             let transaction_id = transaction_id.0.to_string();
@@ -37,7 +63,17 @@ pub async fn handle_error(
             tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, %request_id, "response error");
         }
     }
+}
 
+async fn trigger_udp_error_event(
+    error: Error,
+    client_socket_addr: SocketAddr,
+    server_service_binding: ServiceBinding,
+    opt_transaction_id: Option<TransactionId>,
+
+    opt_udp_server_stats_event_sender: &crate::event::sender::Sender,
+    req_kind: Option<UdpRequestKind>,
+) {
     if opt_transaction_id.is_some() {
         // code-review: why we trigger an event only if transaction_id is present?
 
@@ -51,9 +87,4 @@ pub async fn handle_error(
                 .await;
         }
     }
-
-    Response::from(ErrorResponse {
-        transaction_id: opt_transaction_id.unwrap_or(TransactionId(I32::new(0))),
-        message: error.to_string().into(),
-    })
 }

--- a/packages/udp-tracker-server/src/handlers/error.rs
+++ b/packages/udp-tracker-server/src/handlers/error.rs
@@ -2,8 +2,7 @@
 use std::net::SocketAddr;
 use std::ops::Range;
 
-use aquatic_udp_protocol::{ErrorResponse, RequestParseError, Response, TransactionId};
-use bittorrent_udp_tracker_core::connection_cookie::{check, gen_remote_fingerprint};
+use aquatic_udp_protocol::{ErrorResponse, Response, TransactionId};
 use bittorrent_udp_tracker_core::{self, UDP_TRACKER_LOG_TARGET};
 use torrust_tracker_primitives::service_binding::ServiceBinding;
 use tracing::{instrument, Level};
@@ -40,25 +39,14 @@ pub async fn handle_error(
     }
 
     let e = if let Error::RequestParseError { request_parse_error } = e {
-        match request_parse_error {
-            RequestParseError::Sendable {
-                connection_id,
-                transaction_id,
-                err,
-            } => {
-                if let Err(e) = check(connection_id, gen_remote_fingerprint(&client_socket_addr), cookie_valid_range) {
-                    (e.to_string(), Some(*transaction_id))
-                } else {
-                    ((*err).to_string(), Some(*transaction_id))
-                }
-            }
-            RequestParseError::Unsendable { err } => (err.to_string(), transaction_id),
-        }
+        (request_parse_error.message.clone(), transaction_id)
     } else {
         (e.to_string(), transaction_id)
     };
 
     if e.1.is_some() {
+        // code-review: why we trigger an event only if transaction_id is present?
+
         if let Some(udp_server_stats_event_sender) = opt_udp_server_stats_event_sender.as_deref() {
             udp_server_stats_event_sender
                 .send(Event::UdpError {

--- a/packages/udp-tracker-server/src/handlers/error.rs
+++ b/packages/udp-tracker-server/src/handlers/error.rs
@@ -21,7 +21,7 @@ pub async fn handle_error(
     request_id: Uuid,
     opt_udp_server_stats_event_sender: &crate::event::sender::Sender,
     cookie_valid_range: Range<f64>,
-    e: &Error,
+    error: &Error,
     transaction_id: Option<TransactionId>,
 ) -> Response {
     tracing::trace!("handle error");
@@ -31,17 +31,17 @@ pub async fn handle_error(
     match transaction_id {
         Some(transaction_id) => {
             let transaction_id = transaction_id.0.to_string();
-            tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %e, %client_socket_addr, %server_socket_addr, %request_id, %transaction_id, "response error");
+            tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, %request_id, %transaction_id, "response error");
         }
         None => {
-            tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %e, %client_socket_addr, %server_socket_addr, %request_id, "response error");
+            tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, %request_id, "response error");
         }
     }
 
-    let e = if let Error::RequestParseError { request_parse_error } = e {
+    let e = if let Error::RequestParseError { request_parse_error } = error {
         (request_parse_error.message.clone(), transaction_id)
     } else {
-        (e.to_string(), transaction_id)
+        (error.to_string(), transaction_id)
     };
 
     if e.1.is_some() {
@@ -52,6 +52,7 @@ pub async fn handle_error(
                 .send(Event::UdpError {
                     context: ConnectionContext::new(client_socket_addr, server_service_binding),
                     kind: req_kind,
+                    error: error.clone().into(),
                 })
                 .await;
         }

--- a/packages/udp-tracker-server/src/handlers/error.rs
+++ b/packages/udp-tracker-server/src/handlers/error.rs
@@ -22,13 +22,13 @@ pub async fn handle_error(
     opt_udp_server_stats_event_sender: &crate::event::sender::Sender,
     cookie_valid_range: Range<f64>,
     error: &Error,
-    transaction_id: Option<TransactionId>,
+    opt_transaction_id: Option<TransactionId>,
 ) -> Response {
     tracing::trace!("handle error");
 
     let server_socket_addr = server_service_binding.bind_address();
 
-    match transaction_id {
+    match opt_transaction_id {
         Some(transaction_id) => {
             let transaction_id = transaction_id.0.to_string();
             tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, %request_id, %transaction_id, "response error");
@@ -38,13 +38,7 @@ pub async fn handle_error(
         }
     }
 
-    let e = if let Error::RequestParseError { request_parse_error } = error {
-        (request_parse_error.message.clone(), transaction_id)
-    } else {
-        (error.to_string(), transaction_id)
-    };
-
-    if e.1.is_some() {
+    if opt_transaction_id.is_some() {
         // code-review: why we trigger an event only if transaction_id is present?
 
         if let Some(udp_server_stats_event_sender) = opt_udp_server_stats_event_sender.as_deref() {
@@ -59,7 +53,7 @@ pub async fn handle_error(
     }
 
     Response::from(ErrorResponse {
-        transaction_id: e.1.unwrap_or(TransactionId(I32::new(0))),
-        message: e.0.into(),
+        transaction_id: opt_transaction_id.unwrap_or(TransactionId(I32::new(0))),
+        message: error.to_string().into(),
     })
 }

--- a/packages/udp-tracker-server/src/handlers/mod.rs
+++ b/packages/udp-tracker-server/src/handlers/mod.rs
@@ -110,6 +110,13 @@ pub(crate) async fn handle_packet(
             },
             Err(e) => {
                 // The request payload could not be parsed, so we handle it as an error.
+
+                let opt_transaction_id = if let Error::RequestParseError { request_parse_error } = e.clone() {
+                    request_parse_error.opt_transaction_id
+                } else {
+                    None
+                };
+
                 let response = handle_error(
                     None,
                     udp_request.from,
@@ -118,7 +125,7 @@ pub(crate) async fn handle_packet(
                     &udp_tracker_server_container.stats_event_sender,
                     cookie_time_values.valid_range.clone(),
                     &e,
-                    None,
+                    opt_transaction_id,
                 )
                 .await;
 

--- a/packages/udp-tracker-server/src/handlers/mod.rs
+++ b/packages/udp-tracker-server/src/handlers/mod.rs
@@ -13,7 +13,6 @@ use announce::handle_announce;
 use aquatic_udp_protocol::{Request, Response, TransactionId};
 use bittorrent_tracker_core::MAX_SCRAPE_TORRENTS;
 use bittorrent_udp_tracker_core::container::UdpTrackerCoreContainer;
-use bittorrent_udp_tracker_core::services::announce::UdpAnnounceError;
 use connect::handle_connect;
 use error::handle_error;
 use scrape::handle_scrape;
@@ -84,15 +83,6 @@ pub(crate) async fn handle_packet(
             {
                 Ok((response, req_kid)) => return (response, Some(req_kid)),
                 Err((error, transaction_id, req_kind)) => {
-                    if let Error::UdpAnnounceError {
-                        source: UdpAnnounceError::ConnectionCookieError { .. },
-                    } = error
-                    {
-                        // code-review: should we include `RequestParseError` and `BadRequest`?
-                        let mut ban_service = udp_tracker_core_container.ban_service.write().await;
-                        ban_service.increase_counter(&udp_request.from.ip());
-                    }
-
                     let response = handle_error(
                         Some(req_kind.clone()),
                         udp_request.from,

--- a/packages/udp-tracker-server/src/handlers/mod.rs
+++ b/packages/udp-tracker-server/src/handlers/mod.rs
@@ -109,6 +109,7 @@ pub(crate) async fn handle_packet(
                 }
             },
             Err(e) => {
+                // The request payload could not be parsed, so we handle it as an error.
                 let response = handle_error(
                     None,
                     udp_request.from,

--- a/packages/udp-tracker-server/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-server/src/statistics/event/handler.rs
@@ -232,7 +232,7 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                 Err(err) => tracing::error!("Failed to increase the counter: {}", err),
             };
         }
-        Event::UdpError { context, kind } => {
+        Event::UdpError { context, kind, error: _ } => {
             // Global fixed metrics
             match context.client_socket_addr().ip() {
                 std::net::IpAddr::V4(_) => {
@@ -271,7 +271,7 @@ mod tests {
     use torrust_tracker_clock::clock::Time;
     use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
-    use crate::event::{ConnectionContext, Event, UdpRequestKind};
+    use crate::event::{ConnectionContext, ErrorKind, Event, UdpRequestKind};
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
     use crate::CurrentClock;
@@ -518,6 +518,7 @@ mod tests {
                     .unwrap(),
                 ),
                 kind: None,
+                error: ErrorKind::RequestParse("Invalid request format".to_string()),
             },
             &stats_repository,
             CurrentClock::now(),
@@ -650,6 +651,7 @@ mod tests {
                     .unwrap(),
                 ),
                 kind: None,
+                error: ErrorKind::RequestParse("Invalid request format".to_string()),
             },
             &stats_repository,
             CurrentClock::now(),

--- a/packages/udp-tracker-server/src/statistics/event/handler.rs
+++ b/packages/udp-tracker-server/src/statistics/event/handler.rs
@@ -1,8 +1,12 @@
+use std::sync::Arc;
+
+use bittorrent_udp_tracker_core::services::banning::BanService;
+use tokio::sync::RwLock;
 use torrust_tracker_metrics::label::{LabelSet, LabelValue};
 use torrust_tracker_metrics::{label_name, metric_name};
 use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
-use crate::event::{Event, UdpRequestKind, UdpResponseKind};
+use crate::event::{ErrorKind, Event, UdpRequestKind, UdpResponseKind};
 use crate::statistics::repository::Repository;
 use crate::statistics::{
     UDP_TRACKER_SERVER_ERRORS_TOTAL, UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS,
@@ -16,7 +20,12 @@ use crate::statistics::{
 /// This function panics if the client IP version does not match the expected
 /// version.
 #[allow(clippy::too_many_lines)]
-pub async fn handle_event(event: Event, stats_repository: &Repository, now: DurationSinceUnixEpoch) {
+pub async fn handle_event(
+    event: Event,
+    stats_repository: &Repository,
+    ban_service: &Arc<RwLock<BanService>>,
+    now: DurationSinceUnixEpoch,
+) {
     match event {
         Event::UdpRequestAborted { context } => {
             // Global fixed metrics
@@ -232,7 +241,14 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
                 Err(err) => tracing::error!("Failed to increase the counter: {}", err),
             };
         }
-        Event::UdpError { context, kind, error: _ } => {
+        Event::UdpError { context, kind, error } => {
+            // Increase the number of errors
+            // code-review: should we ban IP due to other errors too?
+            if let ErrorKind::ConnectionCookie(_msg) = error {
+                let mut ban_service = ban_service.write().await;
+                ban_service.increase_counter(&context.client_socket_addr().ip());
+            }
+
             // Global fixed metrics
             match context.client_socket_addr().ip() {
                 std::net::IpAddr::V4(_) => {
@@ -267,7 +283,9 @@ pub async fn handle_event(event: Event, stats_repository: &Repository, now: Dura
 #[cfg(test)]
 mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::sync::Arc;
 
+    use bittorrent_udp_tracker_core::services::banning::BanService;
     use torrust_tracker_clock::clock::Time;
     use torrust_tracker_primitives::service_binding::{Protocol, ServiceBinding};
 
@@ -279,6 +297,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_number_of_aborted_requests_when_it_receives_a_udp_request_aborted_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAborted {
@@ -292,6 +311,7 @@ mod tests {
                 ),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -304,6 +324,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_number_of_banned_requests_when_it_receives_a_udp_request_banned_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestBanned {
@@ -317,6 +338,7 @@ mod tests {
                 ),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -329,6 +351,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_number_of_incoming_requests_when_it_receives_a_udp4_incoming_request_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestReceived {
@@ -342,6 +365,7 @@ mod tests {
                 ),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -354,6 +378,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp_abort_counter_when_it_receives_a_udp_abort_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAborted {
@@ -367,6 +392,7 @@ mod tests {
                 ),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -376,6 +402,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp_ban_counter_when_it_receives_a_udp_banned_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestBanned {
@@ -389,6 +416,7 @@ mod tests {
                 ),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -399,6 +427,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp4_connect_requests_counter_when_it_receives_a_udp4_request_event_of_connect_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -413,6 +442,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Connect,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -425,6 +455,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp4_announce_requests_counter_when_it_receives_a_udp4_request_event_of_announce_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -439,6 +470,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Announce,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -451,6 +483,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp4_scrape_requests_counter_when_it_receives_a_udp4_request_event_of_scrape_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -465,6 +498,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Scrape,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -477,6 +511,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp4_responses_counter_when_it_receives_a_udp4_response_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpResponseSent {
@@ -494,6 +529,7 @@ mod tests {
                 req_processing_time: std::time::Duration::from_secs(1),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -506,6 +542,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp4_errors_counter_when_it_receives_a_udp4_error_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpError {
@@ -521,6 +558,7 @@ mod tests {
                 error: ErrorKind::RequestParse("Invalid request format".to_string()),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -533,6 +571,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp6_connect_requests_counter_when_it_receives_a_udp6_request_event_of_connect_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -547,6 +586,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Connect,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -559,6 +599,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp6_announce_requests_counter_when_it_receives_a_udp6_request_event_of_announce_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -573,6 +614,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Announce,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -585,6 +627,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp6_scrape_requests_counter_when_it_receives_a_udp6_request_event_of_scrape_kind() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpRequestAccepted {
@@ -599,6 +642,7 @@ mod tests {
                 kind: crate::event::UdpRequestKind::Scrape,
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -611,6 +655,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp6_response_counter_when_it_receives_a_udp6_response_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpResponseSent {
@@ -628,6 +673,7 @@ mod tests {
                 req_processing_time: std::time::Duration::from_secs(1),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;
@@ -639,6 +685,7 @@ mod tests {
     #[tokio::test]
     async fn should_increase_the_udp6_errors_counter_when_it_receives_a_udp6_error_event() {
         let stats_repository = Repository::new();
+        let ban_service = Arc::new(tokio::sync::RwLock::new(BanService::new(1)));
 
         handle_event(
             Event::UdpError {
@@ -654,6 +701,7 @@ mod tests {
                 error: ErrorKind::RequestParse("Invalid request format".to_string()),
             },
             &stats_repository,
+            &ban_service,
             CurrentClock::now(),
         )
         .await;

--- a/packages/udp-tracker-server/src/statistics/event/listener.rs
+++ b/packages/udp-tracker-server/src/statistics/event/listener.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 
+use bittorrent_udp_tracker_core::services::banning::BanService;
 use bittorrent_udp_tracker_core::UDP_TRACKER_LOG_TARGET;
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use torrust_tracker_clock::clock::Time;
 use torrust_tracker_events::receiver::RecvError;
@@ -11,19 +13,24 @@ use crate::statistics::repository::Repository;
 use crate::CurrentClock;
 
 #[must_use]
-pub fn run_event_listener(receiver: Receiver, repository: &Arc<Repository>) -> JoinHandle<()> {
-    let stats_repository = repository.clone();
+pub fn run_event_listener(
+    receiver: Receiver,
+    repository: &Arc<Repository>,
+    ban_service: &Arc<RwLock<BanService>>,
+) -> JoinHandle<()> {
+    let repository_clone = repository.clone();
+    let ban_service_clone = ban_service.clone();
 
     tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Starting UDP tracker server event listener");
 
     tokio::spawn(async move {
-        dispatch_events(receiver, stats_repository).await;
+        dispatch_events(receiver, repository_clone, ban_service_clone).await;
 
         tracing::info!(target: UDP_TRACKER_LOG_TARGET, "UDP tracker server event listener finished");
     })
 }
 
-async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repository>) {
+async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repository>, ban_service: Arc<RwLock<BanService>>) {
     let shutdown_signal = tokio::signal::ctrl_c();
     tokio::pin!(shutdown_signal);
 
@@ -38,7 +45,7 @@ async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repositor
 
             result = receiver.recv() => {
                 match result {
-                    Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
+                    Ok(event) => handle_event(event, &stats_repository, &ban_service, CurrentClock::now()).await,
                     Err(e) => {
                         match e {
                             RecvError::Closed => {

--- a/packages/udp-tracker-server/tests/server/contract.rs
+++ b/packages/udp-tracker-server/tests/server/contract.rs
@@ -59,7 +59,9 @@ async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_req
 
     let response = Response::parse_bytes(&response, true).unwrap();
 
-    assert_eq!(get_error_response_message(&response).unwrap(), "Protocol identifier missing");
+    assert!(get_error_response_message(&response)
+        .unwrap()
+        .contains("Protocol identifier missing"));
 
     env.stop().await;
 }

--- a/src/bootstrap/jobs/udp_tracker_server.rs
+++ b/src/bootstrap/jobs/udp_tracker_server.rs
@@ -10,6 +10,7 @@ pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppConta
         let job = torrust_udp_tracker_server::statistics::event::listener::run_event_listener(
             app_container.udp_tracker_server_container.event_bus.receiver(),
             &app_container.udp_tracker_server_container.stats_repository,
+            &app_container.udp_tracker_core_services.ban_service,
         );
         Some(job)
     } else {


### PR DESCRIPTION
Add a new metric to count UDP wrong connection ID errors per client's software.

### Subtasks

- [x] Wrapper for aquatic parse error. It's not sendable.
- [x] Add the error to the `Event::UdpError` event.
- [x] Move logic to increase the number of wrong connection IDs per IP to the event listener.
- [ ] Add a new metric to increment the counter per client's software/version.
  - This requires adding the peer info (if available)