### PR TITLE
dev: extract tls optional before TLS setup (supersedes #1429)

### DIFF
--- a/packages/axum-http-tracker-server/src/environment.rs
+++ b/packages/axum-http-tracker-server/src/environment.rs
@@ -48,9 +48,11 @@ impl Environment<Stopped> {
 
         let bind_to = container.http_tracker_core_container.http_tracker_config.bind_address;
 
-        let tls = make_rust_tls(&container.http_tracker_core_container.http_tracker_config.tsl_config)
-            .await
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = if let Some(tls_config) = &container.http_tracker_core_container.http_tracker_config.tsl_config {
+            Some(make_rust_tls(tls_config).await.expect("tls config failed"))
+        } else {
+            None
+        };
 
         let server = HttpServer::new(Launcher::new(bind_to, tls));
 

--- a/packages/axum-http-tracker-server/src/server.rs
+++ b/packages/axum-http-tracker-server/src/server.rs
@@ -357,9 +357,11 @@ mod tests {
 
         let bind_to = http_tracker_config.bind_address;
 
-        let tls = make_rust_tls(&http_tracker_config.tsl_config)
-            .await
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = if let Some(tls_config) = &http_tracker_config.tsl_config {
+            Some(make_rust_tls(tls_config).await.expect("tls config failed"))
+        } else {
+            None
+        };
 
         let register = &Registar::default();
         let stopped = HttpServer::new(Launcher::new(bind_to, tls));

--- a/packages/axum-rest-tracker-api-server/src/environment.rs
+++ b/packages/axum-rest-tracker-api-server/src/environment.rs
@@ -54,9 +54,11 @@ impl Environment<Stopped> {
 
         let bind_to = container.tracker_http_api_core_container.http_api_config.bind_address;
 
-        let tls = make_rust_tls(&container.tracker_http_api_core_container.http_api_config.tsl_config)
-            .await
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = if let Some(tls_config) = &container.tracker_http_api_core_container.http_api_config.tsl_config {
+            Some(make_rust_tls(tls_config).await.expect("tls config failed"))
+        } else {
+            None
+        };
 
         let server = ApiServer::new(Launcher::new(bind_to, tls));
 

--- a/packages/axum-rest-tracker-api-server/src/server.rs
+++ b/packages/axum-rest-tracker-api-server/src/server.rs
@@ -339,9 +339,11 @@ mod tests {
 
         let bind_to = http_api_config.bind_address;
 
-        let tls = make_rust_tls(&http_api_config.tsl_config)
-            .await
-            .map(|tls| tls.expect("tls config failed"));
+        let tls = if let Some(tls_config) = &http_api_config.tsl_config {
+            Some(make_rust_tls(tls_config).await.expect("tls config failed"))
+        } else {
+            None
+        };
 
         let access_tokens = Arc::new(http_api_config.access_tokens.clone());
 

--- a/packages/axum-server/src/tsl.rs
+++ b/packages/axum-server/src/tsl.rs
@@ -21,63 +21,78 @@ pub enum Error {
     },
 }
 
-#[instrument(skip(opt_tsl_config))]
-pub async fn make_rust_tls(opt_tsl_config: &Option<TslConfig>) -> Option<Result<RustlsConfig, Error>> {
-    match opt_tsl_config {
-        Some(tsl_config) => {
-            let cert = tsl_config.ssl_cert_path.clone();
-            let key = tsl_config.ssl_key_path.clone();
+#[instrument(skip(tsl_config))]
+/// # Errors
+///
+/// Returns [`Error::MissingTlsConfig`] when the certificate or key path does
+/// not exist, and [`Error::BadTlsConfig`] when loading invalid PEM files
+/// fails.
+pub async fn make_rust_tls(tsl_config: &TslConfig) -> Result<RustlsConfig, Error> {
+    let cert = tsl_config.ssl_cert_path.clone();
+    let key = tsl_config.ssl_key_path.clone();
 
-            if !cert.exists() || !key.exists() {
-                return Some(Err(Error::MissingTlsConfig {
-                    location: Location::caller(),
-                }));
-            }
-
-            tracing::info!("Using https: cert path: {cert}.");
-            tracing::info!("Using https: key path: {key}.");
-
-            Some(
-                RustlsConfig::from_pem_file(cert, key)
-                    .await
-                    .map_err(|err| Error::BadTlsConfig {
-                        source: (Arc::new(err) as DynError).into(),
-                    }),
-            )
-        }
-        None => None,
+    if !cert.exists() || !key.exists() {
+        return Err(Error::MissingTlsConfig {
+            location: Location::caller(),
+        });
     }
+
+    tracing::info!("Using https: cert path: {cert}.");
+    tracing::info!("Using https: key path: {key}.");
+
+    RustlsConfig::from_pem_file(cert, key)
+        .await
+        .map_err(|err| Error::BadTlsConfig {
+            source: (Arc::new(err) as DynError).into(),
+        })
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use camino::Utf8PathBuf;
     use torrust_tracker_configuration::TslConfig;
 
     use super::{make_rust_tls, Error};
 
+    fn make_temp_file(prefix: &str, content: &str) -> Utf8PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time should be later than epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{prefix}-{nanos}.pem"));
+        fs::write(&path, content).expect("it should write temporary test file");
+
+        Utf8PathBuf::from_path_buf(path).expect("temporary test file path should be UTF-8")
+    }
+
     #[tokio::test]
     async fn it_should_error_on_bad_tls_config() {
-        let err = make_rust_tls(&Some(TslConfig {
-            ssl_cert_path: Utf8PathBuf::from("bad cert path"),
-            ssl_key_path: Utf8PathBuf::from("bad key path"),
-        }))
+        let cert_path = make_temp_file("bad-cert", "not a valid certificate");
+        let key_path = make_temp_file("bad-key", "not a valid private key");
+
+        let err = make_rust_tls(&TslConfig {
+            ssl_cert_path: cert_path.clone(),
+            ssl_key_path: key_path.clone(),
+        })
         .await
-        .expect("tls_was_enabled")
         .expect_err("bad_cert_and_key_files");
 
-        assert!(matches!(err, Error::MissingTlsConfig { location: _ }));
+        fs::remove_file(cert_path).expect("it should remove temporary cert file");
+        fs::remove_file(key_path).expect("it should remove temporary key file");
+
+        assert!(matches!(err, Error::BadTlsConfig { source: _ }));
     }
 
     #[tokio::test]
     async fn it_should_error_on_missing_cert_or_key_paths() {
-        let err = make_rust_tls(&Some(TslConfig {
+        let err = make_rust_tls(&TslConfig {
             ssl_cert_path: Utf8PathBuf::from(""),
             ssl_key_path: Utf8PathBuf::from(""),
-        }))
+        })
         .await
-        .expect("tls_was_enabled")
         .expect_err("missing_config");
 
         assert!(matches!(err, Error::MissingTlsConfig { location: _ }));

--- a/src/bootstrap/jobs/http_tracker.rs
+++ b/src/bootstrap/jobs/http_tracker.rs
@@ -38,9 +38,15 @@ pub async fn start_job(
 ) -> Option<JoinHandle<()>> {
     let socket = http_tracker_container.http_tracker_config.bind_address;
 
-    let tls = make_rust_tls(&http_tracker_container.http_tracker_config.tsl_config)
-        .await
-        .map(|tls| tls.expect("it should have a valid http tracker tls configuration"));
+    let tls = if let Some(tls_config) = &http_tracker_container.http_tracker_config.tsl_config {
+        Some(
+            make_rust_tls(tls_config)
+                .await
+                .expect("it should have a valid http tracker tls configuration"),
+        )
+    } else {
+        None
+    };
 
     match version {
         Version::V1 => Some(start_v1(socket, tls, http_tracker_container, form).await),

--- a/src/bootstrap/jobs/tracker_apis.rs
+++ b/src/bootstrap/jobs/tracker_apis.rs
@@ -61,9 +61,15 @@ pub async fn start_job(
 ) -> Option<JoinHandle<()>> {
     let bind_to = http_api_container.http_api_config.bind_address;
 
-    let tls = make_rust_tls(&http_api_container.http_api_config.tsl_config)
-        .await
-        .map(|tls| tls.expect("it should have a valid tracker api tls configuration"));
+    let tls = if let Some(tls_config) = &http_api_container.http_api_config.tsl_config {
+        Some(
+            make_rust_tls(tls_config)
+                .await
+                .expect("it should have a valid tracker api tls configuration"),
+        )
+    } else {
+        None
+    };
 
     let access_tokens = Arc::new(http_api_container.http_api_config.access_tokens.clone());
 


### PR DESCRIPTION
## Summary
- supersede old PR #1429 by replaying its intent on top of current `develop`
- make `make_rust_tls` receive a concrete `TslConfig`
- unwrap optional TLS config at call sites before invoking `make_rust_tls`

## Why
PR #1429 no longer applies cleanly to current `develop`. This PR carries the same behavioral intent while resolving code drift in current call sites.

## Validation
- `cargo test -p torrust-axum-server -p torrust-axum-http-tracker-server -p torrust-axum-rest-tracker-api-server`