### PR TITLE
fix: upgrade to Debian 13 (Trixie) to resolve security vulnerabilities [#1628]

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -3,13 +3,13 @@
 # Torrust Tracker
 
 ## Builder Image
-FROM docker.io/library/rust:bookworm AS chef
+FROM docker.io/library/rust:trixie AS chef
 WORKDIR /tmp
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 RUN cargo binstall --no-confirm cargo-chef cargo-nextest
 
 ## Tester Image
-FROM docker.io/library/rust:slim-bookworm AS tester
+FROM docker.io/library/rust:slim-trixie AS tester
 WORKDIR /tmp
 
 RUN apt-get update; apt-get install -y curl sqlite3; apt-get autoclean
@@ -21,7 +21,7 @@ RUN mkdir -p /app/share/torrust/default/database/; \
     sqlite3 /app/share/torrust/default/database/tracker.sqlite3.db  "VACUUM;"
 
 ## Su Exe Compile
-FROM docker.io/library/gcc:bookworm AS gcc
+FROM docker.io/library/gcc:trixie AS gcc
 COPY ./contrib/dev-tools/su-exec/ /usr/local/src/su-exec/
 RUN cc -Wall -Werror -g /usr/local/src/su-exec/su-exec.c -o /usr/local/bin/su-exec; chmod +x /usr/local/bin/su-exec
 
@@ -91,7 +91,7 @@ RUN chown -R root:root /app; chmod -R u=rw,go=r,a+X /app; chmod -R a+x /app/bin
 
 
 ## Runtime
-FROM gcr.io/distroless/cc-debian12:debug AS runtime
+FROM gcr.io/distroless/cc-debian13:debug AS runtime
 RUN ["/busybox/cp", "-sp", "/busybox/sh","/busybox/cat","/busybox/ls","/busybox/env", "/bin/"]
 COPY --from=gcc --chmod=0555 /usr/local/bin/su-exec /bin/su-exec
 


### PR DESCRIPTION
## Description

This PR upgrades all Docker base images from Debian 12 (bookworm) to Debian 13 (trixie) to resolve security vulnerabilities detected by Trivy.

## Changes

- **Builder image**: `rust:bookworm` → `rust:trixie`
- **Tester image**: `rust:slim-bookworm` → `rust:slim-trixie`
- **GCC image**: `gcc:bookworm` → `gcc:trixie`
- **Runtime image**: `gcr.io/distroless/cc-debian12:debug` → `gcr.io/distroless/cc-debian13:debug`

## Security Impact

### Before
Trivy scan detected **5 vulnerabilities** (1 CRITICAL, 4 HIGH):
- **CVE-2019-1010022** (CRITICAL): glibc stack guard protection bypass
- **CVE-2018-20796** (HIGH): glibc uncontrolled recursion in posix/regexec.c
- **CVE-2019-1010023** (HIGH): glibc ldd on malicious ELF leads to code execution
- **CVE-2019-9192** (HIGH): glibc uncontrolled recursion in posix/regexec.c
- **CVE-2023-0286** (HIGH): OpenSSL X.400 address type confusion in X.509 GeneralName

### After
Trivy scan results: **Total: 0 (CRITICAL: 0, HIGH: 0)** ✅

All security vulnerabilities have been resolved.

## Testing

- ✅ Container builds successfully
- ✅ Container runs and passes health checks
- ✅ All services initialize correctly
- ✅ Trivy security scan passes with zero HIGH/CRITICAL vulnerabilities

## Related Issues

Closes #1628

## Checklist

- [x] Updated all base images to Debian 13 (Trixie)
- [x] Built and tested container image
- [x] Verified with Trivy security scan
- [x] Confirmed container runs with health checks passing