### PR TITLE
ci(container): remove redundant compose step from container workflow

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -48,35 +48,6 @@ jobs:
         name: Inspect
         run: docker image inspect torrust-tracker:local
 
-      - id: compose
-        name: Compose
-        run: |
-          QBT_E2E_WORKDIR="${RUNNER_TEMP}/qbt-e2e-compose-build"
-          mkdir -p "${QBT_E2E_WORKDIR}/tracker-storage"
-          mkdir -p "${QBT_E2E_WORKDIR}/seeder-config"
-          mkdir -p "${QBT_E2E_WORKDIR}/seeder-downloads"
-          mkdir -p "${QBT_E2E_WORKDIR}/leecher-config"
-          mkdir -p "${QBT_E2E_WORKDIR}/leecher-downloads"
-          mkdir -p "${QBT_E2E_WORKDIR}/shared"
-
-          export QBT_E2E_TRACKER_IMAGE=torrust-tracker:local
-          export QBT_E2E_QBITTORRENT_IMAGE=ghcr.io/linuxserver/qbittorrent:latest
-          export QBT_E2E_TRACKER_CONFIG_PATH=./share/default/config/tracker.container.sqlite3.toml
-          export QBT_E2E_TRACKER_STORAGE_PATH="${QBT_E2E_WORKDIR}/tracker-storage"
-          export QBT_E2E_TRACKER_HTTP_TRACKER_PORT=7070
-          export QBT_E2E_TRACKER_UDP_PORT=6969
-          export QBT_E2E_TRACKER_HTTP_API_PORT=1212
-          export QBT_E2E_TRACKER_HEALTH_CHECK_API_PORT=1313
-          export QBT_E2E_SEEDER_CONFIG_PATH="${QBT_E2E_WORKDIR}/seeder-config"
-          export QBT_E2E_SEEDER_DOWNLOADS_PATH="${QBT_E2E_WORKDIR}/seeder-downloads"
-          export QBT_E2E_LEECHER_CONFIG_PATH="${QBT_E2E_WORKDIR}/leecher-config"
-          export QBT_E2E_LEECHER_DOWNLOADS_PATH="${QBT_E2E_WORKDIR}/leecher-downloads"
-          export QBT_E2E_SHARED_PATH="${QBT_E2E_WORKDIR}/shared"
-
-          docker compose -f compose.qbittorrent-e2e.sqlite3.yaml build
-          docker compose -f compose.qbittorrent-e2e.mysql.yaml build
-          docker compose -f compose.qbittorrent-e2e.postgresql.yaml build
-
   context:
     name: Context
     needs: test

--- a/docs/issues/1748-remove-redundant-compose-step-from-container-workflow.md
+++ b/docs/issues/1748-remove-redundant-compose-step-from-container-workflow.md
@@ -1,0 +1,58 @@
+# Remove Redundant Compose Step From Container Workflow
+
+## Overview
+
+The `container` workflow still includes a `Compose` step that runs:
+
+- `docker compose -f compose.qbittorrent-e2e.sqlite3.yaml build`
+- `docker compose -f compose.qbittorrent-e2e.mysql.yaml build`
+- `docker compose -f compose.qbittorrent-e2e.postgresql.yaml build`
+
+This step no longer provides unique verification value and adds significant CI time.
+
+- GitHub issue: [#1748](https://github.com/torrust/torrust-tracker/issues/1748)
+- Affected workflow: [`.github/workflows/container.yaml`](../../.github/workflows/container.yaml)
+- Related workflow: [`.github/workflows/testing.yaml`](../../.github/workflows/testing.yaml)
+
+## Background
+
+Historically, the `Compose` step in `container.yaml` was used as a lightweight check to ensure
+compose configuration remained buildable.
+
+The project now has dedicated compose runtime coverage in `testing.yaml` (`docker-e2e` job):
+
+- `e2e_tests_runner --tracker-image torrust-tracker:e2e-local --skip-build`
+- `qbittorrent_e2e_runner --tracker-image torrust-tracker:e2e-local --skip-build --db-driver sqlite3`
+- `qbittorrent_e2e_runner --tracker-image torrust-tracker:e2e-local --skip-build --db-driver mysql`
+- `qbittorrent_e2e_runner --tracker-image torrust-tracker:e2e-local --skip-build --db-driver postgresql`
+
+As a result, compose files are actively validated by tests that matter at runtime.
+
+## Problem
+
+The `Compose` step in `container.yaml` is redundant and expensive:
+
+- It performs only extra build invocations, not runtime verification.
+- It can trigger repeated image builds in the same job.
+- It increases CI duration in the `container` workflow substantially.
+- It makes Docker layer-cache behavior harder to reason about in workflow diagnostics.
+
+## Proposed Change
+
+Remove the `Compose` step from the `test` job in `.github/workflows/container.yaml`.
+
+Keep the existing `Build` + `Inspect` steps in `container.yaml` for image build integrity checks,
+while retaining compose runtime validation in `testing.yaml` (`docker-e2e`).
+
+## Goals
+
+- [ ] Remove the `Compose` step from `.github/workflows/container.yaml`.
+- [ ] Keep `container` workflow matrix build behavior unchanged (`debug` and `release`).
+- [ ] Keep compose runtime verification in `.github/workflows/testing.yaml`.
+- [ ] Confirm reduced CI duration for `container` workflow after merge.
+
+## Non-Goals
+
+- Changing compose files used by E2E tests.
+- Modifying test logic in `e2e_tests_runner` or `qbittorrent_e2e_runner`.
+- Altering publish jobs in `container.yaml`.


### PR DESCRIPTION
## Summary
This PR removes the redundant `Compose` step from the `container` workflow test job.

## Why
The step only rebuilt compose images and did not perform runtime verification. Compose configurations are already actively validated in `.github/workflows/testing.yaml` (`docker-e2e`) with:
- `e2e_tests_runner --skip-build`
- `qbittorrent_e2e_runner --skip-build` for sqlite3/mysql/postgresql

Removing the duplicate compose build reduces CI time and avoids confusing duplicate rebuild behavior.

## Changes
- Added issue spec: `docs/issues/1748-remove-redundant-compose-step-from-container-workflow.md`
- Removed `Compose` step from `.github/workflows/container.yaml`

## Validation
- `linter all`
- `cargo machete`

Closes #1748


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed redundant compose build step from the container workflow to streamline continuous integration and reduce build time. Added documentation detailing the workflow optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->