### PR TITLE
Add a new metric to count peers reverting `Completed` state

### DIFF
--- a/packages/axum-http-tracker-server/src/environment.rs
+++ b/packages/axum-http-tracker-server/src/environment.rs
@@ -144,13 +144,13 @@ impl EnvContainer {
             .expect("missing HTTP tracker configuration");
         let http_tracker_config = Arc::new(http_tracker_config[0].clone());
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             configuration.core.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         let http_tracker_container =

--- a/packages/axum-http-tracker-server/src/environment.rs
+++ b/packages/axum-http-tracker-server/src/environment.rs
@@ -10,7 +10,7 @@ use torrust_axum_server::tsl::make_rust_tls;
 use torrust_server_lib::registar::Registar;
 use torrust_tracker_configuration::{logging, Configuration};
 use torrust_tracker_primitives::peer;
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 use crate::server::{HttpServer, Launcher, Running, Stopped};
 
@@ -144,7 +144,7 @@ impl EnvContainer {
             .expect("missing HTTP tracker configuration");
         let http_tracker_config = Arc::new(http_tracker_config[0].clone());
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             configuration.core.tracker_usage_statistics.into(),
         ));
 

--- a/packages/axum-http-tracker-server/src/server.rs
+++ b/packages/axum-http-tracker-server/src/server.rs
@@ -290,13 +290,13 @@ mod tests {
             let _unused = run_event_listener(http_stats_event_bus.receiver(), &http_stats_repository);
         }
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             configuration.core.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         let announce_service = Arc::new(AnnounceService::new(

--- a/packages/axum-http-tracker-server/src/server.rs
+++ b/packages/axum-http-tracker-server/src/server.rs
@@ -259,7 +259,7 @@ mod tests {
     use torrust_axum_server::tsl::make_rust_tls;
     use torrust_server_lib::registar::Registar;
     use torrust_tracker_configuration::{logging, Configuration};
-    use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+    use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
     use torrust_tracker_test_helpers::configuration::ephemeral_public;
 
     use crate::server::{HttpServer, Launcher};
@@ -290,7 +290,7 @@ mod tests {
             let _unused = run_event_listener(http_stats_event_bus.receiver(), &http_stats_repository);
         }
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             configuration.core.tracker_usage_statistics.into(),
         ));
 

--- a/packages/axum-rest-tracker-api-server/src/environment.rs
+++ b/packages/axum-rest-tracker-api-server/src/environment.rs
@@ -12,7 +12,7 @@ use torrust_rest_tracker_api_core::container::TrackerHttpApiCoreContainer;
 use torrust_server_lib::registar::Registar;
 use torrust_tracker_configuration::{logging, Configuration};
 use torrust_tracker_primitives::peer;
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 
 use crate::server::{ApiServer, Launcher, Running, Stopped};
@@ -173,7 +173,7 @@ impl EnvContainer {
                 .clone(),
         );
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/packages/axum-rest-tracker-api-server/src/environment.rs
+++ b/packages/axum-rest-tracker-api-server/src/environment.rs
@@ -173,13 +173,13 @@ impl EnvContainer {
                 .clone(),
         );
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         let http_tracker_core_container =
@@ -191,7 +191,7 @@ impl EnvContainer {
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
 
         let tracker_http_api_core_container = TrackerHttpApiCoreContainer::initialize_from(
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
             &tracker_core_container,
             &http_tracker_core_container,
             &udp_tracker_core_container,

--- a/packages/axum-rest-tracker-api-server/src/v1/context/stats/routes.rs
+++ b/packages/axum-rest-tracker-api-server/src/v1/context/stats/routes.rs
@@ -30,7 +30,10 @@ pub fn add(prefix: &str, router: Router, http_api_container: &Arc<TrackerHttpApi
                 http_api_container.tracker_core_container.in_memory_torrent_repository.clone(),
                 http_api_container.ban_service.clone(),
                 // Stats
-                http_api_container.torrent_repository_container.stats_repository.clone(),
+                http_api_container
+                    .swarm_coordination_registry_container
+                    .stats_repository
+                    .clone(),
                 http_api_container.tracker_core_container.stats_repository.clone(),
                 http_api_container.http_stats_repository.clone(),
                 http_api_container.udp_core_stats_repository.clone(),

--- a/packages/http-tracker-core/src/container.rs
+++ b/packages/http-tracker-core/src/container.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bittorrent_tracker_core::container::TrackerCoreContainer;
 use torrust_tracker_configuration::{Core, HttpTracker};
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 use crate::event::bus::EventBus;
 use crate::event::sender::Broadcaster;
@@ -27,7 +27,7 @@ pub struct HttpTrackerCoreContainer {
 impl HttpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Arc<Self> {
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/packages/http-tracker-core/src/container.rs
+++ b/packages/http-tracker-core/src/container.rs
@@ -27,13 +27,13 @@ pub struct HttpTrackerCoreContainer {
 impl HttpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Arc<Self> {
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         Self::initialize_from_tracker_core(&tracker_core_container, http_tracker_config)

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -13,7 +13,7 @@ use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 pub struct TrackerHttpApiCoreContainer {
     pub http_api_config: Arc<HttpApi>,
 
-    // Torrent repository
+    // Swarm Coordination Registry Container
     pub swarm_coordination_registry_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Tracker core
@@ -75,7 +75,7 @@ impl TrackerHttpApiCoreContainer {
         Arc::new(TrackerHttpApiCoreContainer {
             http_api_config: http_api_config.clone(),
 
-            // Torrent repository
+            // Swarm Coordination Registry Container
             swarm_coordination_registry_container: swarm_coordination_registry_container.clone(),
 
             // Tracker core

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -7,14 +7,14 @@ use bittorrent_udp_tracker_core::services::banning::BanService;
 use bittorrent_udp_tracker_core::{self};
 use tokio::sync::RwLock;
 use torrust_tracker_configuration::{Core, HttpApi, HttpTracker, UdpTracker};
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 
 pub struct TrackerHttpApiCoreContainer {
     pub http_api_config: Arc<HttpApi>,
 
     // Torrent repository
-    pub torrent_repository_container: Arc<TorrentRepositoryContainer>,
+    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Tracker core
     pub tracker_core_container: Arc<TrackerCoreContainer>,
@@ -36,7 +36,7 @@ impl TrackerHttpApiCoreContainer {
         udp_tracker_config: &Arc<UdpTracker>,
         http_api_config: &Arc<HttpApi>,
     ) -> Arc<TrackerHttpApiCoreContainer> {
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
@@ -65,7 +65,7 @@ impl TrackerHttpApiCoreContainer {
 
     #[must_use]
     pub fn initialize_from(
-        torrent_repository_container: &Arc<TorrentRepositoryContainer>,
+        torrent_repository_container: &Arc<SwarmCoordinationRegistryContainer>,
         tracker_core_container: &Arc<TrackerCoreContainer>,
         http_tracker_core_container: &Arc<HttpTrackerCoreContainer>,
         udp_tracker_core_container: &Arc<UdpTrackerCoreContainer>,

--- a/packages/rest-tracker-api-core/src/container.rs
+++ b/packages/rest-tracker-api-core/src/container.rs
@@ -14,7 +14,7 @@ pub struct TrackerHttpApiCoreContainer {
     pub http_api_config: Arc<HttpApi>,
 
     // Torrent repository
-    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
+    pub swarm_coordination_registry_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Tracker core
     pub tracker_core_container: Arc<TrackerCoreContainer>,
@@ -36,13 +36,13 @@ impl TrackerHttpApiCoreContainer {
         udp_tracker_config: &Arc<UdpTracker>,
         http_api_config: &Arc<HttpApi>,
     ) -> Arc<TrackerHttpApiCoreContainer> {
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         let http_tracker_core_container =
@@ -54,7 +54,7 @@ impl TrackerHttpApiCoreContainer {
         let udp_tracker_server_container = UdpTrackerServerContainer::initialize(core_config);
 
         Self::initialize_from(
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
             &tracker_core_container,
             &http_tracker_core_container,
             &udp_tracker_core_container,
@@ -65,7 +65,7 @@ impl TrackerHttpApiCoreContainer {
 
     #[must_use]
     pub fn initialize_from(
-        torrent_repository_container: &Arc<SwarmCoordinationRegistryContainer>,
+        swarm_coordination_registry_container: &Arc<SwarmCoordinationRegistryContainer>,
         tracker_core_container: &Arc<TrackerCoreContainer>,
         http_tracker_core_container: &Arc<HttpTrackerCoreContainer>,
         udp_tracker_core_container: &Arc<UdpTrackerCoreContainer>,
@@ -76,7 +76,7 @@ impl TrackerHttpApiCoreContainer {
             http_api_config: http_api_config.clone(),
 
             // Torrent repository
-            torrent_repository_container: torrent_repository_container.clone(),
+            swarm_coordination_registry_container: swarm_coordination_registry_container.clone(),
 
             // Tracker core
             tracker_core_container: tracker_core_container.clone(),

--- a/packages/rest-tracker-api-core/src/statistics/services.rs
+++ b/packages/rest-tracker-api-core/src/statistics/services.rs
@@ -165,7 +165,7 @@ mod tests {
     use tokio::sync::RwLock;
     use torrust_tracker_configuration::Configuration;
     use torrust_tracker_events::bus::SenderStatus;
-    use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+    use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
     use torrust_tracker_test_helpers::configuration;
 
     use crate::statistics::metrics::{ProtocolMetrics, TorrentsMetrics};
@@ -180,7 +180,7 @@ mod tests {
         let config = tracker_configuration();
         let core_config = Arc::new(config.core.clone());
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(SenderStatus::Enabled));
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(SenderStatus::Enabled));
 
         let tracker_core_container = TrackerCoreContainer::initialize_from(&core_config, &torrent_repository_container.clone());
 

--- a/packages/rest-tracker-api-core/src/statistics/services.rs
+++ b/packages/rest-tracker-api-core/src/statistics/services.rs
@@ -180,9 +180,11 @@ mod tests {
         let config = tracker_configuration();
         let core_config = Arc::new(config.core.clone());
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(SenderStatus::Enabled));
+        let swarm_coordination_registry_container =
+            Arc::new(SwarmCoordinationRegistryContainer::initialize(SenderStatus::Enabled));
 
-        let tracker_core_container = TrackerCoreContainer::initialize_from(&core_config, &torrent_repository_container.clone());
+        let tracker_core_container =
+            TrackerCoreContainer::initialize_from(&core_config, &swarm_coordination_registry_container.clone());
 
         let ban_service = Arc::new(RwLock::new(BanService::new(MAX_CONNECTION_ID_ERRORS_PER_IP)));
 

--- a/packages/swarm-coordination-registry/src/container.rs
+++ b/packages/swarm-coordination-registry/src/container.rs
@@ -18,7 +18,7 @@ pub struct SwarmCoordinationRegistryContainer {
 impl SwarmCoordinationRegistryContainer {
     #[must_use]
     pub fn initialize(sender_status: SenderStatus) -> Self {
-        // Torrent repository stats
+        // // Swarm Coordination Registry Container stats
         let broadcaster = Broadcaster::default();
         let stats_repository = Arc::new(Repository::new());
 

--- a/packages/swarm-coordination-registry/src/container.rs
+++ b/packages/swarm-coordination-registry/src/container.rs
@@ -8,14 +8,14 @@ use crate::event::{self};
 use crate::statistics::repository::Repository;
 use crate::{statistics, Registry};
 
-pub struct TorrentRepositoryContainer {
+pub struct SwarmCoordinationRegistryContainer {
     pub swarms: Arc<Registry>,
     pub event_bus: Arc<event::bus::EventBus>,
     pub stats_event_sender: event::sender::Sender,
     pub stats_repository: Arc<statistics::repository::Repository>,
 }
 
-impl TorrentRepositoryContainer {
+impl SwarmCoordinationRegistryContainer {
     #[must_use]
     pub fn initialize(sender_status: SenderStatus) -> Self {
         // Torrent repository stats

--- a/packages/swarm-coordination-registry/src/lib.rs
+++ b/packages/swarm-coordination-registry/src/lib.rs
@@ -22,7 +22,7 @@ pub(crate) type CurrentClock = clock::Working;
 #[allow(dead_code)]
 pub(crate) type CurrentClock = clock::Stopped;
 
-pub const TORRENT_REPOSITORY_LOG_TARGET: &str = "TORRENT_REPOSITORY";
+pub const SWARM_COORDINATION_REGISTRY_LOG_TARGET: &str = "SWARM_COORDINATION_REGISTRY";
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/packages/swarm-coordination-registry/src/statistics/activity_metrics_updater.rs
+++ b/packages/swarm-coordination-registry/src/statistics/activity_metrics_updater.rs
@@ -10,7 +10,7 @@ use torrust_tracker_primitives::DurationSinceUnixEpoch;
 use tracing::instrument;
 
 use super::repository::Repository;
-use crate::statistics::{TORRENT_REPOSITORY_PEERS_INACTIVE_TOTAL, TORRENT_REPOSITORY_TORRENTS_INACTIVE_TOTAL};
+use crate::statistics::{SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_INACTIVE_TOTAL};
 use crate::{CurrentClock, Registry};
 
 #[must_use]
@@ -81,7 +81,7 @@ async fn update_inactive_peers_total(stats_repository: &Arc<Repository>, inactiv
 
     let _unused = stats_repository
         .set_gauge(
-            &metric_name!(TORRENT_REPOSITORY_PEERS_INACTIVE_TOTAL),
+            &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL),
             &LabelSet::default(),
             inactive_peers_total,
             CurrentClock::now(),
@@ -95,7 +95,7 @@ async fn update_inactive_torrents_total(stats_repository: &Arc<Repository>, inac
 
     let _unused = stats_repository
         .set_gauge(
-            &metric_name!(TORRENT_REPOSITORY_TORRENTS_INACTIVE_TOTAL),
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_INACTIVE_TOTAL),
             &LabelSet::default(),
             inactive_torrents_total,
             CurrentClock::now(),

--- a/packages/swarm-coordination-registry/src/statistics/event/handler.rs
+++ b/packages/swarm-coordination-registry/src/statistics/event/handler.rs
@@ -8,11 +8,13 @@ use torrust_tracker_primitives::DurationSinceUnixEpoch;
 use crate::event::Event;
 use crate::statistics::repository::Repository;
 use crate::statistics::{
-    TORRENT_REPOSITORY_PEERS_ADDED_TOTAL, TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL, TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL,
-    TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL, TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL,
-    TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL, TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL, TORRENT_REPOSITORY_TORRENTS_TOTAL,
+    SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL,
+    SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL, SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL,
+    SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL,
+    SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL,
 };
 
+#[allow(clippy::too_many_lines)]
 pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now: DurationSinceUnixEpoch) {
     match event {
         // Torrent events
@@ -20,12 +22,16 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             tracing::debug!(info_hash = ?info_hash, "Torrent added",);
 
             let _unused = stats_repository
-                .increment_gauge(&metric_name!(TORRENT_REPOSITORY_TORRENTS_TOTAL), &LabelSet::default(), now)
+                .increment_gauge(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
+                    &LabelSet::default(),
+                    now,
+                )
                 .await;
 
             let _unused = stats_repository
                 .increment_counter(
-                    &metric_name!(TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL),
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL),
                     &LabelSet::default(),
                     now,
                 )
@@ -35,12 +41,16 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             tracing::debug!(info_hash = ?info_hash, "Torrent removed",);
 
             let _unused = stats_repository
-                .decrement_gauge(&metric_name!(TORRENT_REPOSITORY_TORRENTS_TOTAL), &LabelSet::default(), now)
+                .decrement_gauge(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
+                    &LabelSet::default(),
+                    now,
+                )
                 .await;
 
             let _unused = stats_repository
                 .increment_counter(
-                    &metric_name!(TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL),
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL),
                     &LabelSet::default(),
                     now,
                 )
@@ -54,11 +64,15 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             let label_set = label_set_for_peer(&peer);
 
             let _unused = stats_repository
-                .increment_gauge(&metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL), &label_set, now)
+                .increment_gauge(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+                    &label_set,
+                    now,
+                )
                 .await;
 
             let _unused = stats_repository
-                .increment_counter(&metric_name!(TORRENT_REPOSITORY_PEERS_ADDED_TOTAL), &label_set, now)
+                .increment_counter(&metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL), &label_set, now)
                 .await;
         }
         Event::PeerRemoved { info_hash, peer } => {
@@ -67,11 +81,19 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             let label_set = label_set_for_peer(&peer);
 
             let _unused = stats_repository
-                .decrement_gauge(&metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL), &label_set, now)
+                .decrement_gauge(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+                    &label_set,
+                    now,
+                )
                 .await;
 
             let _unused = stats_repository
-                .increment_counter(&metric_name!(TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL), &label_set, now)
+                .increment_counter(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL),
+                    &label_set,
+                    now,
+                )
                 .await;
         }
         Event::PeerUpdated {
@@ -84,7 +106,7 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             if old_peer.role() != new_peer.role() {
                 let _unused = stats_repository
                     .increment_gauge(
-                        &metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL),
+                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
                         &label_set_for_peer(&new_peer),
                         now,
                     )
@@ -92,7 +114,7 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
 
                 let _unused = stats_repository
                     .decrement_gauge(
-                        &metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL),
+                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
                         &label_set_for_peer(&old_peer),
                         now,
                     )
@@ -102,7 +124,11 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
             let label_set = label_set_for_peer(&new_peer);
 
             let _unused = stats_repository
-                .increment_counter(&metric_name!(TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL), &label_set, now)
+                .increment_counter(
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
+                    &label_set,
+                    now,
+                )
                 .await;
         }
         Event::PeerDownloadCompleted { info_hash, peer } => {
@@ -110,7 +136,7 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
 
             let _unused = stats_repository
                 .increment_counter(
-                    &metric_name!(TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL),
+                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL),
                     &label_set_for_peer(&peer),
                     now,
                 )
@@ -217,7 +243,8 @@ mod tests {
         use crate::statistics::event::handler::tests::{expect_counter_metric_to_be, expect_gauge_metric_to_be};
         use crate::statistics::repository::Repository;
         use crate::statistics::{
-            TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL, TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL, TORRENT_REPOSITORY_TORRENTS_TOTAL,
+            SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL,
+            SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL,
         };
         use crate::tests::{sample_info_hash, sample_peer};
         use crate::CurrentClock;
@@ -240,7 +267,7 @@ mod tests {
 
             expect_gauge_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_TORRENTS_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
                 &LabelSet::default(),
                 1.0,
             )
@@ -252,7 +279,7 @@ mod tests {
             clock::Stopped::local_set_to_unix_epoch();
 
             let stats_repository = Arc::new(Repository::new());
-            let metric_name = metric_name!(TORRENT_REPOSITORY_TORRENTS_TOTAL);
+            let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL);
             let label_set = LabelSet::default();
 
             // Increment the gauge first to simulate a torrent being added.
@@ -291,7 +318,7 @@ mod tests {
 
             expect_counter_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL),
                 &LabelSet::default(),
                 1,
             )
@@ -315,7 +342,7 @@ mod tests {
 
             expect_counter_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL),
                 &LabelSet::default(),
                 1,
             )
@@ -335,7 +362,8 @@ mod tests {
         use crate::statistics::event::handler::{handle_event, label_set_for_peer};
         use crate::statistics::repository::Repository;
         use crate::statistics::{
-            TORRENT_REPOSITORY_PEERS_ADDED_TOTAL, TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL, TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL,
+            SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL,
+            SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL,
         };
         use crate::tests::{sample_info_hash, sample_peer};
         use crate::CurrentClock;
@@ -357,7 +385,7 @@ mod tests {
                 expect_gauge_metric_to_be, get_gauge_metric, make_opposite_role_peer, make_peer,
             };
             use crate::statistics::repository::Repository;
-            use crate::statistics::TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL;
+            use crate::statistics::SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL;
             use crate::tests::sample_info_hash;
             use crate::CurrentClock;
 
@@ -373,7 +401,7 @@ mod tests {
                 let peer = make_peer(role);
 
                 let stats_repository = Arc::new(Repository::new());
-                let metric_name = metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL);
+                let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL);
                 let label_set = (label_name!("peer_role"), LabelValue::new(&role.to_string())).into();
 
                 handle_event(
@@ -402,7 +430,7 @@ mod tests {
 
                 let stats_repository = Arc::new(Repository::new());
 
-                let metric_name = metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL);
+                let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL);
                 let label_set = (label_name!("peer_role"), LabelValue::new(&role.to_string())).into();
 
                 // Increment the gauge first to simulate a peer being added.
@@ -438,7 +466,7 @@ mod tests {
                 let old_peer = make_peer(old_role);
                 let new_peer = make_opposite_role_peer(&old_peer);
 
-                let metric_name = metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL);
+                let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL);
                 let old_role_label_set = (label_name!("peer_role"), LabelValue::new(&old_peer.role().to_string())).into();
                 let new_role_label_set = (label_name!("peer_role"), LabelValue::new(&new_peer.role().to_string())).into();
 
@@ -497,7 +525,7 @@ mod tests {
 
             expect_counter_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_PEERS_ADDED_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL),
                 &label_set_for_peer(&peer),
                 1,
             )
@@ -524,7 +552,7 @@ mod tests {
 
             expect_counter_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL),
                 &label_set_for_peer(&peer),
                 1,
             )
@@ -552,7 +580,7 @@ mod tests {
 
             expect_counter_metric_to_be(
                 &stats_repository,
-                &metric_name!(TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL),
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
                 &label_set_for_peer(&new_peer),
                 1,
             )
@@ -574,7 +602,7 @@ mod tests {
             use crate::statistics::event::handler::handle_event;
             use crate::statistics::event::handler::tests::{expect_counter_metric_to_be, make_peer};
             use crate::statistics::repository::Repository;
-            use crate::statistics::TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL;
+            use crate::statistics::SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL;
             use crate::tests::sample_info_hash;
             use crate::CurrentClock;
 
@@ -590,7 +618,7 @@ mod tests {
                 let peer = make_peer(role);
 
                 let stats_repository = Arc::new(Repository::new());
-                let metric_name = metric_name!(TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL);
+                let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL);
                 let label_set = (label_name!("peer_role"), LabelValue::new(&role.to_string())).into();
 
                 handle_event(

--- a/packages/swarm-coordination-registry/src/statistics/event/handler.rs
+++ b/packages/swarm-coordination-registry/src/statistics/event/handler.rs
@@ -8,10 +8,11 @@ use torrust_tracker_primitives::DurationSinceUnixEpoch;
 use crate::event::Event;
 use crate::statistics::repository::Repository;
 use crate::statistics::{
-    SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL,
-    SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL, SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL,
-    SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL,
-    SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL,
+    SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL,
+    SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL,
+    SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL,
+    SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL, SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL,
+    SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL,
 };
 
 #[allow(clippy::too_many_lines)]
@@ -103,6 +104,8 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
         } => {
             tracing::debug!(info_hash = ?info_hash, old_peer = ?old_peer, new_peer = ?new_peer, "Peer updated", );
 
+            // If the peer's role has changed, we need to adjust the number of
+            // connections
             if old_peer.role() != new_peer.role() {
                 let _unused = stats_repository
                     .increment_gauge(
@@ -121,6 +124,20 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
                     .await;
             }
 
+            // If the peer reverted from a completed state to any other state,
+            // we need to increment the counter for reverted completed.
+            if old_peer.is_completed() && !new_peer.is_completed() {
+                let _unused = stats_repository
+                    .increment_counter(
+                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL),
+                        &LabelSet::default(),
+                        now,
+                    )
+                    .await;
+            }
+
+            // Regardless of the role change, we still need to increment the
+            // counter for updated peers.
             let label_set = label_set_for_peer(&new_peer);
 
             let _unused = stats_repository
@@ -134,7 +151,7 @@ pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now:
         Event::PeerDownloadCompleted { info_hash, peer } => {
             tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer download completed", );
 
-            let _unused = stats_repository
+            let _unused: Result<(), torrust_tracker_metrics::metric_collection::Error> = stats_repository
                 .increment_counter(
                     &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL),
                     &label_set_for_peer(&peer),

--- a/packages/swarm-coordination-registry/src/statistics/event/listener.rs
+++ b/packages/swarm-coordination-registry/src/statistics/event/listener.rs
@@ -7,18 +7,18 @@ use torrust_tracker_events::receiver::RecvError;
 use super::handler::handle_event;
 use crate::event::receiver::Receiver;
 use crate::statistics::repository::Repository;
-use crate::{CurrentClock, TORRENT_REPOSITORY_LOG_TARGET};
+use crate::{CurrentClock, SWARM_COORDINATION_REGISTRY_LOG_TARGET};
 
 #[must_use]
 pub fn run_event_listener(receiver: Receiver, repository: &Arc<Repository>) -> JoinHandle<()> {
     let stats_repository = repository.clone();
 
-    tracing::info!(target: TORRENT_REPOSITORY_LOG_TARGET, "Starting torrent repository event listener");
+    tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Starting torrent repository event listener");
 
     tokio::spawn(async move {
         dispatch_events(receiver, stats_repository).await;
 
-        tracing::info!(target: TORRENT_REPOSITORY_LOG_TARGET, "Torrent repository listener finished");
+        tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Torrent repository listener finished");
     })
 }
 
@@ -32,7 +32,7 @@ async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repositor
             biased;
 
             _ = &mut shutdown_signal => {
-                tracing::info!(target: TORRENT_REPOSITORY_LOG_TARGET, "Received Ctrl+C, shutting down torrent repository event listener.");
+                tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Received Ctrl+C, shutting down torrent repository event listener.");
                 break;
             }
 
@@ -42,11 +42,11 @@ async fn dispatch_events(mut receiver: Receiver, stats_repository: Arc<Repositor
                     Err(e) => {
                         match e {
                             RecvError::Closed => {
-                                tracing::info!(target: TORRENT_REPOSITORY_LOG_TARGET, "Torrent repository event receiver closed.");
+                                tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Torrent repository event receiver closed.");
                                 break;
                             }
                             RecvError::Lagged(n) => {
-                                tracing::warn!(target: TORRENT_REPOSITORY_LOG_TARGET, "Torrent repository event receiver lagged by {} events.", n);
+                                tracing::warn!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Torrent repository event receiver lagged by {} events.", n);
                             }
                         }
                     }

--- a/packages/swarm-coordination-registry/src/statistics/mod.rs
+++ b/packages/swarm-coordination-registry/src/statistics/mod.rs
@@ -10,22 +10,22 @@ use torrust_tracker_metrics::unit::Unit;
 
 // Torrent metrics
 
-const TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL: &str = "torrent_repository_torrents_added_total";
-const TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL: &str = "torrent_repository_torrents_removed_total";
+const SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL: &str = "swarm_coordination_registry_torrents_added_total";
+const SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL: &str = "swarm_coordination_registry_torrents_removed_total";
 
-const TORRENT_REPOSITORY_TORRENTS_TOTAL: &str = "torrent_repository_torrents_total";
-const TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL: &str = "torrent_repository_torrents_downloads_total";
-const TORRENT_REPOSITORY_TORRENTS_INACTIVE_TOTAL: &str = "torrent_repository_torrents_inactive_total";
+const SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL: &str = "swarm_coordination_registry_torrents_total";
+const SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL: &str = "swarm_coordination_registry_torrents_downloads_total";
+const SWARM_COORDINATION_REGISTRY_TORRENTS_INACTIVE_TOTAL: &str = "swarm_coordination_registry_torrents_inactive_total";
 
 // Peers metrics
 
-const TORRENT_REPOSITORY_PEERS_ADDED_TOTAL: &str = "torrent_repository_peers_added_total";
-const TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL: &str = "torrent_repository_peers_removed_total";
-const TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL: &str = "torrent_repository_peers_updated_total";
+const SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL: &str = "swarm_coordination_registry_peers_added_total";
+const SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL: &str = "swarm_coordination_registry_peers_removed_total";
+const SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL: &str = "swarm_coordination_registry_peers_updated_total";
 
-const TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL: &str = "torrent_repository_peer_connections_total";
-const TORRENT_REPOSITORY_UNIQUE_PEERS_TOTAL: &str = "torrent_repository_unique_peers_total"; // todo: not implemented yet
-const TORRENT_REPOSITORY_PEERS_INACTIVE_TOTAL: &str = "torrent_repository_peers_inactive_total";
+const SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL: &str = "swarm_coordination_registry_peer_connections_total";
+const SWARM_COORDINATION_REGISTRY_UNIQUE_PEERS_TOTAL: &str = "swarm_coordination_registry_unique_peers_total"; // todo: not implemented yet
+const SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL: &str = "swarm_coordination_registry_peers_inactive_total";
 
 #[must_use]
 pub fn describe_metrics() -> Metrics {
@@ -34,31 +34,31 @@ pub fn describe_metrics() -> Metrics {
     // Torrent metrics
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_TORRENTS_ADDED_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of torrents added.")),
     );
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_TORRENTS_REMOVED_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of torrents removed.")),
     );
 
     metrics.metric_collection.describe_gauge(
-        &metric_name!(TORRENT_REPOSITORY_TORRENTS_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of torrents.")),
     );
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_TORRENTS_DOWNLOADS_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of torrent downloads.")),
     );
 
     metrics.metric_collection.describe_gauge(
-        &metric_name!(TORRENT_REPOSITORY_TORRENTS_INACTIVE_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_INACTIVE_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of inactive torrents.")),
     );
@@ -66,25 +66,25 @@ pub fn describe_metrics() -> Metrics {
     // Peers metrics
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_PEERS_ADDED_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of peers added.")),
     );
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_PEERS_REMOVED_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of peers removed.")),
     );
 
     metrics.metric_collection.describe_counter(
-        &metric_name!(TORRENT_REPOSITORY_PEERS_UPDATED_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of peers updated.")),
     );
 
     metrics.metric_collection.describe_gauge(
-        &metric_name!(TORRENT_REPOSITORY_PEER_CONNECTIONS_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new(
             "The total number of peer connections (one connection per torrent).",
@@ -92,13 +92,13 @@ pub fn describe_metrics() -> Metrics {
     );
 
     metrics.metric_collection.describe_gauge(
-        &metric_name!(TORRENT_REPOSITORY_UNIQUE_PEERS_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_UNIQUE_PEERS_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of unique peers.")),
     );
 
     metrics.metric_collection.describe_gauge(
-        &metric_name!(TORRENT_REPOSITORY_PEERS_INACTIVE_TOTAL),
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of inactive peers.")),
     );

--- a/packages/swarm-coordination-registry/src/statistics/mod.rs
+++ b/packages/swarm-coordination-registry/src/statistics/mod.rs
@@ -26,6 +26,8 @@ const SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL: &str = "swarm_coordinatio
 const SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL: &str = "swarm_coordination_registry_peer_connections_total";
 const SWARM_COORDINATION_REGISTRY_UNIQUE_PEERS_TOTAL: &str = "swarm_coordination_registry_unique_peers_total"; // todo: not implemented yet
 const SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL: &str = "swarm_coordination_registry_peers_inactive_total";
+const SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL: &str =
+    "swarm_coordination_registry_peers_completed_state_reverted_total";
 
 #[must_use]
 pub fn describe_metrics() -> Metrics {
@@ -101,6 +103,14 @@ pub fn describe_metrics() -> Metrics {
         &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_INACTIVE_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("The total number of inactive peers.")),
+    );
+
+    metrics.metric_collection.describe_counter(
+        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL),
+        Some(Unit::Count),
+        Some(MetricDescription::new(
+            "The total number of peers whose completed state was reverted.",
+        )),
     );
 
     metrics

--- a/packages/tracker-core/src/container.rs
+++ b/packages/tracker-core/src/container.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use torrust_tracker_configuration::Core;
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 use crate::announce_handler::AnnounceHandler;
 use crate::authentication::handler::KeysHandler;
@@ -38,7 +38,10 @@ pub struct TrackerCoreContainer {
 
 impl TrackerCoreContainer {
     #[must_use]
-    pub fn initialize_from(core_config: &Arc<Core>, torrent_repository_container: &Arc<TorrentRepositoryContainer>) -> Self {
+    pub fn initialize_from(
+        core_config: &Arc<Core>,
+        torrent_repository_container: &Arc<SwarmCoordinationRegistryContainer>,
+    ) -> Self {
         let database = initialize_database(core_config);
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
         let whitelist_authorization = Arc::new(WhitelistAuthorization::new(core_config, &in_memory_whitelist.clone()));

--- a/packages/tracker-core/src/container.rs
+++ b/packages/tracker-core/src/container.rs
@@ -40,7 +40,7 @@ impl TrackerCoreContainer {
     #[must_use]
     pub fn initialize_from(
         core_config: &Arc<Core>,
-        torrent_repository_container: &Arc<SwarmCoordinationRegistryContainer>,
+        swarm_coordination_registry_container: &Arc<SwarmCoordinationRegistryContainer>,
     ) -> Self {
         let database = initialize_database(core_config);
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
@@ -53,7 +53,9 @@ impl TrackerCoreContainer {
             &db_key_repository.clone(),
             &in_memory_key_repository.clone(),
         ));
-        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::new(torrent_repository_container.swarms.clone()));
+        let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::new(
+            swarm_coordination_registry_container.swarms.clone(),
+        ));
         let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&database));
 
         let torrents_manager = Arc::new(TorrentsManager::new(

--- a/packages/tracker-core/src/statistics/persisted/downloads.rs
+++ b/packages/tracker-core/src/statistics/persisted/downloads.rs
@@ -7,7 +7,7 @@ use torrust_tracker_primitives::{NumberOfDownloads, NumberOfDownloadsBTreeMap};
 use crate::databases::error::Error;
 use crate::databases::Database;
 
-/// Torrent repository implementation that persists torrent metrics in a database.
+/// It persists torrent metrics in a database.
 ///
 /// This repository persists only a subset of the torrent data: the torrent
 /// metrics, specifically the number of downloads (or completed counts) for each

--- a/packages/tracker-core/tests/common/test_env.rs
+++ b/packages/tracker-core/tests/common/test_env.rs
@@ -14,10 +14,10 @@ use torrust_tracker_primitives::core::{AnnounceData, ScrapeData};
 use torrust_tracker_primitives::peer::Peer;
 use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
 use torrust_tracker_primitives::DurationSinceUnixEpoch;
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 pub struct TestEnv {
-    pub torrent_repository_container: Arc<TorrentRepositoryContainer>,
+    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
     pub tracker_core_container: Arc<TrackerCoreContainer>,
 }
 
@@ -33,7 +33,7 @@ impl TestEnv {
     pub fn new(core_config: Core) -> Self {
         let core_config = Arc::new(core_config);
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/packages/tracker-core/tests/common/test_env.rs
+++ b/packages/tracker-core/tests/common/test_env.rs
@@ -17,7 +17,7 @@ use torrust_tracker_primitives::DurationSinceUnixEpoch;
 use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 pub struct TestEnv {
-    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
+    pub swarm_coordination_registry_container: Arc<SwarmCoordinationRegistryContainer>,
     pub tracker_core_container: Arc<TrackerCoreContainer>,
 }
 
@@ -33,17 +33,17 @@ impl TestEnv {
     pub fn new(core_config: Core) -> Self {
         let core_config = Arc::new(core_config);
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         Self {
-            torrent_repository_container,
+            swarm_coordination_registry_container,
             tracker_core_container,
         }
     }
@@ -68,13 +68,13 @@ impl TestEnv {
         let mut jobs = vec![];
 
         let job = torrust_tracker_swarm_coordination_registry::statistics::event::listener::run_event_listener(
-            self.torrent_repository_container.event_bus.receiver(),
-            &self.torrent_repository_container.stats_repository,
+            self.swarm_coordination_registry_container.event_bus.receiver(),
+            &self.swarm_coordination_registry_container.stats_repository,
         );
         jobs.push(job);
 
         let job = bittorrent_tracker_core::statistics::event::listener::run_event_listener(
-            self.torrent_repository_container.event_bus.receiver(),
+            self.swarm_coordination_registry_container.event_bus.receiver(),
             &self.tracker_core_container.stats_repository,
             &self.tracker_core_container.db_downloads_metric_repository,
             self.tracker_core_container
@@ -147,7 +147,7 @@ impl TestEnv {
     }
 
     pub async fn get_swarm_metadata(&self, info_hash: &InfoHash) -> Option<SwarmMetadata> {
-        self.torrent_repository_container
+        self.swarm_coordination_registry_container
             .swarms
             .get_swarm_metadata(info_hash)
             .await
@@ -155,7 +155,11 @@ impl TestEnv {
     }
 
     pub async fn remove_swarm(&self, info_hash: &InfoHash) {
-        self.torrent_repository_container.swarms.remove(info_hash).await.unwrap();
+        self.swarm_coordination_registry_container
+            .swarms
+            .remove(info_hash)
+            .await
+            .unwrap();
     }
 
     pub async fn get_counter_value(&self, metric_name: &str) -> u64 {

--- a/packages/udp-tracker-core/src/container.rs
+++ b/packages/udp-tracker-core/src/container.rs
@@ -32,13 +32,13 @@ pub struct UdpTrackerCoreContainer {
 impl UdpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Arc<UdpTrackerCoreContainer> {
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         Self::initialize_from_tracker_core(&tracker_core_container, udp_tracker_config)

--- a/packages/udp-tracker-core/src/container.rs
+++ b/packages/udp-tracker-core/src/container.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bittorrent_tracker_core::container::TrackerCoreContainer;
 use tokio::sync::RwLock;
 use torrust_tracker_configuration::{Core, UdpTracker};
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 use crate::event::bus::EventBus;
 use crate::event::sender::Broadcaster;
@@ -32,7 +32,7 @@ pub struct UdpTrackerCoreContainer {
 impl UdpTrackerCoreContainer {
     #[must_use]
     pub fn initialize(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Arc<UdpTrackerCoreContainer> {
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/packages/udp-tracker-server/src/environment.rs
+++ b/packages/udp-tracker-server/src/environment.rs
@@ -175,13 +175,13 @@ impl EnvContainer {
         let udp_tracker_configurations = configuration.udp_trackers.clone().expect("missing UDP tracker configuration");
         let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         let udp_tracker_core_container =

--- a/packages/udp-tracker-server/src/environment.rs
+++ b/packages/udp-tracker-server/src/environment.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinHandle;
 use torrust_server_lib::registar::Registar;
 use torrust_tracker_configuration::{logging, Configuration, DEFAULT_TIMEOUT};
 use torrust_tracker_primitives::peer;
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 
 use crate::container::UdpTrackerServerContainer;
 use crate::server::spawner::Spawner;
@@ -175,7 +175,7 @@ impl EnvContainer {
         let udp_tracker_configurations = configuration.udp_trackers.clone().expect("missing UDP tracker configuration");
         let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -71,7 +71,7 @@ async fn load_data_from_database(config: &Configuration, app_container: &Arc<App
 async fn start_jobs(config: &Configuration, app_container: &Arc<AppContainer>) -> JobManager {
     let mut job_manager = JobManager::new();
 
-    start_torrent_repository_event_listener(config, app_container, &mut job_manager);
+    start_swarm_coordination_registry_event_listener(config, app_container, &mut job_manager);
     start_tracker_core_event_listener(config, app_container, &mut job_manager);
     start_http_core_event_listener(config, app_container, &mut job_manager);
     start_udp_core_event_listener(config, app_container, &mut job_manager);
@@ -132,13 +132,13 @@ async fn load_torrent_metrics(config: &Configuration, app_container: &Arc<AppCon
     }
 }
 
-fn start_torrent_repository_event_listener(
+fn start_swarm_coordination_registry_event_listener(
     config: &Configuration,
     app_container: &Arc<AppContainer>,
     job_manager: &mut JobManager,
 ) {
     job_manager.push_opt(
-        "torrent_repository_event_listener",
+        "swarm_coordination_registry_event_listener",
         jobs::torrent_repository::start_event_listener(config, app_container),
     );
 }

--- a/src/bootstrap/jobs/activity_metrics_updater.rs
+++ b/src/bootstrap/jobs/activity_metrics_updater.rs
@@ -12,8 +12,8 @@ use crate::CurrentClock;
 #[must_use]
 pub fn start_job(config: &Configuration, app_container: &Arc<AppContainer>) -> JoinHandle<()> {
     torrust_tracker_swarm_coordination_registry::statistics::activity_metrics_updater::start_job(
-        &app_container.torrent_repository_container.swarms.clone(),
-        &app_container.torrent_repository_container.stats_repository.clone(),
+        &app_container.swarm_coordination_registry_container.swarms.clone(),
+        &app_container.swarm_coordination_registry_container.stats_repository.clone(),
         peer_inactivity_cutoff_timestamp(config.core.tracker_policy.max_peer_timeout),
     )
 }

--- a/src/bootstrap/jobs/torrent_repository.rs
+++ b/src/bootstrap/jobs/torrent_repository.rs
@@ -8,8 +8,8 @@ use crate::container::AppContainer;
 pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) -> Option<JoinHandle<()>> {
     if config.core.tracker_usage_statistics {
         let job = torrust_tracker_swarm_coordination_registry::statistics::event::listener::run_event_listener(
-            app_container.torrent_repository_container.event_bus.receiver(),
-            &app_container.torrent_repository_container.stats_repository,
+            app_container.swarm_coordination_registry_container.event_bus.receiver(),
+            &app_container.swarm_coordination_registry_container.stats_repository,
         );
 
         Some(job)

--- a/src/bootstrap/jobs/tracker_core.rs
+++ b/src/bootstrap/jobs/tracker_core.rs
@@ -8,7 +8,7 @@ use crate::container::AppContainer;
 pub fn start_event_listener(config: &Configuration, app_container: &Arc<AppContainer>) -> Option<JoinHandle<()>> {
     if config.core.tracker_usage_statistics || config.core.tracker_policy.persistent_torrent_completed_stat {
         let job = bittorrent_tracker_core::statistics::event::listener::run_event_listener(
-            app_container.torrent_repository_container.event_bus.receiver(),
+            app_container.swarm_coordination_registry_container.event_bus.receiver(),
             &app_container.tracker_core_container.stats_repository,
             &app_container.tracker_core_container.db_downloads_metric_repository,
             app_container

--- a/src/container.rs
+++ b/src/container.rs
@@ -30,7 +30,7 @@ pub struct AppContainer {
     pub registar: Arc<Registar>,
 
     // Torrent Repository
-    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
+    pub swarm_coordination_registry_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Core
     pub tracker_core_container: Arc<TrackerCoreContainer>,
@@ -60,7 +60,7 @@ impl AppContainer {
 
         // Torrent Repository
 
-        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
+        let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
@@ -68,7 +68,7 @@ impl AppContainer {
 
         let tracker_core_container = Arc::new(TrackerCoreContainer::initialize_from(
             &core_config,
-            &torrent_repository_container,
+            &swarm_coordination_registry_container,
         ));
 
         // HTTP
@@ -98,7 +98,7 @@ impl AppContainer {
             registar,
 
             // Torrent Repository
-            torrent_repository_container,
+            swarm_coordination_registry_container,
 
             // Core
             tracker_core_container,
@@ -146,7 +146,7 @@ impl AppContainer {
         TrackerHttpApiCoreContainer {
             http_api_config: http_api_config.clone(),
 
-            torrent_repository_container: self.torrent_repository_container.clone(),
+            swarm_coordination_registry_container: self.swarm_coordination_registry_container.clone(),
 
             tracker_core_container: self.tracker_core_container.clone(),
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -9,7 +9,7 @@ use bittorrent_udp_tracker_core::{self};
 use torrust_rest_tracker_api_core::container::TrackerHttpApiCoreContainer;
 use torrust_server_lib::registar::Registar;
 use torrust_tracker_configuration::{Configuration, HttpApi};
-use torrust_tracker_swarm_coordination_registry::container::TorrentRepositoryContainer;
+use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 use torrust_udp_tracker_server::container::UdpTrackerServerContainer;
 use tracing::instrument;
 
@@ -30,7 +30,7 @@ pub struct AppContainer {
     pub registar: Arc<Registar>,
 
     // Torrent Repository
-    pub torrent_repository_container: Arc<TorrentRepositoryContainer>,
+    pub torrent_repository_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Core
     pub tracker_core_container: Arc<TrackerCoreContainer>,
@@ -60,7 +60,7 @@ impl AppContainer {
 
         // Torrent Repository
 
-        let torrent_repository_container = Arc::new(TorrentRepositoryContainer::initialize(
+        let torrent_repository_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -29,7 +29,7 @@ pub struct AppContainer {
     // Registar
     pub registar: Arc<Registar>,
 
-    // Torrent Repository
+    // Swarm Coordination Registry Container
     pub swarm_coordination_registry_container: Arc<SwarmCoordinationRegistryContainer>,
 
     // Core
@@ -58,7 +58,7 @@ impl AppContainer {
 
         let registar = Arc::new(Registar::default());
 
-        // Torrent Repository
+        // Swarm Coordination Registry Container
 
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
@@ -97,7 +97,7 @@ impl AppContainer {
             // Registar
             registar,
 
-            // Torrent Repository
+            // Swarm Coordination Registry Container
             swarm_coordination_registry_container,
 
             // Core


### PR DESCRIPTION
Add a new metric to count peers reverting the `Completed` state.

### Subtasks

- Refactor `swarm-coordination-registry` package: rename types, variables, and constants to follow the package's new name.
- Add the new metric: `swarm_coordination_registry_peers_completed_state_reverted_total`