### PR TITLE
Document MySQL DSN password URL-encoding requirement

### DIFF
--- a/docs/containers.md
+++ b/docs/containers.md
@@ -248,6 +248,10 @@ driver = "mysql"
 path = "mysql://db_user:db_user_secret_password@mysql:3306/torrust_tracker"
 ```
 
+Important: if the MySQL password contains reserved URL characters (for example `+`, `/`, `@`, or `:`), it must be percent-encoded in the DSN password component. For example, if the raw password is `a+b/c`, use `a%2Bb%2Fc` in the DSN.
+
+When generating secrets automatically, prefer URL-safe passwords (`A-Z`, `a-z`, `0-9`, `-`, `_`) to avoid DSN parsing issues.
+
 ### Build and Run:
 
 ```sh
@@ -292,7 +296,7 @@ These are some useful commands for MySQL.
 Open a shell in the MySQL container using docker or docker-compose.
 
 ```s
-docker exec -it torrust-mysql-1 /bin/bash 
+docker exec -it torrust-mysql-1 /bin/bash
 docker compose exec mysql /bin/bash
 ```
 

--- a/packages/configuration/src/v2_0_0/database.rs
+++ b/packages/configuration/src/v2_0_0/database.rs
@@ -12,8 +12,10 @@ pub struct Database {
     /// Database connection string. The format depends on the database driver.
     /// For `sqlite3`, the format is `path/to/database.db`, for example:
     /// `./storage/tracker/lib/database/sqlite3.db`.
-    /// For `Mysql`, the format is `mysql://db_user:db_user_password:port/db_name`, for
+    /// For `mysql`, the format is `mysql://db_user:db_user_password@host:port/db_name`, for
     /// example: `mysql://root:password@localhost:3306/torrust`.
+    /// If the password contains reserved URL characters (for example `+` or `/`),
+    /// percent-encode it in the URL.
     #[serde(default = "Database::default_path")]
     pub path: String,
 }

--- a/share/default/config/tracker.container.mysql.toml
+++ b/share/default/config/tracker.container.mysql.toml
@@ -12,6 +12,9 @@ private = false
 
 [core.database]
 driver = "mysql"
+# If the MySQL password includes reserved URL characters (for example + or /),
+# percent-encode it in the DSN password component.
+# Example: password a+b/c -> a%2Bb%2Fc
 path = "mysql://db_user:db_user_secret_password@mysql:3306/torrust_tracker"
 
 # Uncomment to enable services


### PR DESCRIPTION
## Summary
Document that MySQL DSN passwords must be percent-encoded when they contain reserved URL characters.

## Changes
- Add URL-encoding guidance to container deployment docs.
- Add URL-encoding note to the default MySQL tracker config example.
- Clarify MySQL DSN format in configuration docs and add encoding requirement for reserved characters.

## Why
Deployments commonly build DSNs from environment variables. Generated secrets can include characters like `+` and `/`, which break DSN parsing unless encoded.

Fixes #1606