### PR TITLE
ci(workflows): scope persistence workflows to tracker-core changes

### DIFF
--- a/.github/workflows/db-benchmarking.yaml
+++ b/.github/workflows/db-benchmarking.yaml
@@ -1,16 +1,19 @@
 name: Database Benchmarking
 
-# Path policy: skip this workflow when every changed file is documentation.
+# Path policy: run this workflow only for persistence-relevant changes.
+# Scoped intentionally to tracker-core — the benchmarks exercise the
+# persistence layer directly. General compile/cross-package regressions
+# are covered by the Testing workflow.
 # See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
-      - "project-words.txt"
+    paths:
+      - "packages/tracker-core/**"
+      - ".github/workflows/db-benchmarking.yaml"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "project-words.txt"
+    paths:
+      - "packages/tracker-core/**"
+      - ".github/workflows/db-benchmarking.yaml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/db-compatibility.yaml
+++ b/.github/workflows/db-compatibility.yaml
@@ -1,16 +1,20 @@
 name: Database Compatibility
 
-# Path policy: skip this workflow when every changed file is documentation.
+# Path policy: run this workflow only for persistence-relevant changes.
+# Scoped intentionally to tracker-core — the jobs call persistence methods
+# directly against real database instances, so broader dependency closure
+# is not required. General compile/cross-package regressions are covered by
+# the Testing workflow.
 # See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
-    paths-ignore:
-      - "**/*.md"
-      - "project-words.txt"
+    paths:
+      - "packages/tracker-core/**"
+      - ".github/workflows/db-compatibility.yaml"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "project-words.txt"
+    paths:
+      - "packages/tracker-core/**"
+      - ".github/workflows/db-compatibility.yaml"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Implements [#1744](https://github.com/torrust/torrust-tracker/issues/1744) — scope persistence workflows by path.

### Changes

**Updated workflows**:

- `.github/workflows/db-compatibility.yaml`
- `.github/workflows/db-benchmarking.yaml`

Both workflows previously had a broad `paths-ignore` for docs (added in #1746). Those have been replaced with narrow `paths` rules:

```yaml
paths:
  - "packages/tracker-core/**"
  - ".github/workflows/db-compatibility.yaml"   # (or db-benchmarking.yaml)
```

### Path policy

Workflows now run **only** when at least one changed file matches:
- `packages/tracker-core/**` — the persistence layer under test
- The workflow file itself — so changes to the CI config always trigger a run

### Rationale

The DB compatibility jobs run `cargo test -p bittorrent-tracker-core ... run_mysql_driver_tests / run_postgres_driver_tests`. The benchmarks run `cargo run -p bittorrent-tracker-core --bin persistence_benchmark_runner`. Both exercise the persistence layer directly, not the broader workspace. Scoping them to `packages/tracker-core/**` is therefore both safe and correct.

General compile and cross-package regression coverage remains the responsibility of the Testing workflow.

### Branch protection

After merging, branch protection rules should be reviewed. These workflows will no longer run for unrelated pull requests, so they should not be set as required checks for all PRs.

### Related

- Epic: #1742
- Issue: #1744
- Research: #1726