### PR TITLE
feat(tracker-client): handle unrecognized HTTP tracker responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bencode2json"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928290081480add37a5b8ce7777f1ad566a9ab3f44c4c485e4be0d259fe00e88"
+dependencies = [
+ "clap",
+ "derive_more 1.0.0",
+ "hex",
+ "ringbuffer",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "binascii"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +615,7 @@ dependencies = [
  "bittorrent-primitives",
  "bittorrent-tracker-core",
  "bittorrent-udp-tracker-protocol",
- "derive_more",
+ "derive_more 2.1.1",
  "multimap",
  "percent-encoding",
  "serde",
@@ -645,7 +659,7 @@ version = "3.0.0-develop"
 dependencies = [
  "bittorrent-primitives",
  "bittorrent-udp-tracker-protocol",
- "derive_more",
+ "derive_more 2.1.1",
  "hyper",
  "percent-encoding",
  "reqwest",
@@ -671,7 +685,7 @@ dependencies = [
  "bittorrent-primitives",
  "chrono",
  "clap",
- "derive_more",
+ "derive_more 2.1.1",
  "local-ip-address",
  "mockall",
  "rand 0.10.1",
@@ -1507,11 +1521,32 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3952,6 +3987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuffer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5331,7 +5372,7 @@ dependencies = [
  "bittorrent-primitives",
  "bittorrent-tracker-core",
  "bittorrent-udp-tracker-protocol",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "hyper",
  "local-ip-address",
@@ -5370,7 +5411,7 @@ dependencies = [
  "bittorrent-primitives",
  "bittorrent-tracker-core",
  "bittorrent-udp-tracker-core",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "hyper",
  "local-ip-address",
@@ -5453,7 +5494,7 @@ dependencies = [
 name = "torrust-server-lib"
 version = "3.0.0-develop"
 dependencies = [
- "derive_more",
+ "derive_more 2.1.1",
  "rstest 0.25.0",
  "tokio",
  "torrust-tracker-primitives",
@@ -5511,6 +5552,7 @@ name = "torrust-tracker-client"
 version = "3.0.0-develop"
 dependencies = [
  "anyhow",
+ "bencode2json",
  "bittorrent-primitives",
  "bittorrent-tracker-client",
  "bittorrent-udp-tracker-protocol",
@@ -5545,7 +5587,7 @@ name = "torrust-tracker-configuration"
 version = "3.0.0-develop"
 dependencies = [
  "camino",
- "derive_more",
+ "derive_more 2.1.1",
  "figment",
  "serde",
  "serde_json",
@@ -5590,7 +5632,7 @@ version = "3.0.0-develop"
 dependencies = [
  "approx",
  "chrono",
- "derive_more",
+ "derive_more 2.1.1",
  "formatjson",
  "mutants",
  "openmetrics-parser",
@@ -5610,7 +5652,7 @@ dependencies = [
  "binascii",
  "bittorrent-peer-id",
  "bittorrent-primitives",
- "derive_more",
+ "derive_more 2.1.1",
  "rstest 0.25.0",
  "serde",
  "tdyne-peer-id",
@@ -5683,7 +5725,7 @@ dependencies = [
  "bittorrent-tracker-core",
  "bittorrent-udp-tracker-core",
  "bittorrent-udp-tracker-protocol",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "futures-util",
  "local-ip-address",

--- a/console/tracker-client/Cargo.toml
+++ b/console/tracker-client/Cargo.toml
@@ -16,6 +16,7 @@ version.workspace = true
 
 [dependencies]
 anyhow = "1"
+bencode2json = "0.1"
 bittorrent-udp-tracker-protocol = { version = "3.0.0-develop", path = "../../packages/udp-protocol" }
 bittorrent-primitives = "0.2.0"
 bittorrent-tracker-client = { version = "3.0.0-develop", path = "../../packages/tracker-client" }

--- a/console/tracker-client/src/console/clients/http/app.rs
+++ b/console/tracker-client/src/console/clients/http/app.rs
@@ -28,11 +28,24 @@
 //! ```text
 //! cargo run --bin http_tracker_client scrape http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422 | jq
 //! ```
+//!
+//! Unrecognized response fallback (generic JSON):
+//!
+//! ```json
+//! {"files":{"<info_hash_bytes>":{"incomplete":0,"complete":32}}}
+//! ```
+//!
+//! Unrecognized response fallback (raw bytes):
+//!
+//! ```text
+//! Warning: Could not deserialize HTTP tracker response. Raw bytes: [100, 56, ...]
+//! ```
 use std::net::IpAddr;
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::Context;
+use anyhow::{bail, Context};
+use bencode2json::try_bencode_to_json;
 use bittorrent_primitives::info_hash::InfoHash;
 use bittorrent_tracker_client::http::client::requests::announce::{Compact, Event, QueryBuilder};
 use bittorrent_tracker_client::http::client::responses::announce::{Announce, DeserializedCompact};
@@ -174,8 +187,12 @@ pub async fn run() -> anyhow::Result<()> {
 
 async fn announce_command(options: AnnounceOptions, timeout: Duration) -> anyhow::Result<()> {
     let base_url = Url::parse(&options.tracker_url).context("failed to parse HTTP tracker base URL")?;
-    let info_hash = InfoHash::from_str(&options.info_hash)
-        .expect("Invalid infohash. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`");
+    let info_hash = InfoHash::from_str(&options.info_hash).map_err(|_| {
+        anyhow::anyhow!(
+            "invalid infohash `{}`. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`",
+            options.info_hash
+        )
+    })?;
 
     let mut query_builder = QueryBuilder::with_default_values().with_info_hash(&info_hash);
 
@@ -213,7 +230,11 @@ async fn announce_command(options: AnnounceOptions, timeout: Duration) -> anyhow
     } else if let Ok(compact_response) = serde_bencode::from_bytes::<DeserializedCompact>(&body) {
         serde_json::to_string(&compact_response).context("failed to serialize compact announce response into JSON")?
     } else {
-        panic!("response body should be a valid announce response, got: \"{body:#?}\"")
+        let fallback = bencode_to_fallback_json_or_raw_bytes(&body);
+
+        println!("{fallback}");
+
+        bail!("unrecognized announce response from tracker")
     };
 
     println!("{json}");
@@ -255,12 +276,24 @@ async fn scrape_command(tracker_url: &str, info_hashes: &[String], timeout: Dura
 
     let body = response.bytes().await?;
 
-    let scrape_response = scrape::Response::try_from_bencoded(&body)
-        .unwrap_or_else(|_| panic!("response body should be a valid scrape response, got: \"{body:#?}\""));
+    let Ok(scrape_response) = scrape::Response::try_from_bencoded(&body) else {
+        let fallback = bencode_to_fallback_json_or_raw_bytes(&body);
+
+        println!("{fallback}");
+
+        bail!("unrecognized scrape response from tracker")
+    };
 
     let json = serde_json::to_string(&scrape_response).context("failed to serialize scrape response into JSON")?;
 
     println!("{json}");
 
     Ok(())
+}
+
+fn bencode_to_fallback_json_or_raw_bytes(body: &[u8]) -> String {
+    match try_bencode_to_json(body) {
+        Ok(json) => json,
+        Err(_) => format!("Warning: Could not deserialize HTTP tracker response. Raw bytes: {body:?}"),
+    }
 }

--- a/docs/issues/open/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/open/672-http-tracker-client-print-unrecognized-responses.md
@@ -169,6 +169,50 @@ Apply the same two-step fallback to `scrape_command`, replacing the current
 
 Add examples showing the fallback output in the module-level doc comment.
 
+## Manual Verification
+
+This section is a living test plan and result log for validating fallback behavior against real
+HTTP trackers and a forced malformed local response.
+
+### Goal
+
+- Confirm normal typed JSON output for well-behaved HTTP trackers.
+- Confirm non-standard but valid bencoded responses are printed as generic JSON and exit non-zero.
+- Confirm completely unrecognized payloads print raw bytes and exit non-zero.
+
+### Step 1: Collect stable HTTP trackers
+
+- Query the newtrackon HTTP endpoint: <https://newtrackon.com/api#get-/http>
+- Record the sampled tracker list used for this verification run.
+- Note date/time and any filtering criteria.
+
+### Step 2: Probe sampled public trackers
+
+- Run `announce` and/or `scrape` against sampled trackers.
+- Record whether each response is typed JSON or fallback JSON.
+- Record exit code for each probe.
+
+### Step 3: Record results
+
+Use this table to track outcomes:
+
+| Tracker     | Command     | Output mode | Exit code   | Notes       |
+| ----------- | ----------- | ----------- | ----------- | ----------- |
+| _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
+
+### Step 4: Local malformed-response verification
+
+If public trackers do not produce an unrecognized payload, force one locally to verify the raw
+bytes fallback:
+
+1. Apply a temporary local patch to the HTTP tracker response path to return malformed payload bytes.
+2. Run the tracker locally.
+3. Run `http_tracker_client announce` or `scrape` against the local tracker.
+4. Verify fallback prints raw bytes and command exits non-zero.
+
+Record command lines and observed output in this section. If a temporary local patch was used,
+state explicitly that it is not part of the committed implementation.
+
 ## Acceptance Criteria
 
 - [ ] Running the client against a tracker that returns a non-standard response prints the

--- a/docs/issues/open/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/open/672-http-tracker-client-print-unrecognized-responses.md
@@ -81,22 +81,22 @@ Warning: Could not deserialize HTTP tracker response. Raw bytes: [100, 56, ...]
 
 ## Goals
 
-- [ ] Replace both `panic!(...)` / `.unwrap_or_else(|_| panic!(...))` calls in `app.rs` with
+- [x] Replace both `panic!(...)` / `.unwrap_or_else(|_| panic!(...))` calls in `app.rs` with
       graceful fallback logic
-- [ ] Remove panic/unwrap usage from the scrape decode path:
+- [x] Remove panic/unwrap usage from the scrape decode path:
       `expect(...)` in `try_from_bencoded` and nested `.unwrap()` calls in
       parser helpers
-- [ ] Add `bencode2json` as a dependency of the `torrust-tracker-client` console crate
-- [ ] On deserialization failure, print the raw bencoded payload as generic JSON (via
+- [x] Add `bencode2json` as a dependency of the `torrust-tracker-client` console crate
+- [x] On deserialization failure, print the raw bencoded payload as generic JSON (via
       `bencode2json`)
-- [ ] If `bencode2json` conversion also fails, print a warning with the raw byte slice
-- [ ] The process exits with a non-zero exit code when the response cannot be deserialized
+- [x] If `bencode2json` conversion also fails, print a warning with the raw byte slice
+- [x] The process exits with a non-zero exit code when the response cannot be deserialized
       (print the fallback JSON/bytes to stdout, return an `Err` from the command function)
-- [ ] Fallback JSON output is compact by default in this issue; once `--format`
+- [x] Fallback JSON output is compact by default in this issue; once `--format`
       is introduced in #1562, fallback JSON must respect the selected format
-- [ ] `linter all` exits with code `0`
-- [ ] `cargo machete` reports no unused dependencies
-- [ ] All existing tests pass
+- [x] `linter all` exits with code `0`
+- [x] `cargo machete` reports no unused dependencies
+- [x] All existing tests pass
 
 ## Implementation Plan
 
@@ -171,61 +171,41 @@ Add examples showing the fallback output in the module-level doc comment.
 
 ## Manual Verification
 
-This section is a living test plan and result log for validating fallback behavior against real
-HTTP trackers and a forced malformed local response.
+Manual verification was performed using temporary local HTTP fixture servers (Python `http.server`),
+without modifying tracker source code. This validates all response-handling branches deterministically.
 
-### Goal
+### Verification Date
 
-- Confirm normal typed JSON output for well-behaved HTTP trackers.
-- Confirm non-standard but valid bencoded responses are printed as generic JSON and exit non-zero.
-- Confirm completely unrecognized payloads print raw bytes and exit non-zero.
+- 2026-05-11
 
-### Step 1: Collect stable HTTP trackers
+### Commands And Results
 
-- Query the newtrackon HTTP endpoint: <https://newtrackon.com/api#get-/http>
-- Record the sampled tracker list used for this verification run.
-- Note date/time and any filtering criteria.
+| Scenario                                            | Command                                                                                                                                     | Output mode           | Exit code | Notes                                                                                          |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | --------- | ---------------------------------------------------------------------------------------------- |
+| Non-standard but valid bencode scrape response      | `cargo run -p torrust-tracker-client --bin http_tracker_client -- scrape http://127.0.0.1:18080 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`   | Generic JSON fallback | `1`       | Printed `{"foo":"bar"}`, then `Error: unrecognized scrape response from tracker`               |
+| Malformed announce payload (`not-bencode-response`) | `cargo run -p torrust-tracker-client --bin http_tracker_client -- announce http://127.0.0.1:18080 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | Raw-bytes fallback    | `1`       | Printed warning with raw byte slice, then `Error: unrecognized announce response from tracker` |
+| Typed announce payload (tracker-compatible schema)  | `cargo run -p torrust-tracker-client --bin http_tracker_client -- announce http://127.0.0.1:18082 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` | Typed JSON            | `0`       | Printed typed JSON including `min interval` and `peers`                                        |
+| Typed scrape payload (tracker-compatible schema)    | `cargo run -p torrust-tracker-client --bin http_tracker_client -- scrape http://127.0.0.1:18082 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`   | Typed JSON            | `0`       | Printed typed scrape JSON for the provided info-hash                                           |
 
-### Step 2: Probe sampled public trackers
+### Notes
 
-- Run `announce` and/or `scrape` against sampled trackers.
-- Record whether each response is typed JSON or fallback JSON.
-- Record exit code for each probe.
-
-### Step 3: Record results
-
-Use this table to track outcomes:
-
-| Tracker     | Command     | Output mode | Exit code   | Notes       |
-| ----------- | ----------- | ----------- | ----------- | ----------- |
-| _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ | _(pending)_ |
-
-### Step 4: Local malformed-response verification
-
-If public trackers do not produce an unrecognized payload, force one locally to verify the raw
-bytes fallback:
-
-1. Apply a temporary local patch to the HTTP tracker response path to return malformed payload bytes.
-2. Run the tracker locally.
-3. Run `http_tracker_client announce` or `scrape` against the local tracker.
-4. Verify fallback prints raw bytes and command exits non-zero.
-
-Record command lines and observed output in this section. If a temporary local patch was used,
-state explicitly that it is not part of the committed implementation.
+- Local fixture servers were started in temporary terminals and terminated after validation.
+- No temporary response-forcing patch was committed to tracker code.
+- This run validates the fallback behavior required by #672 and compatibility with expected typed response schemas.
 
 ## Acceptance Criteria
 
-- [ ] Running the client against a tracker that returns a non-standard response prints the
+- [x] Running the client against a tracker that returns a non-standard response prints the
       response as generic JSON (via `bencode2json`) and exits non-zero
-- [ ] Running the client against a tracker that returns a completely unrecognized payload
+- [x] Running the client against a tracker that returns a completely unrecognized payload
       prints a warning with the raw bytes and exits non-zero
 - [ ] Running the client against the Torrust Tracker still prints the typed JSON response
-      and exits `0`
-- [ ] No `panic!` or `.unwrap()` in the announce or scrape command paths
-- [ ] No reachable panic/unwrap remains in the scrape decoding path
-- [ ] `linter all` exits with code `0`
-- [ ] `cargo machete` reports no unused dependencies
-- [ ] All existing tests pass
+      and exits `0` (not executed in this run; validated with local tracker-compatible typed fixtures)
+- [x] No `panic!` or `.unwrap()` in the announce or scrape command paths
+- [x] No reachable panic/unwrap remains in the scrape decoding path
+- [x] `linter all` exits with code `0`
+- [x] `cargo machete` reports no unused dependencies
+- [x] All existing tests pass
 
 ## Key Files
 

--- a/packages/tracker-client/src/http/client/responses/scrape.rs
+++ b/packages/tracker-client/src/http/client/responses/scrape.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
-use std::fmt::Write;
 use std::str;
 
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_bencode::value::Value;
+use thiserror::Error;
 
 use crate::http::{ByteArray20, InfoHash};
 
@@ -24,13 +24,9 @@ impl Response {
     /// # Errors
     ///
     /// Will return an error if the deserialized bencoded response can't not be converted into a valid response.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if it can't deserialize the bencoded response.
     pub fn try_from_bencoded(bytes: &[u8]) -> Result<Self, BencodeParseError> {
         let scrape_response: DeserializedResponse =
-            serde_bencode::from_bytes(bytes).expect("provided bytes should be a valid bencoded response");
+            serde_bencode::from_bytes(bytes).map_err(|source| BencodeParseError::DeserializationError { source })?;
         Self::try_from(scrape_response)
     }
 }
@@ -80,10 +76,17 @@ impl Serialize for Response {
 
 // Helper function to convert ByteArray20 to hex string
 fn byte_array_to_hex_string(byte_array: &ByteArray20) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
     let mut hex_string = String::with_capacity(byte_array.len() * 2);
+
     for byte in byte_array {
-        write!(hex_string, "{byte:02x}").expect("Writing to string should never fail");
+        let high = usize::from(byte >> 4);
+        let low = usize::from(byte & 0x0f);
+        hex_string.push(char::from(HEX[high]));
+        hex_string.push(char::from(HEX[low]));
     }
+
     hex_string
 }
 
@@ -105,11 +108,21 @@ impl ResponseBuilder {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum BencodeParseError {
+    #[error("failed to deserialize bencoded scrape response: {source}")]
+    DeserializationError { source: serde_bencode::Error },
+
+    #[error("invalid value: expected dictionary, got: {value:?}")]
     InvalidValueExpectedDict { value: Value },
+
+    #[error("invalid value: expected integer, got: {value:?}")]
     InvalidValueExpectedInt { value: Value },
+
+    #[error("invalid file field in scrape response: {value:?}")]
     InvalidFileField { value: Value },
+
+    #[error("missing required scrape file field: {field_name}")]
     MissingFileField { field_name: String },
 }
 
@@ -140,7 +153,7 @@ fn parse_bencoded_response(value: &Value) -> Result<Response, BencodeParseError>
                 let info_hash_byte_vec = file_element.0;
                 let file_value = file_element.1;
 
-                let file = parse_bencoded_file(file_value).unwrap();
+                let file = parse_bencoded_file(file_value)?;
 
                 files.insert(InfoHash::new(info_hash_byte_vec).bytes(), file);
             }
@@ -218,9 +231,15 @@ fn parse_bencoded_file(value: &Value) -> Result<File, BencodeParseError> {
             }
 
             File {
-                complete: complete.unwrap(),
-                downloaded: downloaded.unwrap(),
-                incomplete: incomplete.unwrap(),
+                complete: complete.ok_or_else(|| BencodeParseError::MissingFileField {
+                    field_name: "complete".to_string(),
+                })?,
+                downloaded: downloaded.ok_or_else(|| BencodeParseError::MissingFileField {
+                    field_name: "downloaded".to_string(),
+                })?,
+                incomplete: incomplete.ok_or_else(|| BencodeParseError::MissingFileField {
+                    field_name: "incomplete".to_string(),
+                })?,
             }
         }
         _ => return Err(BencodeParseError::InvalidValueExpectedDict { value: value.clone() }),

--- a/packages/tracker-client/src/http/client/responses/scrape.rs
+++ b/packages/tracker-client/src/http/client/responses/scrape.rs
@@ -23,7 +23,7 @@ impl Response {
 
     /// # Errors
     ///
-    /// Will return an error if the deserialized bencoded response can't not be converted into a valid response.
+    /// Will return an error if the deserialized bencoded response cannot be converted into a valid response.
     pub fn try_from_bencoded(bytes: &[u8]) -> Result<Self, BencodeParseError> {
         let scrape_response: DeserializedResponse =
             serde_bencode::from_bytes(bytes).map_err(|source| BencodeParseError::DeserializationError { source })?;
@@ -210,24 +210,6 @@ fn parse_bencoded_file(value: &Value) -> Result<File, BencodeParseError> {
                         value: file_field.1.clone(),
                     });
                 }
-            }
-
-            if complete.is_none() {
-                return Err(BencodeParseError::MissingFileField {
-                    field_name: "complete".to_string(),
-                });
-            }
-
-            if downloaded.is_none() {
-                return Err(BencodeParseError::MissingFileField {
-                    field_name: "downloaded".to_string(),
-                });
-            }
-
-            if incomplete.is_none() {
-                return Err(BencodeParseError::MissingFileField {
-                    field_name: "incomplete".to_string(),
-                });
             }
 
             File {

--- a/project-words.txt
+++ b/project-words.txt
@@ -185,6 +185,7 @@ numwant
 nvCFlJCq7fz7Qx6KoKTDiMZvns8l5Kw7
 obra
 oneshot
+oneline
 openmetrics
 ostr
 Pando

--- a/project-words.txt
+++ b/project-words.txt
@@ -184,8 +184,8 @@ notnull
 numwant
 nvCFlJCq7fz7Qx6KoKTDiMZvns8l5Kw7
 obra
-oneshot
 oneline
+oneshot
 openmetrics
 ostr
 Pando


### PR DESCRIPTION
## Summary
- replace panic-based error handling in HTTP announce/scrape commands with graceful fallback behavior
- add fallback conversion via bencode2json for valid but non-standard bencoded responses
- print a raw-bytes warning when bencode-to-JSON conversion fails
- remove reachable panic/unwrap paths in HTTP scrape decoding
- update issue spec with completed checklist items and manual verification logs

## Behavior
- typed announce/scrape responses print typed JSON and exit with code 0
- unrecognized but valid bencoded responses print generic JSON fallback and exit with code 1
- malformed or unparseable responses print raw bytes and exit with code 1

## Validation
- cargo test -p bittorrent-tracker-client
- cargo test -p torrust-tracker-client
- runTests summary: 911 passed, 0 failed
- linter all
- cargo machete

## Notes
- Acceptance criterion "run against Torrust Tracker" remains unchecked in the issue spec and is explicitly documented as not executed in this run.

Closes #672
