### PR TITLE
develop: bump to version 4.0.0-rc.1-develop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bittorrent-http-tracker-core"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-http-tracker-protocol",
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "bittorrent-http-tracker-protocol"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-primitives",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "bittorrent-tracker-client"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-primitives",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "bittorrent-tracker-core"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-primitives",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "bittorrent-udp-tracker-core"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-primitives",
@@ -775,7 +775,7 @@ dependencies = [
 
 [[package]]
 name = "bittorrent-udp-tracker-protocol"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "torrust-tracker-clock",
@@ -5079,9 +5079,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-axum-health-check-api-server"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "axum",
  "axum-server",
@@ -5300,7 +5300,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-axum-http-tracker-server"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "axum",
@@ -5340,7 +5340,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-axum-rest-tracker-api-server"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "axum",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-axum-server"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "axum-server",
  "camino",
@@ -5401,7 +5401,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-rest-tracker-api-client"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "hyper",
  "reqwest",
@@ -5413,7 +5413,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-rest-tracker-api-core"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "bittorrent-http-tracker-core",
  "bittorrent-tracker-core",
@@ -5431,7 +5431,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-server-lib"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "derive_more",
  "rstest 0.25.0",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "anyhow",
  "axum-server",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-client"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "anyhow",
  "aquatic_udp_protocol",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-clock"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -5517,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-configuration"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "camino",
  "derive_more",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-contrib-bencode"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "criterion 0.8.2",
  "thiserror 2.0.18",
@@ -5544,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-events"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "futures",
  "mockall",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-located-error"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "thiserror 2.0.18",
  "tracing",
@@ -5561,7 +5561,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-metrics"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "approx",
  "chrono",
@@ -5578,7 +5578,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-primitives"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "binascii",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-swarm-coordination-registry"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "async-std",
@@ -5623,7 +5623,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-test-helpers"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "rand 0.10.0",
  "torrust-tracker-configuration",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-tracker-torrent-repository-benchmarking"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "async-std",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "torrust-udp-tracker-server"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 dependencies = [
  "aquatic_udp_protocol",
  "bittorrent-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,14 @@ license = "AGPL-3.0-only"
 publish = true
 repository = "https://github.com/torrust/torrust-tracker"
 rust-version = "1.72"
-version = "3.0.0-develop"
+version = "4.0.0-rc.1-develop"
 
 [dependencies]
 anyhow = "1"
 axum-server = { version = "0", features = ["tls-rustls-no-provider"] }
-bittorrent-http-tracker-core = { version = "3.0.0-develop", path = "packages/http-tracker-core" }
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "packages/tracker-core" }
-bittorrent-udp-tracker-core = { version = "3.0.0-develop", path = "packages/udp-tracker-core" }
+bittorrent-http-tracker-core = { version = "4.0.0-rc.1-develop", path = "packages/http-tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "packages/tracker-core" }
+bittorrent-udp-tracker-core = { version = "4.0.0-rc.1-develop", path = "packages/udp-tracker-core" }
 chrono = { version = "0", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive", "env"] }
 rand = "0"
@@ -48,26 +48,26 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2.0.12"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-axum-health-check-api-server = { version = "3.0.0-develop", path = "packages/axum-health-check-api-server" }
-torrust-axum-http-tracker-server = { version = "3.0.0-develop", path = "packages/axum-http-tracker-server" }
-torrust-axum-rest-tracker-api-server = { version = "3.0.0-develop", path = "packages/axum-rest-tracker-api-server" }
-torrust-axum-server = { version = "3.0.0-develop", path = "packages/axum-server" }
-torrust-rest-tracker-api-core = { version = "3.0.0-develop", path = "packages/rest-tracker-api-core" }
-torrust-server-lib = { version = "3.0.0-develop", path = "packages/server-lib" }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "packages/clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "packages/configuration" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "packages/swarm-coordination-registry" }
-torrust-udp-tracker-server = { version = "3.0.0-develop", path = "packages/udp-tracker-server" }
+torrust-axum-health-check-api-server = { version = "4.0.0-rc.1-develop", path = "packages/axum-health-check-api-server" }
+torrust-axum-http-tracker-server = { version = "4.0.0-rc.1-develop", path = "packages/axum-http-tracker-server" }
+torrust-axum-rest-tracker-api-server = { version = "4.0.0-rc.1-develop", path = "packages/axum-rest-tracker-api-server" }
+torrust-axum-server = { version = "4.0.0-rc.1-develop", path = "packages/axum-server" }
+torrust-rest-tracker-api-core = { version = "4.0.0-rc.1-develop", path = "packages/rest-tracker-api-core" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "packages/server-lib" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "packages/clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "packages/configuration" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "packages/swarm-coordination-registry" }
+torrust-udp-tracker-server = { version = "4.0.0-rc.1-develop", path = "packages/udp-tracker-server" }
 tracing = "0"
 tracing-subscriber = { version = "0", features = ["json"] }
 
 [dev-dependencies]
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-client = { version = "3.0.0-develop", path = "packages/tracker-client" }
+bittorrent-tracker-client = { version = "4.0.0-rc.1-develop", path = "packages/tracker-client" }
 local-ip-address = "0"
 mockall = "0"
-torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "packages/rest-tracker-api-client" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "packages/test-helpers" }
+torrust-rest-tracker-api-client = { version = "4.0.0-rc.1-develop", path = "packages/rest-tracker-api-client" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "packages/test-helpers" }
 
 [workspace]
 members = ["console/tracker-client", "packages/torrent-repository-benchmarking"]

--- a/console/tracker-client/Cargo.toml
+++ b/console/tracker-client/Cargo.toml
@@ -18,7 +18,7 @@ version.workspace = true
 anyhow = "1"
 aquatic_udp_protocol = "0"
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-client = { version = "3.0.0-develop", path = "../../packages/tracker-client" }
+bittorrent-tracker-client = { version = "4.0.0-rc.1-develop", path = "../../packages/tracker-client" }
 clap = { version = "4", features = ["derive", "env"] }
 futures = "0"
 hex-literal = "1"
@@ -30,7 +30,7 @@ serde_bytes = "0"
 serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../../packages/configuration" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../../packages/configuration" }
 tracing = "0"
 tracing-subscriber = { version = "0", features = ["json"] }
 url = { version = "2", features = ["serde"] }

--- a/packages/axum-health-check-api-server/Cargo.toml
+++ b/packages/axum-health-check-api-server/Cargo.toml
@@ -21,20 +21,20 @@ hyper = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-axum-server = { version = "3.0.0-develop", path = "../axum-server" }
-torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-axum-server = { version = "4.0.0-rc.1-develop", path = "../axum-server" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "../server-lib" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 tower-http = { version = "0", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 tracing = "0"
 url = "2.5.4"
 
 [dev-dependencies]
 reqwest = { version = "0", features = ["json"] }
-torrust-axum-health-check-api-server = { version = "3.0.0-develop", path = "../axum-health-check-api-server" }
-torrust-axum-http-tracker-server = { version = "3.0.0-develop", path = "../axum-http-tracker-server" }
-torrust-axum-rest-tracker-api-server = { version = "3.0.0-develop", path = "../axum-rest-tracker-api-server" }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
-torrust-udp-tracker-server = { version = "3.0.0-develop", path = "../udp-tracker-server" }
+torrust-axum-health-check-api-server = { version = "4.0.0-rc.1-develop", path = "../axum-health-check-api-server" }
+torrust-axum-http-tracker-server = { version = "4.0.0-rc.1-develop", path = "../axum-http-tracker-server" }
+torrust-axum-rest-tracker-api-server = { version = "4.0.0-rc.1-develop", path = "../axum-rest-tracker-api-server" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
+torrust-udp-tracker-server = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-server" }
 tracing-subscriber = { version = "0", features = ["json"] }

--- a/packages/axum-http-tracker-server/Cargo.toml
+++ b/packages/axum-http-tracker-server/Cargo.toml
@@ -18,10 +18,10 @@ aquatic_udp_protocol = "0"
 axum = { version = "0", features = ["macros"] }
 axum-client-ip = "0"
 axum-server = { version = "0", features = ["tls-rustls-no-provider"] }
-bittorrent-http-tracker-core = { version = "3.0.0-develop", path = "../http-tracker-core" }
-bittorrent-http-tracker-protocol = { version = "3.0.0-develop", path = "../http-protocol" }
+bittorrent-http-tracker-core = { version = "4.0.0-rc.1-develop", path = "../http-tracker-core" }
+bittorrent-http-tracker-protocol = { version = "4.0.0-rc.1-develop", path = "../http-protocol" }
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
 derive_more = { version = "2", features = ["as_ref", "constructor", "from"] }
 futures = "0"
 hyper = "1"
@@ -29,12 +29,12 @@ reqwest = { version = "0", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-axum-server = { version = "3.0.0-develop", path = "../axum-server" }
-torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
+torrust-axum-server = { version = "4.0.0-rc.1-develop", path = "../axum-server" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "../server-lib" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
 tower = { version = "0", features = ["timeout"] }
 tower-http = { version = "0", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 tracing = "0"
@@ -46,8 +46,8 @@ rand = "0"
 serde_bencode = "0"
 serde_bytes = "0"
 serde_repr = "0"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
 uuid = { version = "1", features = ["v4"] }
 zerocopy = "0.7"

--- a/packages/axum-rest-tracker-api-server/Cargo.toml
+++ b/packages/axum-rest-tracker-api-server/Cargo.toml
@@ -18,10 +18,10 @@ aquatic_udp_protocol = "0"
 axum = { version = "0", features = ["macros"] }
 axum-extra = { version = "0", features = ["query"] }
 axum-server = { version = "0", features = ["tls-rustls-no-provider"] }
-bittorrent-http-tracker-core = { version = "3.0.0-develop", path = "../http-tracker-core" }
+bittorrent-http-tracker-core = { version = "4.0.0-rc.1-develop", path = "../http-tracker-core" }
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
-bittorrent-udp-tracker-core = { version = "3.0.0-develop", path = "../udp-tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
+bittorrent-udp-tracker-core = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-core" }
 derive_more = { version = "2", features = ["as_ref", "constructor", "from"] }
 futures = "0"
 hyper = "1"
@@ -31,16 +31,16 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = { version = "3", features = ["json"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-axum-server = { version = "3.0.0-develop", path = "../axum-server" }
-torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "../rest-tracker-api-client" }
-torrust-rest-tracker-api-core = { version = "3.0.0-develop", path = "../rest-tracker-api-core" }
-torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
-torrust-udp-tracker-server = { version = "3.0.0-develop", path = "../udp-tracker-server" }
+torrust-axum-server = { version = "4.0.0-rc.1-develop", path = "../axum-server" }
+torrust-rest-tracker-api-client = { version = "4.0.0-rc.1-develop", path = "../rest-tracker-api-client" }
+torrust-rest-tracker-api-core = { version = "4.0.0-rc.1-develop", path = "../rest-tracker-api-core" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "../server-lib" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
+torrust-udp-tracker-server = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-server" }
 tower = { version = "0", features = ["timeout"] }
 tower-http = { version = "0", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 tracing = "0"
@@ -49,7 +49,7 @@ url = "2"
 [dev-dependencies]
 local-ip-address = "0"
 mockall = "0"
-torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "../rest-tracker-api-client" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-rest-tracker-api-client = { version = "4.0.0-rc.1-develop", path = "../rest-tracker-api-client" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }

--- a/packages/axum-server/Cargo.toml
+++ b/packages/axum-server/Cargo.toml
@@ -23,9 +23,9 @@ hyper-util = { version = "0", features = ["http1", "http2", "tokio"] }
 pin-project-lite = "0"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "../server-lib" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-located-error = { version = "4.0.0-rc.1-develop", path = "../located-error" }
 tower = { version = "0", features = ["timeout"] }
 tracing = "0"
 

--- a/packages/clock/Cargo.toml
+++ b/packages/clock/Cargo.toml
@@ -20,6 +20,6 @@ chrono = { version = "0", default-features = false, features = ["clock"] }
 lazy_static = "1"
 tracing = "0"
 
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 
 [dev-dependencies]

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 serde_with = "3"
 thiserror = "2"
 toml = "0"
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-tracker-located-error = { version = "4.0.0-rc.1-develop", path = "../located-error" }
 tracing = "0"
 tracing-subscriber = { version = "0", features = ["json"] }
 url = "2"

--- a/packages/http-protocol/Cargo.toml
+++ b/packages/http-protocol/Cargo.toml
@@ -17,15 +17,15 @@ version.workspace = true
 [dependencies]
 aquatic_udp_protocol = "0"
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
 derive_more = { version = "2", features = ["as_ref", "constructor", "from"] }
 multimap = "0"
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"] }
 serde_bencode = "0"
 thiserror = "2"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-contrib-bencode = { version = "3.0.0-develop", path = "../../contrib/bencode" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-contrib-bencode = { version = "4.0.0-rc.1-develop", path = "../../contrib/bencode" }
+torrust-tracker-located-error = { version = "4.0.0-rc.1-develop", path = "../located-error" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }

--- a/packages/http-tracker-core/Cargo.toml
+++ b/packages/http-tracker-core/Cargo.toml
@@ -15,28 +15,28 @@ version.workspace = true
 
 [dependencies]
 aquatic_udp_protocol = "0"
-bittorrent-http-tracker-protocol = { version = "3.0.0-develop", path = "../http-protocol" }
+bittorrent-http-tracker-protocol = { version = "4.0.0-rc.1-develop", path = "../http-protocol" }
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
 criterion = { version = "0.5.1", features = ["async_tokio"] }
 futures = "0"
 serde = "1.0.219"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
 tracing = "0"
 
 [dev-dependencies]
 formatjson = "0.3.1"
 mockall = "0"
 serde_json = "1.0.140"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
 
 [[bench]]
 harness = false

--- a/packages/metrics/Cargo.toml
+++ b/packages/metrics/Cargo.toml
@@ -20,7 +20,7 @@ derive_more = { version = "2", features = ["constructor"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.140"
 thiserror = "2"
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/packages/primitives/Cargo.toml
+++ b/packages/primitives/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1", features = ["derive"] }
 tdyne-peer-id = "1"
 tdyne-peer-id-registry = "0"
 thiserror = "2"
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
 url = "2.5.4"
 zerocopy = "0.7"
 

--- a/packages/rest-tracker-api-core/Cargo.toml
+++ b/packages/rest-tracker-api-core/Cargo.toml
@@ -14,17 +14,17 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-bittorrent-http-tracker-core = { version = "3.0.0-develop", path = "../http-tracker-core" }
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
-bittorrent-udp-tracker-core = { version = "3.0.0-develop", path = "../udp-tracker-core" }
+bittorrent-http-tracker-core = { version = "4.0.0-rc.1-develop", path = "../http-tracker-core" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
+bittorrent-udp-tracker-core = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-core" }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
-torrust-udp-tracker-server = { version = "3.0.0-develop", path = "../udp-tracker-server" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
+torrust-udp-tracker-server = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-server" }
 
 [dev-dependencies]
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }

--- a/packages/server-lib/Cargo.toml
+++ b/packages/server-lib/Cargo.toml
@@ -16,7 +16,7 @@ version.workspace = true
 [dependencies]
 derive_more = { version = "2", features = ["as_ref", "constructor", "display", "from"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 tower-http = { version = "0", features = ["compression-full", "cors", "propagate-header", "request-id", "trace"] }
 tracing = "0"
 

--- a/packages/swarm-coordination-registry/Cargo.toml
+++ b/packages/swarm-coordination-registry/Cargo.toml
@@ -25,11 +25,11 @@ serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 tracing = "0"
 
 [dev-dependencies]
@@ -38,4 +38,4 @@ criterion = { version = "0", features = ["async_tokio"] }
 mockall = "0"
 rand = "0"
 rstest = "0"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }

--- a/packages/test-helpers/Cargo.toml
+++ b/packages/test-helpers/Cargo.toml
@@ -16,6 +16,6 @@ version.workspace = true
 
 [dependencies]
 rand = "0"
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
 tracing = "0"
 tracing-subscriber = { version = "0", features = ["json"] }

--- a/packages/torrent-repository-benchmarking/Cargo.toml
+++ b/packages/torrent-repository-benchmarking/Cargo.toml
@@ -23,9 +23,9 @@ dashmap = "6"
 futures = "0"
 parking_lot = "0"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 zerocopy = "0.7"
 
 [dev-dependencies]

--- a/packages/tracker-client/Cargo.toml
+++ b/packages/tracker-client/Cargo.toml
@@ -27,9 +27,9 @@ serde_bytes = "0"
 serde_repr = "0"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-located-error = { version = "4.0.0-rc.1-develop", path = "../located-error" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
 tracing = "0"
 zerocopy = "0.7"
 

--- a/packages/tracker-core/Cargo.toml
+++ b/packages/tracker-core/Cargo.toml
@@ -28,19 +28,19 @@ serde_json = { version = "1", features = ["preserve_order"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-located-error = { version = "4.0.0-rc.1-develop", path = "../located-error" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
 tracing = "0"
 
 [dev-dependencies]
 local-ip-address = "0"
 mockall = "0"
 testcontainers = "0"
-torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "../rest-tracker-api-client" }
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-rest-tracker-api-client = { version = "4.0.0-rc.1-develop", path = "../rest-tracker-api-client" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
 url = "2.5.4"

--- a/packages/udp-protocol/Cargo.toml
+++ b/packages/udp-protocol/Cargo.toml
@@ -16,5 +16,5 @@ version.workspace = true
 
 [dependencies]
 aquatic_udp_protocol = "0"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }

--- a/packages/udp-tracker-core/Cargo.toml
+++ b/packages/udp-tracker-core/Cargo.toml
@@ -16,8 +16,8 @@ version.workspace = true
 [dependencies]
 aquatic_udp_protocol = "0"
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
-bittorrent-udp-tracker-protocol = { version = "3.0.0-develop", path = "../udp-protocol" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
+bittorrent-udp-tracker-protocol = { version = "4.0.0-rc.1-develop", path = "../udp-protocol" }
 bloom = "0.3.2"
 blowfish = "0"
 cipher = "0.4"
@@ -30,18 +30,18 @@ serde = "1.0.219"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-util = "0.7.15"
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
 tracing = "0"
 zerocopy = "0.7"
 
 [dev-dependencies]
 mockall = "0"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }
 
 [[bench]]
 harness = false

--- a/packages/udp-tracker-server/Cargo.toml
+++ b/packages/udp-tracker-server/Cargo.toml
@@ -16,9 +16,9 @@ version.workspace = true
 [dependencies]
 aquatic_udp_protocol = "0"
 bittorrent-primitives = "0.1.0"
-bittorrent-tracker-client = { version = "3.0.0-develop", path = "../tracker-client" }
-bittorrent-tracker-core = { version = "3.0.0-develop", path = "../tracker-core" }
-bittorrent-udp-tracker-core = { version = "3.0.0-develop", path = "../udp-tracker-core" }
+bittorrent-tracker-client = { version = "4.0.0-rc.1-develop", path = "../tracker-client" }
+bittorrent-tracker-core = { version = "4.0.0-rc.1-develop", path = "../tracker-core" }
+bittorrent-udp-tracker-core = { version = "4.0.0-rc.1-develop", path = "../udp-tracker-core" }
 derive_more = { version = "2", features = ["as_ref", "constructor", "from"] }
 futures = "0"
 futures-util = "0"
@@ -27,13 +27,13 @@ serde = "1.0.219"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "sync"] }
 tokio-util = "0.7.15"
-torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
-torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-metrics = { version = "3.0.0-develop", path = "../metrics" }
-torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
-torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }
+torrust-server-lib = { version = "4.0.0-rc.1-develop", path = "../server-lib" }
+torrust-tracker-clock = { version = "4.0.0-rc.1-develop", path = "../clock" }
+torrust-tracker-configuration = { version = "4.0.0-rc.1-develop", path = "../configuration" }
+torrust-tracker-events = { version = "4.0.0-rc.1-develop", path = "../events" }
+torrust-tracker-metrics = { version = "4.0.0-rc.1-develop", path = "../metrics" }
+torrust-tracker-primitives = { version = "4.0.0-rc.1-develop", path = "../primitives" }
+torrust-tracker-swarm-coordination-registry = { version = "4.0.0-rc.1-develop", path = "../swarm-coordination-registry" }
 tracing = "0"
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
@@ -43,4 +43,4 @@ zerocopy = "0.7"
 local-ip-address = "0"
 mockall = "0"
 rand = "0"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
+torrust-tracker-test-helpers = { version = "4.0.0-rc.1-develop", path = "../test-helpers" }


### PR DESCRIPTION
Bumps all workspace package versions to `4.0.0-rc.1-develop` in preparation for the `4.0.0-rc.1` release.