### PR TITLE
feat(tracker-client): add optional announce parameters to UDP tracker client

### DIFF
--- a/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: run-tracker-locally
+description: Run the Torrust Tracker locally for development and testing. Use this skill to start the tracker with default configuration, understand configuration loading, and interact with tracker services (UDP and HTTP). Triggers on "run tracker", "start tracker locally", "develop tracker", "test tracker locally", or "run tracker for testing".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Run Tracker Locally
+
+## Quick Start
+
+To run the tracker with default development configuration:
+
+```bash
+cargo run
+```
+
+The tracker will start and you will see console output (logs) indicating where it's loading configuration from.
+
+## Default Development Configuration
+
+When you run `cargo run` from the repository root, the tracker loads the default development configuration:
+
+```text
+Loading extra configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
+```
+
+**Default database**: SQLite3  
+**Default configuration file**: `./share/default/config/tracker.development.sqlite3.toml`
+
+## Default Services
+
+By default, the development configuration starts:
+
+- **2 UDP trackers** on different ports
+- **2 HTTP trackers** on different ports
+- Health check API endpoint
+
+Check the configuration file to see exact ports and settings.
+
+## Viewing Configuration
+
+To inspect or customize the tracker configuration:
+
+```bash
+# View the default development configuration
+cat ./share/default/config/tracker.development.sqlite3.toml
+```
+
+You can modify this file to change:
+
+- Tracker ports
+- Database location
+- Logging levels
+- Tracker behavior and thresholds
+- Authentication settings
+
+## Common Ports (Default Configuration)
+
+Check `./share/default/config/tracker.development.sqlite3.toml` for exact port assignments. Typical defaults:
+
+- UDP tracker 1: `6969/udp`
+- UDP tracker 2: `6970/udp`
+- HTTP tracker 1: `7070/tcp`
+- HTTP tracker 2: `7071/tcp`
+- Health check API: `1212/tcp`
+
+## Stopping the Tracker
+
+To stop the running tracker:
+
+```bash
+# Press Ctrl+C in the terminal where the tracker is running
+```
+
+## Verifying Tracker is Running
+
+Check if tracker services are listening:
+
+```bash
+# Using ss (Linux)
+ss -ulnp 2>/dev/null | grep -E '6969|6970'
+ss -tlnp 2>/dev/null | grep -E '7070|7071|1212'
+
+# Or using netstat (older systems)
+netstat -ulnp 2>/dev/null | grep -E '6969|6970'
+netstat -tlnp 2>/dev/null | grep -E '7070|7071|1212'
+```
+
+## Database Storage
+
+By default, development tracker uses SQLite3. The database file is stored in:
+
+```text
+./storage/tracker/lib/
+```
+
+This directory is git-ignored. Database state persists between restarts unless you manually delete it.
+
+## Logs Location
+
+Tracker logs are written to:
+
+```text
+./storage/tracker/log/
+```
+
+Check these logs when debugging tracker behavior.
+
+## Testing with UDP Tracker Client
+
+Once the tracker is running, test it with the UDP tracker client:
+
+```bash
+# Default announce (backward compatibility)
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce 127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422
+
+# Announce with all optional parameters
+# NOTE: Use '--peer-id=VALUE' syntax (with equals and single quotes) when peer-id starts with a dash
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
+  --event completed \
+  --uploaded 1234 \
+  --downloaded 5678 \
+  --left 0 \
+  --port 6881 \
+  --ip-address 10.0.0.1 \
+  '--peer-id=-RC00000000000000001' \
+  --key 42 \
+  --peers-wanted 50
+```
+
+**Important**: Peer-id must be exactly 20 bytes. When the peer-id starts with a dash (like `-RC...`), use the `--peer-id='...'` syntax to prevent shell from interpreting it as a flag.
+
+## Testing with HTTP Tracker Client
+
+Test the HTTP tracker:
+
+```bash
+# Default announce
+cargo run --bin http_tracker_client announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422
+```
+
+## Notes
+
+- The tracker runs in the foreground. Use `Ctrl+C` to stop it or run it in a separate terminal.
+- All runtime data (database, logs, config) is stored in `./storage/` which is git-ignored.
+- Each `cargo run` reuses existing database state; delete `./storage/` to start fresh.
+- Log output shows which services are active and on which ports.

--- a/.github/skills/dev/testing/manual-http-download-completion-e2e/SKILL.md
+++ b/.github/skills/dev/testing/manual-http-download-completion-e2e/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: manual-http-download-completion-e2e
+description: Manual end-to-end verification of started -> completed peer lifecycle using the HTTP tracker announce/scrape endpoints with curl (or browser for stats). Use when contributors want a fast, transparent simulation of download completion without containerized clients. Triggers on "manual http e2e", "http announce completed test", "simulate completion with curl", or "verify completed counter http".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Manual HTTP Download-Completion E2E
+
+## Purpose
+
+This skill verifies manually that an HTTP peer transition from `started` to `completed`
+updates tracker state correctly:
+
+- announce response changes from leecher view to seeder view
+- scrape stats change (`incomplete -> complete`, `downloaded` increments)
+- global tracker stats change (`seeders` and `completed` increment)
+
+This is a fast diagnostic workflow. It complements automated E2E (for example,
+`src/bin/qbittorrent_e2e_runner.rs`).
+
+This same started-to-completed scenario can also be exercised with the HTTP tracker client,
+similar to the UDP workflow in
+`.github/skills/dev/testing/manual-udp-download-completion-e2e/SKILL.md`.
+This skill intentionally documents a generic HTTP client approach (curl/browser),
+so contributors can reproduce the flow without relying on a specific tracker client binary.
+
+## Prerequisites
+
+Run all commands from repository root.
+
+- HTTP tracker: `http://127.0.0.1:7070`
+- Stats API: `http://127.0.0.1:1212/api/v1/stats?token=MyAccessToken`
+
+Optional clean baseline:
+
+```bash
+rm -f ./storage/tracker/lib/database/sqlite3.db
+```
+
+## 1. Start tracker
+
+In terminal A:
+
+```bash
+cargo run
+```
+
+Expected startup excerpt:
+
+```text
+Loading extra configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
+... HTTP TRACKER: Started on: http://0.0.0.0:7070
+... API: Started on: http://0.0.0.0:1212
+```
+
+## 2. Define test values
+
+In terminal B:
+
+```bash
+INFO_HASH='TTTTTTTTTTTTTTTTTTTT'
+PEER_ID='HTTPCLIENTPEERID0000'
+BASE='http://127.0.0.1:7070'
+STATS='http://127.0.0.1:1212/api/v1/stats?token=MyAccessToken'
+```
+
+Notes:
+
+- `INFO_HASH` must be exactly 20 bytes in this curl workflow.
+- `PEER_ID` must be exactly 20 bytes.
+
+## 3. Baseline checks
+
+### 3.1 Global stats
+
+Command:
+
+```bash
+curl -s "$STATS"
+```
+
+Output captured during validation:
+
+```json
+{
+  "torrents": 0,
+  "seeders": 0,
+  "completed": 0,
+  "leechers": 0,
+  "tcp4_connections_handled": 0,
+  "tcp4_announces_handled": 0,
+  "tcp4_scrapes_handled": 0,
+  "tcp6_connections_handled": 0,
+  "tcp6_announces_handled": 0,
+  "tcp6_scrapes_handled": 0,
+  "udp_requests_aborted": 0,
+  "udp_requests_banned": 0,
+  "udp_banned_ips_total": 0,
+  "udp_avg_connect_processing_time_ns": 0,
+  "udp_avg_announce_processing_time_ns": 0,
+  "udp_avg_scrape_processing_time_ns": 0,
+  "udp4_requests": 0,
+  "udp4_connections_handled": 0,
+  "udp4_announces_handled": 0,
+  "udp4_scrapes_handled": 0,
+  "udp4_responses": 0,
+  "udp4_errors_handled": 0,
+  "udp6_requests": 0,
+  "udp6_connections_handled": 0,
+  "udp6_announces_handled": 0,
+  "udp6_scrapes_handled": 0,
+  "udp6_responses": 0,
+  "udp6_errors_handled": 0
+}
+```
+
+### 3.2 Torrent scrape
+
+Command:
+
+```bash
+curl -sG "$BASE/scrape" --data-urlencode "info_hash=$INFO_HASH"
+```
+
+Output captured during validation:
+
+```text
+d5:filesd20:TTTTTTTTTTTTTTTTTTTTd8:completei0e10:downloadedi0e10:incompletei0eeee
+```
+
+## 4. Announce started
+
+Command:
+
+```bash
+curl -sG "$BASE/announce" \
+  --data-urlencode "info_hash=$INFO_HASH" \
+  --data-urlencode "peer_id=$PEER_ID" \
+  --data-urlencode "port=6881" \
+  --data-urlencode "uploaded=0" \
+  --data-urlencode "downloaded=0" \
+  --data-urlencode "left=1000" \
+  --data-urlencode "event=started" \
+  --data-urlencode "compact=1" \
+  --data-urlencode "numwant=0"
+```
+
+Output captured during validation:
+
+```text
+d8:completei0e10:incompletei1e8:intervali120e12:min intervali120e5:peers0:6:peers60:e
+```
+
+Then verify scrape and global stats:
+
+```bash
+curl -sG "$BASE/scrape" --data-urlencode "info_hash=$INFO_HASH"
+curl -s "$STATS"
+```
+
+Outputs captured during validation:
+
+```text
+d5:filesd20:TTTTTTTTTTTTTTTTTTTTd8:completei0e10:downloadedi0e10:incompletei1eeee
+```
+
+```json
+{
+  "torrents": 1,
+  "seeders": 0,
+  "completed": 0,
+  "leechers": 1,
+  "tcp4_connections_handled": 3,
+  "tcp4_announces_handled": 1,
+  "tcp4_scrapes_handled": 2,
+  "tcp6_connections_handled": 0,
+  "tcp6_announces_handled": 0,
+  "tcp6_scrapes_handled": 0,
+  "udp_requests_aborted": 0,
+  "udp_requests_banned": 0,
+  "udp_banned_ips_total": 0,
+  "udp_avg_connect_processing_time_ns": 0,
+  "udp_avg_announce_processing_time_ns": 0,
+  "udp_avg_scrape_processing_time_ns": 0,
+  "udp4_requests": 0,
+  "udp4_connections_handled": 0,
+  "udp4_announces_handled": 0,
+  "udp4_scrapes_handled": 0,
+  "udp4_responses": 0,
+  "udp4_errors_handled": 0,
+  "udp6_requests": 0,
+  "udp6_connections_handled": 0,
+  "udp6_announces_handled": 0,
+  "udp6_scrapes_handled": 0,
+  "udp6_responses": 0,
+  "udp6_errors_handled": 0
+}
+```
+
+Expected meaning:
+
+- `incomplete` became `1`
+- global `leechers` became `1`
+- global `completed` still `0`
+
+## 5. Announce completed
+
+Command:
+
+```bash
+curl -sG "$BASE/announce" \
+  --data-urlencode "info_hash=$INFO_HASH" \
+  --data-urlencode "peer_id=$PEER_ID" \
+  --data-urlencode "port=6881" \
+  --data-urlencode "uploaded=0" \
+  --data-urlencode "downloaded=1000" \
+  --data-urlencode "left=0" \
+  --data-urlencode "event=completed" \
+  --data-urlencode "compact=1" \
+  --data-urlencode "numwant=0"
+```
+
+Output captured during validation:
+
+```text
+d8:completei1e10:incompletei0e8:intervali120e12:min intervali120e5:peers0:6:peers60:e
+```
+
+Then verify scrape and global stats:
+
+```bash
+curl -sG "$BASE/scrape" --data-urlencode "info_hash=$INFO_HASH"
+curl -s "$STATS"
+```
+
+Outputs captured during validation:
+
+```text
+d5:filesd20:TTTTTTTTTTTTTTTTTTTTd8:completei1e10:downloadedi1e10:incompletei0eeee
+```
+
+```json
+{
+  "torrents": 1,
+  "seeders": 1,
+  "completed": 1,
+  "leechers": 0,
+  "tcp4_connections_handled": 5,
+  "tcp4_announces_handled": 2,
+  "tcp4_scrapes_handled": 3,
+  "tcp6_connections_handled": 0,
+  "tcp6_announces_handled": 0,
+  "tcp6_scrapes_handled": 0,
+  "udp_requests_aborted": 0,
+  "udp_requests_banned": 0,
+  "udp_banned_ips_total": 0,
+  "udp_avg_connect_processing_time_ns": 0,
+  "udp_avg_announce_processing_time_ns": 0,
+  "udp_avg_scrape_processing_time_ns": 0,
+  "udp4_requests": 0,
+  "udp4_connections_handled": 0,
+  "udp4_announces_handled": 0,
+  "udp4_scrapes_handled": 0,
+  "udp4_responses": 0,
+  "udp4_errors_handled": 0,
+  "udp6_requests": 0,
+  "udp6_connections_handled": 0,
+  "udp6_announces_handled": 0,
+  "udp6_scrapes_handled": 0,
+  "udp6_responses": 0,
+  "udp6_errors_handled": 0
+}
+```
+
+Expected meaning:
+
+- scrape `complete`: `0 -> 1`
+- scrape `downloaded`: `0 -> 1`
+- scrape `incomplete`: `1 -> 0`
+- global `seeders`: `0 -> 1`
+- global `completed`: `0 -> 1`
+
+## 6. Browser option
+
+You can open global stats directly in a browser:
+
+```text
+http://127.0.0.1:1212/api/v1/stats?token=MyAccessToken
+```
+
+Use page refresh between steps to observe the counter changes.
+
+## Troubleshooting
+
+If announce fails with peer-id validation, check peer-id length.
+
+Example failure output captured during validation (peer_id had 21 bytes):
+
+```text
+d14:failure reason269:Bad request. Cannot parse query params for announce request: invalid param value HTTPCLIENTPEERID00001 for peer_id in too many bytes for peer id: got 21 bytes, expected 20 ...e
+```
+
+## Related
+
+- Automated real-client E2E: `src/bin/qbittorrent_e2e_runner.rs`
+- Manual UDP equivalent: `.github/skills/dev/testing/manual-udp-download-completion-e2e/SKILL.md`

--- a/.github/skills/dev/testing/manual-udp-download-completion-e2e/SKILL.md
+++ b/.github/skills/dev/testing/manual-udp-download-completion-e2e/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: manual-udp-download-completion-e2e
+description: Manual end-to-end verification of started -> completed peer lifecycle using udp_tracker_client and tracker stats API. Use when contributors need to simulate a peer completing a download without running containerized qBittorrent E2E. Triggers on "manual e2e", "simulate peer completion", "udp started completed test", or "verify downloads increment manually".
+metadata:
+  author: torrust
+  version: "1.0"
+---
+
+# Manual UDP Download-Completion E2E
+
+## Purpose
+
+This skill verifies, manually and quickly, that a single peer transition from `started` to
+`completed` updates tracker state correctly:
+
+- seeders/leechers transition as expected
+- torrent completed/download count increments
+- global completed/download count increments
+
+This workflow is a **diagnostic complement** to automated E2E (for example, `qbittorrent_e2e_runner`).
+
+## Prerequisites
+
+Run commands from repository root.
+
+- Tracker config: `./share/default/config/tracker.development.sqlite3.toml`
+- UDP tracker endpoint: `127.0.0.1:6969`
+- Stats API endpoint: `http://127.0.0.1:1212/api/v1/stats?token=MyAccessToken`
+
+Optional (recommended for deterministic baseline):
+
+```bash
+rm -f ./storage/tracker/lib/database/sqlite3.db
+```
+
+## 1. Start tracker
+
+In terminal A:
+
+```bash
+cargo run
+```
+
+Expected startup excerpt:
+
+```text
+Loading extra configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
+... API: Started on: http://0.0.0.0:1212
+... UDP TRACKER: Started on: udp://0.0.0.0:6969
+```
+
+## 2. Define test values
+
+In terminal B:
+
+```bash
+INFO_HASH=1111111111111111111111111111111111111111
+PEER_ID=ABCDEFGHIJKLMNOPQRST
+TRACKER=127.0.0.1:6969
+STATS_URL='http://127.0.0.1:1212/api/v1/stats?token=MyAccessToken'
+```
+
+## 3. Capture baseline
+
+### 3.1 Global stats
+
+```bash
+curl -s "$STATS_URL"
+```
+
+Example output:
+
+```json
+{"torrents":0,"seeders":0,"completed":0,"leechers":0,...}
+```
+
+### 3.2 Torrent-specific stats (scrape)
+
+```bash
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client scrape "$TRACKER" "$INFO_HASH"
+```
+
+Example output:
+
+```json
+{
+  "Scrape": {
+    "transaction_id": -214458979,
+    "torrent_stats": [
+      {
+        "seeders": 0,
+        "completed": 0,
+        "leechers": 0
+      }
+    ]
+  }
+}
+```
+
+## 4. Send started announce
+
+```bash
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client announce \
+  "$TRACKER" "$INFO_HASH" \
+  --event started \
+  --uploaded 0 \
+  --downloaded 0 \
+  --left 1000 \
+  --port 6881 \
+  --peer-id "$PEER_ID" \
+  --key 1 \
+  --peers-wanted 0
+```
+
+Example output:
+
+```json
+{
+  "AnnounceIpv4": {
+    "transaction_id": -888840697,
+    "announce_interval": 120,
+    "leechers": 1,
+    "seeders": 0,
+    "peers": []
+  }
+}
+```
+
+Verify after `started`:
+
+```bash
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client scrape "$TRACKER" "$INFO_HASH"
+curl -s "$STATS_URL"
+```
+
+Expected checks:
+
+- scrape `leechers` is `1`
+- scrape `seeders` is `0`
+- global `leechers` increased by `1`
+- global `completed` unchanged
+
+## 5. Send completed announce
+
+```bash
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client announce \
+  "$TRACKER" "$INFO_HASH" \
+  --event completed \
+  --uploaded 0 \
+  --downloaded 1000 \
+  --left 0 \
+  --port 6881 \
+  --peer-id "$PEER_ID" \
+  --key 1 \
+  --peers-wanted 0
+```
+
+Example output:
+
+```json
+{
+  "AnnounceIpv4": {
+    "transaction_id": -888840697,
+    "announce_interval": 120,
+    "leechers": 0,
+    "seeders": 1,
+    "peers": []
+  }
+}
+```
+
+Verify after `completed`:
+
+```bash
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client scrape "$TRACKER" "$INFO_HASH"
+curl -s "$STATS_URL"
+```
+
+Expected checks:
+
+- scrape `seeders` changed `0 -> 1`
+- scrape `completed` changed `0 -> 1`
+- scrape `leechers` changed `1 -> 0`
+- global `seeders` increased by `1`
+- global `completed` increased by `1`
+
+## 6. Optional output formatting with jq (human-friendly)
+
+If `jq` is available, use these helpers:
+
+```bash
+curl -s "$STATS_URL" | jq '{torrents, seeders, completed, leechers}'
+
+cargo run -q -p torrust-tracker-client --bin udp_tracker_client scrape "$TRACKER" "$INFO_HASH" \
+  | jq '.Scrape.torrent_stats[0]'
+```
+
+## Troubleshooting
+
+- Peer ID must be exactly 20 bytes.
+- Use a fresh `INFO_HASH` to avoid contamination from previous runs.
+- If baseline numbers are non-zero, either reset SQLite DB or compare deltas instead of absolute values.
+- Confirm tracker/API are listening on `6969/udp` and `1212/tcp`.
+
+## Related
+
+- Automated E2E runner: `src/bin/qbittorrent_e2e_runner.rs`
+- Local tracker run workflow: `.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`

--- a/console/tracker-client/docs/features/json-request-input/README.md
+++ b/console/tracker-client/docs/features/json-request-input/README.md
@@ -1,0 +1,152 @@
+# Feature Proposal: JSON Input for Tracker Client Requests
+
+## Status
+
+Deferred (not planned for immediate implementation).
+
+## Summary
+
+This document describes an alternative to many CLI flags for announce requests.
+Instead of passing request parameters only as command-line flags, the client could
+accept a full JSON object.
+
+The proposal applies to both clients:
+
+- `http_tracker_client`
+- `udp_tracker_client`
+
+## Motivation
+
+Current CLI flags are clear and practical for manual use. However, a JSON-based
+input mode can be more convenient for larger payloads, reusable test fixtures,
+and future automation.
+
+## Proposed Interfaces
+
+### 1) JSON file input
+
+```bash
+http_tracker_client announce \
+  --tracker-url http://127.0.0.1:7070 \
+  --request-file ./announce.json
+```
+
+```bash
+udp_tracker_client announce \
+  --tracker-socket-addr 127.0.0.1:6969 \
+  --request-file ./announce.json
+```
+
+### 2) Inline JSON input
+
+```bash
+http_tracker_client announce \
+  --tracker-url http://127.0.0.1:7070 \
+  --request-json '{"info_hash":"443c7602b4fde83d1154d6d9da48808418b181b6","event":"completed"}'
+```
+
+### 3) Standard input (stdin)
+
+```bash
+echo '{"info_hash":"443c7602b4fde83d1154d6d9da48808418b181b6","event":"completed"}' \
+  | http_tracker_client announce --tracker-url http://127.0.0.1:7070 --request-stdin
+```
+
+```bash
+cat announce.json | udp_tracker_client announce --tracker-socket-addr 127.0.0.1:6969 --request-stdin
+```
+
+## Input Shape (Draft)
+
+```json
+{
+  "info_hash": "443c7602b4fde83d1154d6d9da48808418b181b6",
+  "event": "completed",
+  "uploaded": 1234,
+  "downloaded": 5678,
+  "left": 0,
+  "port": 6881,
+  "peer_addr": "10.0.0.1",
+  "peer_id": "-RC00000000000000001",
+  "compact": 1,
+  "key": 42,
+  "peers_wanted": 50,
+  "ip_address": "10.0.0.1"
+}
+```
+
+Notes:
+
+- HTTP uses `peer_addr` and `compact`.
+- UDP uses `ip_address`, `key`, and `peers_wanted`.
+- A shared schema can allow optional protocol-specific fields.
+
+## Compatibility Warning: Byte-String Fields
+
+Some protocol fields are byte strings, not guaranteed UTF-8 text.
+The most important example is `peer_id` (20 bytes on the wire).
+
+In practice, many peer IDs are ASCII-like and fit naturally in CLI args or JSON
+strings. However, full protocol compatibility should allow arbitrary byte values.
+
+If strict compatibility becomes a requirement, both CLI and JSON modes should
+support an explicit binary-safe representation.
+
+Possible approaches:
+
+- Keep text form as default for ergonomics.
+- Add an explicit encoded form for binary-safe input (for example
+  `peer_id_hex` or `peer_id_base64`).
+- For CLI, add corresponding flags such as `--peer-id-hex` and
+  `--peer-id-base64`.
+- For stdin mode, allow raw bytes only when the transport format is binary-safe
+  and unambiguous (otherwise prefer explicit encoding).
+
+Example JSON (binary-safe):
+
+```json
+{
+  "info_hash": "443c7602b4fde83d1154d6d9da48808418b181b6",
+  "peer_id_base64": "LVJDMDAwMDAwMDAwMDAwMDAwMDE="
+}
+```
+
+## Precedence Rule (If Implemented)
+
+If JSON input and flags are provided together, flags should override JSON values.
+
+## Pros
+
+- Better ergonomics for complex requests.
+- Easier to store/version fixtures.
+- Better fit for automation and generated input.
+- Easier composition through stdin pipelines.
+
+## Cons
+
+- Lower discoverability than `--help` flags alone.
+- More validation and error-reporting complexity.
+- Inline JSON quoting is cumbersome in shells.
+- Adds maintenance cost without current automation demand.
+
+## Decision: Why Deferred Now
+
+Not implementing now for the following reasons:
+
+- Request parameters are not expected to change very often.
+- There is no current automation pipeline that strongly benefits from JSON input.
+- Existing flag-based UX already satisfies manual day-to-day usage.
+
+## Revisit Triggers
+
+Re-open this proposal if one or more are true:
+
+- CI or external tools begin generating tracker-client requests.
+- Repeated manual tests require many parameter permutations.
+- More request fields are added and CLI flag UX becomes cumbersome.
+
+## Open Questions
+
+- Should stdin mode read from `--request-file -` instead of a dedicated `--request-stdin`?
+- Should unknown JSON fields fail fast or be ignored?
+- Should protocol-specific fields be split into separate JSON schemas?

--- a/console/tracker-client/src/console/clients/checker/checks/udp.rs
+++ b/console/tracker-client/src/console/clients/checker/checks/udp.rs
@@ -7,7 +7,7 @@ use bittorrent_udp_tracker_protocol::TransactionId;
 use serde::Serialize;
 use url::Url;
 
-use crate::console::clients::udp::checker::Client;
+use crate::console::clients::udp::checker::{AnnounceParams, Client};
 use crate::console::clients::udp::Error;
 
 #[derive(Debug, Clone, Serialize)]
@@ -73,7 +73,7 @@ pub async fn run(udp_trackers: Vec<Url>, timeout: Duration) -> Vec<Result<Checks
         // Announce
         {
             let check = client
-                .send_announce_request(transaction_id, connection_id, info_hash)
+                .send_announce_request(transaction_id, connection_id, info_hash, &AnnounceParams::default())
                 .await
                 .map(|_| ());
 

--- a/console/tracker-client/src/console/clients/udp/app.rs
+++ b/console/tracker-client/src/console/clients/udp/app.rs
@@ -19,7 +19,7 @@
 //!   --left 0 \
 //!   --port 6881 \
 //!   --ip-address 10.0.0.1 \
-//!   --peer-id "-RC0000000000000001" \
+//!   '--peer-id=-RC00000000000000001' \
 //!   --key 42 \
 //!   --peers-wanted 50 | jq
 //! ```
@@ -133,7 +133,7 @@ enum Command {
         downloaded: Option<u64>,
         #[arg(long)]
         left: Option<u64>,
-        #[arg(long)]
+        #[arg(long, value_parser = parse_non_zero_port)]
         port: Option<u16>,
         #[arg(long = "ip-address")]
         ip_address: Option<Ipv4Addr>,
@@ -308,5 +308,16 @@ fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<[u8; 20]> {
     }
     let mut arr = [0u8; 20];
     arr.copy_from_slice(bytes);
+
     Ok(arr)
+}
+
+fn parse_non_zero_port(port_str: &str) -> anyhow::Result<u16> {
+    let port = u16::from_str(port_str).with_context(|| format!("invalid port value: `{port_str}`"))?;
+
+    if port == 0 {
+        anyhow::bail!("port must be greater than zero")
+    }
+
+    Ok(port)
 }

--- a/console/tracker-client/src/console/clients/udp/app.rs
+++ b/console/tracker-client/src/console/clients/udp/app.rs
@@ -2,10 +2,26 @@
 //!
 //! Examples:
 //!
-//! Announce request:
+//! Announce request (minimal):
 //!
 //! ```text
 //! cargo run --bin udp_tracker_client announce 127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422 | jq
+//! ```
+//!
+//! Announce request (all optional parameters):
+//!
+//! ```text
+//! cargo run --bin udp_tracker_client announce \
+//!   127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
+//!   --event completed \
+//!   --uploaded 1234 \
+//!   --downloaded 5678 \
+//!   --left 0 \
+//!   --port 6881 \
+//!   --ip-address 10.0.0.1 \
+//!   --peer-id "-RC0000000000000001" \
+//!   --key 42 \
+//!   --peers-wanted 50 | jq
 //! ```
 //!
 //! Announce response:
@@ -56,23 +72,44 @@
 //! ```
 //!
 //! The protocol (`udp://`) in the URL is mandatory. The path (`\scrape`) is optional. It always uses `\scrape`.
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
 use std::str::FromStr;
 
 use anyhow::Context;
 use bittorrent_primitives::info_hash::InfoHash as TorrustInfoHash;
-use bittorrent_udp_tracker_protocol::{Response, TransactionId};
-use clap::{Parser, Subcommand};
+use bittorrent_udp_tracker_protocol::{AnnounceEvent, Response, TransactionId};
+use clap::{Parser, Subcommand, ValueEnum};
 use torrust_tracker_configuration::DEFAULT_TIMEOUT;
 use tracing::level_filters::LevelFilter;
 use url::Url;
 
 use super::Error;
 use crate::console::clients::udp::checker;
+use crate::console::clients::udp::checker::AnnounceParams;
 use crate::console::clients::udp::responses::dto::SerializableResponse;
 use crate::console::clients::udp::responses::json::ToJson;
 
 const RANDOM_TRANSACTION_ID: i32 = -888_840_697;
+
+/// CLI representation of `AnnounceEvent`. Keeps `clap` out of the protocol layer.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliAnnounceEvent {
+    None,
+    Completed,
+    Started,
+    Stopped,
+}
+
+impl From<CliAnnounceEvent> for AnnounceEvent {
+    fn from(value: CliAnnounceEvent) -> Self {
+        match value {
+            CliAnnounceEvent::None => AnnounceEvent::None,
+            CliAnnounceEvent::Completed => AnnounceEvent::Completed,
+            CliAnnounceEvent::Started => AnnounceEvent::Started,
+            CliAnnounceEvent::Stopped => AnnounceEvent::Stopped,
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -88,6 +125,24 @@ enum Command {
         tracker_socket_addr: SocketAddr,
         #[arg(value_parser = parse_info_hash)]
         info_hash: TorrustInfoHash,
+        #[arg(long)]
+        event: Option<CliAnnounceEvent>,
+        #[arg(long)]
+        uploaded: Option<u64>,
+        #[arg(long)]
+        downloaded: Option<u64>,
+        #[arg(long)]
+        left: Option<u64>,
+        #[arg(long)]
+        port: Option<u16>,
+        #[arg(long = "ip-address")]
+        ip_address: Option<Ipv4Addr>,
+        #[arg(long = "peer-id", value_parser = parse_peer_id)]
+        peer_id: Option<[u8; 20]>,
+        #[arg(long)]
+        key: Option<i32>,
+        #[arg(long = "peers-wanted")]
+        peers_wanted: Option<i32>,
     },
     Scrape {
         #[arg(value_parser = parse_socket_addr)]
@@ -111,7 +166,38 @@ pub async fn run() -> anyhow::Result<()> {
         Command::Announce {
             tracker_socket_addr: remote_addr,
             info_hash,
-        } => handle_announce(remote_addr, &info_hash).await?,
+            event,
+            uploaded,
+            downloaded,
+            left,
+            port,
+            ip_address,
+            peer_id,
+            key,
+            peers_wanted,
+        } => {
+            let params = AnnounceParams {
+                event: event.map(Into::into),
+                uploaded: uploaded
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--uploaded value is too large to fit in i64")?,
+                downloaded: downloaded
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--downloaded value is too large to fit in i64")?,
+                left: left
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--left value is too large to fit in i64")?,
+                port,
+                ip_address,
+                peer_id,
+                key,
+                peers_wanted,
+            };
+            handle_announce(remote_addr, &info_hash, &params).await?
+        }
         Command::Scrape {
             tracker_socket_addr: remote_addr,
             info_hashes,
@@ -131,14 +217,20 @@ fn tracing_stdout_init(filter: LevelFilter) {
     tracing::debug!("Logging initialized");
 }
 
-async fn handle_announce(remote_addr: SocketAddr, info_hash: &TorrustInfoHash) -> Result<Response, Error> {
+async fn handle_announce(
+    remote_addr: SocketAddr,
+    info_hash: &TorrustInfoHash,
+    params: &AnnounceParams,
+) -> Result<Response, Error> {
     let transaction_id = TransactionId::new(RANDOM_TRANSACTION_ID);
 
     let client = checker::Client::new(remote_addr, DEFAULT_TIMEOUT).await?;
 
     let connection_id = client.send_connection_request(transaction_id).await?;
 
-    client.send_announce_request(transaction_id, connection_id, *info_hash).await
+    client
+        .send_announce_request(transaction_id, connection_id, *info_hash, params)
+        .await
 }
 
 async fn handle_scrape(remote_addr: SocketAddr, info_hashes: &[TorrustInfoHash]) -> Result<Response, Error> {
@@ -204,4 +296,17 @@ fn parse_socket_addr(tracker_socket_addr_str: &str) -> anyhow::Result<SocketAddr
 fn parse_info_hash(info_hash_str: &str) -> anyhow::Result<TorrustInfoHash> {
     TorrustInfoHash::from_str(info_hash_str)
         .map_err(|e| anyhow::Error::msg(format!("failed to parse info-hash `{info_hash_str}`: {e:?}")))
+}
+
+fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<[u8; 20]> {
+    let bytes = peer_id_str.as_bytes();
+    if bytes.len() != 20 {
+        return Err(anyhow::anyhow!(
+            "peer-id must be exactly 20 bytes, got {} bytes for `{peer_id_str}`",
+            bytes.len()
+        ));
+    }
+    let mut arr = [0u8; 20];
+    arr.copy_from_slice(bytes);
+    Ok(arr)
 }

--- a/console/tracker-client/src/console/clients/udp/checker.rs
+++ b/console/tracker-client/src/console/clients/udp/checker.rs
@@ -13,7 +13,7 @@ use bittorrent_udp_tracker_protocol::{
 use super::Error;
 
 /// Optional parameters for an announce request. When a field is `None`, the
-/// hard-coded default value is used.
+/// default announce value is used (for `port`, the socket local port is used).
 #[derive(Debug, Default)]
 pub struct AnnounceParams {
     pub event: Option<AnnounceEvent>,
@@ -120,7 +120,7 @@ impl Client {
                 .expect("it should get the local address")
                 .port(),
         )
-        .expect("it should no be zero");
+        .expect("it should not be zero");
 
         let port = params.port.and_then(NonZeroU16::new).unwrap_or(local_port);
 

--- a/console/tracker-client/src/console/clients/udp/checker.rs
+++ b/console/tracker-client/src/console/clients/udp/checker.rs
@@ -12,6 +12,21 @@ use bittorrent_udp_tracker_protocol::{
 
 use super::Error;
 
+/// Optional parameters for an announce request. When a field is `None`, the
+/// hard-coded default value is used.
+#[derive(Debug, Default)]
+pub struct AnnounceParams {
+    pub event: Option<AnnounceEvent>,
+    pub uploaded: Option<i64>,
+    pub downloaded: Option<i64>,
+    pub left: Option<i64>,
+    pub port: Option<u16>,
+    pub ip_address: Option<Ipv4Addr>,
+    pub peer_id: Option<[u8; 20]>,
+    pub key: Option<i32>,
+    pub peers_wanted: Option<i32>,
+}
+
 /// A UDP Tracker client to make test requests (checks).
 #[derive(Debug)]
 pub struct Client {
@@ -93,10 +108,11 @@ impl Client {
         transaction_id: TransactionId,
         connection_id: ConnectionId,
         info_hash: TorrustInfoHash,
+        params: &AnnounceParams,
     ) -> Result<Response, Error> {
         tracing::debug!("Sending announce request with transaction id: {transaction_id:#?}");
 
-        let port = NonZeroU16::new(
+        let local_port = NonZeroU16::new(
             self.client
                 .client
                 .socket
@@ -106,19 +122,21 @@ impl Client {
         )
         .expect("it should no be zero");
 
+        let port = params.port.and_then(NonZeroU16::new).unwrap_or(local_port);
+
         let announce_request = AnnounceRequest {
             connection_id,
             action_placeholder: AnnounceActionPlaceholder::default(),
             transaction_id,
             info_hash: InfoHash(info_hash.bytes()),
-            peer_id: PeerId(*b"-qB00000000000000001"),
-            bytes_downloaded: NumberOfBytes(0i64.into()),
-            bytes_uploaded: NumberOfBytes(0i64.into()),
-            bytes_left: NumberOfBytes(0i64.into()),
-            event: AnnounceEvent::Started.into(),
-            ip_address: Ipv4Addr::UNSPECIFIED.into(),
-            key: PeerKey::new(0i32),
-            peers_wanted: NumberOfPeers(1i32.into()),
+            peer_id: params.peer_id.map_or(PeerId(*b"-qB00000000000000001"), PeerId),
+            bytes_downloaded: NumberOfBytes::new(params.downloaded.unwrap_or(0)),
+            bytes_uploaded: NumberOfBytes::new(params.uploaded.unwrap_or(0)),
+            bytes_left: NumberOfBytes::new(params.left.unwrap_or(0)),
+            event: params.event.unwrap_or(AnnounceEvent::Started).into(),
+            ip_address: params.ip_address.unwrap_or(Ipv4Addr::UNSPECIFIED).into(),
+            key: PeerKey::new(params.key.unwrap_or(0)),
+            peers_wanted: NumberOfPeers::new(params.peers_wanted.unwrap_or(1)),
             port: Port::new(port),
         };
 

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -139,6 +139,82 @@ Announce {
 
 - [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
 
+## Manual Verification
+
+This section is for manual validation after implementation is completed. It is a test plan only.
+
+### Setup
+
+Start the tracker locally with default development configuration:
+
+```bash
+cargo run
+```
+
+Expected startup log excerpt:
+
+```text
+Loading extra configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
+```
+
+### Test 1: Default Announce (backward compatibility)
+
+Command:
+
+```bash
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+      http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6
+```
+
+Example output (observed with current behaviour):
+
+```json
+{
+  "complete": 1,
+  "incomplete": 0,
+  "interval": 120,
+  "min interval": 120,
+  "peers": []
+}
+```
+
+Expected output (JSON):
+
+- Response is valid announce JSON
+- Existing defaults are used when flags are omitted
+- The command succeeds without requiring optional flags
+
+### Test 2: Announce with All Optional Parameters
+
+Command:
+
+```bash
+cargo run -p torrust-tracker-client --bin http_tracker_client announce \
+      http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6 \
+      --event completed \
+      --uploaded 1234 \
+      --downloaded 5678 \
+      --left 0 \
+      --port 6881 \
+      --peer-addr 10.0.0.1 \
+      '--peer-id=-RC00000000000000001' \
+      --compact 1
+```
+
+Note: Peer-id must be exactly 20 bytes. Use `--peer-id='...'` (with equals and quotes) for peer-ids that start with a dash (e.g., `-RC0...` style).
+
+Expected output (JSON):
+
+- Response is valid announce JSON
+- Request is accepted and processed by the tracker
+- Query includes overridden values from flags (including `event=completed`)
+
+### Optional Negative-Path Checks
+
+- `--peer-id` with length different from 20 bytes should fail with a CLI argument error
+- Invalid `--event` value should fail and show allowed values
+- Invalid `--compact` value (not `0` or `1`) should fail with a CLI argument error
+
 ## Acceptance Criteria
 
 - [ ] Running `announce ... --event completed` sends `event=completed` in the query string

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -72,18 +72,18 @@ Supported `--event` values: `none`, `completed`, `started`, `stopped` (matching
 
 ## Goals
 
-- [ ] Add optional CLI flags to the `Announce` variant in
+- [x] Add optional CLI flags to the `Announce` variant in
       `console/tracker-client/src/console/clients/udp/app.rs`:
       `--event`, `--uploaded`, `--downloaded`, `--left`, `--port`, `--ip-address`,
       `--peer-id`, `--key`, `--peers-wanted`
-- [ ] Thread the optional values from the CLI into `handle_announce` and then into
+- [x] Thread the optional values from the CLI into `handle_announce` and then into
       `checker::Client::send_announce_request()`
-- [ ] Add `clap::ValueEnum` (or `FromStr`) for `AnnounceEvent` so it can be parsed from the
+- [x] Add `clap::ValueEnum` (or `FromStr`) for `AnnounceEvent` so it can be parsed from the
       command line — implement directly on the in-house type or introduce a thin wrapper in
       the CLI layer for clean separation of concerns
-- [ ] Defaults remain unchanged when a flag is omitted
-- [ ] Pass `linter all` and `cargo machete` with zero warnings
-- [ ] Update the module-level doc comment in `app.rs` with new usage examples
+- [x] Defaults remain unchanged when a flag is omitted
+- [x] Pass `linter all` and `cargo machete` with zero warnings
+- [x] Update the module-level doc comment in `app.rs` with new usage examples
 
 ## Implementation Plan
 
@@ -101,14 +101,14 @@ applies. Two implementation paths are available:
 
 The wrapper approach is recommended to avoid leaking CLI concerns into the protocol layer.
 
-- [ ] Choose and implement one of the above in the CLI layer
+- [x] Choose and implement one of the above in the CLI layer
       (`console/tracker-client/src/console/clients/udp/`)
 
 ### Task 2: Extend the `Announce` sub-command struct
 
 In `console/tracker-client/src/console/clients/udp/app.rs`:
 
-- [ ] Change the `Announce` variant of the `Command` enum to carry optional fields:
+- [x] Change the `Announce` variant of the `Command` enum to carry optional fields:
 
 ```rust
 Announce {
@@ -139,25 +139,31 @@ Announce {
 
 ### Task 3: Thread optional values through `handle_announce`
 
-- [ ] Update `handle_announce` to accept the new optional parameters and pass them to
+- [x] Update `handle_announce` to accept the new optional parameters and pass them to
       `checker::Client::send_announce_request()`
-- [ ] Update `send_announce_request` in `checker.rs` to accept an optional parameter struct
+- [x] Update `send_announce_request` in `checker.rs` to accept an optional parameter struct
       (or individual `Option` arguments) and apply overrides when `Some`
-- [ ] Validate and parse `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
-- [ ] Reject negative values for `uploaded`, `downloaded`, and `left` at the CLI layer
+- [x] Validate and parse `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
+- [x] Reject negative values for `uploaded`, `downloaded`, and `left` at the CLI layer
 
 ### Task 4: Update docs
 
-- [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
+- [x] Update the module-level doc comment in `app.rs` with the new extended usage example
 
 ## Manual Verification
 
 ### Setup
 
-Start a local UDP tracker on the default port 6969:
+Start the tracker locally with default development configuration:
 
 ```bash
-cargo run --bin udp_tracker_server
+cargo run
+```
+
+Expected startup log excerpt:
+
+```text
+Loading extra configuration from default configuration file: `./share/default/config/tracker.development.sqlite3.toml` ...
 ```
 
 ### Test 1: Default Announce (backward compatibility)
@@ -233,11 +239,11 @@ Example response:
 
 ## Acceptance Criteria
 
-- [ ] Running `announce ... --event completed` sends `event=completed` in the UDP packet
-- [ ] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
-- [ ] `linter all` exits with code `0`
-- [ ] `cargo machete` reports no unused dependencies
-- [ ] All existing tests pass
+- [x] Running `announce ... --event completed` sends `event=completed` in the UDP packet
+- [x] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
+- [x] `linter all` exits with code `0`
+- [x] `cargo machete` reports no unused dependencies
+- [x] All existing tests pass
 
 ## Key Files
 

--- a/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1533-udp-tracker-client-add-optional-announce-params.md
@@ -150,6 +150,87 @@ Announce {
 
 - [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
 
+## Manual Verification
+
+### Setup
+
+Start a local UDP tracker on the default port 6969:
+
+```bash
+cargo run --bin udp_tracker_server
+```
+
+### Test 1: Default Announce (backward compatibility)
+
+Command:
+
+```bash
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422
+```
+
+Expected output (JSON):
+
+- `transaction_id`: matches the request transaction ID
+- `announce_interval`: positive integer (e.g., 120)
+- `leechers`: integer >= 0
+- `seeders`: integer >= 0
+- `peers`: array of peers in `"IP:port"` format (may be empty)
+
+Example response:
+
+```json
+{
+  "AnnounceIpv4": {
+    "transaction_id": -888840697,
+    "announce_interval": 120,
+    "leechers": 0,
+    "seeders": 1,
+    "peers": []
+  }
+}
+```
+
+### Test 2: Announce with All Optional Parameters
+
+Command:
+
+```bash
+cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+  127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
+  --event completed \
+  --uploaded 1234 \
+  --downloaded 5678 \
+  --left 0 \
+  --port 6881 \
+  --ip-address 10.0.0.1 \
+  '--peer-id=-RC00000000000000001' \
+  --key 42 \
+  --peers-wanted 50
+```
+
+Note: Peer-id must be exactly 20 bytes. Use `--peer-id='...'` (with equals and quotes) for peer-ids that start with a dash (e.g., `-RC0...` style).
+
+Expected output (JSON):
+
+- Same response structure as Test 1
+- The request is accepted and processed by the tracker
+- Tracker logs (if enabled) should show the announce request with the custom parameters
+
+Example response:
+
+```json
+{
+  "AnnounceIpv4": {
+    "transaction_id": -888840697,
+    "announce_interval": 120,
+    "leechers": 0,
+    "seeders": 1,
+    "peers": []
+  }
+}
+```
+
 ## Acceptance Criteria
 
 - [ ] Running `announce ... --event completed` sends `event=completed` in the UDP packet

--- a/project-words.txt
+++ b/project-words.txt
@@ -336,3 +336,4 @@ zerocopy
 tlnp
 ulnp
 zstd
+LVJDMDAwMDAwMDAwMDAwMDAwMDE

--- a/project-words.txt
+++ b/project-words.txt
@@ -149,6 +149,7 @@ llist
 LOGNAME
 Lphant
 lscr
+LVJDMDAwMDAwMDAwMDAwMDAwMDE
 matchmakes
 Mebibytes
 metainfo
@@ -278,6 +279,7 @@ Tera
 testcontainer
 testcontainers
 thiserror
+tlnp
 timespec
 tlsv
 toki
@@ -294,6 +296,7 @@ trunc
 ttwu
 typenum
 udpv
+ulnp
 Unamed
 underflows
 uninit
@@ -335,7 +338,4 @@ Xunlei
 xxxxxxxxxxxxxxxxxxxxd
 yyyyyyyyyyyyyyyyyyyyd
 zerocopy
-tlnp
-ulnp
 zstd
-LVJDMDAwMDAwMDAwMDAwMDAwMDE

--- a/project-words.txt
+++ b/project-words.txt
@@ -333,4 +333,6 @@ Xunlei
 xxxxxxxxxxxxxxxxxxxxd
 yyyyyyyyyyyyyyyyyyyyd
 zerocopy
+tlnp
+ulnp
 zstd

--- a/project-words.txt
+++ b/project-words.txt
@@ -107,6 +107,7 @@ hexlify
 hlocalhost
 hmac
 hotspot
+httpclientpeerid
 Hydranode
 hyperthread
 Icelake
@@ -308,6 +309,7 @@ unsync
 untuple
 unviable
 upcasting
+urlencode
 uroot
 usize
 Vagaa


### PR DESCRIPTION
## Summary
- add optional announce flags to udp_tracker_client: --event, --uploaded, --downloaded, --left, --port, --ip-address, --peer-id, --key, --peers-wanted
- thread optional values from CLI through handle_announce into send_announce_request
- add CliAnnounceEvent (clap::ValueEnum) and map it to protocol AnnounceEvent
- keep defaults unchanged when flags are omitted
- add peer-id length validation (20 bytes) and explicit manual verification docs
- add repo docs for deferred JSON/stdin request-input proposal

## Feature Example
Command:

```bash
cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
  127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
  --event completed \
  --uploaded 1234 \
  --downloaded 5678 \
  --left 0 \
  --port 6881 \
  --ip-address 10.0.0.1 \
  '--peer-id=-RC00000000000000001' \
  --key 42 \
  --peers-wanted 50
```

Example output:

```json
{
  "AnnounceIpv4": {
    "transaction_id": -888840697,
    "announce_interval": 120,
    "leechers": 0,
    "seeders": 1,
    "peers": []
  }
}
```

## Validation
- linter all passes
- cargo machete passes
- cargo test -p torrust-tracker-client passes
- manual UDP announce checks completed (default + full optional parameters)
- manual HTTP current-behavior check completed for issue #1532 docs

## Related
- Closes #1533
- References #1532 and EPIC #669
