### PR TITLE
docs(skills): experimental semantic coupling for run-tracker-locally

### DIFF
--- a/.github/skills/add-new-skill/SKILL.md
+++ b/.github/skills/add-new-skill/SKILL.md
@@ -119,6 +119,8 @@ Semantic coupling rules:
 - Add a `skill-link: <skill-name>` marker in each linked artifact using language-appropriate comments.
 - Add a short "Skill Links" section in `SKILL.md` listing those artifacts.
 - Prefer a small validation script in `scripts/` to verify linked files and markers.
+- Follow the canonical convention in `docs/skills/semantic-skill-link-convention.md`.
+- Keep marker usage aligned with the marker catalog in `docs/skills/semantic-skill-link-convention.md`.
 
 ### Step 4: Validate and Commit
 
@@ -160,3 +162,4 @@ Use a lightweight marker convention for cross-artifact maintenance links:
 - Agent Skills specification: [references/specification.md](references/specification.md)
 - Skill patterns: [references/patterns.md](references/patterns.md)
 - Real examples: [references/examples.md](references/examples.md)
+- Semantic link convention: [`docs/skills/semantic-skill-link-convention.md`](../../../docs/skills/semantic-skill-link-convention.md)

--- a/.github/skills/add-new-skill/SKILL.md
+++ b/.github/skills/add-new-skill/SKILL.md
@@ -113,6 +113,13 @@ Frontmatter rules:
 - `metadata.author`: `torrust`
 - `metadata.version`: `"1.0"`
 
+Semantic coupling rules:
+
+- Identify critical project artifacts that the skill depends on.
+- Add a `skill-link: <skill-name>` marker in each linked artifact using language-appropriate comments.
+- Add a short "Skill Links" section in `SKILL.md` listing those artifacts.
+- Prefer a small validation script in `scripts/` to verify linked files and markers.
+
 ### Step 4: Validate and Commit
 
 ```bash
@@ -138,6 +145,15 @@ git commit -S -m "docs(skills): add {skill-name} skill"
     scripts/            ← Optional: executable scripts
     assets/             ← Optional: templates, data
 ```
+
+## Skill Link Convention
+
+Use a lightweight marker convention for cross-artifact maintenance links:
+
+- Marker format: `skill-link: <skill-name>`
+- Put markers near constants, configuration blocks, or documentation lines that define behavior used by the skill.
+- Keep links minimal and high signal: only link artifacts that can make the skill stale when they change.
+- Validate links with a script when practical.
 
 ## References
 

--- a/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
@@ -26,7 +26,7 @@ Convention reference: `docs/skills/semantic-skill-link-convention.md`
 
 Before finalizing changes related to this workflow:
 
-1. Run `bash scripts/validate-skill-links.sh`
+1. Run `bash ./scripts/validate-skill-links.sh`
 2. If validation fails, update either artifact markers or this skill content.
 3. Re-run validation until it passes.
 
@@ -173,4 +173,4 @@ cargo run --bin http_tracker_client announce http://127.0.0.1:7070 9c38422213e30
 
 ## Available Scripts
 
-- `scripts/validate-skill-links.sh` validates that all linked artifacts exist and include the expected `skill-link` marker.
+- `./scripts/validate-skill-links.sh` validates that all linked artifacts exist and include the expected `skill-link` marker.

--- a/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
@@ -20,6 +20,8 @@ This skill depends on these artifacts. If any of them change, review this skill.
 
 Use the marker `skill-link: run-tracker-locally` in affected artifacts.
 
+Convention reference: `docs/skills/semantic-skill-link-convention.md`
+
 ## Validation Loop
 
 Before finalizing changes related to this workflow:

--- a/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
@@ -1,12 +1,32 @@
 ---
 name: run-tracker-locally
 description: Run the Torrust Tracker locally for development and testing. Use this skill to start the tracker with default configuration, understand configuration loading, and interact with tracker services (UDP and HTTP). Triggers on "run tracker", "start tracker locally", "develop tracker", "test tracker locally", or "run tracker for testing".
+compatibility: Requires cargo, bash, and local workspace access.
 metadata:
   author: torrust
   version: "1.0"
 ---
 
 # Run Tracker Locally
+
+## Skill Links
+
+This skill depends on these artifacts. If any of them change, review this skill.
+
+- `src/bootstrap/config.rs`
+- `share/default/config/tracker.development.sqlite3.toml`
+- `src/lib.rs`
+- `README.md`
+
+Use the marker `skill-link: run-tracker-locally` in affected artifacts.
+
+## Validation Loop
+
+Before finalizing changes related to this workflow:
+
+1. Run `bash scripts/validate-skill-links.sh`
+2. If validation fails, update either artifact markers or this skill content.
+3. Re-run validation until it passes.
 
 ## Quick Start
 
@@ -148,3 +168,7 @@ cargo run --bin http_tracker_client announce http://127.0.0.1:7070 9c38422213e30
 - All runtime data (database, logs, config) is stored in `./storage/` which is git-ignored.
 - Each `cargo run` reuses existing database state; delete `./storage/` to start fresh.
 - Log output shows which services are active and on which ports.
+
+## Available Scripts
+
+- `scripts/validate-skill-links.sh` validates that all linked artifacts exist and include the expected `skill-link` marker.

--- a/.github/skills/dev/environment-setup/run-tracker-locally/scripts/validate-skill-links.sh
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/scripts/validate-skill-links.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../../.." && pwd)"
+MARKER="skill-link: run-tracker-locally"
+
+required_files=(
+  "src/bootstrap/config.rs"
+  "share/default/config/tracker.development.sqlite3.toml"
+  "src/lib.rs"
+  "README.md"
+)
+
+has_errors=0
+
+for rel_path in "${required_files[@]}"; do
+  full_path="${REPO_ROOT}/${rel_path}"
+
+  if [[ ! -f "${full_path}" ]]; then
+    echo "Missing required file: ${rel_path}" >&2
+    has_errors=1
+    continue
+  fi
+
+  if ! grep -Fq "${MARKER}" "${full_path}"; then
+    echo "Missing marker '${MARKER}' in: ${rel_path}" >&2
+    has_errors=1
+  fi
+done
+
+if [[ "${has_errors}" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "Skill links validation passed"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,10 @@ routine status updates.
    - **Recommended** — after completing each small, independent, deployable change
 7. **Security**: Do not report security vulnerabilities through public GitHub issues. Send an
    email to `info@nautilus-cyberneering.de` instead. See [SECURITY.md](SECURITY.md).
+8. **Skill-link synchronization**: When modifying any artifact containing a `skill-link:` marker,
+   also review and update the linked skill instructions in `.github/skills/` so behavior,
+   commands, and references remain aligned. If the linked skill has a validation script, run it
+   before finishing.
 
 ## 🌿 Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ cargo run
 
 #### Customization
 
+<!-- skill-link: run-tracker-locally -->
+
 ```sh
 # Copy the default configuration into the standard location:
 mkdir -p ./storage/tracker/etc/

--- a/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
+++ b/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
@@ -103,7 +103,14 @@ Notes:
   - allowed values,
   - placement rules,
   - when to add/update/remove links.
+- [ ] Publish this convention in a canonical repository document that can be referenced by skills and reviewers.
 - [ ] Keep convention intentionally small and pragmatic.
+
+### Task 3b: Add a marker catalog
+
+- [ ] Add a repository catalog defining supported marker types (starting with `skill-link`).
+- [ ] Keep the marker catalog intentionally small and grow it only when a concrete need appears.
+- [ ] Document marker semantics and expected usage patterns for reviewers and contributors.
 
 ### Task 4: Update the skill-creation meta-skill
 
@@ -130,6 +137,8 @@ Notes:
 - [ ] [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) is refactored with a concise, maintainable structure.
 - [ ] The key dependent artifacts include explicit back-link reminders to `run-tracker-locally`.
 - [ ] A documented minimal semantic-link convention exists and is understandable by contributors.
+- [ ] A canonical document exists for the `skill-link` convention and is referenced from skill-authoring guidance.
+- [ ] A marker catalog exists, starts minimal, and documents how new markers can be added organically.
 - [ ] [`.github/skills/add-new-skill/SKILL.md`](../../../.github/skills/add-new-skill/SKILL.md) includes the new guidance for semantic coupling.
 - [ ] The approach remains lightweight and does not introduce an over-engineered ontology system.
 - [ ] The implementation is submitted as an explicit experimental PR and reviewed by maintainers before any merge decision.

--- a/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
+++ b/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
@@ -1,0 +1,152 @@
+# Refactor `run-tracker-locally` Skill with Semantic Artifact Coupling
+
+## Goal
+
+Refactor the skill at [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) to align better with the Agent Skills specification and to reduce documentation drift by introducing explicit, maintainable links between the skill and the repository artifacts it depends on.
+
+## Motivation
+
+The current skill works, but it is vulnerable to becoming stale when referenced artifacts change.
+A typical example is changing the default configuration path: the implementation may be updated in code while the skill remains unchanged.
+
+This issue is motivated by three goals:
+
+- Make skill maintenance proactive instead of memory-based.
+- Add explicit semantic coupling between skill instructions and implementation artifacts.
+- Establish a repeatable pattern so future skills do not repeat the same drift problem.
+
+In short, this is not only a content update; it is a refactor of how we represent and maintain skill-to-artifact relationships.
+
+This issue is intentionally **experimental**. It proposes a significant change in how the repository uses AI skills, and should be implemented behind a cautious review workflow.
+
+## Problem
+
+The skill currently references project artifacts (files, commands, defaults) in plain narrative Markdown.
+Those references are human-readable but not operationally coupled.
+
+As a consequence:
+
+- moving or renaming a referenced artifact can silently invalidate the skill,
+- changing semantic meaning in an artifact (not only file existence) can invalidate guidance,
+- there is no built-in reminder at artifact-change time that a skill review is needed.
+
+## Scope
+
+In scope:
+
+- Refactor [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md).
+- Add explicit back-link reminders in artifacts that influence this skill.
+- Define a lightweight semantic-link convention that works across Rust, TOML, and Markdown.
+- Update the meta-skill [`.github/skills/add-new-skill/SKILL.md`](../../../.github/skills/add-new-skill/SKILL.md) so future skills adopt the same pattern.
+
+Out of scope:
+
+- Building a full ontology framework or a generic DSL for all project documentation.
+- Migrating all existing skills in one shot.
+
+## Experimental Rollout and Review Strategy
+
+This issue should be implemented as an experimental branch and left as an open PR for maintainers to review before merge.
+
+- Keep the PR open for cross-maintainer feedback (including maintainers like Cameron).
+- Treat this work as a repository-level policy experiment, not a routine docs edit.
+- Prefer incremental commits that make review easy: convention first, then skill refactor, then validation automation.
+- Do not force immediate adoption across all skills; validate this approach with one skill first.
+
+The implementation should make it easy to evaluate:
+
+- maintenance cost,
+- reviewer confidence,
+- failure modes,
+- and whether this should become a general project convention.
+
+## Trust Model
+
+The refactor should explicitly follow this trust model:
+
+- The agent can propose and execute changes.
+- Scripts and checks validate structural/semantic integrity.
+- Maintainers decide policy acceptance.
+
+Agent self-reporting is not sufficient for link integrity or semantic coupling correctness. Validation must be objective and reproducible.
+
+## Proposed Changes
+
+### Task 1: Refactor the target skill structure
+
+- [ ] Restructure [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) to better match Agent Skills best practices:
+  - concise core workflow,
+  - explicit defaults,
+  - gotchas,
+  - validation loop.
+- [ ] Keep main instructions focused and move secondary details to `references/` when needed.
+- [ ] Add clear default behavior (preferred commands and fallback guidance).
+
+### Task 2: Add semantic back links in impacted artifacts
+
+Add explicit reminder links in artifacts that this skill depends on, using a small structured marker convention (for example: `affects-skill: run-tracker-locally`).
+
+- [ ] Add back-link marker in [`src/bootstrap/config.rs`](../../../src/bootstrap/config.rs) near `DEFAULT_PATH_CONFIG`.
+- [ ] Add back-link marker in [`share/default/config/tracker.development.sqlite3.toml`](../../../share/default/config/tracker.development.sqlite3.toml).
+- [ ] Add back-link marker in [`src/lib.rs`](../../../src/lib.rs) where default config behavior is documented.
+- [ ] Add back-link marker in [`README.md`](../../../README.md) where local run/config copy instructions are documented.
+
+Notes:
+
+- Use language-appropriate syntax (Rust comments, TOML comments, Markdown comments/text).
+- The marker is a maintenance signal, not runtime logic.
+
+### Task 3: Define minimal semantic-link convention
+
+- [ ] Document a minimal convention for cross-artifact links, including:
+  - marker name,
+  - allowed values,
+  - placement rules,
+  - when to add/update/remove links.
+- [ ] Keep convention intentionally small and pragmatic.
+
+### Task 4: Update the skill-creation meta-skill
+
+- [ ] Update [`.github/skills/add-new-skill/SKILL.md`](../../../.github/skills/add-new-skill/SKILL.md) so new skills include semantic coupling considerations from day one.
+- [ ] Add guidance for:
+  - declaring critical artifact dependencies,
+  - adding backlinks in touched artifacts,
+  - validating those links during skill maintenance.
+
+### Task 5: Add lightweight validation (optional in first iteration)
+
+- [ ] Add a basic validation script under the skill directory (`scripts/`) or shared dev tooling to detect broken file references/backlinks.
+- [ ] Integrate as non-blocking initially (warning), then evaluate promoting to CI gate.
+
+### Task 6: Add explicit experimental governance in the implementation PR
+
+- [ ] Open a dedicated PR labeled as experimental and architecture-affecting for AI workflow conventions.
+- [ ] Request review from maintainers who own development workflow and documentation conventions.
+- [ ] Keep merge decision separate from implementation completion: a finished implementation may still remain unmerged pending consensus.
+- [ ] Capture review feedback in the issue/PR and update the convention proposal accordingly.
+
+## Acceptance Criteria
+
+- [ ] [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) is refactored with a concise, maintainable structure.
+- [ ] The key dependent artifacts include explicit back-link reminders to `run-tracker-locally`.
+- [ ] A documented minimal semantic-link convention exists and is understandable by contributors.
+- [ ] [`.github/skills/add-new-skill/SKILL.md`](../../../.github/skills/add-new-skill/SKILL.md) includes the new guidance for semantic coupling.
+- [ ] The approach remains lightweight and does not introduce an over-engineered ontology system.
+- [ ] The implementation is submitted as an explicit experimental PR and reviewed by maintainers before any merge decision.
+
+## Risks and Trade-offs
+
+- Too little structure keeps drift risk high.
+- Too much structure creates maintenance overhead and poor adoption.
+- The proposed design intentionally targets the middle ground: explicit links + lightweight conventions + incremental validation.
+
+## References
+
+- Agent Skills overview: <https://agentskills.io/home>
+- Agent Skills specification: <https://agentskills.io/specification>
+- Best practices: <https://agentskills.io/skill-creation/best-practices>
+- Optimizing descriptions: <https://agentskills.io/skill-creation/optimizing-descriptions>
+- Evaluating skills: <https://agentskills.io/skill-creation/evaluating-skills>
+- Using scripts: <https://agentskills.io/skill-creation/using-scripts>
+- Target skill: [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md)
+- Meta-skill: [`.github/skills/add-new-skill/SKILL.md`](../../../.github/skills/add-new-skill/SKILL.md)

--- a/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
+++ b/docs/issues/1750-refactor-run-tracker-skill-semantic-coupling.md
@@ -84,7 +84,7 @@ Agent self-reporting is not sufficient for link integrity or semantic coupling c
 
 ### Task 2: Add semantic back links in impacted artifacts
 
-Add explicit reminder links in artifacts that this skill depends on, using a small structured marker convention (for example: `affects-skill: run-tracker-locally`).
+Add explicit reminder links in artifacts that this skill depends on, using a small structured marker convention (for example: `skill-link: run-tracker-locally`).
 
 - [ ] Add back-link marker in [`src/bootstrap/config.rs`](../../../src/bootstrap/config.rs) near `DEFAULT_PATH_CONFIG`.
 - [ ] Add back-link marker in [`share/default/config/tracker.development.sqlite3.toml`](../../../share/default/config/tracker.development.sqlite3.toml).

--- a/docs/skills/semantic-skill-link-convention.md
+++ b/docs/skills/semantic-skill-link-convention.md
@@ -1,0 +1,62 @@
+# Semantic Skill Link Convention
+
+## Purpose
+
+Define a lightweight, machine-readable convention to couple Agent Skills and repository artifacts.
+
+This convention is intentionally minimal. It is designed to prevent skill drift without introducing a heavy ontology framework.
+
+## Marker Catalog
+
+The repository keeps a small catalog of marker definitions.
+
+Current markers:
+
+| Marker       | Value          | Meaning                                                                                |
+| ------------ | -------------- | -------------------------------------------------------------------------------------- |
+| `skill-link` | `<skill-name>` | This artifact affects the linked skill and should trigger a skill review when changed. |
+
+Add new markers only when there is a concrete recurring maintenance problem that the current marker set cannot represent.
+
+## Marker Format
+
+Use this marker in comments or documentation text close to behavior-defining lines:
+
+```text
+skill-link: <skill-name>
+```
+
+Rules:
+
+- `skill-name` must match the skill frontmatter `name` value.
+- Use lowercase letters, numbers, and hyphens.
+- Add only high-signal links: artifacts that can make a skill stale when they change.
+
+## Where to Place Markers
+
+Use language-appropriate syntax:
+
+- Rust: `// skill-link: <skill-name>`
+- TOML: `# skill-link: <skill-name>`
+- Markdown: `<!-- skill-link: <skill-name> -->`
+
+Place the marker near:
+
+- constants that encode default behavior,
+- configuration blocks consumed by the workflow,
+- documentation sections that define the operational procedure.
+
+## Maintenance Workflow
+
+1. Add or update `skill-link` markers in touched artifacts.
+2. Update the skill instructions if semantics changed.
+3. Validate links and markers.
+
+## Ontology-Lite Categories
+
+This repository currently uses these minimal categories:
+
+- Skill: instruction protocol with stable `name`
+- Artifact: code, config, or documentation file
+- Relation: `skill-link` from artifact to skill
+- Validator: script that verifies relation integrity

--- a/share/default/config/tracker.development.sqlite3.toml
+++ b/share/default/config/tracker.development.sqlite3.toml
@@ -1,3 +1,4 @@
+# skill-link: run-tracker-locally
 [metadata]
 app = "torrust-tracker"
 purpose = "configuration"

--- a/src/bootstrap/config.rs
+++ b/src/bootstrap/config.rs
@@ -4,6 +4,7 @@
 
 use torrust_tracker_configuration::{Configuration, Info};
 
+// skill-link: run-tracker-locally
 pub const DEFAULT_PATH_CONFIG: &str = "./share/default/config/tracker.development.sqlite3.toml";
 
 /// It loads the application configuration from the environment.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@
 //!
 //! > NOTICE: The `TORRUST_TRACKER_CONFIG_TOML` env var has priority over the `tracker.toml` file.
 //!
+//! skill-link: run-tracker-locally
 //! By default, if you don’t specify any `tracker.toml` file, the application
 //! will use `./share/default/config/tracker.development.sqlite3.toml`.
 //!


### PR DESCRIPTION
## Summary

This draft PR implements issue #1750 as an experimental change to how skills are maintained.

- adds issue spec in docs/issues
- introduces `skill-link: run-tracker-locally` markers in key linked artifacts
- refactors `run-tracker-locally` skill to include skill links and validation loop
- adds a canonical marker catalog document: `docs/skills/semantic-skill-link-convention.md`
- updates `add-new-skill` meta-skill with the marker catalog convention

## Design choice

This PR intentionally keeps the marker system simple and organic:

- maintain a catalog of marker definitions (not a generated inventory of all uses)
- start with one marker (`skill-link`) and add more only when needed

## Why draft

This is intentionally an experimental, policy-level change in AI workflow conventions and should remain open for maintainer review before merge.

## Validation

- `linter all`
- `bash .github/skills/dev/environment-setup/run-tracker-locally/scripts/validate-skill-links.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Semantic Skill Link Convention guide; updated skill authoring guidance and a proposal doc for an experimental refactor.
  * Expanded the run-tracker-local skill docs with compatibility, skill-link guidance, validation steps, and updated references.
  * Added a workflow quality rule requiring skill-link-linked artifacts be reviewed and synchronized.
* **Tooling**
  * Added a lightweight validation script to check required artifacts and skill-link markers.
* **Chores**
  * Inserted non-functional skill-link markers across docs and config for cross-reference consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->