### PR TITLE
chore(deps): consolidate Docker GitHub Action updates

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - id: setup
         name: Setup Toolchain
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - id: build
         name: Build
@@ -124,7 +124,7 @@ jobs:
 
       - id: setup
         name: Setup Toolchain
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -165,7 +165,7 @@ jobs:
 
       - id: setup
         name: Setup Toolchain
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -108,7 +108,7 @@ jobs:
     steps:
       - id: meta
         name: Docker Meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             "${{ secrets.DOCKER_HUB_USERNAME }}/${{secrets.DOCKER_HUB_REPOSITORY_NAME }}"
@@ -146,7 +146,7 @@ jobs:
     steps:
       - id: meta
         name: Docker Meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             "${{ secrets.DOCKER_HUB_USERNAME }}/${{secrets.DOCKER_HUB_REPOSITORY_NAME }}"

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - id: build
         name: Build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Containerfile
           push: false
@@ -127,7 +127,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Containerfile
           push: true
@@ -168,7 +168,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           file: ./Containerfile
           push: true


### PR DESCRIPTION
This PR consolidates the following Dependabot updates into one branch and PR:\n\n- #1670: bump docker/build-push-action from 6 to 7\n- #1668: bump docker/setup-buildx-action from 3 to 4\n- #1667: bump docker/metadata-action from 5 to 6\n- #1666: bump docker/login-action from 3 to 4\n\nEach dependency update was applied as a separate commit.