### PR TITLE
docs(tracker-client): define CLI I/O contract and ADRs

### DIFF
--- a/console/tracker-client/README.md
+++ b/console/tracker-client/README.md
@@ -2,13 +2,18 @@
 
 A collection of console clients to make requests to BitTorrent trackers.
 
-> **Disclaimer**: This project is actively under development. We’re currently extracting and refining common functionality from the[Torrust Tracker](https://github.com/torrust/torrust-tracker) to make it available to the BitTorrent community in Rust. While these tools are functional, they are not yet ready for use in production or third-party projects.
+> **Disclaimer**: This project is actively under development. We’re currently extracting and refining common functionality from the [Torrust Tracker](https://github.com/torrust/torrust-tracker) to make it available to the BitTorrent community in Rust. While these tools are functional, they are not yet ready for use in production or third-party projects.
 
 There are currently three console clients available:
 
 - UDP Client
 - HTTP Client
 - Tracker Checker
+
+## Documentation
+
+- [Tracker CLI I/O Contract](docs/contracts/tracker-cli-io-contract.md)
+- [Tracker Client ADRs](docs/adrs/README.md)
 
 > **Notice**: [Console apps are planned to be merge into a single tracker client in the short-term](https://github.com/torrust/torrust-tracker/discussions/660).
 
@@ -186,7 +191,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the [GNU Lesser General Public License][LGPL_3_0] for more details.
 
-You should have received a copy of the *GNU Lesser General Public License* along with this program. If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the _GNU Lesser General Public License_ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 Some files include explicit copyright notices and/or license notices.
 

--- a/console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md
+++ b/console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md
@@ -1,0 +1,94 @@
+# ADR 20260512080000: Define Tracker CLI I/O Contract and Error Handling
+
+- Status: Accepted
+- Date: 2026-05-12
+- Scope: console/tracker-client
+
+## Context
+
+The tracker client is a growing CLI surface with multiple commands (UDP client, HTTP client,
+tracker checker, and monitor features under active development). The project intends to extract
+this application into an independent repository.
+
+Without an explicit contract, command outputs and error behavior can diverge, breaking user
+automation and increasing maintenance cost.
+
+At the same time, existing commands may not yet fully match the desired target behavior, so the
+team needs a migration policy, not a flag day rewrite.
+
+## Decision
+
+Define a global Tracker CLI I/O contract for console/tracker-client.
+
+### 1. Default output format
+
+- JSON is the default output format.
+
+### 2. Output channels
+
+- stdout: normal command results and machine-consumable output.
+- stderr: progress reporting, diagnostics, warnings, and error output.
+
+For monitor-style streaming behavior:
+
+- Progress/probe events may be emitted as one JSON object per line (NDJSON style).
+- If emitted as progress, they go to stderr.
+- Final command result summary goes to stdout as JSON.
+
+### 3. Exit-code semantics
+
+Exit codes represent tracker client app execution state, not tracker endpoint health status.
+
+- 0: command executed successfully, even if one or more trackers reported failures/timeouts.
+- 1: generic application/runtime failure (unexpected internal error).
+- 2: invalid tracker checker configuration/input errors.
+
+Tracker-specific failures (for example announce timeout, scrape timeout, non-200 HTTP from a
+tracker) are represented in JSON result payloads, not in non-zero exit codes.
+
+### 4. Progressive migration policy
+
+- New features and new subcommands must follow this contract.
+- Existing features that do not yet comply will be migrated progressively when touched by new
+  feature work or dedicated refactors.
+- No immediate broad rewrite is required.
+
+### 5. Scope location
+
+This policy is intentionally documented under console/tracker-client docs because the tracker
+client is expected to be extracted into its own repository.
+
+### 6. Auditability and testing strategy
+
+- Contracts should be auditable through stable structured payloads and explicit field definitions.
+- During the monorepo phase, conformance is enforced through issue specs and acceptance criteria.
+- After tracker-client extraction to its own repository, add dedicated E2E contract tests for
+  stdout/stderr behavior, exit codes, NDJSON events, and JSON schema conformance.
+
+## Consequences
+
+### Positive
+
+- Predictable behavior for shell pipelines and automation.
+- Clear separation between app-level failure and tracker-level status.
+- Lower migration risk through incremental adoption.
+- Documentation remains aligned with future repository extraction boundaries.
+- Auditable CLI behavior suitable for compliance and regression verification.
+
+### Negative
+
+- Transitional inconsistency until all legacy paths are migrated.
+- Additional implementation and review burden to keep channel/exit behavior consistent.
+- Full E2E contract coverage is deferred until extraction, so short-term assurance relies on
+  spec-driven validation.
+
+## Implementation Notes
+
+- Command specs should reference the tracker client I/O contract document.
+- New command acceptance criteria should include channel correctness and exit-code behavior.
+- Contract schema updates should be backward compatible or explicitly versioned.
+
+## References
+
+- [Tracker CLI I/O Contract](../contracts/tracker-cli-io-contract.md)
+- [console/tracker-client/README.md](../../README.md)

--- a/console/tracker-client/docs/adrs/README.md
+++ b/console/tracker-client/docs/adrs/README.md
@@ -1,0 +1,17 @@
+# Tracker Client ADRs
+
+Architecture Decision Records (ADRs) for the console tracker client live in this folder.
+
+These ADRs are scoped to the tracker client application and are intentionally separated from
+repository-level ADRs because the tracker client is expected to be extracted into its own
+repository in the future.
+
+## Goals
+
+- Capture durable decisions for tracker client behavior and architecture
+- Keep CLI/API contracts explicit and stable for automation users
+- Allow progressive migration of existing commands toward the target contract
+
+## Index
+
+See [ADR Index](index.md).

--- a/console/tracker-client/docs/adrs/index.md
+++ b/console/tracker-client/docs/adrs/index.md
@@ -1,0 +1,5 @@
+# ADR Index
+
+| ADR                                                                                   | Date       | Title                                              | Short Description                                                                                                                                                  |
+| ------------------------------------------------------------------------------------- | ---------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [20260512080000](20260512080000_define_tracker_cli_io_contract_and_error_handling.md) | 2026-05-12 | Define Tracker CLI I/O Contract and Error Handling | Standardize JSON-first output, stdout/stderr channel rules, and exit-code semantics for tracker checker commands with progressive migration for existing features. |

--- a/console/tracker-client/docs/contracts/tracker-cli-io-contract.md
+++ b/console/tracker-client/docs/contracts/tracker-cli-io-contract.md
@@ -1,0 +1,165 @@
+# Tracker CLI I/O Contract
+
+Status: Active
+
+Scope: console/tracker-client commands, with explicit emphasis on tracker checker behavior.
+
+## Purpose
+
+Define stable rules for:
+
+- output format
+- stdout/stderr channel usage
+- error payload structure
+- process exit codes
+
+This contract is designed for automation-first CLI usage and progressive adoption.
+
+## Core Rules
+
+### JSON-first output
+
+- JSON is the default output format for command results.
+- Result payloads on stdout are machine-consumable.
+
+### Channel usage
+
+- stdout:
+  - final command results
+  - structured status/results intended for downstream processing
+- stderr:
+  - progress reporting
+  - diagnostics and warnings
+  - application error output
+
+### Monitor/progress events
+
+For monitor commands (for example `tracker_checker monitor udp`):
+
+- Per-probe progress is emitted as NDJSON style: one JSON object per line.
+- Per-probe progress events go to stderr.
+- Final aggregate summary goes to stdout as JSON.
+
+## Error Payload Schema
+
+Application errors should use this envelope:
+
+```json
+{ "error": { "kind": "string", "source": "string", "message": "string" } }
+```
+
+Field meaning:
+
+- kind: machine-readable error category (for example `invalid_configuration`)
+- source: where the error originated (for example `TORRUST_CHECKER_CONFIG`, `config_path`, `runtime`)
+- message: human-readable detail
+
+## Exit Codes
+
+Exit codes represent CLI app execution status.
+
+- 0: command executed successfully (tracker failures can still be present in JSON results)
+- 1: generic application/runtime failure
+- 2: invalid tracker checker configuration/input
+
+Important:
+
+- Tracker endpoint failures do not map to non-zero process exit codes.
+- Tracker endpoint failures are part of result JSON payloads.
+
+## Distinguishing App Errors vs Tracker Failures
+
+- App errors:
+  - invalid CLI/config input
+  - internal command failures
+  - serialization/runtime failures
+  - reported via stderr error JSON and non-zero exit code
+- Tracker failures:
+  - timeout
+  - connection refused
+  - non-success status from tracker endpoint
+  - reported inside stdout result JSON, exit code remains 0
+
+## Stability and Migration
+
+- New features and subcommands must comply with this contract.
+- Legacy behavior is migrated progressively.
+- Contract changes should remain backward compatible; if a breaking change is required,
+  introduce a schema version and migration note.
+
+## Auditability Requirements
+
+This contract is intended to be auditable.
+
+- Prefer explicit structured payloads over ad-hoc text messages.
+- Keep field names stable once published.
+- If any required field changes, bump a schema version and document migration steps.
+
+Recommended metadata fields for auditable outputs:
+
+- `schema_version`
+- `command`
+- `timestamp`
+- `run_id`
+
+These fields can be added progressively as commands are migrated.
+
+## Verification Strategy
+
+### Current repository phase
+
+- Contract conformance is validated by documentation reviews and issue-level acceptance criteria.
+- New feature specs should include explicit checks for:
+  - stdout/stderr channel behavior
+  - JSON envelope conformance
+  - exit-code semantics
+
+### Post-extraction phase (target)
+
+When `console/tracker-client` is extracted to its own repository, add dedicated E2E conformance
+tests for this contract.
+
+Recommended E2E coverage:
+
+- golden stdout/stderr fixtures for representative command runs
+- exit-code assertions (`0`, `1`, `2`)
+- NDJSON per-line validation for monitor probe events
+- JSON schema validation for final summaries and error envelopes
+
+Until extraction, this remains a planned verification step.
+
+## Examples
+
+### Example 1: Successful run with tracker failures
+
+```text
+stdout:
+{"udp_trackers":[{"url":"udp://127.0.0.1:6969","status":{"code":"timeout","message":"announce timeout"}}]}
+
+stderr:
+{"event":"probe","url":"udp://127.0.0.1:6969","result":"timeout","elapsed_ms":10000}
+
+exit code: 0
+```
+
+### Example 2: Invalid configuration
+
+```text
+stdout:
+
+stderr:
+{"error":{"kind":"invalid_configuration","source":"TORRUST_CHECKER_CONFIG","message":"JSON parse error: trailing comma at line 7 column 5"}}
+
+exit code: 2
+```
+
+### Example 3: Generic application failure
+
+```text
+stdout:
+
+stderr:
+{"error":{"kind":"runtime_failure","source":"runtime","message":"failed to initialize async runtime"}}
+
+exit code: 1
+```

--- a/console/tracker-client/docs/contracts/tracker-cli-io-contract.md
+++ b/console/tracker-client/docs/contracts/tracker-cli-io-contract.md
@@ -137,7 +137,7 @@ stdout:
 {"udp_trackers":[{"url":"udp://127.0.0.1:6969","status":{"code":"timeout","message":"announce timeout"}}]}
 
 stderr:
-{"event":"probe","url":"udp://127.0.0.1:6969","result":"timeout","elapsed_ms":10000}
+{"event":"probe","url":"udp://127.0.0.1:6969","status":"timeout","elapsed_ms":null}
 
 exit code: 0
 ```

--- a/docs/issues/open/1042-tracker-checker-http-improve-error-message-json-config.md
+++ b/docs/issues/open/1042-tracker-checker-http-improve-error-message-json-config.md
@@ -1,0 +1,241 @@
+# Issue #1042 — Tracker Checker (HTTP): Improve Error Message When JSON Config Is Not Well-Formatted
+
+## Overview
+
+When the Tracker Checker is supplied with a malformed JSON configuration (e.g. a trailing comma),
+it panics with a generic `invalid config format` message followed by a buried "Caused by" chain.
+The goal is to surface the specific JSON parse error at the top level so the user can fix the
+configuration immediately without inspecting the full backtrace.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1042>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+
+## Motivation
+
+The current output on a malformed config is:
+
+```text
+thread 'main' panicked at console/tracker-client/src/bin/tracker_checker.rs:6:22:
+Some checks fail: invalid config format
+
+Caused by:
+    JSON parse error: trailing comma at line 7 column 5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+The useful detail (`JSON parse error: trailing comma at line 7 column 5`) is buried in the
+"Caused by" chain. A developer who does not know to look for that will see only
+`invalid config format` and have no idea where the problem is.
+
+The fix should make the detailed JSON parse error visible immediately — either by improving
+the context message, removing the generic context so the underlying error propagates directly,
+or by printing the error cleanly to stderr before exiting non-zero (instead of panicking).
+
+## How to Reproduce
+
+Run the checker with invalid JSON (note the trailing comma in the `http_trackers` array):
+
+```console
+TORRUST_CHECKER_CONFIG='{
+    "udp_trackers": [],
+    "http_trackers": [
+        "http://127.0.0.1:7070",
+        "http://127.0.0.1:7070/",
+        "http://127.0.0.1:7070/announce",
+    ],
+    "health_checks": []
+}' cargo run --bin tracker_checker
+```
+
+Current output:
+
+```text
+thread 'main' panicked at console/tracker-client/src/bin/tracker_checker.rs:6:22:
+Some checks fail: invalid config format
+
+Caused by:
+    JSON parse error: trailing comma at line 7 column 5
+```
+
+## Current Behaviour
+
+In `console/tracker-client/src/console/clients/checker/app.rs`, both code paths that call
+`parse_from_json` wrap the error with `.context("invalid config format")`:
+
+```rust
+fn setup_config(args: Args) -> Result<Configuration> {
+    match (args.config_path, args.config_content) {
+        (Some(config_path), _) => load_config_from_file(&config_path),
+        (_, Some(config_content)) => parse_from_json(&config_content).context("invalid config format"),
+        _ => Err(anyhow::anyhow!("no configuration provided")),
+    }
+}
+
+fn load_config_from_file(path: &PathBuf) -> Result<Configuration> {
+    let file_content = std::fs::read_to_string(path)
+        .with_context(|| format!("can't read config file {}", path.display()))?;
+    parse_from_json(&file_content).context("invalid config format")
+}
+```
+
+And the binary entry-point panics on error:
+
+```rust
+app::run().await.expect("Some checks fail");
+```
+
+## Proposed Behaviour
+
+Replace the generic context string with a message that includes the source of the configuration
+and directs the user to the specific problem.
+
+Do not panic on configuration errors. Print a structured JSON error to stderr and exit with a
+non-zero status code.
+
+Example stderr output:
+
+```text
+{"error":{"kind":"invalid_configuration","source":"TORRUST_CHECKER_CONFIG","message":"JSON parse error: trailing comma at line 7 column 5"}}
+```
+
+The key requirement is that the specific serde/JSON error message is immediately visible without
+needing `RUST_BACKTRACE=1`.
+
+Standardize checker error payloads with this shape:
+
+```json
+{ "error": { "kind": "...", "source": "...", "message": "..." } }
+```
+
+Exit code policy for this issue:
+
+- `2` for configuration errors (invalid JSON, invalid config source values)
+- `1` reserved for non-config general checker failures
+
+## Key Files
+
+| File                                                           | Role                                                                             |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `console/tracker-client/src/console/clients/checker/app.rs`    | `setup_config`, `load_config_from_file` — context wrapping                       |
+| `console/tracker-client/src/console/clients/checker/config.rs` | `parse_from_json` + `ConfigurationError` — already has good per-variant messages |
+| `console/tracker-client/src/bin/tracker_checker.rs`            | Binary entry point with `expect` panic                                           |
+
+## Goals
+
+- [ ] The specific JSON parse error is visible to the user without `RUST_BACKTRACE=1`
+- [ ] The error output clearly identifies whether the bad configuration came from an environment
+      variable or from a file
+- [ ] On configuration errors, the binary prints JSON error output to stderr and exits non-zero
+- [ ] Checker errors follow a standardized JSON schema: `{ "error": { "kind", "source", "message" } }`
+- [ ] Configuration errors use process exit code `2`
+- [ ] Valid configurations are unaffected
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Implementation Plan
+
+### Task 1: Replace generic context string in `setup_config`
+
+In `app.rs`, replace `.context("invalid config format")` with a context string that includes
+the origin of the configuration. For example:
+
+```rust
+parse_from_json(&config_content)
+    .context("invalid TORRUST_CHECKER_CONFIG value — check your JSON")
+```
+
+### Task 2: Replace generic context string in `load_config_from_file`
+
+Similarly, include the file path in the context:
+
+```rust
+parse_from_json(&file_content)
+    .context(format!("invalid JSON in config file '{}'", path.display()))
+```
+
+### Task 3: Consider replacing `expect` with proper error reporting
+
+In `tracker_checker.rs`, replace:
+
+```rust
+app::run().await.expect("Some checks fail");
+```
+
+with a non-panicking error exit that prints structured JSON to stderr and exits with
+`std::process::exit(2)` for configuration errors.
+
+For example, the output can be:
+
+```text
+{"error":{"kind":"invalid_configuration","source":"TORRUST_CHECKER_CONFIG","message":"JSON parse error: trailing comma at line 7 column 5"}}
+```
+
+This step is required by the maintainer decision.
+
+## Acceptance Criteria
+
+- [ ] AC1: Running the checker with a trailing comma in `TORRUST_CHECKER_CONFIG` shows the JSON
+      parse error message (e.g. `trailing comma at line N column M`) without `RUST_BACKTRACE=1`
+- [ ] AC2: Running the checker with a trailing comma in a config file shows both the file path
+      and the JSON parse error message
+- [ ] AC3: Configuration errors are reported as JSON to stderr and process exits non-zero
+- [ ] AC4: Configuration errors use exit code `2`
+- [ ] AC5: Running the checker with a valid configuration produces the same output as before
+- [ ] AC6: `linter all` exits with code `0`
+- [ ] AC7: `cargo machete` reports no unused dependencies
+- [ ] AC8: Existing tests pass
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   |          |
+| AC2   | TODO                   |          |
+| AC3   | TODO                   |          |
+| AC4   | TODO                   |          |
+| AC5   | TODO                   |          |
+| AC6   | TODO                   |          |
+| AC7   | TODO                   |          |
+| AC8   | TODO                   |          |
+
+## Metadata
+
+| Field              | Value                                                                             |
+| ------------------ | --------------------------------------------------------------------------------- |
+| Type               | Bug / Enhancement                                                                 |
+| Status             | Planned                                                                           |
+| Priority           | P3                                                                                |
+| GitHub Issue       | [#1042](https://github.com/torrust/torrust-tracker/issues/1042)                   |
+| Spec Path          | `docs/issues/open/1042-tracker-checker-http-improve-error-message-json-config.md` |
+| Branch             | `1042-tracker-checker-http-improve-error-message-json-config`                     |
+| Related PR         | To be assigned                                                                    |
+| Last Updated (UTC) | 2026-05-12 08:00                                                                  |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/open/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Implementation completed
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-05-11 20:00 UTC - Agent - Spec created from GitHub issue #1042 content
+- 2026-05-12 00:00 UTC - Agent - Incorporated maintainer decisions: JSON error output, no panic, both env and file config paths
+- 2026-05-12 08:00 UTC - Agent - Incorporated answered follow-ups: standardized checker error schema and exit code `2` for configuration errors
+
+## Open Questions
+
+No open questions at this time.
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Clients extracted to new package: <https://github.com/torrust/torrust-tracker/issues/1067>
+- Tracker CLI I/O contract: `console/tracker-client/docs/contracts/tracker-cli-io-contract.md`
+- Tracker CLI ADR: `console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md`

--- a/docs/issues/open/1178-tracker-checker-udp-add-monitor-uptime-command.md
+++ b/docs/issues/open/1178-tracker-checker-udp-add-monitor-uptime-command.md
@@ -1,0 +1,244 @@
+# Issue #1178 — Tracker Checker (UDP): Add Command to Monitor Uptime
+
+## Overview
+
+Add a new `monitor` subcommand (or standalone binary) to the Tracker Checker that periodically
+sends UDP `announce` requests to a tracker and prints live statistics. The goal is to reproduce
+locally what <https://newtrackon.com/> does, so maintainers can investigate intermittent uptime
+drops without relying on a third-party service.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1178>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- Related: <https://github.com/torrust/torrust-demo/issues/26>
+
+## Background
+
+[newtrackon.com](https://newtrackon.com/) reported 93% uptime for the Torrust demo UDP tracker.
+The host `netstat -su` output shows no packet loss at the network level, and the measured
+announce processing time inside the tracker is well under 10 ms. Yet newtrackon reports ~222 ms
+response time and occasional timeouts.
+
+To reproduce and diagnose the problem, a local monitoring loop is needed that does the same as
+newtrackon: sends an announce request at a fixed interval and accumulates response-time
+statistics.
+
+The relevant newtrackon checking interval is every 5 minutes; the tool should default to the
+same interval, but the interval should be configurable.
+
+## Goals
+
+- [ ] Add a UDP uptime-monitor command to the tracker-client toolbox
+- [ ] The command accepts a UDP tracker URL and optional configuration (interval, timeout, info-hash)
+- [ ] On every probe the command prints one JSON object per line to stderr (NDJSON)
+- [ ] At the end of execution, the command prints final statistics to stdout in JSON format
+- [ ] Final statistics include:
+  - Total probe count
+  - Timeout count (and percentage)
+  - Minimum response time
+  - Maximum response time
+  - Average response time
+  - Last response time
+- [ ] The command accepts a duration argument and exits automatically after that duration
+- [ ] `Ctrl+C` is supported to stop monitoring early and still print final JSON results
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Proposed CLI
+
+```text
+cargo run --bin tracker_checker -- monitor udp \
+    --url     udp://127.0.0.1:6969 \
+    --interval 300 \
+  --timeout  10 \
+  --duration 86400
+```
+
+Or as part of a possible future unified `tracker-client` CLI:
+
+```text
+cargo run --bin torrust-tracker-client -- \
+    checker monitor udp \
+    --url     udp://127.0.0.1:6969 \
+    --interval 300 \
+    --timeout  10
+```
+
+### Options
+
+| Option       | Default | Description                                  |
+| ------------ | ------- | -------------------------------------------- |
+| `--url`      | —       | UDP tracker URL (required)                   |
+| `--interval` | `300`   | Seconds between probes                       |
+| `--timeout`  | `10`    | Seconds to wait for a response before timeout |
+| `--duration` | `86400` | Total monitor runtime in seconds             |
+
+### Sample Output
+
+```text
+stderr:
+{"event":"probe","sequence":1,"url":"udp://127.0.0.1:6969","status":"ok","elapsed_ms":122}
+{"event":"probe","sequence":2,"url":"udp://127.0.0.1:6969","status":"ok","elapsed_ms":98}
+{"event":"probe","sequence":3,"url":"udp://127.0.0.1:6969","status":"timeout","elapsed_ms":null}
+
+stdout:
+{"udp_trackers":[{"url":"udp://127.0.0.1:6969","status":{"code":"ok","message":"monitor completed","stats":{"total":3,"timeouts":1,"timeout_percent":33.3,"min_ms":98,"max_ms":122,"average_ms":110,"last_ms":null}}}]}
+```
+
+## Implementation Plan
+
+### Task 1: Add `monitor udp` subcommand to `tracker_checker`
+
+In `console/tracker-client/src/console/clients/checker/app.rs`, add a new CLI subcommand
+`monitor` (or extend the existing args structure) that accepts:
+
+- `--url` (required): UDP tracker URL
+- `--interval` (optional, default 300): probe interval in seconds
+- `--timeout` (optional, default 10): per-probe timeout in seconds
+- `--duration` (optional, default 86400): total monitor runtime in seconds
+
+### Task 2: Implement probe loop
+
+Create a new module, e.g.
+`console/tracker-client/src/console/clients/checker/monitor/udp.rs`, containing:
+
+- A `run_monitor` async function that loops forever (until Ctrl+C signal)
+- Each iteration sends a UDP `announce` request using the existing `UdpTrackerClient`
+- Records `start` / `end` timestamps and computes elapsed milliseconds
+- Treats no response within `--timeout` as a timeout event
+
+### Task 3: Track statistics
+
+Maintain an in-memory stats struct across iterations:
+
+```rust
+struct Stats {
+    total: u64,
+    timeouts: u64,
+    min_ms: Option<u64>,
+    max_ms: Option<u64>,
+    sum_ms: u64,
+    last_ms: Option<u64>,
+}
+```
+
+Implement `average_ms` as `sum_ms / (total - timeouts)` (guard against divide-by-zero).
+
+### Task 4: Print status and stats after each probe
+
+After each probe, print to stderr:
+
+1. A one-line JSON probe event (NDJSON) including sequence number, status, and elapsed time
+2. Optionally, a compact running summary (still on stderr)
+
+At the end of monitoring (timeout reached or Ctrl+C), print final aggregate stats to stdout as JSON.
+The JSON shape should align with the existing checker output structure.
+
+### Task 5: Add duration-based stop condition and Ctrl+C support
+
+Stop automatically when `--duration` elapses.
+
+Register a `tokio::signal::ctrl_c` handler (or `signal_hook`) that breaks the loop cleanly and
+still prints final JSON stats before exiting.
+
+When monitoring completes (including timeout-heavy runs), return exit code `0` if the tool itself
+ran successfully.
+
+### Task 6: Wire the new subcommand into the binary entry point
+
+Update `console/tracker-client/src/bin/tracker_checker.rs` to dispatch to the new monitor loop
+when the `monitor` subcommand is selected.
+
+## Key Files
+
+| File                                                                                  | Role                              |
+| ------------------------------------------------------------------------------------- | --------------------------------- |
+| `console/tracker-client/src/console/clients/checker/app.rs`                          | CLI argument parsing, entry point |
+| `console/tracker-client/src/console/clients/checker/`                                | Checker module root               |
+| `packages/tracker-client/src/udp/`                                                   | Existing UDP tracker client       |
+| `console/tracker-client/src/bin/tracker_checker.rs`                                  | Binary entry point                |
+
+## Acceptance Criteria
+
+- [ ] AC1: `monitor udp --url udp://127.0.0.1:6969` starts a probe loop and prints a status
+           JSON line after each probe to stderr (NDJSON)
+- [ ] AC2: When monitoring ends, final aggregate statistics are printed to stdout as valid JSON
+- [ ] AC3: When a probe does not receive a response within the timeout, it is recorded as
+           `TIMEOUT` and excluded from response-time averages
+- [ ] AC4: `--duration` controls total runtime and the command exits normally when elapsed
+- [ ] AC5: `Ctrl+C` stops monitoring early and still emits final JSON stats
+- [ ] AC6: The `--interval` option controls the delay between probes
+- [ ] AC7: `--duration` defaults to `86400` seconds when omitted
+- [ ] AC8: If all probes timeout but execution is otherwise successful, exit code is `0`
+- [ ] AC9: `linter all` exits with code `0`
+- [ ] AC10: `cargo machete` reports no unused dependencies
+- [ ] AC11: Existing tests pass
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   |          |
+| AC2   | TODO                   |          |
+| AC3   | TODO                   |          |
+| AC4   | TODO                   |          |
+| AC5   | TODO                   |          |
+| AC6   | TODO                   |          |
+| AC7   | TODO                   |          |
+| AC8   | TODO                   |          |
+| AC9   | TODO                   |          |
+| AC10  | TODO                   |          |
+| AC11  | TODO                   |          |
+
+## Risks and Trade-offs
+
+- **Scope**: A continuously running loop binary is heavier than a one-shot check. The feature is
+  explicitly for developer/admin use, so this is acceptable.
+- **Signal handling**: Cross-platform `Ctrl+C` handling in async Tokio requires `tokio::signal`.
+  Windows support is nice-to-have but not a hard requirement for the initial implementation.
+- **UDP announcement contents**: The monitor sends a real announce request. The info-hash and
+  peer fields will be test values (re-using the existing `QueryBuilder::with_default_values`
+  defaults unless overridden). This is acceptable for monitoring purposes.
+
+## Metadata
+
+| Field              | Value                                                                  |
+| ------------------ | ---------------------------------------------------------------------- |
+| Type               | Feature                                                                |
+| Status             | Planned                                                                |
+| Priority           | P2                                                                     |
+| GitHub Issue       | [#1178](https://github.com/torrust/torrust-tracker/issues/1178)        |
+| Spec Path          | `docs/issues/open/1178-tracker-checker-udp-add-monitor-uptime-command.md` |
+| Branch             | `1178-tracker-checker-udp-add-monitor-uptime-command`                 |
+| Related PR         | To be assigned                                                         |
+| Last Updated (UTC) | 2026-05-12 08:00                                                       |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/open/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Implementation completed
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-05-11 20:00 UTC - Agent - Spec created from GitHub issue #1178 content
+- 2026-05-12 00:00 UTC - Agent - Incorporated maintainer decisions: monitor in tracker_checker, seconds unit, UDP-only scope, duration-controlled run, stderr live output plus final JSON on stdout
+- 2026-05-12 08:00 UTC - Agent - Incorporated answered follow-ups: default duration `86400`, align final JSON with checker shape, keep exit code `0` for timeout-heavy but successful runs
+
+## Open Questions
+
+No open questions at this time.
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- newtrackon uptime discussion: <https://github.com/torrust/torrust-demo/issues/26>
+- Existing UDP checker: `console/tracker-client/src/console/clients/udp/checker.rs`
+- UDP tracker client: `packages/tracker-client/src/udp/`
+- Tracker CLI I/O contract: `console/tracker-client/docs/contracts/tracker-cli-io-contract.md`
+- Tracker CLI ADR: `console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md`

--- a/docs/issues/open/1564-tracker-client-change-default-peer-id.md
+++ b/docs/issues/open/1564-tracker-client-change-default-peer-id.md
@@ -40,7 +40,7 @@ Proposed candidates:
 - `-TC` — Torrust Client (if/when a full Torrust BitTorrent client ships)
 
 The GitHub issue suggests `-RC` for now and reserves `-TC` for a future full BitTorrent client.
-A concrete example from the issue: `b"-RC53070047639607806"` (the last 12 bytes are random).
+A properly-formed example following the Azureus format: `b"-RC3000-000000000000"` (the 12 bytes after the separator are random per process).
 
 ## Current Behaviour
 

--- a/docs/issues/open/1564-tracker-client-change-default-peer-id.md
+++ b/docs/issues/open/1564-tracker-client-change-default-peer-id.md
@@ -1,0 +1,233 @@
+# Issue #1564 — Tracker Client: Change the Default `PeerId` Used in Clients
+
+## Overview
+
+The default `PeerId` used in all tracker client requests is `b"-qB00000000000000001"`.
+The prefix `-qB` is the registered [Azureus-style](https://www.bittorrent.org/beps/bep_0020.html)
+client identifier for [qBittorrent](https://www.qbittorrent.org/). Using another client's
+registered prefix is incorrect — it misrepresents the Torrust tooling as qBittorrent traffic.
+
+The goal is to register and use a Torrust-specific prefix so that requests sent by the
+Torrust Tracker client (both in production tooling and in test code) are clearly
+identifiable.
+
+- GitHub issue: <https://github.com/torrust/torrust-tracker/issues/1564>
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- BEP 20 (peer ID conventions): <https://www.bittorrent.org/beps/bep_0020.html>
+- BitTorrent peer_id spec: <https://wiki.theory.org/BitTorrentSpecification#peer_id>
+
+## Background
+
+The Azureus-style peer ID format is:
+
+```text
+-<CC><VVVV>-<random-12-bytes>
+```
+
+Where `CC` is a two-character client identifier and `VVVV` is a four-character version string.
+
+The current default is:
+
+```rust
+peer_id: PeerId(*b"-qB00000000000000001").0,
+```
+
+This is the qBittorrent prefix (`qB`). The Torrust Tracker project needs its own identifier.
+
+Proposed candidates:
+
+- `-RC` — Rust Client (for the current Torrust Tracker REST/checker client)
+- `-TC` — Torrust Client (if/when a full Torrust BitTorrent client ships)
+
+The GitHub issue suggests `-RC` for now and reserves `-TC` for a future full BitTorrent client.
+A concrete example from the issue: `b"-RC53070047639607806"` (the last 12 bytes are random).
+
+## Current Behaviour
+
+The literal `b"-qB00000000000000001"` appears in several places:
+
+| File                                                           | Context                                             |
+| -------------------------------------------------------------- | --------------------------------------------------- |
+| `packages/tracker-client/src/http/client/requests/announce.rs` | `QueryBuilder::with_default_values()` — HTTP client |
+| `console/tracker-client/src/console/clients/udp/checker.rs`    | UDP checker default peer ID                         |
+| `packages/http-protocol/src/v1/requests/announce.rs`           | Protocol test fixtures                              |
+| `packages/http-protocol/src/v1/responses/announce.rs`          | Protocol test fixtures                              |
+| `packages/http-protocol/src/v1/query.rs`                       | Protocol test fixtures                              |
+| `src/lib.rs`                                                   | Library doc example URL                             |
+
+## Proposed Behaviour
+
+1. Define a named constant for the Torrust client default `PeerId` in a shared location
+   (e.g. `packages/tracker-client/src/`) so all uses reference a single source of truth.
+
+2. Change the default value to a Torrust-specific prefix using `RC` (approved by maintainer),
+   with version bytes that reflect the client version. For current v3.0.0, use `3000`.
+   Version bytes are hard-coded per release for now.
+
+   Example test default:
+
+   ```rust
+   pub const DEFAULT_TEST_PEER_ID: PeerId = PeerId(*b"-RC3000-000000000001");
+   ```
+
+3. Use deterministic peer ID values in tests and fixtures, but use a random suffix for production
+   defaults while preserving the Azureus-style structure and version bytes.
+   The production random suffix is generated once per process run.
+
+4. Update all call sites that hard-code `b"-qB00000000000000001"` to use the new convention
+   or an equivalent Torrust-prefixed value.
+
+5. Test fixtures that hard-code `-qB...` for protocol-level assertions should use a clearly named
+   local test constant following the convention, without introducing cross-package constant
+   coupling.
+
+6. Add an ADR documenting the PeerId convention for Torrust client defaults and test fixtures.
+
+## Goals
+
+- [ ] Replace all hard-coded `b"-qB00000000000000001"` peer IDs with a Torrust-specific prefix
+- [ ] Define tracker-client constants for deterministic test PeerId and production default generation
+- [ ] Update all affected test fixtures so protocol-level tests still pass
+- [ ] Add ADR documenting the PeerId convention for production and tests
+- [ ] Version bytes are hard-coded per release in tracker-client defaults
+- [ ] Production default PeerId suffix is generated once per process run
+- [ ] `linter all` exits with code `0`
+- [ ] `cargo machete` reports no unused dependencies
+- [ ] Existing tests pass
+
+## Implementation Plan
+
+### Task 1: Choose and define the constant
+
+In `packages/tracker-client/src/` (or the appropriate shared module), define:
+
+```rust
+/// Default deterministic Peer ID used in tests and fixtures.
+///
+/// Uses the Azureus-style format: `-<CC><VVVV>-<random-12-bytes>`.
+/// Prefix `RC` stands for "Rust Client".
+pub const DEFAULT_TEST_PEER_ID_BYTES: &[u8; 20] = b"-RC3000-000000000001";
+```
+
+Also define a helper for production defaults that keeps prefix/version but randomizes suffix.
+Use per-process generation (generate once and reuse during process lifetime).
+
+### Task 2: Update `QueryBuilder::with_default_values`
+
+In `packages/tracker-client/src/http/client/requests/announce.rs`:
+
+```rust
+peer_id: make_default_production_peer_id().0,
+```
+
+### Task 3: Update the UDP checker default
+
+In `console/tracker-client/src/console/clients/udp/checker.rs`:
+
+```rust
+peer_id: params.peer_id.map_or(make_default_production_peer_id(), PeerId),
+```
+
+### Task 4: Update protocol test fixtures
+
+In `packages/http-protocol/src/v1/requests/announce.rs`,
+`packages/http-protocol/src/v1/responses/announce.rs`, and
+`packages/http-protocol/src/v1/query.rs`:
+
+Replace the literal `-qB00000000000000001` bytes in test data with the new convention value
+or with an explicit local test constant.
+
+> **Note**: Keep packages decoupled. Protocol packages should not import tracker-client constants;
+> duplicate the same convention value in local test constants where needed.
+
+### Task 5: Update doc examples
+
+In `src/lib.rs`, update the example announce URL that contains the old peer ID.
+
+### Task 6: Add ADR for PeerId convention
+
+Create an ADR under `docs/adrs/` documenting:
+
+- Approved prefix (`RC`) and rationale
+- Version field convention (e.g. `3000` for v3.0.0)
+- Version source policy: hard-coded per release for now
+- Deterministic test fixtures vs randomized production suffix
+- Production random suffix lifecycle: generated once per process run
+- Cross-repository convention and package-decoupling rule
+
+## Acceptance Criteria
+
+- [ ] AC1: `b"-qB00000000000000001"` no longer appears as a default in any client or checker code
+- [ ] AC2: Tracker-client defines deterministic test PeerId constant(s) and production default generation helper
+- [ ] AC3: The HTTP and UDP clients use `RC` + versioned prefix for production default requests
+- [ ] AC4: Protocol fixtures adopt the new convention without creating cross-package coupling
+- [ ] AC5: ADR for PeerId convention is added under `docs/adrs/`
+- [ ] AC6: Version bytes are hard-coded per release in tracker-client defaults
+- [ ] AC7: Production random suffix is generated once per process run
+- [ ] AC8: All tests that assert on default PeerId behavior pass with the new convention
+- [ ] AC9: `linter all` exits with code `0`
+- [ ] AC10: `cargo machete` reports no unused dependencies
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   |          |
+| AC2   | TODO                   |          |
+| AC3   | TODO                   |          |
+| AC4   | TODO                   |          |
+| AC5   | TODO                   |          |
+| AC6   | TODO                   |          |
+| AC7   | TODO                   |          |
+| AC8   | TODO                   |          |
+| AC9   | TODO                   |          |
+| AC10  | TODO                   |          |
+
+## Risks and Trade-offs
+
+- **Test fixture churn**: Many tests hard-code the qBittorrent peer ID as part of expected
+  byte payloads. Changing the default requires updating those fixtures carefully to avoid
+  accidentally masking regressions.
+- **External compatibility**: The default peer ID is only used by Torrust tooling (client
+  binaries and checker). It is not a protocol compatibility concern. Changing it will not
+  break interoperability with any tracker.
+
+## Metadata
+
+| Field              | Value                                                            |
+| ------------------ | ---------------------------------------------------------------- |
+| Type               | Enhancement                                                      |
+| Status             | Planned                                                          |
+| Priority           | P3                                                               |
+| GitHub Issue       | [#1564](https://github.com/torrust/torrust-tracker/issues/1564)  |
+| Spec Path          | `docs/issues/open/1564-tracker-client-change-default-peer-id.md` |
+| Branch             | `1564-tracker-client-change-default-peer-id`                     |
+| Related PR         | To be assigned                                                   |
+| Last Updated (UTC) | 2026-05-12 08:00                                                 |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/open/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Implementation completed
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-05-11 20:00 UTC - Agent - Spec created from GitHub issue #1564 content
+- 2026-05-12 00:00 UTC - Agent - Incorporated maintainer decisions: use RC prefix, versioned bytes, deterministic tests + randomized production suffix, tracker-client constant location, no cross-package coupling, add ADR
+- 2026-05-12 08:00 UTC - Agent - Incorporated answered follow-ups: hard-coded per-release version bytes and per-process production random suffix lifecycle
+
+## Open Questions
+
+No open questions at this time.
+
+## References
+
+- Parent EPIC: <https://github.com/torrust/torrust-tracker/issues/669>
+- BEP 20 — Peer ID Conventions: <https://www.bittorrent.org/beps/bep_0020.html>
+- BitTorrent Specification — peer_id: <https://wiki.theory.org/BitTorrentSpecification#peer_id>


### PR DESCRIPTION
## Summary
- add tracker-client-scoped CLI I/O contract document under console/tracker-client/docs/contracts
- add tracker-client ADR set and index under console/tracker-client/docs/adrs
- define global stdout/stderr channel rules, JSON-first output, and exit code semantics for tracker checker
- document auditability requirements and deferred E2E conformance strategy for post-extraction phase
- add issue specs for #1042, #1178, and #1564 with aligned acceptance criteria and references to the new contract
- align monitor spec with NDJSON per-probe stderr events and JSON summary output conventions
- update tracker-client README to link the new contract and ADR docs

## Validation
- linter markdown
- linter all

## Notes
This PR establishes the desired target-state contract for console/tracker-client and uses progressive migration for existing behavior that is not yet fully aligned.
