### PR TITLE
docs(ci): add change-aware workflow issue specs

### DIFF
--- a/docs/issues/1742-ci-change-aware-workflows-epic.md
+++ b/docs/issues/1742-ci-change-aware-workflows-epic.md
@@ -1,0 +1,168 @@
+# EPIC: Make CI Change-Aware
+
+## Goal
+
+Reduce unnecessary CI time and runner usage by making heavyweight workflows run only when the
+changed files can affect the behavior they validate.
+
+The current CI setup runs several expensive workflows for almost every pull request, including
+documentation-only changes. That slows down review and merge for low-risk changes and consumes
+GitHub-hosted runner minutes without increasing confidence.
+
+This EPIC groups two implementation subissues plus one related research track:
+
+1. Existing issue [#1726](https://github.com/torrust/torrust-tracker/issues/1726), which researches
+   whether `sccache` can reduce Rust build times for the workflows that still need to run.
+2. A new docs-only CI fast path so documentation changes do not wait for full test and E2E
+   matrices.
+3. A new persistence-scoped CI strategy so database compatibility and benchmarking workflows only
+   run for persistence-relevant changes.
+
+The intent is to reduce waste without weakening the safety net for code changes.
+
+## Why This Is Needed
+
+The following workflows currently run broadly on `push` and `pull_request` events:
+
+- [`.github/workflows/testing.yaml`](../../../.github/workflows/testing.yaml)
+- [`.github/workflows/os-compatibility.yaml`](../../../.github/workflows/os-compatibility.yaml)
+- [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+- [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)
+
+This has two visible effects:
+
+- Small documentation-only pull requests wait behind workflows that cannot be affected by the
+  change.
+- Persistence-specific workflows run even when a pull request does not touch persistence-related
+  code.
+
+The repository already has adjacent CI optimization work in progress:
+
+- [#1726](https://github.com/torrust/torrust-tracker/issues/1726) is an evidence-driven research
+  issue about Rust compilation costs and whether `sccache` should be adopted at all.
+- [#1740](../1740-fix-container-workflow-caching.md) addresses container build cache behavior.
+
+That makes this a good time to define a coherent, change-aware CI strategy rather than continuing
+with one-off workflow tweaks.
+
+## Scope
+
+This EPIC covers workflow triggering and workflow gating only.
+
+In scope:
+
+- Add a docs-only CI fast path with lightweight checks.
+- Restrict persistence-specific workflows to persistence-relevant changes.
+- Review required-check behavior so selective triggers do not leave pull requests blocked by
+  missing or permanently pending checks.
+- Document the path rules and rationale in the workflow files.
+
+Out of scope:
+
+- Rewriting the test matrix.
+- Replacing the current cache strategy wholesale.
+- Container cache optimization already tracked in [#1740](../1740-fix-container-workflow-caching.md).
+
+## Related Research Track
+
+### Research `sccache` impact on remaining heavy workflows
+
+- Existing issue: [#1726](https://github.com/torrust/torrust-tracker/issues/1726)
+- Local spec: [docs/issues/1726-reduce-build-times-sccache/ISSUE.md](./1726-reduce-build-times-sccache/ISSUE.md)
+- Focus: determine, with benchmarks, whether `sccache` reduces compilation cost for workflows that
+  still need to run.
+- Relationship to this EPIC: complementary, but not a blocker. The docs-only fast path and
+  persistence scoping issues can proceed independently of the `1726` research outcome.
+
+## Implementation Subissues
+
+### Subissue 1: Add a Docs-Only CI Fast Path
+
+- Issue: [#1743](https://github.com/torrust/torrust-tracker/issues/1743)
+- Local spec: [docs/issues/1743-docs-only-ci-fast-path.md](./1743-docs-only-ci-fast-path.md)
+- Focus: skip heavyweight workflows for documentation-only changes while still running markdown
+  and spelling checks.
+
+### Subissue 2: Scope Persistence Workflows by Path
+
+- Issue: [#1744](https://github.com/torrust/torrust-tracker/issues/1744)
+- Local spec:
+  [docs/issues/1744-scope-persistence-workflows-by-path.md](./1744-scope-persistence-workflows-by-path.md)
+- Focus: run database compatibility and persistence benchmarking only when changes can affect
+  persistence behavior.
+
+## Risks and Constraints
+
+### 1. Required checks must remain mergeable
+
+If a workflow is skipped entirely via `paths` or `paths-ignore`, branch protection can treat a
+required check as missing. The implementation must either:
+
+- update required-check configuration to match the new workflow model, or
+- keep the workflow running and use an early change-detection job that exits green when the
+  workflow is not relevant.
+
+### 2. `#1726` should not block change-aware trigger work
+
+Issue `#1726` is about reducing the cost of relevant workflows after they start. This EPIC is
+about avoiding irrelevant workflow runs in the first place.
+
+That means:
+
+- docs-only fast-path work should not wait for `sccache` research to finish,
+- persistence workflow scoping should not wait for `sccache` research to finish, and
+- any implementation here should avoid assuming that `sccache` will be adopted.
+
+### 3. "Docs-only" must be defined explicitly
+
+Documentation is not limited to `docs/` in this repository. Relevant documentation paths also
+include files such as:
+
+- `README.md`
+- `SECURITY.md`
+- `AGENTS.md`
+- `.github/skills/**/SKILL.md`
+- package and console `README.md` files
+
+The subissue should define the exact path set and justify it.
+
+### 4. Docs workflow must stay lightweight even if `#1726` is unresolved
+
+The live `#1726` issue confirms that Rust compilation is a major part of CI cost and that the
+benefit of `sccache` is still under research. A docs-only workflow should therefore avoid relying
+on Rust compilation for its main checks when possible.
+
+In practice, that means keeping the docs-only workflow lightweight and avoiding unnecessary
+workspace compilation. Using the internal `linter` binary is acceptable if its installation and
+execution cost stays low enough that the workflow remains fast for documentation-only pull
+requests.
+
+### 5. Persistence workflow scope is intentionally narrower than general regression coverage
+
+The persistence-specific workflows are intended to validate schema, migration, query, and
+persistence-driver behavior in `tracker-core`, not to provide full cross-package regression
+coverage.
+
+For that reason, the corresponding subissue intentionally prefers a narrow trigger centered on
+`packages/tracker-core/**` plus workflow-file changes when relevant. Broader compile and
+integration regressions remain the responsibility of the general testing workflows.
+
+## Acceptance Criteria
+
+- [ ] A documented change-aware CI strategy exists for docs-only and persistence-related changes.
+- [ ] The EPIC links `#1726` as a related research track and links the two new implementation
+      subissues.
+- [ ] The final implementation keeps pull requests mergeable under the repository's required-check
+      policy.
+- [ ] Heavy workflows no longer run for documentation-only pull requests.
+- [ ] Persistence-specific workflows no longer run for unrelated changes.
+
+## References
+
+- Related issue: [#1726](https://github.com/torrust/torrust-tracker/issues/1726)
+- Related local spec: [docs/issues/1740-fix-container-workflow-caching.md](./1740-fix-container-workflow-caching.md)
+- Related workflows:
+  - [`.github/workflows/testing.yaml`](../../../.github/workflows/testing.yaml)
+  - [`.github/workflows/os-compatibility.yaml`](../../../.github/workflows/os-compatibility.yaml)
+  - [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+  - [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)

--- a/docs/issues/1743-docs-only-ci-fast-path.md
+++ b/docs/issues/1743-docs-only-ci-fast-path.md
@@ -1,0 +1,109 @@
+# Add a Docs-Only CI Fast Path
+
+## Goal
+
+Avoid running heavyweight test, compatibility, and E2E workflows for documentation-only pull
+requests while still validating documentation quality in CI.
+
+## Problem
+
+Documentation changes currently trigger the same expensive workflows as code changes, including
+the `Testing` workflow in [`.github/workflows/testing.yaml`](../../../.github/workflows/testing.yaml).
+That workflow runs full-workspace linters, tests, and Docker-based E2E jobs, which is slow and
+unnecessary when a pull request only changes documentation.
+
+This is particularly costly in this repository because AI-assisted work produces frequent updates
+to issue specs, ADRs, agent instructions, and other Markdown documents.
+
+## Constraints
+
+### 1. Documentation still needs CI coverage
+
+We should not skip CI entirely for docs-only changes. At minimum, documentation-only pull requests
+should run:
+
+- Markdown linting
+- Spell checking (`cspell`)
+
+These checks should stay lightweight. Because [#1726](https://github.com/torrust/torrust-tracker/issues/1726)
+is still researching whether Rust compilation can be sped up enough in CI, this issue should avoid
+designs that introduce unnecessary workspace compilation just to validate documentation.
+
+### 2. "Docs-only" must cover all documentation surfaces
+
+This repository stores documentation in multiple places, not only in `docs/`. The trigger rules
+should review at least the following categories:
+
+- `docs/**`
+- top-level Markdown such as `README.md`, `SECURITY.md`, and `AGENTS.md`
+- package `README.md` files
+- console `README.md` files
+- `.github/skills/**/SKILL.md`
+- `.github/agents/*.md`
+
+The issue implementation should define the final path set explicitly.
+
+### 3. Required checks must not block merge
+
+If the repository marks heavyweight workflows as required checks, skipping them entirely with
+`paths-ignore` may leave pull requests stuck. For this issue, the preferred approach is to update
+branch protection so heavyweight workflows are no longer required for documentation-only pull
+requests.
+
+Keeping workflows running only to satisfy required-check mechanics defeats much of the value of a
+docs-only fast path. Since pull requests are reviewed manually before merge, this issue should
+prioritize faster workflow execution over preserving the current required-check set unchanged.
+
+## Proposed Changes
+
+### Task 1: Define the docs-only path policy
+
+- [ ] List every documentation path category that should count as "docs-only".
+- [ ] List the non-doc paths that should always force full CI, even if Markdown files also
+      changed.
+- [ ] Document the policy in the workflow comments so the rationale remains obvious.
+
+### Task 2: Add a dedicated lightweight docs workflow
+
+- [ ] Create a workflow dedicated to documentation validation.
+- [ ] Run only the documentation-relevant checks, at minimum markdownlint and `cspell`.
+- [ ] Keep the workflow lightweight. Using the internal `linter` binary is acceptable if its
+      installation and execution cost stays low enough for documentation-only pull requests.
+- [ ] Ensure the workflow is fast enough to serve as the main required signal for docs-only pull
+      requests.
+
+### Task 3: Exclude docs-only changes from heavyweight workflows
+
+- [ ] Update the heavyweight PR workflows so docs-only changes do not run the full CI matrix.
+- [ ] Update branch protection rules so skipped heavyweight workflows do not block
+      documentation-only pull requests.
+- [ ] Verify behavior for `pull_request` and, if needed, `push` events.
+- [ ] Confirm that docs-only pull requests remain mergeable.
+
+### Task 4: Validate mixed-change behavior
+
+- [ ] Verify that a pull request touching both docs and Rust code still runs the full CI set.
+- [ ] Verify that a pull request touching docs plus workflow files still runs the appropriate CI.
+- [ ] Document at least one representative example for each case.
+
+## Acceptance Criteria
+
+- [ ] Documentation-only pull requests do not run heavyweight test and E2E workflows.
+- [ ] Documentation-only pull requests still run markdownlint and `cspell` in CI.
+- [ ] The docs-only workflow remains lightweight enough for documentation-only pull requests,
+      including when implemented via the internal `linter` binary.
+- [ ] Pull requests that touch code continue to run the full relevant CI workflows.
+- [ ] Branch protection rules are adjusted so docs-only pull requests are not blocked by skipped
+      heavyweight workflows.
+- [ ] Workflow comments document the path policy clearly.
+
+## References
+
+- Related workflow: [`.github/workflows/testing.yaml`](../../../.github/workflows/testing.yaml)
+- Related workflow: [`.github/workflows/os-compatibility.yaml`](../../../.github/workflows/os-compatibility.yaml)
+- Related workflow: [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+- Related workflow: [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)
+- Related EPIC: [docs/issues/1742-ci-change-aware-workflows-epic.md](./1742-ci-change-aware-workflows-epic.md)
+- Related issue: [#1726](https://github.com/torrust/torrust-tracker/issues/1726) (research on
+  reducing the cost of workflows that still need to run)
+- Related local spec: [docs/issues/1740-fix-container-workflow-caching.md](./1740-fix-container-workflow-caching.md)

--- a/docs/issues/1744-scope-persistence-workflows-by-path.md
+++ b/docs/issues/1744-scope-persistence-workflows-by-path.md
@@ -1,0 +1,96 @@
+# Scope Persistence Workflows by Path
+
+## Goal
+
+Run persistence-specific CI workflows only when a pull request changes files that can affect
+database compatibility or persistence benchmarking.
+
+## Problem
+
+The following workflows currently run broadly on most pull requests:
+
+- [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+- [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)
+
+Both workflows are persistence-specific. They validate database compatibility and benchmark the
+`bittorrent-tracker-core` persistence layer, but they currently run even when a pull request only
+changes unrelated areas such as documentation, HTTP client code, or other non-persistence
+packages.
+
+That wastes CI time and runner capacity without increasing confidence.
+
+Issue [#1726](https://github.com/torrust/torrust-tracker/issues/1726) may reduce the runtime cost
+of these workflows later, but it does not change the fact that they should not run for unrelated
+pull requests.
+
+## Scope Decision
+
+This issue should intentionally scope the persistence workflows to changes in `tracker-core`,
+because the workflows are validating the persistence implementation directly.
+
+The database compatibility jobs in
+[`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+run `cargo test -p bittorrent-tracker-core ... run_mysql_driver_tests` and
+`run_postgres_driver_tests`. Those tests construct the database drivers and call the persistence
+methods directly against real database instances.
+
+Because of that, the intent of these workflows is narrower than general workspace regression
+coverage: they are primarily checking schema, migration, query, and persistence-driver behavior in
+`tracker-core`.
+
+The preferred trigger scope for this issue is therefore:
+
+- `packages/tracker-core/**`
+- the workflow files themselves when they are modified
+
+General compile or cross-package integration regressions remain the responsibility of the broader
+testing workflows.
+
+This issue should also avoid depending on the outcome of `#1726`. Even if `sccache` proves useful,
+running persistence workflows for unrelated changes would still be wasteful.
+
+## Proposed Changes
+
+### Task 1: Define the persistence-relevant path set
+
+- [ ] Define the narrow path set for persistence workflows, centered on `packages/tracker-core/**`.
+- [ ] Decide whether workflow file changes should also trigger the workflows.
+- [ ] Document explicitly that this is an intentional optimization tradeoff, not full dependency
+      closure analysis.
+
+### Task 2: Restrict the database compatibility workflow
+
+- [ ] Update [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+      so it only runs for persistence-relevant changes.
+- [ ] Validate behavior for both MySQL and PostgreSQL jobs.
+- [ ] Confirm that required-check behavior remains mergeable for unrelated pull requests.
+
+### Task 3: Restrict the persistence benchmarking workflow
+
+- [ ] Update [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)
+      so it only runs for persistence-relevant changes.
+- [ ] Ensure the path policy stays aligned with the compatibility workflow.
+- [ ] Confirm that unrelated pull requests no longer trigger the benchmarking workflow.
+
+### Task 4: Add guardrails for future dependency drift
+
+- [ ] Add comments near the trigger rules explaining that the scope is intentionally limited to
+      tracker-core persistence changes.
+- [ ] Consider whether workflow file changes should bypass the path filter.
+- [ ] Verify at least one negative case and one positive case with representative pull requests.
+
+## Acceptance Criteria
+
+- [ ] `db-compatibility` does not run for unrelated pull requests.
+- [ ] `db-benchmarking` does not run for unrelated pull requests.
+- [ ] Both workflows run when `packages/tracker-core/**` changes.
+- [ ] The trigger rules are documented and maintainable.
+- [ ] Required-check behavior does not leave unrelated pull requests blocked.
+
+## References
+
+- Related workflow: [`.github/workflows/db-compatibility.yaml`](../../../.github/workflows/db-compatibility.yaml)
+- Related workflow: [`.github/workflows/db-benchmarking.yaml`](../../../.github/workflows/db-benchmarking.yaml)
+- Related EPIC: [docs/issues/1742-ci-change-aware-workflows-epic.md](./1742-ci-change-aware-workflows-epic.md)
+- Related issue: [#1726](https://github.com/torrust/torrust-tracker/issues/1726) (complementary
+  build-time research, not a blocker for this change)


### PR DESCRIPTION
## Summary
- add the EPIC issue spec for #1742
- add the docs-only CI fast path issue spec for #1743
- add the persistence workflow scoping issue spec for #1744
- rename the reviewed specs out of `docs/issues/drafts/` into final numbered paths

## Validation
- `linter markdown`

## Related
- #1742
- #1743
- #1744