### PR TITLE
Add debug logs for average processing time metric update

### DIFF
--- a/packages/udp-tracker-server/src/statistics/event/handler/response_sent.rs
+++ b/packages/udp-tracker-server/src/statistics/event/handler/response_sent.rs
@@ -19,6 +19,9 @@ pub async fn handle_event(
                 let new_avg = stats_repository
                     .recalculate_udp_avg_connect_processing_time_ns(req_processing_time)
                     .await;
+
+                tracing::debug!("Updating average processing time metric for connect requests: {} ns", new_avg);
+
                 let mut label_set = LabelSet::from(context.clone());
                 label_set.upsert(label_name!("request_kind"), LabelValue::new(&req_kind.to_string()));
                 match stats_repository
@@ -39,6 +42,12 @@ pub async fn handle_event(
                 let new_avg = stats_repository
                     .recalculate_udp_avg_announce_processing_time_ns(req_processing_time)
                     .await;
+
+                tracing::debug!(
+                    "Updating average processing time metric for announce requests: {} ns",
+                    new_avg
+                );
+
                 let mut label_set = LabelSet::from(context.clone());
                 label_set.upsert(label_name!("request_kind"), LabelValue::new(&req_kind.to_string()));
                 match stats_repository
@@ -59,6 +68,9 @@ pub async fn handle_event(
                 let new_avg = stats_repository
                     .recalculate_udp_avg_scrape_processing_time_ns(req_processing_time)
                     .await;
+
+                tracing::debug!("Updating average processing time metric for scrape requests: {} ns", new_avg);
+
                 let mut label_set = LabelSet::from(context.clone());
                 label_set.upsert(label_name!("request_kind"), LabelValue::new(&req_kind.to_string()));
                 match stats_repository


### PR DESCRIPTION
Related to: https://github.com/torrust/torrust-tracker/issues/1589

Add more debug logs for the average processing time metric update.

I will deploy to the tracker demo and collect more data.