### PR TITLE
docs(build): add sccache research issue spec (#1726)

### DIFF
--- a/docs/issues/1726-reduce-build-times-sccache/ISSUE.md
+++ b/docs/issues/1726-reduce-build-times-sccache/ISSUE.md
@@ -1,0 +1,222 @@
+# Reduce Build Times with `sccache`
+
+## Goal
+
+Research whether `sccache` is effective for this workspace in local development and GitHub-hosted
+CI runners, and decide if it should be adopted fully, partially, or not at all.
+
+This issue is intentionally evidence-driven. No workflow replacement is assumed until benchmarks
+confirm a measurable benefit.
+
+Further build-time improvements (crate splitting, linker changes, C-dependency reduction) are left
+for follow-up issues.
+
+## Background
+
+A benchmark run on 2026-05-01 measured the following for a clean workspace:
+
+| Command                                                                            | Wall time    |
+| ---------------------------------------------------------------------------------- | ------------ |
+| `cargo clean`                                                                      | 1.28 s       |
+| `cargo fetch`                                                                      | 0.20 s       |
+| `cargo test --tests --benches --examples --workspace --all-targets --all-features` | **142.47 s** |
+
+**89 % of the 142 s is compilation; only 10 % is test execution.**
+
+The `unit` job in `.github/workflows/testing.yaml` runs the same full-workspace test command
+after a clean checkout. `Swatinem/rust-cache` is already present in every CI job and appears to
+have limited benefit for this workspace based on size and transfer estimates:
+
+- The `target/` directory after a build is ~9 GB.
+- GitHub Actions cache restore/upload at 30–70 MB/s costs 130–300 s — more than a cold build.
+- Cache is keyed per-job and per-toolchain; no cross-job sharing occurs.
+- Any `Cargo.lock` change invalidates the entire cache.
+
+`sccache` may help because it caches individual codegen units keyed by source content hash, so a
+miss on one changed crate does not invalidate unrelated crates. The GHA cache backend
+(`SCCACHE_GHA_ENABLED=true`) uses GitHub's own cache storage with no extra infrastructure.
+
+However, there are known limitations that may reduce the effective benefit:
+
+- **Non-sticky runners**: on GitHub-hosted runners, every job starts with an empty local disk;
+  compiled objects must be fetched from the GHA cache backend on every run. First-run cache
+  misses are expected.
+- **`bin`, `dylib`, `cdylib`, and `proc-macro` crates are never cached** by sccache — it only
+  caches `rlib`/`lib` units. The heaviest crate in this workspace,
+  `torrust-tracker` (rank 1, 77 s single unit), is a `bin` crate and will **always** recompile.
+- **Incremental compilation must be disabled**: Cargo enables incremental compilation by default
+  in the `dev` profile for workspace members. sccache cannot cache incrementally compiled units;
+  `CARGO_INCREMENTAL=0` (or `incremental = false` in the profile) is required.
+- **Rate-limiting**: if the GHA cache service is rate-limited, sccache silently skips storing
+  objects; builds continue but cache population may be incomplete.
+
+Therefore, the decision to adopt `sccache` must be based on measured repeat-run behavior, not
+assumptions.
+
+Full benchmark data and compile-hotspot analysis are in
+[`benchmark-results.md`](./benchmark-results.md).
+
+## References
+
+- GitHub issue: https://github.com/torrust/torrust-tracker/issues/1726
+- `sccache` repository: https://github.com/mozilla/sccache
+- `mozilla-actions/sccache-action`: https://github.com/mozilla-actions/sccache-action
+- Benchmark artifact: [`docs/issues/1726-reduce-build-times-sccache/benchmark-results.md`](./benchmark-results.md)
+- CI workflow: [`.github/workflows/testing.yaml`](../../../.github/workflows/testing.yaml)
+
+---
+
+## Tasks
+
+### Task 0: Create a local branch
+
+- Branch name: `1726-reduce-build-times-sccache`
+- Commands:
+
+  ```sh
+  git fetch --all --prune
+  git checkout develop
+  git pull --ff-only
+  git checkout -b 1726-reduce-build-times-sccache
+  ```
+
+- Checkpoint: `git branch --show-current` outputs `1726-reduce-build-times-sccache`.
+
+---
+
+### Task 1: Local Research (A/B)
+
+Measure whether `sccache` improves local rebuild times versus baseline.
+
+- [ ] Baseline (no `sccache`) measurement:
+
+  ```sh
+  unset RUSTC_WRAPPER
+  export CARGO_INCREMENTAL=0
+  cargo clean
+  /usr/bin/time -f 'real=%e' cargo test --tests --benches --examples \
+    --workspace --all-targets --all-features --no-run
+  /usr/bin/time -f 'real=%e' cargo test --tests --benches --examples \
+    --workspace --all-targets --all-features --no-run
+  ```
+
+  Record cold and warm baseline times.
+
+- [ ] Install `sccache`:
+
+  ```sh
+  cargo install sccache
+  ```
+
+- [ ] Run a cold build through `sccache`:
+
+  ```sh
+  sccache --stop-server 2>/dev/null; sccache --start-server
+  export RUSTC_WRAPPER=sccache
+  export CARGO_INCREMENTAL=0
+  cargo clean
+  /usr/bin/time -f 'real=%e' cargo test --tests --benches --examples \
+    --workspace --all-targets --all-features --no-run
+  sccache --show-stats
+  ```
+
+  Record the wall time and the cache hit/miss ratio from `sccache --show-stats`.
+
+- [ ] Run a warm build (no `cargo clean`) through `sccache` to confirm cache hits:
+
+  ```sh
+  /usr/bin/time -f 'real=%e' cargo test --tests --benches --examples \
+    --workspace --all-targets --all-features --no-run
+  sccache --show-stats
+  ```
+
+- [ ] Run a warm build after a single-file change in a leaf crate
+      (e.g., touch a file in `packages/primitives/`) to confirm only the affected
+      downstream units miss the cache.
+
+- [ ] Compare baseline vs `sccache` results in a table (cold, warm, warm-after-change).
+
+- Checkpoint: data shows whether `sccache` materially improves local rebuilds.
+
+Commit message: `docs(build): record local sccache benchmark results`
+
+---
+
+### Task 2: Local Configuration Decision
+
+Decide whether to enable `sccache` in `.cargo/config.toml` for developers.
+
+- [ ] If local research is positive, add to `.cargo/config.toml` under `[build]`:
+
+  ```toml
+  [build]
+  rustc-wrapper = "sccache"
+  ```
+
+  Add a comment explaining that `sccache` must be installed (`cargo install sccache`);
+  the build falls back to the plain compiler if the wrapper is not found only when
+  `RUSTC_WRAPPER` is unset — with the config key set, a missing binary is an error.
+  Consider using `RUSTC_WRAPPER` in the config only if `sccache` is present
+  (use a wrapper script or document the requirement clearly).
+
+- [ ] If enabled, update `AGENTS.md` and/or `README.md` with the `sccache` install step under
+      "Setup".
+- [ ] Verify `linter all` still exits `0`.
+
+- Checkpoint: explicit decision recorded: enable by default, keep opt-in, or defer.
+
+Commit message: `chore(build): configure local sccache usage`
+
+---
+
+### Task 3: CI Research (A/B)
+
+Benchmark CI behavior on GitHub-hosted runners before deciding on replacement.
+
+- [ ] Run and record baseline CI timings with current setup (`Swatinem/rust-cache`) for
+      at least two comparable pushes (cold-ish and repeat).
+
+- [ ] Create an experiment branch/workflow variant using `sccache` (GHA backend):
+  - Add the following two steps **before** any `cargo` step in jobs that compile Rust
+    (`format`, `check`, `build`, `unit`, `database-compatibility`, `e2e`):
+
+    ```yaml
+    - name: Install sccache
+      uses: mozilla-actions/sccache-action@v0.0.10
+
+    - name: Enable sccache
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+        echo "CARGO_INCREMENTAL=0" >> "$GITHUB_ENV"
+    ```
+
+  To purge the remote cache (e.g. after a toolchain or `Cargo.lock` bump), increment
+  `SCCACHE_GHA_VERSION` in the workflow env:
+
+  ```yaml
+  env:
+    SCCACHE_GHA_VERSION: 1 # bump to bust the cache
+  ```
+
+- [ ] Verify that the `linter` install step (`cargo install --locked --git ...`) still works
+      correctly with the chosen env setup.
+- [ ] Push the experiment branch and check that the CI workflow passes end-to-end.
+- [ ] Compare CI timing before and after by inspecting workflow run durations on GitHub.
+      Record per-job times, especially `unit`, for first and repeat runs.
+- [ ] Optional: if results are mixed, test a hybrid strategy (retain small Cargo dependency
+      cache, avoid full `target` cache, and keep `sccache` for compilation units).
+
+- Checkpoint: recommendation documented: keep current cache, switch to `sccache`, or use hybrid.
+
+Commit message: `ci(testing): benchmark sccache against current cache strategy`
+
+---
+
+## Acceptance Criteria
+
+- [ ] Local benchmark report exists with baseline vs `sccache` (cold, warm, warm-after-change).
+- [ ] CI benchmark report exists with current strategy vs `sccache` strategy (first and repeat runs).
+- [ ] Recommendation is documented with evidence: adopt `sccache`, adopt hybrid, or reject for now.
+- [ ] If adoption is recommended, implementation changes are applied and verified (`linter all`, tests, CI).
+- [ ] If adoption is not recommended, issue documents why and proposes next optimization steps.

--- a/docs/issues/1726-reduce-build-times-sccache/benchmark-results.md
+++ b/docs/issues/1726-reduce-build-times-sccache/benchmark-results.md
@@ -1,0 +1,232 @@
+# Cargo Build & Test Benchmark Results
+
+Recorded on: 2026-05-01  
+Machine: local dev (clean workspace)
+
+---
+
+## Command Timings
+
+| #   | Command                                                                            | Wall time    | User CPU     | Sys CPU |
+| --- | ---------------------------------------------------------------------------------- | ------------ | ------------ | ------- |
+| 1   | `cargo clean`                                                                      | **1.28 s**   | 0.04 s       | 1.21 s  |
+| 2   | `cargo fetch`                                                                      | **0.20 s**   | 0.11 s       | 0.07 s  |
+| 3   | `cargo test --tests --benches --examples --workspace --all-targets --all-features` | **142.47 s** | 2171 s (CPU) | 151 s   |
+
+---
+
+## Breakdown of Command 3 (142.47 s total)
+
+| Phase                                              | Duration | Share |
+| -------------------------------------------------- | -------- | ----- |
+| Compilation (`test` profile, from clean)           | ~127 s   | ~89 % |
+| Test execution (sum of all `finished in Xs` lines) | ~13.6 s  | ~10 % |
+| Process startup / harness overhead                 | ~1.9 s   | ~1 %  |
+
+### Evidence
+
+- `cargo test ... --no-run` (build-only, from clean): **126.72 s wall / 2m06s reported by Cargo**
+- Warm rerun of full command (artifacts already built): **15.26 s wall / 0.63 s Cargo build phase**
+
+> **Conclusion: the bottleneck is compilation, not test execution.**
+
+---
+
+## Slowest Test Binaries (execution time only)
+
+| Rank | Execution time | Binary / suite                                                                    |
+| ---- | -------------- | --------------------------------------------------------------------------------- |
+| 1    | **5.04 s**     | `tests/integration.rs` — `torrust_udp_tracker_server` (6 tests)                   |
+| 2    | **3.21 s**     | `unittests src/lib.rs` — `torrust_tracker_swarm_coordination_registry` (95 tests) |
+| 3    | **2.08 s**     | `unittests src/lib.rs` — `torrust_udp_tracker_server` (122 tests)                 |
+| 4    | **2.05 s**     | `tests/integration.rs` — `torrust_axum_health_check_api_server` (7 tests)         |
+| 5    | **0.36 s**     | `tests/integration.rs` — `torrust_axum_rest_tracker_api_server` (53 tests)        |
+| 6    | **0.23 s**     | `tests/integration.rs` — `bittorrent_tracker_core` (5 tests)                      |
+| 7    | **0.21 s**     | `tests/integration.rs` — `torrust_axum_http_tracker_server` (52 tests)            |
+| …    | ≤ 0.10 s       | all remaining binaries                                                            |
+
+Top 4 binaries account for **12.38 s** out of **13.60 s** total execution time (~91 %).
+
+The slow integration tests in ranks 1, 3, and 4 are expected: they spin up real server instances and use OS-level socket connections. Rank 2 (`swarm_coordination_registry`) runs 95 async tests against an in-memory registry with `tokio::time` sleep calls inside test cases, which adds up.
+
+---
+
+## Compile Hotspot Analysis
+
+Run from a clean build with `cargo test ... --no-run --timings`.  
+Total wall time: **126 s** (matches the `--no-run` measurement above).  
+Total CPU-time across all parallel jobs: **2088 s** (summed across all units).
+
+### Top 20 — longest single compilation unit (critical path)
+
+These are the crates that directly control the minimum possible build time because nothing
+can be parallelised past them.
+
+| Rank | Max single unit | Sum (all units) | # units | Crate                                             |
+| ---- | --------------- | --------------- | ------- | ------------------------------------------------- |
+| 1    | 77.19 s         | 606.43 s        | 13      | `torrust-tracker` (workspace root)                |
+| 2    | 67.46 s         | 83.09 s         | 3       | `torrust-axum-health-check-api-server`            |
+| 3    | 62.94 s         | 182.15 s        | 5       | `bittorrent-tracker-core`                         |
+| 4    | 60.87 s         | 96.73 s         | 4       | `torrust-tracker-torrent-repository-benchmarking` |
+| 5    | 59.04 s         | 116.97 s        | 3       | `torrust-axum-rest-tracker-api-server`            |
+| 6    | 56.97 s         | 116.96 s        | 3       | `torrust-axum-http-tracker-server`                |
+| 7    | 50.02 s         | 99.74 s         | 3       | `torrust-udp-tracker-server`                      |
+| 8    | 33.82 s         | 34.21 s         | 2       | `torrust-rest-tracker-api-core`                   |
+| 9    | 31.01 s         | 60.37 s         | 3       | `bittorrent-http-tracker-core`                    |
+| 10   | 28.50 s         | 48.40 s         | 3       | `bittorrent-udp-tracker-core`                     |
+| 11   | 21.01 s         | 22.01 s         | 3       | `aws-lc-sys` (external C build)                   |
+| 12   | 18.94 s         | 19.36 s         | 2       | `bittorrent-http-tracker-protocol`                |
+| 13   | 18.86 s         | 24.76 s         | 5       | `libsqlite3-sys` (external C build)               |
+| 14   | 14.48 s         | 24.06 s         | 4       | `torrust-tracker-contrib-bencode`                 |
+| 15   | 13.28 s         | 13.58 s         | 3       | `zstd-sys` (external C build)                     |
+| 16   | 12.76 s         | 15.60 s         | 2       | `torrust-tracker-configuration`                   |
+| 17   | 12.71 s         | 14.19 s         | 2       | `torrust-tracker-swarm-coordination-registry`     |
+| 18   | 12.27 s         | 46.54 s         | 5       | `torrust-tracker-client`                          |
+| 19   | 12.08 s         | 13.23 s         | 2       | `torrust-tracker-metrics`                         |
+| 20   | 9.85 s          | 10.18 s         | 2       | `torrust-axum-server`                             |
+
+### Heaviest external/C dependencies
+
+| Sum     | Max unit | Crate            |
+| ------- | -------- | ---------------- |
+| 24.76 s | 18.86 s  | `libsqlite3-sys` |
+| 22.01 s | 21.01 s  | `aws-lc-sys`     |
+| 13.58 s | 13.28 s  | `zstd-sys`       |
+| 9.71 s  | 5.58 s   | `tokio`          |
+| 7.89 s  | 5.23 s   | `ring`           |
+| 7.71 s  | 5.00 s   | `regex-automata` |
+| 6.96 s  | 3.36 s   | `zerocopy`       |
+| 6.62 s  | 3.55 s   | `openssl`        |
+| 5.12 s  | 5.12 s   | `bollard-stubs`  |
+
+---
+
+## Recommendations
+
+### Ranked optimization plan (compile — biggest gains first)
+
+**1 — `sccache` (easiest, zero code changes, works on CI and locally)**
+
+Caches compiled artifacts keyed by source hash. After the first cold build, every
+subsequent clean build skips already-cached units. For the 126 s cold build here, a
+warm `sccache` run would be roughly 5–10 s (only changed crates recompile).
+
+```sh
+cargo install sccache
+export RUSTC_WRAPPER=sccache
+cargo test --tests --benches --examples --workspace --all-targets --all-features
+```
+
+Add `RUSTC_WRAPPER=sccache` to `.cargo/config.toml` or CI env to make it permanent.
+
+#### 2 — CI caching: the current setup doesn't help and here is why
+
+`Swatinem/rust-cache` is already present in the `unit`, `check`, `database-compatibility`,
+and `e2e` jobs, but it provides little to no benefit for this workspace. The reasons:
+
+- **Cache size vs transfer speed tradeoff.** A cold `target/` for this workspace is ~9 GB.
+  GitHub Actions cache upload/download runs at roughly 30–70 MB/s on `ubuntu-latest`.
+  Restoring a 9 GB cache therefore costs 130–300 s — which is _more_ than the 127 s
+  cold build. The cache pays off only if restore is faster than compile, which it isn't
+  here.
+- **No cross-job cache sharing.** Each job (format, check, unit, e2e) has its own cache
+  key (`${{ runner.os }}-${{ matrix.toolchain }}-...`). They never share a build from a
+  previous job in the same run. The `unit` job always rebuilds from scratch.
+- **Cache is invalidated too often.** `Swatinem/rust-cache` keys on `Cargo.lock` hash
+  plus toolchain. Any dependency bump or toolchain update flushes the entire cache.
+
+The options that actually work at this scale:
+
+| Option                                             | Mechanism                                                                                | Expected gain                                |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------------------------------------- |
+| **`sccache` with S3/GCS backend**                  | Caches individual codegen units by content hash; misses are granular, not all-or-nothing | ~80–90 % compile time saved on repeat pushes |
+| **`sccache` with GitHub Actions cache backend**    | Same as above but uses GH cache storage instead of S3; free, but limited to 10 GB total  | ~60–80 % saved on repeat pushes              |
+| **Shared `sccache` server** (self-hosted runner)   | Single cache server shared across all jobs and runs                                      | ~90 % saved; best ROI for a busy repo        |
+| **Reduce what is compiled** (see points 3–8 below) | Smaller total work means smaller cache and faster misses                                 | Permanent gain, works in CI and locally      |
+
+The most pragmatic immediate action is `sccache` with the GitHub Actions cache backend —
+it requires no infrastructure, is free within the 10 GB limit, and unlike `Swatinem/rust-cache`
+it caches at the _crate unit_ level so a single changed crate doesn't force a full rebuild.
+
+```yaml
+# In every job that compiles Rust, add before the cargo step:
+- name: Install sccache
+  uses: mozilla-actions/sccache-action@v0.0.6
+
+- name: Enable sccache
+  run: |
+    echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+    echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+```
+
+Remove the `Swatinem/rust-cache` step from those same jobs — the two caches conflict
+and the `sccache` GHA backend handles registry caching as well.
+
+**3 — Reduce monomorphisation in `torrust-tracker` (rank 1, 77 s single unit, 606 s total)**
+
+The root crate compiles 13 separate codegen units (one per binary + test variants).
+Each pays the full monomorphisation cost. Strategies:
+
+- Move heavy generic code behind a `#[inline(never)]` boundary or into a shared
+  internal crate so it is compiled once and linked.
+- Extract large `impl` blocks into a `tracker-impl` crate that binaries depend on,
+  rather than living in the root crate.
+
+**4 — Split `bittorrent-tracker-core` (rank 3, 63 s single unit, 182 s CPU)**
+
+This is the most-depended-upon workspace crate. Its size directly multiplies the cost
+of every downstream crate that imports it. Consider splitting it along its subdomain
+boundaries (e.g., separate announce logic, scrape logic, auth) so that a change in
+one subdomain only forces recompilation of a smaller unit.
+
+**5 — Reduce `--all-features` feature flag explosion**
+
+The `--all-features` flag enables every combination of features across the workspace.
+Many crates compile multiple times under different feature sets. Profile which feature
+combinations are exercised in practice; disable unused combinations in CI by running
+per-crate with only the features that combination actually exercises.
+
+**6 — Link-time: switch to `lld` or `mold` linker**
+
+Linking is not the dominant cost here (compile is), but switching the linker reduces
+the final 10–20 % of cold build time at no code-change cost.
+
+```toml
+# .cargo/config.toml
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+```
+
+**7 — C build scripts: `aws-lc-sys`, `libsqlite3-sys`, `zstd-sys` (combined 60 s)**
+
+These C libraries are compiled from source each clean build. Options:
+
+- `SQLITE_USE_SYSTEM` / `SQLX_SQLITE_USE_SYSTEM` env vars make `libsqlite3-sys` use
+  the system-installed SQLite, skipping the C compile entirely.
+- `aws-lc-sys` can be replaced by `ring` for TLS if the feature set allows it, saving
+  ~21 s. Check whether `aws-lc` is pulled in by `rustls` and whether the `ring`
+  backend can be selected instead.
+
+**8 — `torrust-tracker-contrib-bencode` (rank 14, 14 s single unit)**
+
+The `bencode` crate in `contrib/` takes ~14 s per unit despite being a small
+domain-specific library. Investigate whether it carries unexpectedly heavy trait
+bounds or large constant arrays that inflate codegen time. Adding
+`codegen-units = 16` to its dev profile would parallelise it.
+
+---
+
+### To speed up test execution (minor gain, ~10 % of total time)
+
+- The slow integration tests (UDP server 5.04 s, health-check 2.05 s) spin up real OS
+  sockets; they cannot be sped up without test-design changes.
+- `swarm_coordination_registry` (3.21 s, 95 tests) likely contains real `sleep` calls.
+  Replacing them with the project's `clock` mock would cut this to near zero.
+- `cargo nextest` runs test binaries in parallel and reports per-test timing; it would
+  reduce the 15.26 s warm execution to roughly 6–8 s on a multi-core machine.
+
+  ```sh
+  cargo install cargo-nextest
+  cargo nextest run --workspace --all-features
+  ```

--- a/project-words.txt
+++ b/project-words.txt
@@ -56,6 +56,7 @@ connectionless
 Containerfile
 conv
 curr
+cdylib
 cvar
 Cyberneering
 cyclomatic
@@ -73,6 +74,7 @@ Dmqcd
 dockerhub
 downloadedi
 dtolnay
+dylib
 elif
 endianness
 Eray
@@ -99,6 +101,7 @@ hexdigit
 hexlify
 hlocalhost
 hmac
+hotspot
 Hydranode
 hyperthread
 Icelake
@@ -148,6 +151,7 @@ misresolved
 mmap
 mmdb
 mockall
+monomorphisation
 mprotect
 MSRV
 multimap
@@ -173,6 +177,8 @@ obra
 oneshot
 ostr
 Pando
+parallelise
+parallelised
 peekable
 peerlist
 peersld
@@ -197,6 +203,7 @@ randomised
 Rasterbar
 realpath
 reannounce
+recompiles
 referer
 Registar
 repomix
@@ -207,6 +214,7 @@ reuseaddr
 rerequests
 ringbuf
 ringsize
+rlib
 rngs
 rosegment
 routable
@@ -221,6 +229,7 @@ Rustls
 rustup
 Ryzen
 savepath
+sccache
 Seedable
 serde
 setgroups
@@ -275,6 +284,7 @@ Unamed
 underflows
 uninit
 Uninit
+unittests
 unparked
 Unparker
 Unsendable
@@ -298,6 +308,7 @@ Werror
 whitespaces
 Xacrimon
 XBTT
+zstd
 Xdebug
 Xeon
 Xtorrent


### PR DESCRIPTION
## Description
Adds the issue spec document for [#1726](https://github.com/torrust/torrust-tracker/issues/1726) - researching `sccache` as a build-time optimization for the torrust-tracker CI pipeline.

## Changes
- `docs/issues/1726-reduce-build-times-sccache/ISSUE.md` - research-framed issue spec covering:
  - Background with benchmark data and known limitations (bin crate exclusion, non-sticky runners, incremental compilation conflict)
  - Four tasks: branch creation, local A/B benchmark, local config decision, CI A/B benchmark
  - Acceptance criteria gating on measured CI speedup
- `docs/issues/1726-reduce-build-times-sccache/benchmark-results.md` - raw benchmark artifact from 2026-05-01
- `project-words.txt` - added `cdylib`, `dylib`, `rlib`

## Related
- Related to #1726
