### PR TITLE
Overhaul stats: Add new metric to the `metrics` endpoint with the current number of banned IPs

### DIFF
--- a/packages/udp-tracker-server/src/banning/event/handler.rs
+++ b/packages/udp-tracker-server/src/banning/event/handler.rs
@@ -2,11 +2,20 @@ use std::sync::Arc;
 
 use bittorrent_udp_tracker_core::services::banning::BanService;
 use tokio::sync::RwLock;
+use torrust_tracker_metrics::label::LabelSet;
+use torrust_tracker_metrics::metric_name;
 use torrust_tracker_primitives::DurationSinceUnixEpoch;
 
 use crate::event::{ErrorKind, Event};
+use crate::statistics::repository::Repository;
+use crate::statistics::UDP_TRACKER_SERVER_IPS_BANNED_TOTAL;
 
-pub async fn handle_event(event: Event, ban_service: &Arc<RwLock<BanService>>, _now: DurationSinceUnixEpoch) {
+pub async fn handle_event(
+    event: Event,
+    ban_service: &Arc<RwLock<BanService>>,
+    repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
     if let Event::UdpError {
         context,
         kind: _,
@@ -14,6 +23,25 @@ pub async fn handle_event(event: Event, ban_service: &Arc<RwLock<BanService>>, _
     } = event
     {
         let mut ban_service = ban_service.write().await;
+
         ban_service.increase_counter(&context.client_socket_addr().ip());
+
+        update_metric_for_banned_ips_total(repository, ban_service.get_banned_ips_total(), now).await;
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+async fn update_metric_for_banned_ips_total(repository: &Repository, ips_banned_total: usize, now: DurationSinceUnixEpoch) {
+    match repository
+        .set_gauge(
+            &metric_name!(UDP_TRACKER_SERVER_IPS_BANNED_TOTAL),
+            &LabelSet::default(),
+            ips_banned_total as f64,
+            now,
+        )
+        .await
+    {
+        Ok(()) => {}
+        Err(err) => tracing::error!("Failed to increase the counter: {}", err),
     }
 }

--- a/packages/udp-tracker-server/src/banning/event/listener.rs
+++ b/packages/udp-tracker-server/src/banning/event/listener.rs
@@ -9,22 +9,28 @@ use torrust_tracker_events::receiver::RecvError;
 
 use super::handler::handle_event;
 use crate::event::receiver::Receiver;
+use crate::statistics::repository::Repository;
 use crate::CurrentClock;
 
 #[must_use]
-pub fn run_event_listener(receiver: Receiver, ban_service: &Arc<RwLock<BanService>>) -> JoinHandle<()> {
+pub fn run_event_listener(
+    receiver: Receiver,
+    ban_service: &Arc<RwLock<BanService>>,
+    repository: &Arc<Repository>,
+) -> JoinHandle<()> {
     let ban_service_clone = ban_service.clone();
+    let repository_clone = repository.clone();
 
     tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Starting UDP tracker server event listener (banning)");
 
     tokio::spawn(async move {
-        dispatch_events(receiver, ban_service_clone).await;
+        dispatch_events(receiver, ban_service_clone, repository_clone).await;
 
         tracing::info!(target: UDP_TRACKER_LOG_TARGET, "UDP tracker server event listener (banning) finished");
     })
 }
 
-async fn dispatch_events(mut receiver: Receiver, ban_service: Arc<RwLock<BanService>>) {
+async fn dispatch_events(mut receiver: Receiver, ban_service: Arc<RwLock<BanService>>, repository: Arc<Repository>) {
     let shutdown_signal = tokio::signal::ctrl_c();
     tokio::pin!(shutdown_signal);
 
@@ -39,7 +45,7 @@ async fn dispatch_events(mut receiver: Receiver, ban_service: Arc<RwLock<BanServ
 
             result = receiver.recv() => {
                 match result {
-                    Ok(event) => handle_event(event, &ban_service, CurrentClock::now()).await,
+                    Ok(event) => handle_event(event, &ban_service, &repository, CurrentClock::now()).await,
                     Err(e) => {
                         match e {
                             RecvError::Closed => {

--- a/packages/udp-tracker-server/src/environment.rs
+++ b/packages/udp-tracker-server/src/environment.rs
@@ -73,6 +73,7 @@ impl Environment<Stopped> {
         let udp_server_banning_event_listener_job = Some(crate::banning::event::listener::run_event_listener(
             self.container.udp_tracker_server_container.event_bus.receiver(),
             &self.container.udp_tracker_core_container.ban_service,
+            &self.container.udp_tracker_server_container.stats_repository,
         ));
 
         // Start the UDP tracker server

--- a/packages/udp-tracker-server/src/statistics/mod.rs
+++ b/packages/udp-tracker-server/src/statistics/mod.rs
@@ -10,6 +10,7 @@ use torrust_tracker_metrics::unit::Unit;
 
 const UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL: &str = "udp_tracker_server_requests_aborted_total";
 const UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL: &str = "udp_tracker_server_requests_banned_total";
+pub(crate) const UDP_TRACKER_SERVER_IPS_BANNED_TOTAL: &str = "udp_tracker_server_ips_banned_total";
 const UDP_TRACKER_SERVER_CONNECTION_ID_ERRORS_TOTAL: &str = "udp_tracker_server_connection_id_errors_total";
 const UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL: &str = "udp_tracker_server_requests_received_total";
 const UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL: &str = "udp_tracker_server_requests_accepted_total";
@@ -31,6 +32,12 @@ pub fn describe_metrics() -> Metrics {
         &metric_name!(UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL),
         Some(Unit::Count),
         Some(MetricDescription::new("Total number of UDP requests banned")),
+    );
+
+    metrics.metric_collection.describe_gauge(
+        &metric_name!(UDP_TRACKER_SERVER_IPS_BANNED_TOTAL),
+        Some(Unit::Count),
+        Some(MetricDescription::new("Total number of IPs banned from UDP requests")),
     );
 
     metrics.metric_collection.describe_counter(

--- a/src/bootstrap/jobs/udp_tracker_server.rs
+++ b/src/bootstrap/jobs/udp_tracker_server.rs
@@ -23,5 +23,6 @@ pub fn start_banning_event_listener(app_container: &Arc<AppContainer>) -> JoinHa
     torrust_udp_tracker_server::banning::event::listener::run_event_listener(
         app_container.udp_tracker_server_container.event_bus.receiver(),
         &app_container.udp_tracker_core_services.ban_service,
+        &app_container.udp_tracker_server_container.stats_repository,
     )
 }


### PR DESCRIPTION
Add a new metric to the `metrics` endpoint with the current number of banned IPs.