### PR TITLE
docs(issues): refine EPIC #669 sub-issue specs

### DIFF
--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -61,28 +61,39 @@ cargo run -p torrust-tracker-client --bin http_tracker_client announce \
 
 Supported `--event` values: `started`, `stopped`, `completed` (case-insensitive).
 
+`--peer-id` input contract:
+
+- Accept a 20-character ASCII value.
+- Reject any value that is not exactly 20 bytes.
+- Surface validation errors as CLI argument errors.
+
 ## Goals
 
 - [ ] Add optional CLI flags to the `announce` sub-command in
       `console/tracker-client/src/console/clients/http/app.rs`:
       `--event`, `--uploaded`, `--downloaded`, `--left`, `--port`, `--peer-addr`,
       `--peer-id`, `--compact`
-- [ ] Parse each flag and pass its value to the corresponding `QueryBuilder` setter
+- [ ] Parse each flag and map it into `announce::Query` values
+- [ ] Extend `QueryBuilder` with missing setters for
+      `event`, `uploaded`, `downloaded`, `left`, and `port`
 - [ ] Defaults remain unchanged when a flag is omitted
-- [ ] Add `FromStr` / `clap` value parsing for `Event` (already has `Display`; needs `FromStr`)
+- [ ] Add CLI parsing for `Event` in the tracker-client layer
 - [ ] Pass `linter all` and `cargo machete` with zero warnings
 - [ ] Update the module-level doc comment in `app.rs` with new usage examples
 
 ## Implementation Plan
 
-### Task 1: Add `FromStr` for `Event`
+### Task 1: Add CLI parsing for `Event`
 
-`Event` already implements `Display`. Add a `FromStr` implementation (or derive it via `clap`'s
-`ValueEnum`) so it can be parsed directly from the command line.
+Use a CLI-facing enum (for example `CliEvent`) in
+`console/tracker-client/src/console/clients/http/app.rs` and map it into
+`bittorrent_tracker_client::http::client::requests::announce::Event`.
 
-- [ ] Implement `clap::ValueEnum` for `Event` in
-      `packages/tracker-client/src/http/client/requests/announce.rs`
-      (or add `FromStr` and map it in the CLI layer)
+Do not rely on `packages/http-protocol` `Event`, which is a different type and
+belongs to a different layer.
+
+- [ ] Implement `clap::ValueEnum` for the CLI-facing `event` type
+- [ ] Add explicit mapping from CLI event type to tracker-client request `Event`
 
 ### Task 2: Extend the `Announce` sub-command struct
 
@@ -95,7 +106,7 @@ Announce {
     tracker_url: String,
     info_hash: String,
     #[arg(long)]
-    event: Option<Event>,
+  event: Option<CliEvent>,
     #[arg(long)]
     uploaded: Option<u64>,
     #[arg(long)]
@@ -109,14 +120,20 @@ Announce {
     #[arg(long, name = "peer-id")]
     peer_id: Option<String>,
     #[arg(long)]
-    compact: Option<u8>,
+    compact: Option<CliCompact>,
 }
 ```
+
+`CliCompact` should accept only `0` and `1` and map to
+`announce::Compact::{NotAccepted, Accepted}`.
 
 ### Task 3: Thread optional values through `announce_command`
 
 - [ ] Update `announce_command` signature to accept the optional parameters
+- [ ] Add missing `QueryBuilder` setters in
+      `packages/tracker-client/src/http/client/requests/announce.rs`
 - [ ] Apply each `Some(value)` to the `QueryBuilder` chain before calling `.query()`
+- [ ] Parse and validate `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
 
 ### Task 4: Update docs
 

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -106,7 +106,7 @@ Announce {
     tracker_url: String,
     info_hash: String,
     #[arg(long)]
-  event: Option<CliEvent>,
+    event: Option<CliEvent>,
     #[arg(long)]
     uploaded: Option<u64>,
     #[arg(long)]
@@ -115,9 +115,9 @@ Announce {
     left: Option<u64>,
     #[arg(long)]
     port: Option<u16>,
-    #[arg(long, name = "peer-addr")]
+    #[arg(long = "peer-addr")]
     peer_addr: Option<IpAddr>,
-    #[arg(long, name = "peer-id")]
+    #[arg(long = "peer-id")]
     peer_id: Option<String>,
     #[arg(long)]
     compact: Option<CliCompact>,

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -1,0 +1,145 @@
+# Issue #1532 — HTTP Tracker Client: Add Optional Parameters to Announce Command
+
+## Overview
+
+The HTTP Tracker client's `announce` sub-command accepts only two arguments: the tracker URL and
+the `info_hash`. All other announce query parameters (`event`, `uploaded`, `downloaded`, `left`,
+`port`, `peer_addr`, `compact`, `peer_id`) are hard-coded with default values inside
+`QueryBuilder::with_default_values()`.
+
+This means that to simulate a state transition (e.g., a peer completing a download by sending
+`event=completed`) a developer must edit the source, recompile, run, revert, recompile, and run
+again. The goal of this issue is to make those parameters available as optional CLI flags.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1532>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-tracker/issues/1533> (same feature for UDP client)
+
+## Motivation
+
+The `downloads` counter on a tracker only increments when a peer transitions from `started` to
+`completed`. Without being able to control the `event` field from the command line, testing this
+behaviour requires source-level changes. An example of a test that triggered this pain:
+<https://github.com/torrust/torrust-tracker/pull/1531>
+
+## Current Behaviour
+
+```console
+cargo run -p torrust-tracker-client --bin http_tracker_client \
+  announce http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6
+```
+
+All announce query parameters other than `info_hash` use defaults:
+
+| Parameter    | Hard-coded default     |
+| ------------ | ---------------------- |
+| `event`      | `started`              |
+| `uploaded`   | `0`                    |
+| `downloaded` | `0`                    |
+| `left`       | `0`                    |
+| `port`       | `17548`                |
+| `peer_addr`  | `192.168.1.88`         |
+| `peer_id`    | `-qB00000000000000001` |
+| `compact`    | `0` (not accepted)     |
+
+## Proposed CLI
+
+All announce-query parameters become optional flags. When omitted, the existing defaults apply.
+
+```console
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+  http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6 \
+  --event completed \
+  --uploaded 1234 \
+  --downloaded 5678 \
+  --left 0 \
+  --port 6881 \
+  --peer-addr 10.0.0.1 \
+  --peer-id "-RC0000000000000001" \
+  --compact 1
+```
+
+Supported `--event` values: `started`, `stopped`, `completed` (case-insensitive).
+
+## Goals
+
+- [ ] Add optional CLI flags to the `announce` sub-command in
+      `console/tracker-client/src/console/clients/http/app.rs`:
+      `--event`, `--uploaded`, `--downloaded`, `--left`, `--port`, `--peer-addr`,
+      `--peer-id`, `--compact`
+- [ ] Parse each flag and pass its value to the corresponding `QueryBuilder` setter
+- [ ] Defaults remain unchanged when a flag is omitted
+- [ ] Add `FromStr` / `clap` value parsing for `Event` (already has `Display`; needs `FromStr`)
+- [ ] Pass `linter all` and `cargo machete` with zero warnings
+- [ ] Update the module-level doc comment in `app.rs` with new usage examples
+
+## Implementation Plan
+
+### Task 1: Add `FromStr` for `Event`
+
+`Event` already implements `Display`. Add a `FromStr` implementation (or derive it via `clap`'s
+`ValueEnum`) so it can be parsed directly from the command line.
+
+- [ ] Implement `clap::ValueEnum` for `Event` in
+      `packages/tracker-client/src/http/client/requests/announce.rs`
+      (or add `FromStr` and map it in the CLI layer)
+
+### Task 2: Extend the `Announce` sub-command struct
+
+In `console/tracker-client/src/console/clients/http/app.rs`:
+
+- [ ] Change the `Announce` variant of the `Command` enum to carry optional fields:
+
+```rust
+Announce {
+    tracker_url: String,
+    info_hash: String,
+    #[arg(long)]
+    event: Option<Event>,
+    #[arg(long)]
+    uploaded: Option<u64>,
+    #[arg(long)]
+    downloaded: Option<u64>,
+    #[arg(long)]
+    left: Option<u64>,
+    #[arg(long)]
+    port: Option<u16>,
+    #[arg(long, name = "peer-addr")]
+    peer_addr: Option<IpAddr>,
+    #[arg(long, name = "peer-id")]
+    peer_id: Option<String>,
+    #[arg(long)]
+    compact: Option<u8>,
+}
+```
+
+### Task 3: Thread optional values through `announce_command`
+
+- [ ] Update `announce_command` signature to accept the optional parameters
+- [ ] Apply each `Some(value)` to the `QueryBuilder` chain before calling `.query()`
+
+### Task 4: Update docs
+
+- [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
+
+## Acceptance Criteria
+
+- [ ] Running `announce ... --event completed` sends `event=completed` in the query string
+- [ ] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Key Files
+
+| File                                                           | Role                                                              |
+| -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `console/tracker-client/src/console/clients/http/app.rs`       | CLI entry point — add flags here                                  |
+| `packages/tracker-client/src/http/client/requests/announce.rs` | `QueryBuilder`, `Event`, `Query` — add `ValueEnum`/`FromStr` here |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related UDP issue: <https://github.com/torrust/torrust-tracker/issues/1533>
+- PR that motivated this issue: <https://github.com/torrust/torrust-tracker/pull/1531>
+- BitTorrent tracker spec: <https://wiki.theory.org/BitTorrentSpecification#Tracker_HTTP.2FHTTPS_Protocol>

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -1,0 +1,159 @@
+# Issue #1533 — UDP Tracker Client: Add Optional Parameters to Announce Command
+
+## Overview
+
+The UDP Tracker client's `announce` sub-command accepts only two arguments: the tracker socket
+address and the `info_hash`. All other announce request parameters (`event`, `uploaded`,
+`downloaded`, `left`, `port`, `peer_id`, `ip_address`, `key`, `peers_wanted`) are hard-coded
+with default values directly inside `checker::Client::send_announce_request()`.
+
+This is the UDP counterpart of issue
+[#1532](https://github.com/torrust/torrust-tracker/issues/1532), which adds the same capability
+to the HTTP Tracker client.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1533>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-tracker/issues/1532> (same feature for HTTP client)
+
+## Motivation
+
+Same motivation as #1532. The `downloads` counter only increments when a peer transitions from
+`started` to `completed`. Without control over the `event` field at the command line, testing
+this behaviour requires source-level edits, recompilation, and manual repetition.
+
+## Current Behaviour
+
+```console
+cargo run -p torrust-tracker-client --bin udp_tracker_client \
+  announce 127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422
+```
+
+All announce request fields other than `info_hash` use hard-coded defaults (from
+`console/tracker-client/src/console/clients/udp/checker.rs`):
+
+| Parameter          | Hard-coded default           |
+| ------------------ | ---------------------------- |
+| `event`            | `AnnounceEvent::Started`     |
+| `bytes_uploaded`   | `0`                          |
+| `bytes_downloaded` | `0`                          |
+| `bytes_left`       | `0`                          |
+| `port`             | socket's local port (random) |
+| `ip_address`       | `0.0.0.0` (unspecified)      |
+| `peer_id`          | `-qB00000000000000001`       |
+| `key`              | `0`                          |
+| `peers_wanted`     | `1`                          |
+
+## Proposed CLI
+
+All announce request parameters become optional flags. When omitted, the existing defaults apply.
+
+```console
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
+  --event completed \
+  --uploaded 1234 \
+  --downloaded 5678 \
+  --left 0 \
+  --port 6881 \
+  --ip-address 10.0.0.1 \
+  --peer-id "-RC0000000000000001" \
+  --key 42 \
+  --peers-wanted 50
+```
+
+Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
+`aquatic_udp_protocol::AnnounceEvent` variants, case-insensitive).
+
+## Goals
+
+- [ ] Add optional CLI flags to the `Announce` variant in
+      `console/tracker-client/src/console/clients/udp/app.rs`:
+      `--event`, `--uploaded`, `--downloaded`, `--left`, `--port`, `--ip-address`,
+      `--peer-id`, `--key`, `--peers-wanted`
+- [ ] Thread the optional values from the CLI into `handle_announce` and then into
+      `checker::Client::send_announce_request()`
+- [ ] Add `clap::ValueEnum` (or `FromStr`) for `AnnounceEvent` so it can be parsed from the
+      command line — or introduce a thin wrapper enum in the CLI layer
+- [ ] Defaults remain unchanged when a flag is omitted
+- [ ] Pass `linter all` and `cargo machete` with zero warnings
+- [ ] Update the module-level doc comment in `app.rs` with new usage examples
+
+## Implementation Plan
+
+### Task 1: Add `clap` parsing for `AnnounceEvent`
+
+`aquatic_udp_protocol::AnnounceEvent` is an external type so we cannot implement foreign traits
+on it directly. Two options:
+
+- Introduce a thin `CliAnnounceEvent` wrapper enum that implements `clap::ValueEnum`, then map
+  it to `AnnounceEvent` when building the request.
+- Add `FromStr` on a newtype in the CLI crate.
+
+- [ ] Choose and implement one of the above in the CLI layer
+      (`console/tracker-client/src/console/clients/udp/`)
+
+### Task 2: Extend the `Announce` sub-command struct
+
+In `console/tracker-client/src/console/clients/udp/app.rs`:
+
+- [ ] Change the `Announce` variant of the `Command` enum to carry optional fields:
+
+```rust
+Announce {
+    #[arg(value_parser = parse_socket_addr)]
+    tracker_socket_addr: SocketAddr,
+    #[arg(value_parser = parse_info_hash)]
+    info_hash: TorrustInfoHash,
+    #[arg(long)]
+    event: Option<CliAnnounceEvent>,
+    #[arg(long)]
+    uploaded: Option<i64>,
+    #[arg(long)]
+    downloaded: Option<i64>,
+    #[arg(long)]
+    left: Option<i64>,
+    #[arg(long)]
+    port: Option<u16>,
+    #[arg(long, name = "ip-address")]
+    ip_address: Option<Ipv4Addr>,
+    #[arg(long, name = "peer-id")]
+    peer_id: Option<String>,
+    #[arg(long)]
+    key: Option<i32>,
+    #[arg(long, name = "peers-wanted")]
+    peers_wanted: Option<i32>,
+}
+```
+
+### Task 3: Thread optional values through `handle_announce`
+
+- [ ] Update `handle_announce` to accept the new optional parameters and pass them to
+      `checker::Client::send_announce_request()`
+- [ ] Update `send_announce_request` in `checker.rs` to accept an optional parameter struct
+      (or individual `Option` arguments) and apply overrides when `Some`
+
+### Task 4: Update docs
+
+- [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
+
+## Acceptance Criteria
+
+- [ ] Running `announce ... --event completed` sends `event=completed` in the UDP packet
+- [ ] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Key Files
+
+| File                                                        | Role                                               |
+| ----------------------------------------------------------- | -------------------------------------------------- |
+| `console/tracker-client/src/console/clients/udp/app.rs`     | CLI entry point — add flags here                   |
+| `console/tracker-client/src/console/clients/udp/checker.rs` | `send_announce_request` — propagate overrides here |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related HTTP issue: <https://github.com/torrust/torrust-tracker/issues/1532>
+- `aquatic_udp_protocol::AnnounceEvent`: <https://docs.rs/aquatic_udp_protocol>
+- UDP tracker protocol spec (BEP 15): <https://www.bittorrent.org/beps/bep_0015.html>

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -126,13 +126,13 @@ Announce {
     left: Option<i64>,
     #[arg(long)]
     port: Option<u16>,
-    #[arg(long, name = "ip-address")]
+    #[arg(long = "ip-address")]
     ip_address: Option<Ipv4Addr>,
-    #[arg(long, name = "peer-id")]
+    #[arg(long = "peer-id")]
     peer_id: Option<String>,
     #[arg(long)]
     key: Option<i32>,
-    #[arg(long, name = "peers-wanted")]
+    #[arg(long = "peers-wanted")]
     peers_wanted: Option<i32>,
 }
 ```

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -62,7 +62,7 @@ cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
 ```
 
 Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
-`aquatic_udp_protocol::AnnounceEvent` variants, case-insensitive).
+`bittorrent_udp_tracker_protocol::AnnounceEvent` variants, case-insensitive).
 
 ## Goals
 
@@ -73,7 +73,8 @@ Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
 - [ ] Thread the optional values from the CLI into `handle_announce` and then into
       `checker::Client::send_announce_request()`
 - [ ] Add `clap::ValueEnum` (or `FromStr`) for `AnnounceEvent` so it can be parsed from the
-      command line — or introduce a thin wrapper enum in the CLI layer
+      command line — implement directly on the in-house type or introduce a thin wrapper in
+      the CLI layer for clean separation of concerns
 - [ ] Defaults remain unchanged when a flag is omitted
 - [ ] Pass `linter all` and `cargo machete` with zero warnings
 - [ ] Update the module-level doc comment in `app.rs` with new usage examples
@@ -82,12 +83,17 @@ Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
 
 ### Task 1: Add `clap` parsing for `AnnounceEvent`
 
-`aquatic_udp_protocol::AnnounceEvent` is an external type so we cannot implement foreign traits
-on it directly. Two options:
+`AnnounceEvent` is now an in-house type defined in `packages/udp-protocol/src/announce.rs`
+(re-exported by `bittorrent_udp_tracker_protocol`), so the foreign-trait constraint no longer
+applies. Two implementation paths are available:
 
-- Introduce a thin `CliAnnounceEvent` wrapper enum that implements `clap::ValueEnum`, then map
-  it to `AnnounceEvent` when building the request.
-- Add `FromStr` on a newtype in the CLI crate.
+- Implement `clap::ValueEnum` directly on `AnnounceEvent` in `packages/udp-protocol` by
+  adding `clap` as an optional feature-gated dependency there.
+- Introduce a thin `CliAnnounceEvent` wrapper enum in the CLI crate that implements
+  `clap::ValueEnum`, then map it to `AnnounceEvent` when building the request. This keeps
+  `clap` out of the protocol crate and preserves clean separation of concerns.
+
+The wrapper approach is recommended to avoid leaking CLI concerns into the protocol layer.
 
 - [ ] Choose and implement one of the above in the CLI layer
       (`console/tracker-client/src/console/clients/udp/`)
@@ -155,5 +161,6 @@ Announce {
 
 - Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
 - Related HTTP issue: <https://github.com/torrust/torrust-tracker/issues/1532>
-- `aquatic_udp_protocol::AnnounceEvent`: <https://docs.rs/aquatic_udp_protocol>
+- `bittorrent_udp_tracker_protocol::AnnounceEvent`: `packages/udp-protocol/src/announce.rs`
+- `bittorrent_peer_id::PeerId`: `packages/peer-id/src/peer_id.rs`
 - UDP tracker protocol spec (BEP 15): <https://www.bittorrent.org/beps/bep_0015.html>

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -64,6 +64,12 @@ cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
 Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
 `bittorrent_udp_tracker_protocol::AnnounceEvent` variants, case-insensitive).
 
+`--peer-id` input contract:
+
+- Accept a 20-character ASCII value.
+- Reject any value that is not exactly 20 bytes.
+- Surface validation errors as CLI argument errors.
+
 ## Goals
 
 - [ ] Add optional CLI flags to the `Announce` variant in
@@ -137,6 +143,8 @@ Announce {
       `checker::Client::send_announce_request()`
 - [ ] Update `send_announce_request` in `checker.rs` to accept an optional parameter struct
       (or individual `Option` arguments) and apply overrides when `Some`
+- [ ] Validate and parse `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
+- [ ] Reject negative values for `uploaded`, `downloaded`, and `left` at the CLI layer
 
 ### Task 4: Update docs
 

--- a/docs/issues/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
+++ b/docs/issues/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
@@ -1,0 +1,194 @@
+# Issue #1561 — HTTP Tracker Client: Avoid Duplicating the `announce` Suffix
+
+## Overview
+
+The HTTP tracker client currently assumes the user passes a tracker base URL
+without the request path suffix. When the user provides a full tracker URL that
+already ends in `/announce`, the client appends another `announce` segment and
+sends the request to an invalid endpoint.
+
+This is a bug in the HTTP client URL construction logic. The client should
+accept both forms:
+
+- base URL, for example `https://tracker.torrust-demo.com/`
+- full announce URL, for example `https://tracker.torrust-demo.com/announce`
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1561>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+
+## Motivation
+
+A user naturally expects the HTTP client to accept the same long-form tracker
+URL that appears in torrent metadata and public tracker lists.
+
+Today this command fails:
+
+```text
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+  https://tracker.torrust-demo.com/announce \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82
+```
+
+Because the final request URL becomes:
+
+```text
+https://tracker.torrust-demo.com/announceannounce?...query...
+```
+
+That produces a `404 Not Found` even though the provided tracker URL is valid.
+
+## Current Behaviour
+
+The console binary parses the user input URL and passes it unchanged into the
+package client in `console/tracker-client/src/console/clients/http/app.rs`.
+
+The actual bug is in
+`packages/tracker-client/src/http/client/mod.rs`, where request URLs are built
+by plain string concatenation:
+
+```rust
+fn build_announce_path_and_query(&self, query: &announce::Query) -> String {
+    format!("{}?{query}", self.build_path("announce"))
+}
+
+fn build_url(&self, path: &str) -> String {
+    let base_url = self.base_url();
+    format!("{base_url}{path}")
+}
+```
+
+If `base_url` already ends in `announce`, the client still appends `announce`
+again. The same risk exists for `scrape` if a full scrape URL is passed.
+
+## Proposed Behaviour
+
+The HTTP client should normalize the request URL before sending requests.
+
+Expected accepted inputs for announce:
+
+- `https://tracker.torrust-demo.com`
+- `https://tracker.torrust-demo.com/`
+- `https://tracker.torrust-demo.com/announce`
+
+Expected final request path for announce:
+
+- exactly one `/announce`
+
+Expected accepted inputs for scrape:
+
+- `https://tracker.torrust-demo.com`
+- `https://tracker.torrust-demo.com/`
+- `https://tracker.torrust-demo.com/scrape`
+
+Expected final request path for scrape:
+
+- exactly one `/scrape`
+
+The client should not rely on callers pre-trimming or pre-normalizing the URL.
+
+## Goals
+
+- [ ] Accept both bare tracker base URLs and full announce URLs in the HTTP
+      client
+- [ ] Avoid duplicating the `announce` path suffix in the final request URL
+- [ ] Avoid duplicating the `scrape` path suffix in the final request URL
+- [ ] Keep authenticated path handling working, including URLs that append the
+      authentication key after the endpoint path
+- [ ] Preserve existing behaviour for valid base URLs
+- [ ] Add tests covering the supported input forms
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Implementation Plan
+
+### Task 1: Replace string concatenation with URL-aware path building
+
+In `packages/tracker-client/src/http/client/mod.rs`, stop constructing request
+URLs through `format!("{base_url}{path}")`.
+
+Instead, add a helper that derives a normalized endpoint URL from the parsed
+`reqwest::Url`, for example by:
+
+- inspecting the current path segments
+- detecting whether the last segment is already `announce` or `scrape`
+- replacing or appending path segments as needed
+- preserving scheme, host, port, and query construction
+
+The key rule is: the final URL must contain the endpoint suffix exactly once.
+
+### Task 2: Normalize announce and scrape independently
+
+Ensure announce requests always resolve to exactly one `announce` segment and
+scrape requests always resolve to exactly one `scrape` segment.
+
+Do not implement a narrow fix that only handles `announce`.
+
+### Task 3: Preserve authenticated endpoint support
+
+`build_path()` currently appends the optional authentication key as:
+
+```rust
+announce/<key>
+```
+
+or
+
+```rust
+scrape/<key>
+```
+
+The normalization logic must preserve this behaviour without producing broken
+paths like:
+
+- `/announce/announce/<key>`
+- `/announce/<key>/<key>`
+
+### Task 4: Add focused unit tests for URL building
+
+Add tests in `packages/tracker-client/src/http/client/mod.rs` covering at least:
+
+- base URL without trailing slash + announce
+- base URL with trailing slash + announce
+- full `/announce` URL + announce
+- base URL without trailing slash + scrape
+- full `/scrape` URL + scrape
+- authenticated announce path with a full `/announce` base URL
+
+The tests should assert the exact final URL string.
+
+### Task 5: Update HTTP client docs/examples
+
+Update the module docs in
+`console/tracker-client/src/console/clients/http/app.rs` or package docs so the
+accepted URL forms are explicit.
+
+## Acceptance Criteria
+
+- [ ] Passing `https://tracker.torrust-demo.com` to the announce command sends
+      the request to `/announce`
+- [ ] Passing `https://tracker.torrust-demo.com/announce` to the announce
+      command also sends the request to `/announce`
+- [ ] Passing `https://tracker.torrust-demo.com` to the scrape command sends
+      the request to `/scrape`
+- [ ] Passing `https://tracker.torrust-demo.com/scrape` to the scrape command
+      also sends the request to `/scrape`
+- [ ] Authenticated requests still generate correct URLs
+- [ ] No duplicated endpoint suffix appears in final request URLs
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Key Files
+
+| File                                                     | Role                                      |
+| -------------------------------------------------------- | ----------------------------------------- |
+| `packages/tracker-client/src/http/client/mod.rs`         | Main bug location and URL normalization   |
+| `console/tracker-client/src/console/clients/http/app.rs` | Console entry point that accepts user URL |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1561>
+- HTTP client package: `packages/tracker-client/src/http/client/`
+- HTTP client console app: `console/tracker-client/src/console/clients/http/app.rs`

--- a/docs/issues/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
+++ b/docs/issues/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
@@ -13,6 +13,14 @@ accept both forms:
 - base URL, for example `https://tracker.torrust-demo.com/`
 - full announce URL, for example `https://tracker.torrust-demo.com/announce`
 
+The `/announce` suffix is common in public tracker lists (for example
+newtrackon), but not guaranteed by protocol-level requirements. The client
+should therefore support a mixed strategy:
+
+- If the input URL path is empty (domain only) or exactly `/`, append
+  `/announce`.
+- If the input URL already contains a path segment, keep it as provided.
+
 - GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1561>
 - Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
 
@@ -69,33 +77,35 @@ Expected accepted inputs for announce:
 - `https://tracker.torrust-demo.com`
 - `https://tracker.torrust-demo.com/`
 - `https://tracker.torrust-demo.com/announce`
+- `https://tracker.torrust-demo.com/custom-tracker-endpoint`
 
 Expected final request path for announce:
 
-- exactly one `/announce`
+- exactly one effective endpoint path, resolved by the rule below
 
-Expected accepted inputs for scrape:
+Path resolution rule for `announce`:
 
-- `https://tracker.torrust-demo.com`
-- `https://tracker.torrust-demo.com/`
-- `https://tracker.torrust-demo.com/scrape`
-
-Expected final request path for scrape:
-
-- exactly one `/scrape`
+- Input path empty or `/` -> resolve to `/announce`
+- Input path non-empty (for example `/announce`, `/foo`, `/foo/bar`) -> keep it
+  unchanged
 
 The client should not rely on callers pre-trimming or pre-normalizing the URL.
+
+Scope note: this issue is about tracker protocol endpoints (`announce` and
+`scrape`). The `health_check` endpoint is out of scope.
 
 ## Goals
 
 - [ ] Accept both bare tracker base URLs and full announce URLs in the HTTP
       client
+- [ ] Append `/announce` only for bare URLs (`host` or `host/`)
+- [ ] Keep provided path unchanged when a non-empty path already exists
 - [ ] Avoid duplicating the `announce` path suffix in the final request URL
-- [ ] Avoid duplicating the `scrape` path suffix in the final request URL
 - [ ] Keep authenticated path handling working, including URLs that append the
       authentication key after the endpoint path
 - [ ] Preserve existing behaviour for valid base URLs
 - [ ] Add tests covering the supported input forms
+- [ ] Keep `health_check` behaviour unchanged in this issue
 - [ ] `linter all` exits with code `0`
 - [ ] `cargo machete` reports no unused dependencies
 - [ ] Existing tests pass
@@ -117,12 +127,14 @@ Instead, add a helper that derives a normalized endpoint URL from the parsed
 
 The key rule is: the final URL must contain the endpoint suffix exactly once.
 
-### Task 2: Normalize announce and scrape independently
+### Task 2: Apply base-URL detection for announce
 
-Ensure announce requests always resolve to exactly one `announce` segment and
-scrape requests always resolve to exactly one `scrape` segment.
+For announce requests:
 
-Do not implement a narrow fix that only handles `announce`.
+- If the input URL path is empty or `/`, append `announce`
+- Otherwise, keep the original path unchanged
+
+Do not append `announce` when any path segment already exists.
 
 ### Task 3: Preserve authenticated endpoint support
 
@@ -151,8 +163,7 @@ Add tests in `packages/tracker-client/src/http/client/mod.rs` covering at least:
 - base URL without trailing slash + announce
 - base URL with trailing slash + announce
 - full `/announce` URL + announce
-- base URL without trailing slash + scrape
-- full `/scrape` URL + scrape
+- full custom path URL + announce (path unchanged)
 - authenticated announce path with a full `/announce` base URL
 
 The tests should assert the exact final URL string.
@@ -163,16 +174,20 @@ Update the module docs in
 `console/tracker-client/src/console/clients/http/app.rs` or package docs so the
 accepted URL forms are explicit.
 
+### Task 6: Keep `health_check` out of scope
+
+Do not change `health_check` behavior as part of this bug fix. If endpoint
+normalization is later generalized to all methods, that should be handled in a
+separate issue with dedicated tests.
+
 ## Acceptance Criteria
 
 - [ ] Passing `https://tracker.torrust-demo.com` to the announce command sends
       the request to `/announce`
 - [ ] Passing `https://tracker.torrust-demo.com/announce` to the announce
       command also sends the request to `/announce`
-- [ ] Passing `https://tracker.torrust-demo.com` to the scrape command sends
-      the request to `/scrape`
-- [ ] Passing `https://tracker.torrust-demo.com/scrape` to the scrape command
-      also sends the request to `/scrape`
+- [ ] Passing a URL with a non-empty path (for example `/foo`) keeps `/foo`
+      unchanged and does not append `announce`
 - [ ] Authenticated requests still generate correct URLs
 - [ ] No duplicated endpoint suffix appears in final request URLs
 - [ ] `linter all` exits with code `0`

--- a/docs/issues/1562-http-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/1562-http-tracker-client-add-option-show-response-pretty-json.md
@@ -41,6 +41,10 @@ Add `--format` to HTTP commands with the following values:
 - `compact` (default)
 - `pretty`
 
+Formatting applies to both typed responses and fallback JSON generated for
+unrecognized responses (from #672). Raw-byte fallback remains plain text and is
+not reformatted.
+
 Defaulting to `compact` is intentional because:
 
 - It is better for shell pipelines and machine parsing.
@@ -121,6 +125,8 @@ Update examples in `app.rs` module docs to include `--format pretty` usage.
 - [ ] `announce --format pretty` prints multiline indented JSON
 - [ ] `scrape --format pretty` prints multiline indented JSON
 - [ ] Omitting `--format` still produces compact single-line JSON
+- [ ] When fallback JSON is produced, `--format pretty` prints indented JSON and
+      default output remains compact
 - [ ] Invalid format values are rejected by clap with usage guidance
 - [ ] `linter all` exits with code `0`
 - [ ] `cargo machete` reports no unused dependencies

--- a/docs/issues/1562-http-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/1562-http-tracker-client-add-option-show-response-pretty-json.md
@@ -1,0 +1,139 @@
+# Issue #1562 — HTTP Tracker Client: Add Option to Show Response in Pretty JSON
+
+## Overview
+
+The HTTP tracker client currently prints JSON as a single compact line.
+Developers often pipe output to `jq` to make it readable.
+
+This issue adds a CLI output formatting option so users can request pretty JSON
+without external tools.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1562>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-tracker/issues/1563>
+
+## Motivation
+
+A common workflow is:
+
+```text
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+  https://tracker.torrust-demo.com \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82 | jq
+```
+
+Needing `jq` is not ideal for quick local debugging, CI scripts, or machines
+where the tool is not installed.
+
+## Current Behaviour
+
+In `console/tracker-client/src/console/clients/http/app.rs`, both
+`announce_command` and `scrape_command` serialize with:
+
+- `serde_json::to_string(...)`
+
+So output is compact JSON only. There is no output-format CLI option.
+
+## Proposed Behaviour
+
+Add `--format` to HTTP commands with the following values:
+
+- `compact` (default)
+- `pretty`
+
+Defaulting to `compact` is intentional because:
+
+- It is better for shell pipelines and machine parsing.
+- It keeps logs and CI output smaller and easier to scan.
+- It provides a consistent default that can be shared by both HTTP and UDP
+  clients.
+
+Examples:
+
+```text
+# Existing behavior (still default)
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+  https://tracker.torrust-demo.com \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82
+```
+
+```text
+# New behavior
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+  https://tracker.torrust-demo.com \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82 \
+  --format pretty
+```
+
+## Goals
+
+- [ ] Add a `--format` option to HTTP `announce` and `scrape`
+- [ ] Keep default output as `compact` for script and CI friendliness
+- [ ] Support `pretty` output using `serde_json::to_string_pretty`
+- [ ] Update CLI docs/examples for both commands
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests keep passing
+
+## Implementation Plan
+
+### Task 1: Define output format enum
+
+In `console/tracker-client/src/console/clients/http/app.rs`:
+
+- Add a small `OutputFormat` enum deriving `clap::ValueEnum`
+- Values: `Compact`, `Pretty`
+
+### Task 2: Add `--format` to CLI subcommands
+
+Extend both `Command::Announce` and `Command::Scrape` variants with:
+
+- `format: OutputFormat`
+
+Use clap defaults so current command lines remain valid and default to compact.
+
+### Task 3: Centralize JSON serialization helper
+
+Add helper:
+
+- `fn serialize_json<T: serde::Serialize>(value: &T, format: OutputFormat) -> anyhow::Result<String>`
+
+Use:
+
+- `serde_json::to_string` for `Compact`
+- `serde_json::to_string_pretty` for `Pretty`
+
+### Task 4: Wire format through command handlers
+
+Pass selected format from the parsed subcommand into:
+
+- `announce_command`
+- `scrape_command`
+
+Replace direct `serde_json::to_string(...)` calls with the helper.
+
+### Task 5: Update module docs
+
+Update examples in `app.rs` module docs to include `--format pretty` usage.
+
+## Acceptance Criteria
+
+- [ ] `announce --format pretty` prints multiline indented JSON
+- [ ] `scrape --format pretty` prints multiline indented JSON
+- [ ] Omitting `--format` still produces compact single-line JSON
+- [ ] Invalid format values are rejected by clap with usage guidance
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Key Files
+
+| File                                                     | Role                                      |
+| -------------------------------------------------------- | ----------------------------------------- |
+| `console/tracker-client/src/console/clients/http/app.rs` | Main CLI parsing and output serialization |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related UDP issue: <https://github.com/torrust/torrust-tracker/issues/1563>
+- HTTP client CLI source: `console/tracker-client/src/console/clients/http/app.rs`

--- a/docs/issues/1563-udp-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/1563-udp-tracker-client-add-option-show-response-pretty-json.md
@@ -43,6 +43,10 @@ Add `--format` to UDP commands with values:
 - `compact` (default)
 - `pretty`
 
+Formatting applies to both typed responses and fallback JSON generated for
+unrecognized responses (from #671 style behavior). Raw-byte fallback remains
+plain text and is not reformatted.
+
 Defaulting to `compact` is intentional because:
 
 - It is better for shell pipelines and machine parsing.
@@ -128,6 +132,8 @@ Update examples to show both default and explicit `--format pretty` usage.
 - [ ] Running UDP `announce --format compact` prints single-line JSON
 - [ ] Running UDP `scrape --format pretty` prints multiline JSON
 - [ ] Omitting `--format` produces compact single-line JSON
+- [ ] When fallback JSON is produced, `--format pretty` prints indented JSON and
+      default output remains compact
 - [ ] Invalid format values are rejected by clap with usage guidance
 - [ ] `linter all` exits with code `0`
 - [ ] `cargo machete` reports no unused dependencies

--- a/docs/issues/1563-udp-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/1563-udp-tracker-client-add-option-show-response-pretty-json.md
@@ -1,0 +1,148 @@
+# Issue #1563 — UDP Tracker Client: Add Option to Show Response in Pretty JSON
+
+## Overview
+
+The UDP tracker client already prints pretty JSON by default. This issue adds an
+explicit `--format` option so output style is user-controlled and aligned with
+the HTTP client UX.
+
+This spec intentionally changes the default to `compact` for consistency with
+HTTP and better machine-oriented ergonomics.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1563>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-tracker/issues/1562>
+
+## Motivation
+
+The issue request asks for native pretty JSON output without piping to `jq`:
+
+```text
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  udp://tracker.torrust-demo.com:6969/announce \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82 | jq
+```
+
+In the current codebase, this output is already pretty-printed. The missing
+piece is an explicit formatting option and parity with HTTP client CLI options.
+
+## Current Behaviour
+
+In `console/tracker-client/src/console/clients/udp/responses/json.rs`,
+`ToJson::to_json_string()` always calls:
+
+- `serde_json::to_string_pretty(...)`
+
+So there is no way to request compact output, and no `--format` flag in
+`console/tracker-client/src/console/clients/udp/app.rs`.
+
+## Proposed Behaviour
+
+Add `--format` to UDP commands with values:
+
+- `compact` (default)
+- `pretty`
+
+Defaulting to `compact` is intentional because:
+
+- It is better for shell pipelines and machine parsing.
+- It keeps logs and CI output smaller and easier to scan.
+- It aligns default behavior across HTTP and UDP clients.
+
+Even though this changes current UDP default behavior, it is acceptable at this
+stage because the client is still internal and not yet published.
+
+Examples:
+
+```text
+# New default behavior
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  udp://tracker.torrust-demo.com:6969/announce \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82
+```
+
+```text
+# New explicit pretty behavior
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  udp://tracker.torrust-demo.com:6969/announce \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82 \
+  --format pretty
+```
+
+```text
+# Explicit compact behavior
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  udp://tracker.torrust-demo.com:6969/announce \
+  000620bbc6c52d5a96d98f6c0f1dfa523a40df82 \
+  --format compact
+```
+
+## Goals
+
+- [ ] Add a `--format` option to UDP `announce` and `scrape`
+- [ ] Change default output to `compact`
+- [ ] Support `pretty` output for human-readable inspection
+- [ ] Keep response DTO conversion unchanged
+- [ ] Update CLI docs/examples
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests keep passing
+
+## Implementation Plan
+
+### Task 1: Define output format enum for UDP app
+
+In `console/tracker-client/src/console/clients/udp/app.rs`:
+
+- Add `OutputFormat` enum deriving `clap::ValueEnum`
+- Values: `Compact`, `Pretty`
+- Default to `Compact`
+
+### Task 2: Add `--format` argument to subcommands
+
+Extend both `Command::Announce` and `Command::Scrape` with:
+
+- `format: OutputFormat`
+
+### Task 3: Make JSON serializer format-aware
+
+In `console/tracker-client/src/console/clients/udp/responses/json.rs`:
+
+- Replace `to_json_string()` with one that accepts format, or add a new method
+  such as `to_json_string_with_format(format)`
+- Use:
+  - `serde_json::to_string(...)` for `Compact`
+  - `serde_json::to_string_pretty(...)` for `Pretty`
+
+### Task 4: Thread format through command execution
+
+In `udp/app.rs`, pass selected format to response serialization before printing.
+
+### Task 5: Update module docs
+
+Update examples to show both default and explicit `--format pretty` usage.
+
+## Acceptance Criteria
+
+- [ ] Running UDP `announce --format pretty` prints multiline JSON
+- [ ] Running UDP `announce --format compact` prints single-line JSON
+- [ ] Running UDP `scrape --format pretty` prints multiline JSON
+- [ ] Omitting `--format` produces compact single-line JSON
+- [ ] Invalid format values are rejected by clap with usage guidance
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Key Files
+
+| File                                                               | Role                                  |
+| ------------------------------------------------------------------ | ------------------------------------- |
+| `console/tracker-client/src/console/clients/udp/app.rs`            | CLI parsing and command wiring        |
+| `console/tracker-client/src/console/clients/udp/responses/json.rs` | JSON serialization strategy by format |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related HTTP issue: <https://github.com/torrust/torrust-tracker/issues/1562>
+- UDP app source: `console/tracker-client/src/console/clients/udp/app.rs`
+- UDP JSON response helper: `console/tracker-client/src/console/clients/udp/responses/json.rs`

--- a/docs/issues/669-overhaul-clients.md
+++ b/docs/issues/669-overhaul-clients.md
@@ -99,6 +99,10 @@ Each pending sub-issue has a dedicated spec document in this folder:
 
 - [1532-http-tracker-client-add-optional-announce-params.md](1532-http-tracker-client-add-optional-announce-params.md)
 - [1533-udp-tracker-client-add-optional-announce-params.md](1533-udp-tracker-client-add-optional-announce-params.md)
+- [671-udp-tracker-client-print-unrecognized-responses.md](671-udp-tracker-client-print-unrecognized-responses.md)
+- [672-http-tracker-client-print-unrecognized-responses.md](672-http-tracker-client-print-unrecognized-responses.md)
+- [1562-http-tracker-client-add-option-show-response-pretty-json.md](1562-http-tracker-client-add-option-show-response-pretty-json.md)
+- [1563-udp-tracker-client-add-option-show-response-pretty-json.md](1563-udp-tracker-client-add-option-show-response-pretty-json.md)
 
 ## References
 

--- a/docs/issues/669-overhaul-clients.md
+++ b/docs/issues/669-overhaul-clients.md
@@ -101,6 +101,7 @@ Each pending sub-issue has a dedicated spec document in this folder:
 - [1533-udp-tracker-client-add-optional-announce-params.md](1533-udp-tracker-client-add-optional-announce-params.md)
 - [671-udp-tracker-client-print-unrecognized-responses.md](671-udp-tracker-client-print-unrecognized-responses.md)
 - [672-http-tracker-client-print-unrecognized-responses.md](672-http-tracker-client-print-unrecognized-responses.md)
+- [1561-http-tracker-client-avoid-duplicating-announce-suffix.md](1561-http-tracker-client-avoid-duplicating-announce-suffix.md)
 - [1562-http-tracker-client-add-option-show-response-pretty-json.md](1562-http-tracker-client-add-option-show-response-pretty-json.md)
 - [1563-udp-tracker-client-add-option-show-response-pretty-json.md](1563-udp-tracker-client-add-option-show-response-pretty-json.md)
 

--- a/docs/issues/669-overhaul-clients.md
+++ b/docs/issues/669-overhaul-clients.md
@@ -1,0 +1,110 @@
+# Issue #669 — Overhaul Clients (EPIC)
+
+## Overview
+
+This EPIC tracks the work to overhaul the three client/tool binaries that ship with the Torrust
+Tracker: the **UDP Tracker client**, the **HTTP Tracker client**, and the **Tracker Checker**.
+The long-term goal is to merge them into a single, polished **Tracker Client** CLI.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/669>
+
+## Background
+
+Three console commands were added to aid developers and sysadmins in testing and debugging
+trackers:
+
+- **HTTP Tracker Client** — sends `announce` and `scrape` requests to HTTP trackers and returns
+  responses as JSON.
+- **UDP Tracker Client** — sends `announce` and `scrape` requests to UDP trackers and returns
+  responses as JSON.
+- **Tracker Checker** — checks whether UDP trackers, HTTP trackers, and health-check endpoints
+  are alive and responding correctly.
+
+The initial implementations were quick prototypes: some parts were moved from test code to
+production code without full coverage, parameters are hard-coded, and error handling is fragile.
+This EPIC systematically improves each tool and eventually unifies them.
+
+## Goals
+
+- [ ] Overhaul the UDP Tracker client (see sub-issues below)
+- [ ] Overhaul the HTTP Tracker client (see sub-issues below)
+- [ ] Overhaul the Tracker Checker (see sub-issues below)
+- [ ] Merge all clients into a single unified Tracker Client CLI
+
+## Pending Sub-Issues
+
+### UDP Tracker Client
+
+| Issue                                                           | Title                                                        | Status |
+| --------------------------------------------------------------- | ------------------------------------------------------------ | ------ |
+| [#1533](https://github.com/torrust/torrust-tracker/issues/1533) | Add optional parameters with the rest of the announce params | Open   |
+| [#671](https://github.com/torrust/torrust-tracker/issues/671)   | Print unrecognized responses                                 | Open   |
+| [#1563](https://github.com/torrust/torrust-tracker/issues/1563) | Add option to show response in pretty JSON                   | Open   |
+
+### HTTP Tracker Client
+
+| Issue                                                           | Title                                                        | Status |
+| --------------------------------------------------------------- | ------------------------------------------------------------ | ------ |
+| [#1532](https://github.com/torrust/torrust-tracker/issues/1532) | Add optional parameters with the rest of the announce params | Open   |
+| [#672](https://github.com/torrust/torrust-tracker/issues/672)   | Print unrecognized responses in JSON                         | Open   |
+| [#1561](https://github.com/torrust/torrust-tracker/issues/1561) | Duplicate URL suffix `announce` when already in tracker URL  | Open   |
+| [#1562](https://github.com/torrust/torrust-tracker/issues/1562) | Add option to show response in pretty JSON                   | Open   |
+
+### Tracker Checker
+
+| Issue                                                           | Title                                                               | Status |
+| --------------------------------------------------------------- | ------------------------------------------------------------------- | ------ |
+| [#1042](https://github.com/torrust/torrust-tracker/issues/1042) | (HTTP) Improve error message when JSON config is not well-formatted | Open   |
+| [#1178](https://github.com/torrust/torrust-tracker/issues/1178) | (UDP) Add command to monitor uptime                                 | Open   |
+
+### Unified Tracker Client
+
+| Issue                                                           | Title                                       | Status |
+| --------------------------------------------------------------- | ------------------------------------------- | ------ |
+| [#1564](https://github.com/torrust/torrust-tracker/issues/1564) | Change the default `PeerId` used in clients | Open   |
+
+## Already Closed Sub-Issues
+
+### UDP Tracker Client
+
+- [#670](https://github.com/torrust/torrust-tracker/issues/670) — Closed
+
+### Tracker Checker
+
+- [#674](https://github.com/torrust/torrust-tracker/issues/674) — Closed
+- [#675](https://github.com/torrust/torrust-tracker/issues/675) — Closed
+- [#677](https://github.com/torrust/torrust-tracker/issues/677) — Closed (and its sub-issues #682, #681, #679, #680, #678)
+- [#683](https://github.com/torrust/torrust-tracker/issues/683) — Closed
+- [#676](https://github.com/torrust/torrust-tracker/issues/676) — Closed
+- [#1040](https://github.com/torrust/torrust-tracker/issues/1040) — Closed
+- [#767](https://github.com/torrust/torrust-tracker/issues/767) — Closed
+- [#673](https://github.com/torrust/torrust-tracker/issues/673) — Closed
+
+## Recommended Implementation Order
+
+The list order in the EPIC is the recommended order of implementation. In broad terms:
+
+1. Add missing announce parameters to both UDP and HTTP clients (#1533, #1532)
+2. Fix panics on unrecognized responses in both clients (#671, #672)
+3. Fix the HTTP client URL duplication bug (#1561)
+4. Add pretty-print JSON output to both clients (#1562, #1563)
+5. Fix Tracker Checker error messages (#1042)
+6. Add uptime monitoring to Tracker Checker (#1178)
+7. Fix the default `PeerId` in all clients (#1564)
+8. Merge the three tools into a single unified Tracker Client CLI
+
+## Implementation Specs
+
+Each pending sub-issue has a dedicated spec document in this folder:
+
+- [1532-http-tracker-client-add-optional-announce-params.md](1532-http-tracker-client-add-optional-announce-params.md)
+- [1533-udp-tracker-client-add-optional-announce-params.md](1533-udp-tracker-client-add-optional-announce-params.md)
+
+## References
+
+- EPIC issue: <https://github.com/torrust/torrust-tracker/issues/669>
+- Discussion: <https://github.com/torrust/torrust-tracker/discussions/660>
+- HTTP tracker client source: `console/tracker-client/src/console/clients/http/`
+- UDP tracker client source: `console/tracker-client/src/console/clients/udp/`
+- Tracker Checker source: `console/tracker-client/src/console/clients/checker/`
+- `tracker-client` package: `packages/tracker-client/`

--- a/docs/issues/671-udp-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/671-udp-tracker-client-print-unrecognized-responses.md
@@ -1,0 +1,138 @@
+# Issue #671 — UDP Tracker Client: Print Unrecognized Responses
+
+## Overview
+
+When the UDP tracker client sends a request and receives bytes it cannot parse into a known
+`Response` variant, the error currently surfaces as a deeply-nested `anyhow` chain that includes
+the raw bytes in Rust `Debug` format. The result is technically correct but unreadable for the
+developer trying to debug what the remote tracker sent.
+
+The goal of this issue is to ensure that whenever a UDP response cannot be deserialized, the CLI
+prints a clean, human-readable message that includes the raw bytes in decimal array notation,
+matching the style expected by the caller:
+
+```text
+Error: Unrecognized UDP tracker response. Expected a valid UDP response, got: [0, 0, 0, 1]
+```
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/671>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-tracker/issues/672> (same feature for HTTP client)
+
+## Motivation
+
+When testing against real-world public trackers (e.g. from <https://newtrackon.com/>), some
+trackers respond with bytes that do not conform to the BEP 15 wire format. The developer should
+be able to see those bytes immediately to understand what the tracker sent, without reaching for
+`RUST_BACKTRACE=1` or a network sniffer.
+
+## Current Behaviour
+
+The error chain is constructed correctly — `Error::UnableToParseResponse` in
+`packages/tracker-client/src/udp/mod.rs` already carries the raw `Vec<u8>` — but its `Display`
+output is in `Debug` format:
+
+```text
+Error: Failed to receive a announce response, with error: Failed to parse response:
+[0, 0, 0, 1], with error: failed to fill whole buffer
+```
+
+This is the result of the `thiserror` `#[error]` attribute using `{response:?}` rather than a
+deliberately formatted byte list. The nesting also makes it hard to see which part is the raw
+payload.
+
+## Key Observation: Infrastructure Is Already in Place
+
+The underlying `UdpTrackerClient::receive()` in
+`packages/tracker-client/src/udp/client.rs` already returns
+`Result<Response, Error>` where the `Err` variant carries the raw bytes:
+
+```rust
+Response::parse_bytes(&response, true)
+    .map_err(|e| Error::UnableToParseResponse { err: e.into(), response })
+```
+
+No changes to `UdpClient` or `UdpTrackerClient` are required. The improvement is
+**purely at the display/application layer**.
+
+## Proposed Output
+
+On a parse error the CLI should print to stderr and exit non-zero:
+
+```text
+Error: Unrecognized UDP tracker response. Expected a valid UDP response, got: [0, 0, 0, 1]
+```
+
+The decimal byte array (as formatted by `Vec<u8>`'s `Debug`) is acceptable; a hex representation
+is a quality-of-life improvement but not required for the initial fix.
+
+## Goals
+
+- [ ] When a UDP response cannot be parsed, the CLI prints the raw bytes in a clean, readable
+      message instead of a deeply-nested Rust error chain
+- [ ] The exit code is non-zero on parse failure (already true via `anyhow` propagation;
+      must not regress)
+- [ ] Normal (valid) responses are unaffected
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Implementation Plan
+
+### Task 1: Improve the `UnableToParseResponse` error message
+
+In `packages/tracker-client/src/udp/mod.rs`, update the `#[error(...)]` attribute on
+`UnableToParseResponse` to emit a clean, developer-friendly message:
+
+```rust
+#[error("Unrecognized UDP tracker response. Expected a valid UDP response, got: {response:?}")]
+UnableToParseResponse { err: Arc<std::io::Error>, response: Vec<u8> },
+```
+
+This change alone makes the top-level error message readable, because the wrapping
+`UnableToReceiveAnnounceResponse` simply delegates to its inner `err`'s `Display`.
+
+### Task 2: Simplify the wrapper error messages (optional polish)
+
+In `console/tracker-client/src/console/clients/udp/mod.rs`, the wrapper variants such as
+`UnableToReceiveAnnounceResponse` add a prefix that can obscure the root cause. Consider
+simplifying them so the most important part (the bytes) is visible at the top level:
+
+```rust
+#[error("Failed to receive an announce response: {err}")]
+UnableToReceiveAnnounceResponse { err: udp::Error },
+```
+
+### Task 3: Update the module doc comment in `app.rs`
+
+In `console/tracker-client/src/console/clients/udp/app.rs`, add an example showing what
+the error output looks like when an unrecognized response is received.
+
+## Acceptance Criteria
+
+- [ ] Running the client against a tracker that returns an invalid packet produces output
+      matching:
+      `Error: Unrecognized UDP tracker response. Expected a valid UDP response, got: [...]`
+- [ ] Running the client against a well-behaved tracker still prints the JSON response and
+      exits `0`
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Key Files
+
+| File                                                        | Role                                                    |
+| ----------------------------------------------------------- | ------------------------------------------------------- |
+| `packages/tracker-client/src/udp/mod.rs`                    | `Error` enum — improve `UnableToParseResponse` message  |
+| `console/tracker-client/src/console/clients/udp/mod.rs`     | Wrapper `Error` enum — optional message polish          |
+| `console/tracker-client/src/console/clients/udp/checker.rs` | Calls `UdpTrackerClient::receive()` — no changes needed |
+| `console/tracker-client/src/console/clients/udp/app.rs`     | CLI entry point — update doc comment                    |
+| `packages/tracker-client/src/udp/client.rs`                 | `UdpTrackerClient::receive()` — no changes needed       |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related HTTP issue: <https://github.com/torrust/torrust-tracker/issues/672>
+- Comment with context: <https://github.com/torrust/torrust-tracker/pull/814#issuecomment-2093272796>
+- BEP 15 (UDP Tracker Protocol): <https://www.bittorrent.org/beps/bep_0015.html>
+- List of public UDP trackers: <https://newtrackon.com/>

--- a/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
@@ -1,0 +1,193 @@
+# Issue #672 — HTTP Tracker Client: Print Unrecognized Responses in JSON
+
+## Overview
+
+When the HTTP tracker client's `announce` or `scrape` command receives a response body that
+cannot be deserialized into the expected Rust struct, the application currently panics with
+an unhelpful message. The goal of this issue is to handle that failure gracefully: instead of
+panicking, the client should attempt to convert the raw bencoded payload to a generic JSON
+representation and print it. If even that conversion fails, the raw bytes should be printed.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/672>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Depends on: <https://github.com/torrust/torrust-tracker/issues/673> (bencode-to-JSON
+  conversion — **already resolved**: `bencode2json` crate published at
+  <https://crates.io/crates/bencode2json>)
+- Related: <https://github.com/torrust/torrust-tracker/issues/671> (same feature for UDP client)
+
+## Motivation
+
+Real-world HTTP trackers often return valid but non-standard bencoded responses. For example,
+the scrape response from `open.acgnxtracker.com` omits the `downloaded` field, which is
+required by the Torrust `scrape::File` struct. This causes:
+
+```text
+thread 'main' panicked at src/shared/bit_torrent/tracker/http/client/responses/scrape.rs:143:60:
+called `Result::unwrap()` on an `Err` value: MissingFileField { field_name: "downloaded" }
+```
+
+When testing the client against multiple trackers (e.g. from <https://newtrackon.com/>), any
+non-standard response crashes the process without showing what the tracker actually sent.
+
+## Current Behaviour
+
+Both `announce_command` and `scrape_command` in
+`console/tracker-client/src/console/clients/http/app.rs` use `.unwrap_or_else(|_| panic!(...))`:
+
+```rust
+// announce_command:
+let announce_response: Announce = serde_bencode::from_bytes(&body)
+    .unwrap_or_else(|_| panic!("response body should be a valid announce response, got: \"{body:#?}\""));
+
+// scrape_command:
+let scrape_response = scrape::Response::try_from_bencoded(&body)
+    .unwrap_or_else(|_| panic!("response body should be a valid scrape response, got: \"{body:#?}\""));
+```
+
+`scrape::Response::try_from_bencoded` also panics internally via
+`serde_bencode::from_bytes(bytes).expect(...)`.
+
+## Proposed Behaviour
+
+The two-step fallback strategy:
+
+1. **Try to deserialize into the typed struct** (existing behaviour).
+2. **On failure, convert the raw bencoded bytes to generic JSON** using the `bencode2json` crate
+   and print that instead.
+3. **If bencode-to-JSON conversion also fails**, print the raw bytes in their debug form so the
+   developer can see what was received.
+
+Example output when the response is non-standard but valid bencode:
+
+```json
+{
+  "files": {
+    "<info_hash_bytes>": {
+      "incomplete": 0,
+      "complete": 32
+    }
+  }
+}
+```
+
+Example output when even bencode parsing fails (raw bytes):
+
+```text
+Warning: Could not deserialize HTTP tracker response. Raw bytes: [100, 56, ...]
+```
+
+## Goals
+
+- [ ] Replace both `panic!(...)` / `.unwrap_or_else(|_| panic!(...))` calls in `app.rs` with
+      graceful fallback logic
+- [ ] Remove the `panic!` inside `scrape::Response::try_from_bencoded`; change the internal
+      `expect(...)` to return `Err` properly
+- [ ] Add `bencode2json` as a dependency of the `torrust-tracker-client` console crate
+- [ ] On deserialization failure, print the raw bencoded payload as generic JSON (via
+      `bencode2json`)
+- [ ] If `bencode2json` conversion also fails, print a warning with the raw byte slice
+- [ ] The process exits with a non-zero exit code when the response cannot be deserialized
+      (print the fallback JSON/bytes to stdout, return an `Err` from the command function)
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Implementation Plan
+
+### Task 1: Fix `scrape::Response::try_from_bencoded` to not panic
+
+In `packages/tracker-client/src/http/client/responses/scrape.rs`, replace the internal
+`expect(...)` with a proper `?`-based propagation so callers can handle the error:
+
+```rust
+pub fn try_from_bencoded(bytes: &[u8]) -> Result<Self, BencodeParseError> {
+    let scrape_response: DeserializedResponse = serde_bencode::from_bytes(bytes)
+        .map_err(|e| BencodeParseError::DeserializationError { source: e })?;
+    Self::try_from(scrape_response)
+}
+```
+
+A new `BencodeParseError` variant may be needed for `serde_bencode::Error`.
+
+### Task 2: Add `bencode2json` dependency
+
+In `console/tracker-client/Cargo.toml`, add:
+
+```toml
+bencode2json = "0.1"   # adjust to the published version
+```
+
+### Task 3: Implement the two-step fallback helper
+
+Add a private helper in `console/tracker-client/src/console/clients/http/app.rs`:
+
+```rust
+fn bencode_to_fallback_json(body: &[u8]) -> String {
+    match bencode2json::to_json(body) {
+        Ok(json) => json,
+        Err(_) => format!("(raw bytes) {body:?}"),
+    }
+}
+```
+
+### Task 4: Replace panics in `announce_command`
+
+```rust
+let body = response.bytes().await?;
+
+match serde_bencode::from_bytes::<Announce>(&body) {
+    Ok(announce_response) => {
+        let json = serde_json::to_string(&announce_response)
+            .context("failed to serialize announce response into JSON")?;
+        println!("{json}");
+        Ok(())
+    }
+    Err(_) => {
+        let fallback = bencode_to_fallback_json(&body);
+        eprintln!("Warning: Could not deserialize HTTP tracker announce response.");
+        println!("{fallback}");
+        Err(anyhow::anyhow!("unrecognized announce response from tracker"))
+    }
+}
+```
+
+### Task 5: Replace panics in `scrape_command`
+
+Apply the same two-step fallback to `scrape_command`, replacing the current
+`.unwrap_or_else(|_| panic!(...))`.
+
+### Task 6: Update the module doc comment in `app.rs`
+
+Add examples showing the fallback output in the module-level doc comment.
+
+## Acceptance Criteria
+
+- [ ] Running the client against a tracker that returns a non-standard response prints the
+      response as generic JSON (via `bencode2json`) and exits non-zero
+- [ ] Running the client against a tracker that returns a completely unrecognized payload
+      prints a warning with the raw bytes and exits non-zero
+- [ ] Running the client against the Torrust Tracker still prints the typed JSON response
+      and exits `0`
+- [ ] No `panic!` or `.unwrap()` in the announce or scrape command paths
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] All existing tests pass
+
+## Key Files
+
+| File                                                          | Role                                                |
+| ------------------------------------------------------------- | --------------------------------------------------- |
+| `console/tracker-client/src/console/clients/http/app.rs`      | Replace panics with two-step fallback — main change |
+| `packages/tracker-client/src/http/client/responses/scrape.rs` | Fix `try_from_bencoded` to not panic internally     |
+| `console/tracker-client/Cargo.toml`                           | Add `bencode2json` dependency                       |
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Depends on: <https://github.com/torrust/torrust-tracker/issues/673>
+  (bencode-to-JSON, resolved — `bencode2json` on crates.io)
+- Related UDP issue: <https://github.com/torrust/torrust-tracker/issues/671>
+- `bencode2json` crate: <https://crates.io/crates/bencode2json>
+- `bencode2json` source: <https://github.com/torrust/bencode2json>
+- BitTorrent scrape spec: <https://www.bittorrent.org/beps/bep_0048.html>
+- List of public HTTP trackers: <https://newtrackon.com/>

--- a/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
@@ -47,6 +47,9 @@ let scrape_response = scrape::Response::try_from_bencoded(&body)
 `scrape::Response::try_from_bencoded` also panics internally via
 `serde_bencode::from_bytes(bytes).expect(...)`.
 
+The scrape parser path also contains nested `.unwrap()` calls while iterating
+decoded file dictionaries. Those must be removed from reachable runtime paths.
+
 ## Proposed Behaviour
 
 The two-step fallback strategy:
@@ -80,14 +83,17 @@ Warning: Could not deserialize HTTP tracker response. Raw bytes: [100, 56, ...]
 
 - [ ] Replace both `panic!(...)` / `.unwrap_or_else(|_| panic!(...))` calls in `app.rs` with
       graceful fallback logic
-- [ ] Remove the `panic!` inside `scrape::Response::try_from_bencoded`; change the internal
-      `expect(...)` to return `Err` properly
+- [ ] Remove panic/unwrap usage from the scrape decode path:
+      `expect(...)` in `try_from_bencoded` and nested `.unwrap()` calls in
+      parser helpers
 - [ ] Add `bencode2json` as a dependency of the `torrust-tracker-client` console crate
 - [ ] On deserialization failure, print the raw bencoded payload as generic JSON (via
       `bencode2json`)
 - [ ] If `bencode2json` conversion also fails, print a warning with the raw byte slice
 - [ ] The process exits with a non-zero exit code when the response cannot be deserialized
       (print the fallback JSON/bytes to stdout, return an `Err` from the command function)
+- [ ] Fallback JSON output is compact by default in this issue; once `--format`
+      is introduced in #1562, fallback JSON must respect the selected format
 - [ ] `linter all` exits with code `0`
 - [ ] `cargo machete` reports no unused dependencies
 - [ ] All existing tests pass
@@ -108,6 +114,9 @@ pub fn try_from_bencoded(bytes: &[u8]) -> Result<Self, BencodeParseError> {
 ```
 
 A new `BencodeParseError` variant may be needed for `serde_bencode::Error`.
+
+Also replace nested `.unwrap()` calls in scrape parsing helpers with proper
+error propagation into `BencodeParseError`.
 
 ### Task 2: Add `bencode2json` dependency
 
@@ -169,6 +178,7 @@ Add examples showing the fallback output in the module-level doc comment.
 - [ ] Running the client against the Torrust Tracker still prints the typed JSON response
       and exits `0`
 - [ ] No `panic!` or `.unwrap()` in the announce or scrape command paths
+- [ ] No reachable panic/unwrap remains in the scrape decoding path
 - [ ] `linter all` exits with code `0`
 - [ ] `cargo machete` reports no unused dependencies
 - [ ] All existing tests pass

--- a/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/672-http-tracker-client-print-unrecognized-responses.md
@@ -22,7 +22,7 @@ the scrape response from `open.acgnxtracker.com` omits the `downloaded` field, w
 required by the Torrust `scrape::File` struct. This causes:
 
 ```text
-thread 'main' panicked at src/shared/bit_torrent/tracker/http/client/responses/scrape.rs:143:60:
+thread 'main' panicked at packages/tracker-client/src/http/client/responses/scrape.rs:143:60:
 called `Result::unwrap()` on an `Err` value: MissingFileField { field_name: "downloaded" }
 ```
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,3 +1,4 @@
+acgnxtracker
 actix
 Addrs
 adduser
@@ -79,6 +80,7 @@ dtolnay
 dylib
 elif
 endianness
+eprintln
 Eray
 eventfd
 fastrand

--- a/project-words.txt
+++ b/project-words.txt
@@ -167,6 +167,7 @@ mysqld
 Naim
 nanos
 newkey
+newtrackon
 newtype
 newtypes
 nextest


### PR DESCRIPTION
## Summary

This PR adds and refines EPIC #669 documentation and implementation specs for pending client sub-issues before coding starts.

## Included Changes

- Added EPIC spec and sub-issue index:
  - `docs/issues/669-overhaul-clients.md`
- Added specs for pending sub-issues:
  - `docs/issues/1532-http-tracker-client-add-optional-announce-params.md`
  - `docs/issues/1533-udp-tracker-client-add-optional-announce-params.md`
  - `docs/issues/671-udp-tracker-client-print-unrecognized-responses.md`
  - `docs/issues/672-http-tracker-client-print-unrecognized-responses.md`
  - `docs/issues/1561-http-tracker-client-avoid-duplicating-announce-suffix.md`
  - `docs/issues/1562-http-tracker-client-add-option-show-response-pretty-json.md`
  - `docs/issues/1563-udp-tracker-client-add-option-show-response-pretty-json.md`
- Updated #1533 spec to reflect current in-house UDP protocol crate usage.
- Clarified cross-spec contracts to reduce implementation ambiguity:
  - event/peer-id parsing contracts
  - panic-removal scope in #672
  - `--format` behavior and fallback-output behavior
  - #1561 URL-path handling decision (append `/announce` only for bare URLs; preserve non-empty paths)
- Updated dictionary entries in `project-words.txt` needed by the docs.

## Validation

- `linter all` passes.

## Notes

This PR is documentation/specification only. No runtime code behavior is changed in this PR.
