### PR TITLE
fix(ci): add docs-only paths-ignore to container and coverage workflows

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,15 +1,23 @@
 name: Container
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   push:
     branches:
       - "develop"
       - "main"
       - "releases/**/*"
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
   pull_request:
     branches:
       - "develop"
       - "main"
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -6,8 +6,9 @@
 # via `paths-ignore` rules in those workflows.
 #
 # "Docs-only" path policy (mirrored in the `paths-ignore` lists of
-# testing.yaml, os-compatibility.yaml, db-compatibility.yaml, and
-# db-benchmarking.yaml):
+# testing.yaml, os-compatibility.yaml, container.yaml, and
+# generate_coverage_pr.yaml; db-compatibility.yaml and db-benchmarking.yaml
+# are already scoped to code paths via `paths:` inclusion rules):
 #   - **/*.md        — all Markdown files (docs/, READMEs, AGENTS.md, SKILL.md, …)
 #   - project-words.txt — spell-check dictionary (documentation artefact)
 #

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -1,9 +1,14 @@
 name: Generate Coverage Report (PR)
 
+# Path policy: skip this workflow when every changed file is documentation.
+# See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
   pull_request:
     branches:
       - develop
+    paths-ignore:
+      - "**/*.md"
+      - "project-words.txt"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Bug

Issue #1743 added `paths-ignore` rules to the CI "docs-only fast path" for
`testing.yaml` and `os-compatibility.yaml`, but two workflows were missed:

- `container.yaml` — the container build job
- `generate_coverage_pr.yaml` — the coverage report job

As a result, docs-only pull requests (e.g. PR #1760) were still triggering the
container build and coverage jobs unnecessarily, wasting CI minutes and
delaying feedback.

## Fix

Add the same `paths-ignore` exclusions to both workflows:

```yaml
paths-ignore:
  - "**/*.md"
  - "project-words.txt"
```

Also update the path-policy comment in `docs-lint.yaml` to accurately list all
workflows that carry the `paths-ignore` rule (replacing the stale list that
mentioned `db-compatibility.yaml` and `db-benchmarking.yaml`, which are already
scoped to code paths via `paths:` inclusion rules).

## Changed files

- `.github/workflows/container.yaml` — Added `paths-ignore` to both `push` and `pull_request` triggers, plus path-policy comment.
- `.github/workflows/generate_coverage_pr.yaml` — Added `paths-ignore` to the `pull_request` trigger, plus path-policy comment.
- `.github/workflows/docs-lint.yaml` — Updated header comment to correctly list workflows that carry `paths-ignore` rules.

## References

- Fixes part of issue #1743
- Related to PR #1760 (docs-only PR that triggered unnecessary CI jobs)
