### PR TITLE
feat(tracker-client): add optional announce params to HTTP client

### DIFF
--- a/console/tracker-client/src/console/clients/http/app.rs
+++ b/console/tracker-client/src/console/clients/http/app.rs
@@ -8,23 +8,74 @@
 //! cargo run --bin http_tracker_client announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422 | jq
 //! ```
 //!
+//! `Announce` request (all optional parameters):
+//!
+//! ```text
+//! cargo run --bin http_tracker_client announce \
+//!   http://127.0.0.1:7070 443c7602b4fde83d1154d6d9da48808418b181b6 \
+//!   --event completed \
+//!   --uploaded 1234 \
+//!   --downloaded 5678 \
+//!   --left 0 \
+//!   --port 6881 \
+//!   --peer-addr 10.0.0.1 \
+//!   '--peer-id=-RC00000000000000001' \
+//!   --compact 1 | jq
+//! ```
+//!
 //! `Scrape` request:
 //!
 //! ```text
 //! cargo run --bin http_tracker_client scrape http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422 | jq
 //! ```
+use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::Context;
 use bittorrent_primitives::info_hash::InfoHash;
-use bittorrent_tracker_client::http::client::requests::announce::QueryBuilder;
-use bittorrent_tracker_client::http::client::responses::announce::Announce;
+use bittorrent_tracker_client::http::client::requests::announce::{Compact, Event, QueryBuilder};
+use bittorrent_tracker_client::http::client::responses::announce::{Announce, DeserializedCompact};
 use bittorrent_tracker_client::http::client::responses::scrape;
 use bittorrent_tracker_client::http::client::{requests, Client};
-use clap::{Parser, Subcommand};
+use bittorrent_udp_tracker_protocol::PeerId;
+use clap::{Parser, Subcommand, ValueEnum};
 use reqwest::Url;
 use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliEvent {
+    Started,
+    Stopped,
+    Completed,
+}
+
+impl From<CliEvent> for Event {
+    fn from(value: CliEvent) -> Self {
+        match value {
+            CliEvent::Started => Event::Started,
+            CliEvent::Stopped => Event::Stopped,
+            CliEvent::Completed => Event::Completed,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum CliCompact {
+    #[value(name = "0")]
+    NotAccepted,
+    #[value(name = "1")]
+    Accepted,
+}
+
+impl From<CliCompact> for Compact {
+    fn from(value: CliCompact) -> Self {
+        match value {
+            CliCompact::NotAccepted => Compact::NotAccepted,
+            CliCompact::Accepted => Compact::Accepted,
+        }
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -35,8 +86,43 @@ struct Args {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    Announce { tracker_url: String, info_hash: String },
-    Scrape { tracker_url: String, info_hashes: Vec<String> },
+    Announce {
+        tracker_url: String,
+        info_hash: String,
+        #[arg(long)]
+        event: Option<CliEvent>,
+        #[arg(long)]
+        uploaded: Option<u64>,
+        #[arg(long)]
+        downloaded: Option<u64>,
+        #[arg(long)]
+        left: Option<u64>,
+        #[arg(long)]
+        port: Option<u16>,
+        #[arg(long = "peer-addr")]
+        peer_addr: Option<IpAddr>,
+        #[arg(long = "peer-id", value_parser = parse_peer_id)]
+        peer_id: Option<PeerId>,
+        #[arg(long, value_enum)]
+        compact: Option<CliCompact>,
+    },
+    Scrape {
+        tracker_url: String,
+        info_hashes: Vec<String>,
+    },
+}
+
+struct AnnounceOptions {
+    tracker_url: String,
+    info_hash: String,
+    event: Option<CliEvent>,
+    uploaded: Option<u64>,
+    downloaded: Option<u64>,
+    left: Option<u64>,
+    port: Option<u16>,
+    peer_addr: Option<IpAddr>,
+    peer_id: Option<PeerId>,
+    compact: Option<CliCompact>,
 }
 
 /// # Errors
@@ -46,8 +132,34 @@ pub async fn run() -> anyhow::Result<()> {
     let args = Args::parse();
 
     match args.command {
-        Command::Announce { tracker_url, info_hash } => {
-            announce_command(tracker_url, info_hash, DEFAULT_TIMEOUT).await?;
+        Command::Announce {
+            tracker_url,
+            info_hash,
+            event,
+            uploaded,
+            downloaded,
+            left,
+            port,
+            peer_addr,
+            peer_id,
+            compact,
+        } => {
+            announce_command(
+                AnnounceOptions {
+                    tracker_url,
+                    info_hash,
+                    event,
+                    uploaded,
+                    downloaded,
+                    left,
+                    port,
+                    peer_addr,
+                    peer_id,
+                    compact,
+                },
+                DEFAULT_TIMEOUT,
+            )
+            .await?;
         }
         Command::Scrape {
             tracker_url,
@@ -60,25 +172,68 @@ pub async fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn announce_command(tracker_url: String, info_hash: String, timeout: Duration) -> anyhow::Result<()> {
-    let base_url = Url::parse(&tracker_url).context("failed to parse HTTP tracker base URL")?;
-    let info_hash =
-        InfoHash::from_str(&info_hash).expect("Invalid infohash. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`");
+async fn announce_command(options: AnnounceOptions, timeout: Duration) -> anyhow::Result<()> {
+    let base_url = Url::parse(&options.tracker_url).context("failed to parse HTTP tracker base URL")?;
+    let info_hash = InfoHash::from_str(&options.info_hash)
+        .expect("Invalid infohash. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`");
 
-    let response = Client::new(base_url, timeout)?
-        .announce(&QueryBuilder::with_default_values().with_info_hash(&info_hash).query())
-        .await?;
+    let mut query_builder = QueryBuilder::with_default_values().with_info_hash(&info_hash);
+
+    if let Some(event) = options.event {
+        query_builder = query_builder.with_event(event.into());
+    }
+    if let Some(uploaded) = options.uploaded {
+        query_builder = query_builder.with_uploaded(uploaded);
+    }
+    if let Some(downloaded) = options.downloaded {
+        query_builder = query_builder.with_downloaded(downloaded);
+    }
+    if let Some(left) = options.left {
+        query_builder = query_builder.with_left(left);
+    }
+    if let Some(port) = options.port {
+        query_builder = query_builder.with_port(port);
+    }
+    if let Some(peer_addr) = options.peer_addr {
+        query_builder = query_builder.with_peer_addr(&peer_addr);
+    }
+    if let Some(peer_id) = options.peer_id {
+        query_builder = query_builder.with_peer_id(&peer_id);
+    }
+    if let Some(compact) = options.compact {
+        query_builder = query_builder.with_compact(compact.into());
+    }
+
+    let response = Client::new(base_url, timeout)?.announce(&query_builder.query()).await?;
 
     let body = response.bytes().await?;
 
-    let announce_response: Announce = serde_bencode::from_bytes(&body)
-        .unwrap_or_else(|_| panic!("response body should be a valid announce response, got: \"{body:#?}\""));
-
-    let json = serde_json::to_string(&announce_response).context("failed to serialize scrape response into JSON")?;
+    let json = if let Ok(announce_response) = serde_bencode::from_bytes::<Announce>(&body) {
+        serde_json::to_string(&announce_response).context("failed to serialize announce response into JSON")?
+    } else if let Ok(compact_response) = serde_bencode::from_bytes::<DeserializedCompact>(&body) {
+        serde_json::to_string(&compact_response).context("failed to serialize compact announce response into JSON")?
+    } else {
+        panic!("response body should be a valid announce response, got: \"{body:#?}\"")
+    };
 
     println!("{json}");
 
     Ok(())
+}
+
+fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<PeerId> {
+    let bytes = peer_id_str.as_bytes();
+    if bytes.len() != 20 {
+        return Err(anyhow::anyhow!(
+            "peer-id must be exactly 20 bytes, got {} bytes for `{peer_id_str}`",
+            bytes.len()
+        ));
+    }
+
+    let mut arr = [0u8; 20];
+    arr.copy_from_slice(bytes);
+
+    Ok(PeerId(arr))
 }
 
 async fn scrape_command(tracker_url: &str, info_hashes: &[String], timeout: Duration) -> anyhow::Result<()> {

--- a/console/tracker-client/src/console/clients/http/app.rs
+++ b/console/tracker-client/src/console/clients/http/app.rs
@@ -97,7 +97,7 @@ enum Command {
         downloaded: Option<u64>,
         #[arg(long)]
         left: Option<u64>,
-        #[arg(long)]
+        #[arg(long, value_parser = parse_non_zero_port)]
         port: Option<u16>,
         #[arg(long = "peer-addr")]
         peer_addr: Option<IpAddr>,
@@ -234,6 +234,16 @@ fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<PeerId> {
     arr.copy_from_slice(bytes);
 
     Ok(PeerId(arr))
+}
+
+fn parse_non_zero_port(port_str: &str) -> anyhow::Result<u16> {
+    let port = u16::from_str(port_str).with_context(|| format!("invalid port value: `{port_str}`"))?;
+
+    if port == 0 {
+        anyhow::bail!("port must be greater than zero")
+    }
+
+    Ok(port)
 }
 
 async fn scrape_command(tracker_url: &str, info_hashes: &[String], timeout: Duration) -> anyhow::Result<()> {

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -69,17 +69,17 @@ Supported `--event` values: `started`, `stopped`, `completed` (case-insensitive)
 
 ## Goals
 
-- [ ] Add optional CLI flags to the `announce` sub-command in
+- [x] Add optional CLI flags to the `announce` sub-command in
       `console/tracker-client/src/console/clients/http/app.rs`:
       `--event`, `--uploaded`, `--downloaded`, `--left`, `--port`, `--peer-addr`,
       `--peer-id`, `--compact`
-- [ ] Parse each flag and map it into `announce::Query` values
-- [ ] Extend `QueryBuilder` with missing setters for
+- [x] Parse each flag and map it into `announce::Query` values
+- [x] Extend `QueryBuilder` with missing setters for
       `event`, `uploaded`, `downloaded`, `left`, and `port`
-- [ ] Defaults remain unchanged when a flag is omitted
-- [ ] Add CLI parsing for `Event` in the tracker-client layer
-- [ ] Pass `linter all` and `cargo machete` with zero warnings
-- [ ] Update the module-level doc comment in `app.rs` with new usage examples
+- [x] Defaults remain unchanged when a flag is omitted
+- [x] Add CLI parsing for `Event` in the tracker-client layer
+- [x] Pass `linter all` and `cargo machete` with zero warnings
+- [x] Update the module-level doc comment in `app.rs` with new usage examples
 
 ## Implementation Plan
 
@@ -92,14 +92,14 @@ Use a CLI-facing enum (for example `CliEvent`) in
 Do not rely on `packages/http-protocol` `Event`, which is a different type and
 belongs to a different layer.
 
-- [ ] Implement `clap::ValueEnum` for the CLI-facing `event` type
-- [ ] Add explicit mapping from CLI event type to tracker-client request `Event`
+- [x] Implement `clap::ValueEnum` for the CLI-facing `event` type
+- [x] Add explicit mapping from CLI event type to tracker-client request `Event`
 
 ### Task 2: Extend the `Announce` sub-command struct
 
 In `console/tracker-client/src/console/clients/http/app.rs`:
 
-- [ ] Change the `Announce` variant of the `Command` enum to carry optional fields:
+- [x] Change the `Announce` variant of the `Command` enum to carry optional fields:
 
 ```rust
 Announce {
@@ -129,15 +129,15 @@ Announce {
 
 ### Task 3: Thread optional values through `announce_command`
 
-- [ ] Update `announce_command` signature to accept the optional parameters
-- [ ] Add missing `QueryBuilder` setters in
+- [x] Update `announce_command` signature to accept the optional parameters
+- [x] Add missing `QueryBuilder` setters in
       `packages/tracker-client/src/http/client/requests/announce.rs`
-- [ ] Apply each `Some(value)` to the `QueryBuilder` chain before calling `.query()`
-- [ ] Parse and validate `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
+- [x] Apply each `Some(value)` to the `QueryBuilder` chain before calling `.query()`
+- [x] Parse and validate `--peer-id` into `bittorrent_udp_tracker_protocol::PeerId`
 
 ### Task 4: Update docs
 
-- [ ] Update the module-level doc comment in `app.rs` with the new extended usage example
+- [x] Update the module-level doc comment in `app.rs` with the new extended usage example
 
 ## Manual Verification
 
@@ -203,11 +203,36 @@ cargo run -p torrust-tracker-client --bin http_tracker_client announce \
 
 Note: Peer-id must be exactly 20 bytes. Use `--peer-id='...'` (with equals and quotes) for peer-ids that start with a dash (e.g., `-RC0...` style).
 
+Observed output after implementation:
+
+```json
+{
+  "complete": 1,
+  "incomplete": 0,
+  "interval": 120,
+  "min interval": 120,
+  "peers": []
+}
+```
+
 Expected output (JSON):
 
 - Response is valid announce JSON
 - Request is accepted and processed by the tracker
 - Query includes overridden values from flags (including `event=completed`)
+
+Observed follow-up verification:
+
+- Scrape transitioned from
+  `{"complete":0,"downloaded":0,"incomplete":1}`
+  to
+  `{"complete":1,"downloaded":1,"incomplete":0}`
+- Global stats transitioned from
+  `"seeders":0,"completed":1,"leechers":1`
+  to
+  `"seeders":1,"completed":2,"leechers":0`
+
+This confirms the started -> completed transition was applied and completed/download counters increased.
 
 ### Optional Negative-Path Checks
 
@@ -217,11 +242,11 @@ Expected output (JSON):
 
 ## Acceptance Criteria
 
-- [ ] Running `announce ... --event completed` sends `event=completed` in the query string
-- [ ] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
-- [ ] `linter all` exits with code `0`
-- [ ] `cargo machete` reports no unused dependencies
-- [ ] All existing tests pass
+- [x] Running `announce ... --event completed` sends `event=completed` in the query string
+- [x] Running `announce ...` without flags behaves exactly as today (defaults unchanged)
+- [x] `linter all` exits with code `0`
+- [x] `cargo machete` reports no unused dependencies
+- [x] All existing tests pass
 
 ## Key Files
 

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -55,7 +55,7 @@ cargo run -p torrust-tracker-client --bin http_tracker_client announce \
   --left 0 \
   --port 6881 \
   --peer-addr 10.0.0.1 \
-  --peer-id "-RC0000000000000001" \
+  '--peer-id=-RC00000000000000001' \
   --compact 1
 ```
 
@@ -239,6 +239,19 @@ This confirms the started -> completed transition was applied and completed/down
 - `--peer-id` with length different from 20 bytes should fail with a CLI argument error
 - Invalid `--event` value should fail and show allowed values
 - Invalid `--compact` value (not `0` or `1`) should fail with a CLI argument error
+
+## Learnings
+
+- Exposing `--compact 1` required the client to support compact HTTP announce response decoding,
+  not only compact request generation. During manual verification, the client initially panicked
+  because it only attempted to deserialize the dictionary-style announce response. The final
+  implementation handles both response shapes.
+- Manual verification is more reliable when comparing before/after deltas instead of assuming all
+  tracker counters start at zero. Tracker state may persist across runs, so scrape/global stats
+  transitions are the meaningful validation signal.
+- For dash-prefixed peer IDs, the most reliable CLI form is
+  `--peer-id=-RC00000000000000001` (typically quoted as a whole shell argument), combined with the
+  explicit 20-byte validation enforced by the client.
 
 ## Acceptance Criteria
 

--- a/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/1532-http-tracker-client-add-optional-announce-params.md
@@ -239,6 +239,7 @@ This confirms the started -> completed transition was applied and completed/down
 - `--peer-id` with length different from 20 bytes should fail with a CLI argument error
 - Invalid `--event` value should fail and show allowed values
 - Invalid `--compact` value (not `0` or `1`) should fail with a CLI argument error
+- `--port 0` should fail with a CLI argument error
 
 ## Learnings
 

--- a/packages/tracker-client/src/http/client/requests/announce.rs
+++ b/packages/tracker-client/src/http/client/requests/announce.rs
@@ -123,6 +123,36 @@ impl QueryBuilder {
     }
 
     #[must_use]
+    pub fn with_event(mut self, event: Event) -> Self {
+        self.announce_query.event = Some(event);
+        self
+    }
+
+    #[must_use]
+    pub fn with_uploaded(mut self, uploaded: BaseTenASCII) -> Self {
+        self.announce_query.uploaded = uploaded;
+        self
+    }
+
+    #[must_use]
+    pub fn with_downloaded(mut self, downloaded: BaseTenASCII) -> Self {
+        self.announce_query.downloaded = downloaded;
+        self
+    }
+
+    #[must_use]
+    pub fn with_left(mut self, left: BaseTenASCII) -> Self {
+        self.announce_query.left = left;
+        self
+    }
+
+    #[must_use]
+    pub fn with_port(mut self, port: PortNumber) -> Self {
+        self.announce_query.port = port;
+        self
+    }
+
+    #[must_use]
     pub fn with_compact(mut self, compact: Compact) -> Self {
         self.announce_query.compact = Some(compact);
         self


### PR DESCRIPTION
## Summary
- add optional announce flags to http_tracker_client: --event, --uploaded, --downloaded, --left, --port, --peer-addr, --peer-id, --compact
- thread optional CLI values into the HTTP announce query builder while preserving existing defaults
- add CLI-facing enums for announce event and compact mode
- add missing QueryBuilder setters for event, uploaded, downloaded, left, and port
- support both dictionary and compact announce response decoding when compact=1 is used
- update the issue spec with manual verification results and implementation learnings
- reject --port 0 with a clear CLI validation error after manual edge-case testing exposed the gap

## Feature Example
Command:

```bash
cargo run -p torrust-tracker-client --bin http_tracker_client announce \
  http://127.0.0.1:7070 2222222222222222222222222222222222222222 \
  --event completed \
  --uploaded 1000 \
  --downloaded 1000 \
  --left 0 \
  --port 6881 \
  --peer-addr 10.0.0.1 \
  '--peer-id=-RC00000000000000001' \
  --compact 1
```

Observed output:

```json
{"complete":1,"incomplete":0,"interval":120,"min interval":120,"peers":[]}
```

Observed follow-up verification:
- scrape changed from `{"complete":0,"downloaded":0,"incomplete":1}` to `{"complete":1,"downloaded":1,"incomplete":0}`
- global stats changed from `seeders=0, completed=1, leechers=1` to `seeders=1, completed=2, leechers=0`

## Edge-Case Checks
- invalid peer-id length fails with `peer-id must be exactly 20 bytes`
- invalid event fails and lists the allowed values: `started`, `stopped`, `completed`
- invalid compact fails and lists the allowed values: `0`, `1`
- invalid peer-addr fails with `invalid IP address syntax`
- `--port 0` now fails with `port must be greater than zero`
- dash-prefixed peer IDs require the documented `--peer-id=-RC...` form to avoid clap parsing `-R` as another flag

## Validation
- cargo test -p torrust-tracker-client passes
- cargo machete passes
- linter all passes
- manual started -> completed HTTP verification completed against local tracker
- manual negative-path verification completed for peer-id, event, compact, peer-addr, and zero port

## Related
- Closes #1532
- References #1533 and EPIC #669
