### PR TITLE
ci(workflows): add docs-only CI fast path

### DIFF
--- a/.github/workflows/db-benchmarking.yaml
+++ b/.github/workflows/db-benchmarking.yaml
@@ -1,8 +1,16 @@
 name: Database Benchmarking
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/db-compatibility.yaml
+++ b/.github/workflows/db-compatibility.yaml
@@ -1,8 +1,16 @@
 name: Database Compatibility
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -1,0 +1,61 @@
+# Docs-Lint Workflow
+#
+# Runs lightweight documentation checks on every push and pull request.
+# Serves as the required CI signal for documentation-only pull requests,
+# which are excluded from the heavyweight test and compatibility workflows
+# via `paths-ignore` rules in those workflows.
+#
+# "Docs-only" path policy (mirrored in the `paths-ignore` lists of
+# testing.yaml, os-compatibility.yaml, db-compatibility.yaml, and
+# db-benchmarking.yaml):
+#   - **/*.md        — all Markdown files (docs/, READMEs, AGENTS.md, SKILL.md, …)
+#   - project-words.txt — spell-check dictionary (documentation artefact)
+#
+# A pull request is treated as docs-only when every changed file matches
+# one of the patterns above. Mixed pull requests (docs + code) still run
+# the full CI matrix because the code-side changes escape `paths-ignore`.
+
+name: Docs Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  docs:
+    name: Docs Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - id: checkout
+        name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - id: setup
+        name: Setup Toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - id: node
+        name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - id: cache
+        name: Enable Job Cache
+        uses: Swatinem/rust-cache@v2
+
+      - id: linter
+        name: Install Internal Linter
+        run: cargo install --locked --git https://github.com/torrust/torrust-linting --bin linter
+
+      - id: lint-markdown
+        name: Lint Markdown
+        run: linter markdown
+
+      - id: lint-spelling
+        name: Check Spelling
+        run: linter cspell

--- a/.github/workflows/os-compatibility.yaml
+++ b/.github/workflows/os-compatibility.yaml
@@ -1,8 +1,16 @@
 name: OS Compatibility
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,8 +1,16 @@
 name: Testing
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Torrust Tracker
 
-[![container_wf_b]][container_wf] [![coverage_wf_b]][coverage_wf] [![deployment_wf_b]][deployment_wf] [![testing_wf_b]][testing_wf] [![os_compat_wf_b]][os_compat_wf] [![db_compat_wf_b]][db_compat_wf] [![db_bench_wf_b]][db_bench_wf]
+[![container_wf_b]][container_wf] [![coverage_wf_b]][coverage_wf] [![deployment_wf_b]][deployment_wf] [![testing_wf_b]][testing_wf] [![os_compat_wf_b]][os_compat_wf] [![db_compat_wf_b]][db_compat_wf] [![db_bench_wf_b]][db_bench_wf] [![docs_lint_wf_b]][docs_lint_wf]
 
 **Torrust Tracker** is a [BitTorrent][bittorrent] Tracker that matchmakes peers and collects statistics. Written in [Rust Language][rust] with the [Axum] web framework. **This tracker aims to be respectful to established standards, (both [formal][BEP 00] and [otherwise][torrent_source_felid]).**
 
@@ -256,6 +256,8 @@ This project was a joint effort by [Nautilus Cyberneering GmbH][nautilus] and [D
 [db_compat_wf_b]: ../../actions/workflows/db-compatibility.yaml/badge.svg
 [db_bench_wf]: ../../actions/workflows/db-benchmarking.yaml
 [db_bench_wf_b]: ../../actions/workflows/db-benchmarking.yaml/badge.svg
+[docs_lint_wf]: ../../actions/workflows/docs-lint.yaml
+[docs_lint_wf_b]: ../../actions/workflows/docs-lint.yaml/badge.svg
 [bittorrent]: http://bittorrent.org/
 [rust]: https://www.rust-lang.org/
 [axum]: https://github.com/tokio-rs/axum


### PR DESCRIPTION
## Summary

Implements [#1743](https://github.com/torrust/torrust-tracker/issues/1743) — docs-only CI fast path.

### Changes

**New workflow**: `.github/workflows/docs-lint.yaml`
- Runs on every push and pull request (no path filter)
- Installs the internal `linter` binary and runs `linter markdown` and `linter cspell`
- Serves as the required CI signal for documentation-only pull requests
- Timeout: 10 minutes

**Updated workflows** — `paths-ignore` added to each:
- `.github/workflows/testing.yaml`
- `.github/workflows/os-compatibility.yaml`
- `.github/workflows/db-compatibility.yaml`
- `.github/workflows/db-benchmarking.yaml`

### Path policy

Workflows are skipped when **all** changed files match:
- `**/*.md` — all Markdown files (docs/, READMEs, AGENTS.md, SKILL.md, etc.)
- `project-words.txt` — spell-check dictionary

Mixed PRs (docs + code) still run the full CI matrix.

### Branch protection

After merging, branch protection rules should be updated to mark **Docs Lint** as a required check instead of (or in addition to) the heavyweight workflows, so docs-only pull requests are not blocked by skipped jobs.

### Related

- Epic: #1742
- Issue: #1743
- Research: #1726