### PR TITLE
docs: Add build-essential to Prerequisites (#1595)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,12 @@
 //!
 //! The tracker has some system dependencies:
 //!
+//! First, you need to install the build tools:
+//!
+//! ```text
+//! sudo apt-get install build-essential
+//! ```
+//!
 //! Since we are using the `openssl` crate with the [vendored feature](https://docs.rs/openssl/latest/openssl/#vendored),
 //! enabled, you will need to install the following dependencies:
 //!


### PR DESCRIPTION
## Description

Resolves #1595

### Changes

Added `build-essential` package to the Prerequisites section of the documentation. This package is required to provide the C compiler (`cc`) which is essential for compiling Rust code and its dependencies.

### Why

When building on a fresh Ubuntu 24 machine, users encountered the error:
```
error: linker `cc` not found
```

This error occurs because `build-essential` (which includes the C compiler) was not installed. The documentation did not mention this requirement, so users had to discover it through trial and error.

### What Changed

- Added a new prerequisite step to install `build-essential` before other dependencies
- This ensures users have the necessary build tools before attempting to compile the project

### Documentation

The change is reflected in the Rust documentation under the "Prerequisites" section which is published to [docs.rs](https://docs.rs/torrust-tracker/latest/torrust_tracker/#prerequisites).