### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: compose
         name: Compose

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain
@@ -42,7 +42,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -59,13 +59,13 @@ jobs:
       # Triggered sub-workflow is not able to detect the original commit/PR which is available
       # in this workflow.
       - name: Store PR number
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: pr_number
           path: pr_number.txt
 
       - name: Store commit SHA
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: commit_sha
           path: commit_sha.txt
@@ -74,7 +74,7 @@ jobs:
       # is executed by a different workflow `upload_coverage.yml`. The reason for this
       # split is because `on.pull_request` workflows don't have access to secrets.
       - name: Store coverage report in artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: codecov_report
           path: ./codecov.json

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: sync
         name: Apply Labels from File

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain
@@ -44,7 +44,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain
@@ -119,7 +119,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: setup
         name: Setup Toolchain
@@ -173,7 +173,7 @@ jobs:
 
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - id: test
         name: Run E2E Tests

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: "Download existing coverage report"
         id: prepare_report
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             var fs = require('fs');

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "override_commit=$(<commit_sha.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
           path: repo_root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3484,9 +3484,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "101fec8d036f8d9d4a1e8ebf90d566d1d798f3b1aa379d2576a54a0d9acea5bd"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3494,9 +3494,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d93e596a829ebe00afa41c3a056e6308d6b8a4c7d869edf184e2c91b1ba564"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3507,9 +3507,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.2"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d7b7346e150de32340ae3390b8b3ffa37ad93ec31fb5dad86afe817619e4e7"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
 dependencies = [
  "prost",
 ]
@@ -5631,9 +5631,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",


### PR DESCRIPTION
## Summary

This PR consolidates several dependency updates from dependabot PRs.

### GitHub Actions Updates

- **actions/checkout**: v4 → v6 (PR #1622)
- **actions/upload-artifact**: v4 → v5 (PR #1621)
- **actions/github-script**: v7 → v8 (PR #1615)

### Cargo Dependencies Updates

- **tokio**: 1.45.1 → 1.48.0 (PR #1629)
- **reqwest**: 0.12.20 → 0.12.24 (PR #1630)
- **clap**: 4.5.40 → 4.5.53 (PR #1623)
- **tracing-subscriber**: 0.3.19 → 0.3.22 (PR #1614)
- **ringbuf**: 0.4.4 → 0.4.8 (PR #1604)
- **uuid**: 1.18.1 → 1.19.0
- Other transitive dependencies

### Not Included

- **zerocopy**: 0.7 → 0.8 (PR #1496) - Blocked by upstream dependency `aquatic_udp_protocol` which still uses zerocopy 0.7. See: https://github.com/greatest-ape/aquatic/issues/224

## Testing

All tests pass with the updated dependencies.

## Related PRs

Closes #1622, closes #1621, closes #1615, closes #1629, closes #1630, closes #1623, closes #1614, closes #1604