### PR TITLE
fix: add sleep after HTTP server stop in health check test to avoid race condition

### DIFF
--- a/packages/axum-health-check-api-server/tests/server/contract.rs
+++ b/packages/axum-health-check-api-server/tests/server/contract.rs
@@ -202,6 +202,9 @@ mod http {
 
         service.server.stop().await.expect("it should stop udp server");
 
+        // Give the OS a moment to fully release the TCP port after the server stops.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
         {
             let config = configuration.health_check_api.clone();
             let env = Started::new(&config.into(), registar).await;


### PR DESCRIPTION
The test `it_should_return_error_when_http_service_was_stopped_after_registration` was flaky on nightly Rust because the OS can keep a TCP port in `CLOSE_WAIT`/`TIME_WAIT` briefly after the server stops, causing the health check to still return `Ok` instead of `Error`.\n\nAdds a 100ms sleep after `stop().await` to let the OS fully release the TCP port before the health check runs.