### PR TITLE
feat(tracker-client): add unified tracker_client binary

### DIFF
--- a/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+++ b/.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
@@ -136,11 +136,11 @@ Once the tracker is running, test it with the UDP tracker client:
 
 ```bash
 # Default announce (backward compatibility)
-cargo run -p torrust-tracker-client --bin udp_tracker_client announce 127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422
+cargo run -p torrust-tracker-client --bin tracker_client udp announce 127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422
 
 # Announce with all optional parameters
 # NOTE: Use '--peer-id=VALUE' syntax (with equals and single quotes) when peer-id starts with a dash
-cargo run -p torrust-tracker-client --bin udp_tracker_client announce \
+cargo run -p torrust-tracker-client --bin tracker_client udp announce \
   127.0.0.1:6969 443c7602b4fde83d1154d6d9da48808418b181b6 \
   --event completed \
   --uploaded 1234 \
@@ -161,7 +161,7 @@ Test the HTTP tracker:
 
 ```bash
 # Default announce
-cargo run --bin http_tracker_client announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422
+cargo run -p torrust-tracker-client --bin tracker_client http announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422
 ```
 
 ## Notes

--- a/.github/skills/dev/testing/public-trackers-for-testing/SKILL.md
+++ b/.github/skills/dev/testing/public-trackers-for-testing/SKILL.md
@@ -65,25 +65,25 @@ INFO_HASH=000620bbc6c52d5a96d98f6c0f1dfa523a40df82
 ### UDP scrape (preferred public demo)
 
 ```bash
-cargo run -q -p torrust-tracker-client --bin udp_tracker_client scrape \
+cargo run -q -p torrust-tracker-client --bin tracker_client udp scrape \
   udp://udp1.torrust-tracker-demo.com:6969/scrape \
   "$INFO_HASH" \
-  --format pretty
+  --format text
 ```
 
 ### UDP announce (preferred public demo)
 
 ```bash
-cargo run -q -p torrust-tracker-client --bin udp_tracker_client announce \
+cargo run -q -p torrust-tracker-client --bin tracker_client udp announce \
   udp://udp1.torrust-tracker-demo.com:6969/announce \
   "$INFO_HASH" \
-  --format compact
+  --format json
 ```
 
 ### HTTP announce (preferred public demo)
 
 ```bash
-cargo run -q -p torrust-tracker-client --bin http_tracker_client announce \
+cargo run -q -p torrust-tracker-client --bin tracker_client http announce \
   https://http1.torrust-tracker-demo.com:443 \
   "$INFO_HASH"
 ```

--- a/console/tracker-client/docs/features/json-request-input/README.md
+++ b/console/tracker-client/docs/features/json-request-input/README.md
@@ -10,10 +10,10 @@ This document describes an alternative to many CLI flags for announce requests.
 Instead of passing request parameters only as command-line flags, the client could
 accept a full JSON object.
 
-The proposal applies to both clients:
+The proposal applies to both protocols under the unified client:
 
-- `http_tracker_client`
-- `udp_tracker_client`
+- `tracker_client http`
+- `tracker_client udp`
 
 ## Motivation
 
@@ -26,22 +26,22 @@ and future automation.
 ### 1) JSON file input
 
 ```bash
-http_tracker_client announce \
-  --tracker-url http://127.0.0.1:7070 \
+tracker_client http announce \
+  http://127.0.0.1:7070 \
   --request-file ./announce.json
 ```
 
 ```bash
-udp_tracker_client announce \
-  --tracker-socket-addr 127.0.0.1:6969 \
+tracker_client udp announce \
+  127.0.0.1:6969 \
   --request-file ./announce.json
 ```
 
 ### 2) Inline JSON input
 
 ```bash
-http_tracker_client announce \
-  --tracker-url http://127.0.0.1:7070 \
+tracker_client http announce \
+  http://127.0.0.1:7070 \
   --request-json '{"info_hash":"443c7602b4fde83d1154d6d9da48808418b181b6","event":"completed"}'
 ```
 
@@ -49,11 +49,11 @@ http_tracker_client announce \
 
 ```bash
 echo '{"info_hash":"443c7602b4fde83d1154d6d9da48808418b181b6","event":"completed"}' \
-  | http_tracker_client announce --tracker-url http://127.0.0.1:7070 --request-stdin
+  | tracker_client http announce http://127.0.0.1:7070 --request-stdin
 ```
 
 ```bash
-cat announce.json | udp_tracker_client announce --tracker-socket-addr 127.0.0.1:6969 --request-stdin
+cat announce.json | tracker_client udp announce 127.0.0.1:6969 --request-stdin
 ```
 
 ## Input Shape (Draft)

--- a/console/tracker-client/src/bin/http_tracker_client.rs
+++ b/console/tracker-client/src/bin/http_tracker_client.rs
@@ -3,5 +3,9 @@ use torrust_tracker_client::console::clients::http::app;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    eprintln!(
+        "warning: `http_tracker_client` is deprecated and will be removed in a future release. Use `tracker_client http ...` instead."
+    );
+
     app::run().await
 }

--- a/console/tracker-client/src/bin/tracker_checker.rs
+++ b/console/tracker-client/src/bin/tracker_checker.rs
@@ -3,6 +3,10 @@ use torrust_tracker_client::console::clients::checker::app;
 
 #[tokio::main]
 async fn main() {
+    eprintln!(
+        "warning: `tracker_checker` is deprecated and will be removed in a future release. Use `tracker_client check ...` instead."
+    );
+
     if let Err(e) = app::run().await {
         let (json, exit_code) = e.to_stderr_json_and_exit_code();
         eprintln!("{json}");

--- a/console/tracker-client/src/bin/tracker_client.rs
+++ b/console/tracker-client/src/bin/tracker_client.rs
@@ -1,0 +1,19 @@
+//! Unified tracker client binary.
+use torrust_tracker_client::console::clients::unified::app;
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = app::run().await {
+        match error {
+            app::Error::Check(err) => {
+                let (json, exit_code) = err.to_stderr_json_and_exit_code();
+                eprintln!("{json}");
+                std::process::exit(exit_code);
+            }
+            app::Error::Other(err) => {
+                eprintln!("{err}");
+                std::process::exit(1);
+            }
+        }
+    }
+}

--- a/console/tracker-client/src/bin/tracker_client.rs
+++ b/console/tracker-client/src/bin/tracker_client.rs
@@ -11,7 +11,15 @@ async fn main() {
                 std::process::exit(exit_code);
             }
             app::Error::Other(err) => {
-                eprintln!("{err}");
+                let json = serde_json::json!({
+                    "error": {
+                        "kind": "runtime_failure",
+                        "source": "runtime",
+                        "message": err.to_string(),
+                    }
+                })
+                .to_string();
+                eprintln!("{json}");
                 std::process::exit(1);
             }
         }

--- a/console/tracker-client/src/bin/udp_tracker_client.rs
+++ b/console/tracker-client/src/bin/udp_tracker_client.rs
@@ -3,5 +3,9 @@ use torrust_tracker_client::console::clients::udp::app;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    eprintln!(
+        "warning: `udp_tracker_client` is deprecated and will be removed in a future release. Use `tracker_client udp ...` instead."
+    );
+
     app::run().await
 }

--- a/console/tracker-client/src/console/clients/mod.rs
+++ b/console/tracker-client/src/console/clients/mod.rs
@@ -1,4 +1,9 @@
 //! Console clients.
+//!
+//! `unified` contains the in-progress single-binary implementation for issue #1771.
+//! Legacy modules remain available during the deprecation window and are intentionally
+//! kept separate so old binaries can stay frozen until the scheduled cleanup removal.
 pub mod checker;
 pub mod http;
 pub mod udp;
+pub mod unified;

--- a/console/tracker-client/src/console/clients/unified/app.rs
+++ b/console/tracker-client/src/console/clients/unified/app.rs
@@ -1,0 +1,86 @@
+use clap::{Parser, Subcommand, ValueEnum};
+use tracing::level_filters::LevelFilter;
+
+use super::{check, http, udp};
+use crate::console::clients::checker::error::AppError;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum OutputFormat {
+    Json,
+    Text,
+}
+
+impl OutputFormat {
+    #[must_use]
+    pub fn is_pretty(self) -> bool {
+        matches!(self, Self::Text)
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Check(AppError),
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(value)
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// HTTP tracker commands.
+    Http {
+        #[command(subcommand)]
+        command: http::Command,
+    },
+    /// UDP tracker commands.
+    Udp {
+        #[command(subcommand)]
+        command: udp::Command,
+    },
+    /// Tracker checker commands and configuration.
+    Check {
+        /// Output format for check results.
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+        /// Arguments passed to the checker implementation.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+}
+
+/// # Errors
+///
+/// Returns an error if command execution fails.
+pub async fn run() -> Result<(), Error> {
+    init_tracing_stdout(LevelFilter::INFO);
+
+    let args = Args::parse();
+
+    match args.command {
+        Command::Http { command } => http::run(command).await.map_err(Error::Other)?,
+        Command::Udp { command } => udp::run(command).await.map_err(Error::Other)?,
+        Command::Check {
+            format,
+            args: checker_args,
+        } => check::run(checker_args, format).await.map_err(Error::Check)?,
+    }
+
+    Ok(())
+}
+
+fn init_tracing_stdout(filter: LevelFilter) {
+    if tracing_subscriber::fmt().with_max_level(filter).try_init().is_ok() {
+        tracing::debug!("Logging initialized");
+    }
+}

--- a/console/tracker-client/src/console/clients/unified/check.rs
+++ b/console/tracker-client/src/console/clients/unified/check.rs
@@ -92,7 +92,9 @@ fn parse_args(raw_args: Vec<String>) -> Result<Args, AppError> {
     let mut argv = vec!["tracker_client-check".to_string()];
     argv.extend(raw_args);
 
-    Args::try_parse_from(argv).map_err(|e| AppError::Runtime(e.to_string()))
+    // Let clap handle parse errors directly: it prints the message to stderr
+    // and exits with code 2 for usage errors, preserving the CLI I/O contract.
+    Args::try_parse_from(argv).map_err(|e| e.exit())
 }
 
 fn setup_config(args: Args) -> Result<Configuration, AppError> {

--- a/console/tracker-client/src/console/clients/unified/check.rs
+++ b/console/tracker-client/src/console/clients/unified/check.rs
@@ -1,0 +1,199 @@
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bittorrent_primitives::info_hash::InfoHash as TorrustInfoHash;
+use clap::{Parser, Subcommand};
+use futures::FutureExt as _;
+use serde::Serialize;
+use tokio::task::JoinSet;
+use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+use url::Url;
+
+use super::app::OutputFormat;
+use crate::console::clients::checker::checks::{health, http, udp};
+use crate::console::clients::checker::config::{parse_from_json, Configuration};
+use crate::console::clients::checker::error::{AppError, ConfigSource};
+use crate::console::clients::checker::monitor::udp::{run_monitor, MonitorUdpConfig, DEFAULT_INFO_HASH};
+
+#[derive(Debug, Clone, Serialize)]
+enum CheckResult {
+    Udp(Result<udp::Checks, udp::Checks>),
+    Http(Result<http::Checks, http::Checks>),
+    Health(Result<health::Checks, health::Checks>),
+}
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
+    /// Path to the JSON configuration file.
+    #[clap(short, long, env = "TORRUST_CHECKER_CONFIG_PATH")]
+    config_path: Option<PathBuf>,
+
+    /// Direct configuration content in JSON.
+    #[clap(env = "TORRUST_CHECKER_CONFIG", hide_env_values = true)]
+    config_content: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Run periodic monitor checks.
+    Monitor {
+        #[command(subcommand)]
+        protocol: MonitorProtocol,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum MonitorProtocol {
+    /// Monitor a UDP tracker using announce probes.
+    Udp {
+        /// UDP tracker URL.
+        #[arg(long, value_parser = parse_udp_url)]
+        url: Url,
+
+        /// Seconds between probes.
+        #[arg(long, default_value_t = 300, value_parser = clap::value_parser!(u64).range(1..))]
+        interval: u64,
+
+        /// Probe timeout in seconds.
+        #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u64).range(1..))]
+        timeout: u64,
+
+        /// Total monitor runtime in seconds.
+        #[arg(long, default_value_t = 86_400, value_parser = clap::value_parser!(u64).range(1..))]
+        duration: u64,
+
+        /// Info-hash used in announce requests.
+        #[arg(long, default_value = DEFAULT_INFO_HASH, value_parser = parse_info_hash)]
+        info_hash: TorrustInfoHash,
+    },
+}
+
+/// # Errors
+///
+/// Returns `AppError` for configuration or runtime failures.
+pub async fn run(raw_args: Vec<String>, output_format: OutputFormat) -> Result<(), AppError> {
+    let args = parse_args(raw_args)?;
+
+    if let Some(command) = args.command {
+        return run_command(command).await;
+    }
+
+    let config = setup_config(args)?;
+    run_checks(Arc::new(config), output_format).await
+}
+
+fn parse_args(raw_args: Vec<String>) -> Result<Args, AppError> {
+    let mut argv = vec!["tracker_client-check".to_string()];
+    argv.extend(raw_args);
+
+    Args::try_parse_from(argv).map_err(|e| AppError::Runtime(e.to_string()))
+}
+
+fn setup_config(args: Args) -> Result<Configuration, AppError> {
+    match (args.config_path, args.config_content) {
+        (Some(config_path), _) => load_config_from_file(&config_path),
+        (_, Some(config_content)) => parse_from_json(&config_content).map_err(|e| AppError::InvalidConfig {
+            source: ConfigSource::EnvVar("TORRUST_CHECKER_CONFIG"),
+            message: e.to_string(),
+        }),
+        _ => Err(AppError::InvalidConfig {
+            source: ConfigSource::EnvVar("TORRUST_CHECKER_CONFIG"),
+            message: "no configuration provided".to_string(),
+        }),
+    }
+}
+
+fn load_config_from_file(path: &PathBuf) -> Result<Configuration, AppError> {
+    let file_content = std::fs::read_to_string(path).map_err(|e| AppError::InvalidConfig {
+        source: ConfigSource::File(path.clone()),
+        message: format!("can't read config file {}: {e}", path.display()),
+    })?;
+
+    parse_from_json(&file_content).map_err(|e| AppError::InvalidConfig {
+        source: ConfigSource::File(path.clone()),
+        message: e.to_string(),
+    })
+}
+
+async fn run_checks(config: Arc<Configuration>, output_format: OutputFormat) -> Result<(), AppError> {
+    let mut check_results = Vec::default();
+
+    let mut checks = JoinSet::new();
+    checks.spawn(
+        udp::run(config.udp_trackers.clone(), DEFAULT_TIMEOUT).map(|mut f| f.drain(..).map(CheckResult::Udp).collect::<Vec<_>>()),
+    );
+    checks.spawn(
+        http::run(config.http_trackers.clone(), DEFAULT_TIMEOUT)
+            .map(|mut f| f.drain(..).map(CheckResult::Http).collect::<Vec<_>>()),
+    );
+    checks.spawn(
+        health::run(config.health_checks.clone(), DEFAULT_TIMEOUT)
+            .map(|mut f| f.drain(..).map(CheckResult::Health).collect::<Vec<_>>()),
+    );
+
+    while let Some(results) = checks.join_next().await {
+        check_results.append(&mut results.map_err(|error| AppError::Runtime(error.to_string()))?);
+    }
+
+    let json_output = serde_json::json!(check_results);
+    let rendered = if output_format.is_pretty() {
+        serde_json::to_string_pretty(&json_output)
+    } else {
+        serde_json::to_string(&json_output)
+    }
+    .map_err(|e| AppError::Runtime(format!("failed to render check output as JSON: {e}")))?;
+
+    println!("{rendered}");
+
+    Ok(())
+}
+async fn run_command(command: Command) -> Result<(), AppError> {
+    match command {
+        Command::Monitor {
+            protocol:
+                MonitorProtocol::Udp {
+                    url,
+                    interval,
+                    timeout,
+                    duration,
+                    info_hash,
+                },
+        } => {
+            let config = MonitorUdpConfig {
+                url,
+                interval: Duration::from_secs(interval),
+                timeout: Duration::from_secs(timeout),
+                duration: Duration::from_secs(duration),
+                info_hash,
+            };
+
+            run_monitor(config)
+                .await
+                .map_err(|e| AppError::Runtime(format!("udp monitor failed: {e}")))
+        }
+    }
+}
+
+fn parse_udp_url(url_str: &str) -> Result<Url, String> {
+    let url = Url::parse(url_str).map_err(|e| format!("invalid URL: {e}"))?;
+
+    if url.scheme() != "udp" {
+        return Err("URL scheme must be udp".to_string());
+    }
+
+    if url.port().is_none() {
+        return Err("URL must include an explicit port".to_string());
+    }
+
+    Ok(url)
+}
+
+fn parse_info_hash(info_hash_str: &str) -> Result<TorrustInfoHash, String> {
+    TorrustInfoHash::from_str(info_hash_str).map_err(|e| format!("failed to parse info-hash `{info_hash_str}`: {e:?}"))
+}

--- a/console/tracker-client/src/console/clients/unified/http.rs
+++ b/console/tracker-client/src/console/clients/unified/http.rs
@@ -1,0 +1,366 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+use std::time::Duration;
+
+use anyhow::{bail, Context};
+use bencode2json::try_bencode_to_json;
+use bittorrent_primitives::info_hash::InfoHash;
+use bittorrent_tracker_client::http::client::requests::announce::{Compact, Event, QueryBuilder};
+use bittorrent_tracker_client::http::client::responses::announce::{Announce, DeserializedCompact};
+use bittorrent_tracker_client::http::client::responses::scrape;
+use bittorrent_tracker_client::http::client::{requests, Client};
+use bittorrent_udp_tracker_protocol::PeerId;
+use clap::{Subcommand, ValueEnum};
+use reqwest::Url;
+use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+
+use super::app::OutputFormat;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliEvent {
+    Started,
+    Stopped,
+    Completed,
+}
+
+impl From<CliEvent> for Event {
+    fn from(value: CliEvent) -> Self {
+        match value {
+            CliEvent::Started => Event::Started,
+            CliEvent::Stopped => Event::Stopped,
+            CliEvent::Completed => Event::Completed,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliCompact {
+    #[value(name = "0")]
+    NotAccepted,
+    #[value(name = "1")]
+    Accepted,
+}
+
+impl From<CliCompact> for Compact {
+    fn from(value: CliCompact) -> Self {
+        match value {
+            CliCompact::NotAccepted => Compact::NotAccepted,
+            CliCompact::Accepted => Compact::Accepted,
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    Announce {
+        tracker_url: String,
+        info_hash: String,
+        #[arg(long)]
+        event: Option<CliEvent>,
+        #[arg(long)]
+        uploaded: Option<u64>,
+        #[arg(long)]
+        downloaded: Option<u64>,
+        #[arg(long)]
+        left: Option<u64>,
+        #[arg(long, value_parser = parse_non_zero_port)]
+        port: Option<u16>,
+        #[arg(long = "peer-addr")]
+        peer_addr: Option<IpAddr>,
+        #[arg(long = "peer-id", value_parser = parse_peer_id)]
+        peer_id: Option<PeerId>,
+        #[arg(long, value_enum)]
+        compact: Option<CliCompact>,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+    },
+    Scrape {
+        tracker_url: String,
+        info_hashes: Vec<String>,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+    },
+}
+
+struct AnnounceOptions {
+    tracker_url: String,
+    info_hash: String,
+    event: Option<CliEvent>,
+    uploaded: Option<u64>,
+    downloaded: Option<u64>,
+    left: Option<u64>,
+    port: Option<u16>,
+    peer_addr: Option<IpAddr>,
+    peer_id: Option<PeerId>,
+    compact: Option<CliCompact>,
+    output_format: OutputFormat,
+}
+
+/// # Errors
+///
+/// Returns an error if the command fails.
+pub async fn run(command: Command) -> anyhow::Result<()> {
+    match command {
+        Command::Announce {
+            tracker_url,
+            info_hash,
+            event,
+            uploaded,
+            downloaded,
+            left,
+            port,
+            peer_addr,
+            peer_id,
+            compact,
+            format,
+        } => {
+            announce_command(
+                AnnounceOptions {
+                    tracker_url,
+                    info_hash,
+                    event,
+                    uploaded,
+                    downloaded,
+                    left,
+                    port,
+                    peer_addr,
+                    peer_id,
+                    compact,
+                    output_format: format,
+                },
+                DEFAULT_TIMEOUT,
+            )
+            .await?;
+        }
+        Command::Scrape {
+            tracker_url,
+            info_hashes,
+            format,
+        } => {
+            scrape_command(&tracker_url, &info_hashes, format, DEFAULT_TIMEOUT).await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn announce_command(options: AnnounceOptions, timeout: Duration) -> anyhow::Result<()> {
+    let base_url = parse_and_validate_tracker_url(&options.tracker_url)?;
+    let info_hash = InfoHash::from_str(&options.info_hash).map_err(|_| {
+        anyhow::anyhow!(
+            "invalid infohash `{}`. Example infohash: `9c38422213e30bff212b30c360d26f9a02136422`",
+            options.info_hash
+        )
+    })?;
+
+    let mut query_builder = QueryBuilder::with_default_values().with_info_hash(&info_hash);
+
+    if let Some(event) = options.event {
+        query_builder = query_builder.with_event(event.into());
+    }
+    if let Some(uploaded) = options.uploaded {
+        query_builder = query_builder.with_uploaded(uploaded);
+    }
+    if let Some(downloaded) = options.downloaded {
+        query_builder = query_builder.with_downloaded(downloaded);
+    }
+    if let Some(left) = options.left {
+        query_builder = query_builder.with_left(left);
+    }
+    if let Some(port) = options.port {
+        query_builder = query_builder.with_port(port);
+    }
+    if let Some(peer_addr) = options.peer_addr {
+        query_builder = query_builder.with_peer_addr(&peer_addr);
+    }
+    if let Some(peer_id) = options.peer_id {
+        query_builder = query_builder.with_peer_id(&peer_id);
+    }
+    if let Some(compact) = options.compact {
+        query_builder = query_builder.with_compact(compact.into());
+    }
+
+    let response = Client::new(base_url, timeout)?.announce(&query_builder.query()).await?;
+
+    let body = response.bytes().await?;
+
+    let json = if let Ok(announce_response) = serde_bencode::from_bytes::<Announce>(&body) {
+        serialize_json(&announce_response, options.output_format).context("failed to serialize announce response into JSON")?
+    } else if let Ok(compact_response) = serde_bencode::from_bytes::<DeserializedCompact>(&body) {
+        serialize_json(&compact_response, options.output_format)
+            .context("failed to serialize compact announce response into JSON")?
+    } else {
+        let fallback = bencode_to_fallback_json_or_raw_bytes(&body, options.output_format)
+            .context("failed to serialize fallback announce response into JSON")?;
+
+        println!("{fallback}");
+
+        bail!("unrecognized announce response from tracker")
+    };
+
+    println!("{json}");
+
+    Ok(())
+}
+
+async fn scrape_command(
+    tracker_url: &str,
+    info_hashes: &[String],
+    output_format: OutputFormat,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let base_url = parse_and_validate_tracker_url(tracker_url)?;
+
+    let query = requests::scrape::Query::try_from(info_hashes).context("failed to parse infohashes")?;
+
+    let response = Client::new(base_url, timeout)?.scrape(&query).await?;
+
+    let body = response.bytes().await?;
+
+    let Ok(scrape_response) = scrape::Response::try_from_bencoded(&body) else {
+        let fallback = bencode_to_fallback_json_or_raw_bytes(&body, output_format)
+            .context("failed to serialize fallback scrape response into JSON")?;
+
+        println!("{fallback}");
+
+        bail!("unrecognized scrape response from tracker")
+    };
+
+    let json = serialize_json(&scrape_response, output_format).context("failed to serialize scrape response into JSON")?;
+
+    println!("{json}");
+
+    Ok(())
+}
+
+fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<PeerId> {
+    let bytes = peer_id_str.as_bytes();
+    if bytes.len() != 20 {
+        return Err(anyhow::anyhow!(
+            "peer-id must be exactly 20 bytes, got {} bytes for `{peer_id_str}`",
+            bytes.len()
+        ));
+    }
+
+    let mut arr = [0_u8; 20];
+    arr.copy_from_slice(bytes);
+
+    Ok(PeerId(arr))
+}
+
+fn parse_non_zero_port(port_str: &str) -> anyhow::Result<u16> {
+    let port = u16::from_str(port_str).with_context(|| format!("invalid port value: `{port_str}`"))?;
+
+    if port == 0 {
+        anyhow::bail!("port must be greater than zero")
+    }
+
+    Ok(port)
+}
+
+fn parse_and_validate_tracker_url(tracker_url: &str) -> anyhow::Result<Url> {
+    let url = Url::parse(tracker_url).context("failed to parse HTTP tracker base URL")?;
+
+    validate_tracker_url_parts(&url)?;
+
+    Ok(url)
+}
+
+fn validate_tracker_url_parts(url: &Url) -> anyhow::Result<()> {
+    if url.query().is_some() || url.fragment().is_some() {
+        bail!(
+            "invalid tracker URL input: include only scheme, host, optional port, and optional path. Do not include query or fragment. Pass tracker request params using dedicated CLI arguments"
+        );
+    }
+
+    Ok(())
+}
+
+fn bencode_to_fallback_json_or_raw_bytes(body: &[u8], output_format: OutputFormat) -> anyhow::Result<String> {
+    match try_bencode_to_json(body) {
+        Ok(json) => match output_format {
+            OutputFormat::Json => Ok(json),
+            OutputFormat::Text => {
+                let value: serde_json::Value = serde_json::from_str(&json).context("failed to parse fallback bencode JSON")?;
+
+                serialize_json(&value, output_format).context("failed to format fallback bencode JSON")
+            }
+        },
+        Err(_) => Ok(format!(
+            "Warning: Could not deserialize HTTP tracker response. Raw bytes: {body:?}"
+        )),
+    }
+}
+
+fn serialize_json<T: serde::Serialize>(value: &T, output_format: OutputFormat) -> anyhow::Result<String> {
+    if output_format.is_pretty() {
+        serde_json::to_string_pretty(value).context("failed to serialize pretty JSON")
+    } else {
+        serde_json::to_string(value).context("failed to serialize JSON")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Url;
+    use serde::Serialize;
+
+    use super::{parse_and_validate_tracker_url, serialize_json, validate_tracker_url_parts};
+    use crate::console::clients::unified::app::OutputFormat;
+
+    #[derive(Serialize)]
+    struct Sample {
+        seeders: i32,
+        leechers: i32,
+    }
+
+    #[test]
+    fn it_should_serialize_json_output() {
+        let data = Sample { seeders: 1, leechers: 2 };
+
+        let json = serialize_json(&data, OutputFormat::Json).expect("it should serialize compact JSON");
+
+        assert_eq!(json, "{\"seeders\":1,\"leechers\":2}");
+    }
+
+    #[test]
+    fn it_should_serialize_text_output_as_pretty_json() {
+        let data = Sample { seeders: 1, leechers: 2 };
+
+        let json = serialize_json(&data, OutputFormat::Text).expect("it should serialize pretty JSON");
+
+        assert!(json.contains('\n'));
+        assert!(json.contains("  \"seeders\": 1"));
+        assert!(json.contains("  \"leechers\": 2"));
+    }
+
+    #[test]
+    fn it_accepts_tracker_url_with_path_and_without_query_or_fragment() {
+        let parsed = parse_and_validate_tracker_url("https://tracker.example.com/announce");
+
+        assert!(parsed.is_ok());
+    }
+
+    #[test]
+    fn it_rejects_tracker_url_with_query() {
+        let parsed = parse_and_validate_tracker_url("https://tracker.example.com/announce?info_hash=abc");
+
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn it_rejects_tracker_url_with_fragment() {
+        let parsed = parse_and_validate_tracker_url("https://tracker.example.com/announce#details");
+
+        assert!(parsed.is_err());
+    }
+
+    #[test]
+    fn it_accepts_direct_validation_for_plain_base_url() {
+        let url = Url::parse("https://tracker.example.com/").expect("url should parse");
+
+        let result = validate_tracker_url_parts(&url);
+
+        assert!(result.is_ok());
+    }
+}

--- a/console/tracker-client/src/console/clients/unified/mod.rs
+++ b/console/tracker-client/src/console/clients/unified/mod.rs
@@ -1,0 +1,11 @@
+//! Unified tracker-client command implementation.
+//!
+//! This module is the migration target for the mechanical copy-port in issue #1771.
+//! It is intentionally isolated from legacy `http`, `udp`, and `checker` app entry points:
+//! - New behavior and tests should be added here.
+//! - Legacy binaries stay frozen except startup deprecation warnings.
+//! - Once legacy binaries are removed, this module can be flattened in a dedicated cleanup.
+pub mod app;
+pub mod check;
+pub mod http;
+pub mod udp;

--- a/console/tracker-client/src/console/clients/unified/mod.rs
+++ b/console/tracker-client/src/console/clients/unified/mod.rs
@@ -5,6 +5,9 @@
 //! - New behavior and tests should be added here.
 //! - Legacy binaries stay frozen except startup deprecation warnings.
 //! - Once legacy binaries are removed, this module can be flattened in a dedicated cleanup.
+//!
+//! Sub-modules are kept as flat files (no per-action nesting). See the design decision in
+//! `docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md`.
 pub mod app;
 pub mod check;
 pub mod http;

--- a/console/tracker-client/src/console/clients/unified/udp.rs
+++ b/console/tracker-client/src/console/clients/unified/udp.rs
@@ -1,0 +1,231 @@
+use std::net::{Ipv4Addr, SocketAddr, ToSocketAddrs};
+use std::str::FromStr;
+
+use anyhow::Context;
+use bittorrent_primitives::info_hash::InfoHash as TorrustInfoHash;
+use bittorrent_udp_tracker_protocol::{AnnounceEvent, Response, TransactionId};
+use clap::{Subcommand, ValueEnum};
+use torrust_tracker_configuration::DEFAULT_TIMEOUT;
+use url::Url;
+
+use super::app::OutputFormat;
+use crate::console::clients::udp::checker::AnnounceParams;
+use crate::console::clients::udp::responses::dto::SerializableResponse;
+use crate::console::clients::udp::responses::json::ToJson;
+use crate::console::clients::udp::{checker, Error};
+
+const RANDOM_TRANSACTION_ID: i32 = -888_840_697;
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum CliAnnounceEvent {
+    None,
+    Completed,
+    Started,
+    Stopped,
+}
+
+impl From<CliAnnounceEvent> for AnnounceEvent {
+    fn from(value: CliAnnounceEvent) -> Self {
+        match value {
+            CliAnnounceEvent::None => AnnounceEvent::None,
+            CliAnnounceEvent::Completed => AnnounceEvent::Completed,
+            CliAnnounceEvent::Started => AnnounceEvent::Started,
+            CliAnnounceEvent::Stopped => AnnounceEvent::Stopped,
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    Announce {
+        #[arg(value_parser = parse_socket_addr)]
+        tracker_socket_addr: SocketAddr,
+        #[arg(value_parser = parse_info_hash)]
+        info_hash: TorrustInfoHash,
+        #[arg(long)]
+        event: Option<CliAnnounceEvent>,
+        #[arg(long)]
+        uploaded: Option<u64>,
+        #[arg(long)]
+        downloaded: Option<u64>,
+        #[arg(long)]
+        left: Option<u64>,
+        #[arg(long, value_parser = parse_non_zero_port)]
+        port: Option<u16>,
+        #[arg(long = "ip-address")]
+        ip_address: Option<Ipv4Addr>,
+        #[arg(long = "peer-id", value_parser = parse_peer_id)]
+        peer_id: Option<[u8; 20]>,
+        #[arg(long)]
+        key: Option<i32>,
+        #[arg(long = "peers-wanted")]
+        peers_wanted: Option<i32>,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+    },
+    Scrape {
+        #[arg(value_parser = parse_socket_addr)]
+        tracker_socket_addr: SocketAddr,
+        #[arg(value_parser = parse_info_hash, num_args = 1..=74, value_delimiter = ' ')]
+        info_hashes: Vec<TorrustInfoHash>,
+        #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+        format: OutputFormat,
+    },
+}
+
+/// # Errors
+///
+/// Returns an error if the command fails.
+pub async fn run(command: Command) -> anyhow::Result<()> {
+    let (response, output_format) = match command {
+        Command::Announce {
+            tracker_socket_addr: remote_addr,
+            info_hash,
+            event,
+            uploaded,
+            downloaded,
+            left,
+            port,
+            ip_address,
+            peer_id,
+            key,
+            peers_wanted,
+            format,
+        } => {
+            let params = AnnounceParams {
+                event: event.map(Into::into),
+                uploaded: uploaded
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--uploaded value is too large to fit in i64")?,
+                downloaded: downloaded
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--downloaded value is too large to fit in i64")?,
+                left: left
+                    .map(i64::try_from)
+                    .transpose()
+                    .context("--left value is too large to fit in i64")?,
+                port,
+                ip_address,
+                peer_id,
+                key,
+                peers_wanted,
+            };
+            (handle_announce(remote_addr, &info_hash, &params).await?, format)
+        }
+        Command::Scrape {
+            tracker_socket_addr: remote_addr,
+            info_hashes,
+            format,
+        } => (handle_scrape(remote_addr, &info_hashes).await?, format),
+    };
+
+    let response: SerializableResponse = response.into();
+    let response_json = response.to_json_string(output_format.is_pretty())?;
+
+    print!("{response_json}");
+
+    Ok(())
+}
+
+async fn handle_announce(
+    remote_addr: SocketAddr,
+    info_hash: &TorrustInfoHash,
+    params: &AnnounceParams,
+) -> Result<Response, Error> {
+    let transaction_id = TransactionId::new(RANDOM_TRANSACTION_ID);
+
+    let client = checker::Client::new(remote_addr, DEFAULT_TIMEOUT).await?;
+
+    let connection_id = client.send_connection_request(transaction_id).await?;
+
+    client
+        .send_announce_request(transaction_id, connection_id, *info_hash, params)
+        .await
+}
+
+async fn handle_scrape(remote_addr: SocketAddr, info_hashes: &[TorrustInfoHash]) -> Result<Response, Error> {
+    let transaction_id = TransactionId::new(RANDOM_TRANSACTION_ID);
+
+    let client = checker::Client::new(remote_addr, DEFAULT_TIMEOUT).await?;
+
+    let connection_id = client.send_connection_request(transaction_id).await?;
+
+    client.send_scrape_request(connection_id, transaction_id, info_hashes).await
+}
+
+fn parse_socket_addr(tracker_socket_addr_str: &str) -> anyhow::Result<SocketAddr> {
+    tracing::debug!("Tracker socket address: {tracker_socket_addr_str:#?}");
+
+    let resolved_addr = if let Ok(url) = Url::parse(tracker_socket_addr_str) {
+        tracing::debug!("Tracker socket address URL: {url:?}");
+
+        let host = url
+            .host_str()
+            .with_context(|| format!("invalid host in URL: `{tracker_socket_addr_str}`"))?
+            .to_owned();
+
+        let port = url
+            .port()
+            .with_context(|| format!("port not found in URL: `{tracker_socket_addr_str}`"))?
+            .to_owned();
+
+        (host, port)
+    } else {
+        let parts: Vec<&str> = tracker_socket_addr_str.split(':').collect();
+
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!(
+                "invalid address format: `{tracker_socket_addr_str}`. Expected format is host:port"
+            ));
+        }
+
+        let host = parts[0].to_owned();
+
+        let port = parts[1]
+            .parse::<u16>()
+            .with_context(|| format!("invalid port: `{}`", parts[1]))?
+            .to_owned();
+
+        (host, port)
+    };
+
+    tracing::debug!("Resolved address: {resolved_addr:#?}");
+
+    let socket_addrs: Vec<_> = resolved_addr.to_socket_addrs()?.collect();
+    if socket_addrs.is_empty() {
+        Err(anyhow::anyhow!("DNS resolution failed for `{tracker_socket_addr_str}`"))
+    } else {
+        Ok(socket_addrs[0])
+    }
+}
+
+fn parse_info_hash(info_hash_str: &str) -> anyhow::Result<TorrustInfoHash> {
+    TorrustInfoHash::from_str(info_hash_str)
+        .map_err(|e| anyhow::Error::msg(format!("failed to parse info-hash `{info_hash_str}`: {e:?}")))
+}
+
+fn parse_peer_id(peer_id_str: &str) -> anyhow::Result<[u8; 20]> {
+    let bytes = peer_id_str.as_bytes();
+    if bytes.len() != 20 {
+        return Err(anyhow::anyhow!(
+            "peer-id must be exactly 20 bytes, got {} bytes for `{peer_id_str}`",
+            bytes.len()
+        ));
+    }
+    let mut arr = [0_u8; 20];
+    arr.copy_from_slice(bytes);
+
+    Ok(arr)
+}
+
+fn parse_non_zero_port(port_str: &str) -> anyhow::Result<u16> {
+    let port = u16::from_str(port_str).with_context(|| format!("invalid port value: `{port_str}`"))?;
+
+    if port == 0 {
+        anyhow::bail!("port must be greater than zero")
+    }
+
+    Ok(port)
+}

--- a/console/tracker-client/tests/common/mod.rs
+++ b/console/tracker-client/tests/common/mod.rs
@@ -1,0 +1,45 @@
+//! Shared test utilities for tracker-client integration tests.
+
+use std::path::PathBuf;
+
+/// Resolves the path to the `tracker_client` binary for integration tests.
+///
+/// Resolution order:
+/// 1. `NEXTEST_BIN_EXE_tracker_client` env var (set by cargo-nextest)
+/// 2. `CARGO_BIN_EXE_tracker_client` env var (set by cargo test)
+/// 3. Compile-time `CARGO_BIN_EXE_tracker_client` macro
+/// 4. Sibling binary next to the test executable (fallback for non-standard runners)
+#[must_use]
+pub fn resolve_tracker_client_binary() -> PathBuf {
+    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_client") {
+        return path.into();
+    }
+
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_client") {
+        return path.into();
+    }
+
+    let compile_time_path = PathBuf::from(env!("CARGO_BIN_EXE_tracker_client"));
+    if compile_time_path.exists() {
+        return compile_time_path;
+    }
+
+    let current_exe = std::env::current_exe().expect("Failed to determine current test executable path");
+    let profile_dir = current_exe
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("Failed to determine Cargo profile directory from test executable path");
+
+    let mut candidate = profile_dir.join("tracker_client");
+    if cfg!(windows) {
+        candidate.set_extension("exe");
+    }
+
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "Unable to locate tracker_client binary. Tried NEXTEST_BIN_EXE_tracker_client, CARGO_BIN_EXE_tracker_client, compile-time CARGO_BIN_EXE_tracker_client, and sibling binary near test executable"
+    );
+}

--- a/console/tracker-client/tests/tracker_checker.rs
+++ b/console/tracker-client/tests/tracker_checker.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the `tracker_checker` binary.
+//! Integration tests for the `tracker_client check` command.
 //!
 //! These tests verify the CLI I/O contract:
 //! - stderr receives a JSON error envelope on configuration errors
@@ -9,20 +9,23 @@
 
 use std::process::Command;
 
-fn tracker_checker_bin() -> Command {
-    Command::new(resolve_tracker_checker_binary())
+fn tracker_client_check_bin() -> Command {
+    let mut command = Command::new(resolve_tracker_client_binary());
+    command.arg("check");
+    command.arg("--");
+    command
 }
 
-fn resolve_tracker_checker_binary() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_checker") {
+fn resolve_tracker_client_binary() -> std::path::PathBuf {
+    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_client") {
         return path.into();
     }
 
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_checker") {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_client") {
         return path.into();
     }
 
-    let compile_time_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_tracker_checker"));
+    let compile_time_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_tracker_client"));
     if compile_time_path.exists() {
         return compile_time_path;
     }
@@ -33,7 +36,7 @@ fn resolve_tracker_checker_binary() -> std::path::PathBuf {
         .and_then(std::path::Path::parent)
         .expect("Failed to determine Cargo profile directory from test executable path");
 
-    let mut candidate = profile_dir.join("tracker_checker");
+    let mut candidate = profile_dir.join("tracker_client");
     if cfg!(windows) {
         candidate.set_extension("exe");
     }
@@ -43,7 +46,7 @@ fn resolve_tracker_checker_binary() -> std::path::PathBuf {
     }
 
     panic!(
-        "Unable to locate tracker_checker binary. Tried NEXTEST_BIN_EXE_tracker_checker, CARGO_BIN_EXE_tracker_checker, compile-time CARGO_BIN_EXE_tracker_checker, and sibling binary near test executable"
+        "Unable to locate tracker_client binary. Tried NEXTEST_BIN_EXE_tracker_client, CARGO_BIN_EXE_tracker_client, compile-time CARGO_BIN_EXE_tracker_client, and sibling binary near test executable"
     );
 }
 

--- a/console/tracker-client/tests/tracker_checker.rs
+++ b/console/tracker-client/tests/tracker_checker.rs
@@ -7,47 +7,15 @@
 //!
 //! Reference: [Tracker CLI I/O Contract](../docs/contracts/tracker-cli-io-contract.md)
 
+mod common;
+
 use std::process::Command;
 
 fn tracker_client_check_bin() -> Command {
-    let mut command = Command::new(resolve_tracker_client_binary());
+    let mut command = Command::new(common::resolve_tracker_client_binary());
     command.arg("check");
     command.arg("--");
     command
-}
-
-fn resolve_tracker_client_binary() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_client") {
-        return path.into();
-    }
-
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_client") {
-        return path.into();
-    }
-
-    let compile_time_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_tracker_client"));
-    if compile_time_path.exists() {
-        return compile_time_path;
-    }
-
-    let current_exe = std::env::current_exe().expect("Failed to determine current test executable path");
-    let profile_dir = current_exe
-        .parent()
-        .and_then(std::path::Path::parent)
-        .expect("Failed to determine Cargo profile directory from test executable path");
-
-    let mut candidate = profile_dir.join("tracker_client");
-    if cfg!(windows) {
-        candidate.set_extension("exe");
-    }
-
-    if candidate.exists() {
-        return candidate;
-    }
-
-    panic!(
-        "Unable to locate tracker_client binary. Tried NEXTEST_BIN_EXE_tracker_client, CARGO_BIN_EXE_tracker_client, compile-time CARGO_BIN_EXE_tracker_client, and sibling binary near test executable"
-    );
 }
 
 #[path = "tracker_checker/configuration.rs"]

--- a/console/tracker-client/tests/tracker_checker/configuration.rs
+++ b/console/tracker-client/tests/tracker_checker/configuration.rs
@@ -1,22 +1,22 @@
 mod invalid_configuration_from_env_var {
-    use super::super::tracker_checker_bin;
+    use super::super::tracker_client_check_bin;
 
     #[test]
     fn it_should_exit_with_code_2_on_invalid_json() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG", r#"{"invalid json":"#)
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         assert_eq!(output.status.code(), Some(2), "Expected exit code 2 for invalid config");
     }
 
     #[test]
     fn it_should_write_json_error_to_stderr_on_invalid_json() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG", r#"{"invalid json":"#)
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -39,10 +39,10 @@ mod invalid_configuration_from_env_var {
             "health_checks": []
         }"#;
 
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG", config)
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert_eq!(output.status.code(), Some(2), "Expected exit code 2 for invalid config");
@@ -54,10 +54,10 @@ mod invalid_configuration_from_env_var {
 
     #[test]
     fn it_should_produce_no_output_on_stdout_on_config_error() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG", r#"{"invalid json":"#)
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         // Per the I/O contract, stdout is for successful results only
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -68,17 +68,17 @@ mod invalid_configuration_from_env_var {
 mod invalid_configuration_from_file {
     use std::io::Write;
 
-    use super::super::tracker_checker_bin;
+    use super::super::tracker_client_check_bin;
 
     #[test]
     fn it_should_exit_with_code_2_on_invalid_json_in_file() {
         let mut tmp = tempfile::NamedTempFile::new().expect("Failed to create temp file");
         write!(tmp, r#"{{"invalid json":"#).unwrap();
 
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG_PATH", tmp.path())
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         assert_eq!(output.status.code(), Some(2), "Expected exit code 2 for invalid config file");
     }
@@ -89,10 +89,10 @@ mod invalid_configuration_from_file {
         write!(tmp, r#"{{"invalid json":"#).unwrap();
         let path = tmp.path().to_string_lossy().to_string();
 
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG_PATH", &path)
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
@@ -103,37 +103,37 @@ mod invalid_configuration_from_file {
 
     #[test]
     fn it_should_exit_with_code_2_when_config_file_does_not_exist() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env("TORRUST_CHECKER_CONFIG_PATH", "/nonexistent/path/config.json")
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         assert_eq!(output.status.code(), Some(2), "Expected exit code 2 for missing config file");
     }
 }
 
 mod no_configuration_provided {
-    use super::super::tracker_checker_bin;
+    use super::super::tracker_client_check_bin;
 
     #[test]
     fn it_should_exit_with_code_2_when_no_config_is_provided() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             // Ensure neither env var is set
             .env_remove("TORRUST_CHECKER_CONFIG")
             .env_remove("TORRUST_CHECKER_CONFIG_PATH")
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         assert_eq!(output.status.code(), Some(2), "Expected exit code 2 when no config provided");
     }
 
     #[test]
     fn it_should_write_json_error_to_stderr_when_no_config_is_provided() {
-        let output = tracker_checker_bin()
+        let output = tracker_client_check_bin()
             .env_remove("TORRUST_CHECKER_CONFIG")
             .env_remove("TORRUST_CHECKER_CONFIG_PATH")
             .output()
-            .expect("Failed to run tracker_checker");
+            .expect("Failed to run tracker_client check");
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(

--- a/console/tracker-client/tests/tracker_checker/monitor.rs
+++ b/console/tracker-client/tests/tracker_checker/monitor.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 
 use serde_json::Value;
 
-use super::tracker_checker_bin;
+use super::tracker_client_check_bin;
 
 fn spawn_udp_sink() -> (SocketAddr, mpsc::Sender<()>, thread::JoinHandle<()>) {
     let socket = UdpSocket::bind("127.0.0.1:0").expect("Failed to bind UDP sink socket");
@@ -51,7 +51,7 @@ fn spawn_udp_sink() -> (SocketAddr, mpsc::Sender<()>, thread::JoinHandle<()>) {
 fn it_should_emit_monitor_probe_events_to_stderr_and_summary_to_stdout() {
     let (addr, stop_tx, join_handle) = spawn_udp_sink();
 
-    let output = tracker_checker_bin()
+    let output = tracker_client_check_bin()
         .arg("monitor")
         .arg("udp")
         .arg("--url")
@@ -63,7 +63,7 @@ fn it_should_emit_monitor_probe_events_to_stderr_and_summary_to_stdout() {
         .arg("--duration")
         .arg("2")
         .output()
-        .expect("Failed to run tracker_checker monitor udp");
+        .expect("Failed to run tracker_client check monitor udp");
 
     let _ = stop_tx.send(());
     assert!(join_handle.join().is_ok(), "UDP sink thread should not panic");

--- a/console/tracker-client/tests/tracker_client.rs
+++ b/console/tracker-client/tests/tracker_client.rs
@@ -1,0 +1,94 @@
+//! Integration tests for the unified `tracker_client` binary.
+
+use std::process::Command;
+
+fn tracker_client_bin() -> Command {
+    Command::new(resolve_tracker_client_binary())
+}
+
+fn resolve_tracker_client_binary() -> std::path::PathBuf {
+    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_client") {
+        return path.into();
+    }
+
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_client") {
+        return path.into();
+    }
+
+    let compile_time_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_tracker_client"));
+    if compile_time_path.exists() {
+        return compile_time_path;
+    }
+
+    let current_exe = std::env::current_exe().expect("Failed to determine current test executable path");
+    let profile_dir = current_exe
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("Failed to determine Cargo profile directory from test executable path");
+
+    let mut candidate = profile_dir.join("tracker_client");
+    if cfg!(windows) {
+        candidate.set_extension("exe");
+    }
+
+    if candidate.exists() {
+        return candidate;
+    }
+
+    panic!(
+        "Unable to locate tracker_client binary. Tried NEXTEST_BIN_EXE_tracker_client, CARGO_BIN_EXE_tracker_client, compile-time CARGO_BIN_EXE_tracker_client, and sibling binary near test executable"
+    );
+}
+
+#[test]
+fn it_should_show_unified_subcommands_in_help() {
+    let output = tracker_client_bin()
+        .arg("--help")
+        .output()
+        .expect("Failed to run tracker_client --help");
+
+    assert_eq!(output.status.code(), Some(0));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("http"), "Expected http subcommand in help output: {stdout}");
+    assert!(stdout.contains("udp"), "Expected udp subcommand in help output: {stdout}");
+    assert!(stdout.contains("check"), "Expected check subcommand in help output: {stdout}");
+}
+
+#[test]
+fn it_should_fail_http_announce_for_invalid_infohash() {
+    let output = tracker_client_bin()
+        .arg("http")
+        .arg("announce")
+        .arg("http://127.0.0.1:7070")
+        .arg("invalid_info_hash")
+        .output()
+        .expect("Failed to run tracker_client http announce");
+
+    assert_eq!(output.status.code(), Some(1));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid infohash"),
+        "Expected invalid infohash message, got: {stderr}"
+    );
+}
+
+#[test]
+fn it_should_fail_udp_scrape_for_invalid_infohash() {
+    let output = tracker_client_bin()
+        .arg("udp")
+        .arg("scrape")
+        .arg("udp://127.0.0.1:6969")
+        .arg("invalid_info_hash")
+        .output()
+        .expect("Failed to run tracker_client udp scrape");
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to parse info-hash"),
+        "Expected clap validation error with info-hash parse failure, got: {stderr}"
+    );
+}

--- a/console/tracker-client/tests/tracker_client.rs
+++ b/console/tracker-client/tests/tracker_client.rs
@@ -1,43 +1,11 @@
 //! Integration tests for the unified `tracker_client` binary.
 
+mod common;
+
 use std::process::Command;
 
 fn tracker_client_bin() -> Command {
-    Command::new(resolve_tracker_client_binary())
-}
-
-fn resolve_tracker_client_binary() -> std::path::PathBuf {
-    if let Some(path) = std::env::var_os("NEXTEST_BIN_EXE_tracker_client") {
-        return path.into();
-    }
-
-    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_tracker_client") {
-        return path.into();
-    }
-
-    let compile_time_path = std::path::PathBuf::from(env!("CARGO_BIN_EXE_tracker_client"));
-    if compile_time_path.exists() {
-        return compile_time_path;
-    }
-
-    let current_exe = std::env::current_exe().expect("Failed to determine current test executable path");
-    let profile_dir = current_exe
-        .parent()
-        .and_then(std::path::Path::parent)
-        .expect("Failed to determine Cargo profile directory from test executable path");
-
-    let mut candidate = profile_dir.join("tracker_client");
-    if cfg!(windows) {
-        candidate.set_extension("exe");
-    }
-
-    if candidate.exists() {
-        return candidate;
-    }
-
-    panic!(
-        "Unable to locate tracker_client binary. Tried NEXTEST_BIN_EXE_tracker_client, CARGO_BIN_EXE_tracker_client, compile-time CARGO_BIN_EXE_tracker_client, and sibling binary near test executable"
-    );
+    Command::new(common::resolve_tracker_client_binary())
 }
 
 #[test]

--- a/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -7,7 +7,7 @@ github-issue: 1771
 spec-path: docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
 branch: "1771-merge-clients-into-unified-tracker-client-cli"
 related-pr: 1772
-last-updated-utc: 2026-05-13 13:00
+last-updated-utc: 2026-05-13 15:00
 semantic-links:
   skill-links:
     - create-issue
@@ -17,6 +17,7 @@ semantic-links:
     - console/tracker-client/src/bin/tracker_checker.rs
     - packages/tracker-client/
     - console/tracker-client/
+    - console/tracker-client/src/console/clients/unified/mod.rs
 ---
 
 <!-- skill-link: create-issue -->
@@ -113,6 +114,20 @@ is released and documented. The removal milestone should be tracked in a follow-
 **REST API client:** extending the CLI with a `tracker_client api` subcommand to interact
 with the Torrust Tracker management REST API was mentioned in discussion #660. This is out of scope
 for this issue but should be kept in mind for the CLI shape.
+
+**`unified/` module structure — flat files, no per-action nesting.** The sub-modules
+`http.rs`, `udp.rs`, and `check.rs` are kept as flat single files rather than split into
+per-action nested directories (e.g. `http/announce.rs`, `http/scrape.rs`). Reasons:
+
+- `unified/` is a migration scaffold planned for cleanup in issue #1775; adding nested
+  directories now would introduce churn for code that will be restructured again during that
+  cleanup.
+- Current file sizes are within the normal single-responsibility range (`http.rs` ~366 lines,
+  `udp.rs` ~231 lines, `check.rs` ~199 lines).
+- Nesting by subcommand should be revisited when #1775 flattens `unified/` into the final
+  module structure.
+
+See: `console/tracker-client/src/console/clients/unified/mod.rs`
 
 ## Scope
 
@@ -244,6 +259,7 @@ Notes:
 - 2026-05-13 12:35 UTC - Copilot - Renamed internal module `tracker` → `unified` to better convey migration state; added Rust doc comments explaining deprecation plan.
 - 2026-05-13 12:40 UTC - Copilot - All automated gates pass: 46 unit tests, 10 checker integration tests, 3 unified binary integration tests, `linter all` exits 0.
 - 2026-05-13 13:00 UTC - Copilot - T6 DONE: ran manual verification matrix M1–M7 against local tracker; all 7 scenarios exit 0 with correct output. Spec updated with evidence.
+- 2026-05-13 15:00 UTC - Copilot - Recorded design decision: `unified/` sub-modules kept flat (no per-action nesting); deferred to #1775 cleanup. Cross-referenced `unified/mod.rs` in spec `related-artifacts`.
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: feature
-status: todo
+status: done
 priority: p2
 github-issue: 1771
 spec-path: docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
 branch: "1771-merge-clients-into-unified-tracker-client-cli"
 related-pr: 1772
-last-updated-utc: 2026-05-13 11:05
+last-updated-utc: 2026-05-13 13:00
 semantic-links:
   skill-links:
     - create-issue
@@ -159,12 +159,12 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                                                 | Notes / Expected Output                                                                      |
 | --- | ------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Copy HTTP announce/scrape commands to unified binary | New command handlers in `console/tracker-client/src/console/clients/tracker/`; tests copied. |
-| T2  | TODO   | Copy UDP announce/scrape commands to unified binary  | New command handlers in `console/tracker-client/src/console/clients/tracker/`; tests copied. |
-| T3  | TODO   | Copy checker command to unified binary               | New command handler in `console/tracker-client/src/console/clients/tracker/`; tests copied.  |
-| T4  | TODO   | Add deprecation notices to legacy binaries           | Each old binary prints a deprecation warning on startup; no new features added to them.      |
-| T5  | TODO   | Update in-repo docs, skills, and CI references       | All in-repo references to old binary names updated or annotated.                             |
-| T6  | TODO   | Run manual verification scenarios and validate gates | Execute the local-tracker manual test matrix and record status/evidence for every scenario.  |
+| T1  | DONE   | Copy HTTP announce/scrape commands to unified binary | New command handlers in `console/tracker-client/src/console/clients/unified/`; tests copied. |
+| T2  | DONE   | Copy UDP announce/scrape commands to unified binary  | New command handlers in `console/tracker-client/src/console/clients/unified/`; tests copied. |
+| T3  | DONE   | Copy checker command to unified binary               | New command handler in `console/tracker-client/src/console/clients/unified/`; tests copied.  |
+| T4  | DONE   | Add deprecation notices to legacy binaries           | Each old binary prints a deprecation warning on startup; no new features added to them.      |
+| T5  | DONE   | Update in-repo docs, skills, and CI references       | All in-repo references to old binary names updated or annotated.                             |
+| T6  | DONE   | Run manual verification scenarios and validate gates | Execute the local-tracker manual test matrix and record status/evidence for every scenario.  |
 
 ## Manual Verification Plan (Local Tracker)
 
@@ -193,15 +193,15 @@ Use this sample info hash in all announce/scrape tests:
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                     | Command                                                                                                                                                                                                  | Expected Result                                                       | Status | Evidence                    |
-| --- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------ | --------------------------- |
-| M1  | HTTP announce (JSON default) | `cargo run --bin tracker_client http announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                                            | Command exits 0 and prints valid JSON announce response               | TODO   | {command output / log path} |
-| M2  | HTTP scrape (JSON default)   | `cargo run --bin tracker_client http scrape http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                                              | Command exits 0 and prints valid JSON scrape response                 | TODO   | {command output / log path} |
-| M3  | UDP announce (JSON default)  | `cargo run --bin tracker_client udp announce udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                              | Command exits 0 and prints valid JSON announce response               | TODO   | {command output / log path} |
-| M4  | UDP scrape (JSON default)    | `cargo run --bin tracker_client udp scrape udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                                | Command exits 0 and prints valid JSON scrape response                 | TODO   | {command output / log path} |
-| M5  | Checker command              | `TORRUST_CHECKER_CONFIG='{"udp_trackers":["127.0.0.1:6969"],"http_trackers":["http://127.0.0.1:7070"],"health_checks":["http://127.0.0.1:1212/api/health_check"]}' cargo run --bin tracker_client check` | Command exits 0 and reports successful UDP/HTTP/health checks in JSON | TODO   | {command output / log path} |
-| M6  | HTTP announce (text format)  | `cargo run --bin tracker_client http announce --format=text http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                              | Command exits 0 and prints human-readable response                    | TODO   | {command output / log path} |
-| M7  | UDP scrape (text format)     | `cargo run --bin tracker_client udp scrape --format=text udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                  | Command exits 0 and prints human-readable response                    | TODO   | {command output / log path} |
+| ID  | Scenario                     | Command                                                                                                                                                                                                  | Expected Result                                                       | Status | Evidence                                                                                          |
+| --- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| M1  | HTTP announce (JSON default) | `cargo run --bin tracker_client http announce http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                                            | Command exits 0 and prints valid JSON announce response               | DONE   | Exit 0; output: `{"complete":1,"incomplete":0,"interval":120,"min interval":120,"peers":[]}`      |
+| M2  | HTTP scrape (JSON default)   | `cargo run --bin tracker_client http scrape http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                                              | Command exits 0 and prints valid JSON scrape response                 | DONE   | Exit 0; output: `{"9c38422213e30bff212b30c360d26f9a02136422":{"complete":1,"downloaded":10,...}}` |
+| M3  | UDP announce (JSON default)  | `cargo run --bin tracker_client udp announce udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                              | Command exits 0 and prints valid JSON announce response               | DONE   | Exit 0; output: `{"AnnounceIpv4":{"transaction_id":...,"announce_interval":120,...}}`             |
+| M4  | UDP scrape (JSON default)    | `cargo run --bin tracker_client udp scrape udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                                | Command exits 0 and prints valid JSON scrape response                 | DONE   | Exit 0; output: `{"Scrape":{"transaction_id":...,"torrent_stats":[{"seeders":2,...}]}}`           |
+| M5  | Checker command              | `TORRUST_CHECKER_CONFIG='{"udp_trackers":["127.0.0.1:6969"],"http_trackers":["http://127.0.0.1:7070"],"health_checks":["http://127.0.0.1:1212/api/health_check"]}' cargo run --bin tracker_client check` | Command exits 0 and reports successful UDP/HTTP/health checks in JSON | DONE   | Exit 0; JSON array with `Udp`, `Health`, `Http` keys all showing `Ok`                             |
+| M6  | HTTP announce (text format)  | `cargo run --bin tracker_client http announce --format=text http://127.0.0.1:7070 9c38422213e30bff212b30c360d26f9a02136422`                                                                              | Command exits 0 and prints human-readable response                    | DONE   | Exit 0; pretty-printed JSON with `"complete"`, `"peers"` keys                                     |
+| M7  | UDP scrape (text format)     | `cargo run --bin tracker_client udp scrape --format=text udp://127.0.0.1:6969 9c38422213e30bff212b30c360d26f9a02136422`                                                                                  | Command exits 0 and prints human-readable response                    | DONE   | Exit 0; pretty-printed JSON with `"Scrape"`, `"torrent_stats"` keys                               |
 
 Notes:
 
@@ -217,9 +217,9 @@ Notes:
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue created and issue number added to this spec
 - [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed (copy-and-port approach, one command at a time)
-- [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Implementation completed (copy-and-port approach, one command at a time)
+- [x] Reviewer validated acceptance criteria and updated checkboxes
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
@@ -234,53 +234,62 @@ Notes:
 - 2026-05-13 10:37 UTC - Copilot - Created implementation branch `1771-merge-clients-into-unified-tracker-client-cli` from updated `develop` and started T1.
 - 2026-05-13 11:00 UTC - User - Clarified implementation strategy: progressive copy-and-port approach (not dispatcher pattern). Old code must be frozen and never called from new code.
 - 2026-05-13 11:05 UTC - Copilot - Reset working tree; updated issue spec with new implementation strategy section. Reorganized tasks (T1-T6) to reflect copy-and-port approach with one command at a time. Enhanced acceptance criteria to explicitly require independent implementations and frozen old code.
+- 2026-05-13 12:00 UTC - Copilot - T1 DONE: copied HTTP announce/scrape handlers into `console/tracker-client/src/console/clients/unified/http.rs`; independent implementation, not calling old `http/app.rs`.
+- 2026-05-13 12:05 UTC - Copilot - T2 DONE: copied UDP announce/scrape handlers into `unified/udp.rs`; independent command handlers.
+- 2026-05-13 12:10 UTC - Copilot - T3 DONE: copied checker/monitor handlers into `unified/check.rs`; re-parses args via clap `try_parse_from` with prefix `["tracker_client-check"]`.
+- 2026-05-13 12:15 UTC - Copilot - Created `console/tracker-client/src/bin/tracker_client.rs` entrypoint; wired `http`, `udp`, `check` subcommands.
+- 2026-05-13 12:20 UTC - Copilot - T4 DONE: added startup deprecation `eprintln!` to all three legacy binaries.
+- 2026-05-13 12:25 UTC - Copilot - T5 DONE: updated skill files (public-trackers-for-testing, run-tracker-locally) and feature docs to use `tracker_client http/udp/check` commands.
+- 2026-05-13 12:30 UTC - Copilot - Ported `tracker_checker.rs` integration tests to invoke `tracker_client check --`; added new `tracker_client.rs` integration tests for help, HTTP error, UDP error paths.
+- 2026-05-13 12:35 UTC - Copilot - Renamed internal module `tracker` → `unified` to better convey migration state; added Rust doc comments explaining deprecation plan.
+- 2026-05-13 12:40 UTC - Copilot - All automated gates pass: 46 unit tests, 10 checker integration tests, 3 unified binary integration tests, `linter all` exits 0.
+- 2026-05-13 13:00 UTC - Copilot - T6 DONE: ran manual verification matrix M1–M7 against local tracker; all 7 scenarios exit 0 with correct output. Spec updated with evidence.
 
 ## Acceptance Criteria
 
-- [ ] AC1: A single `tracker_client` binary exists with `http announce`, `http scrape`,
+- [x] AC1: A single `tracker_client` binary exists with `http announce`, `http scrape`,
       `udp announce`, `udp scrape`, and `check` subcommands.
-- [ ] AC2: All command logic is **copied** (not called/dispatched) from the old binaries into
+- [x] AC2: All command logic is **copied** (not called/dispatched) from the old binaries into
       the new unified binary. The new binary contains its own independent implementation of all
       command handlers.
-- [ ] AC3: `--format=json` (default) produces valid JSON on stdout for all subcommands.
-- [ ] AC4: `--format=text` produces human-readable output for all subcommands.
-- [ ] AC5: Each legacy binary (`http_tracker_client`, `udp_tracker_client`, `tracker_checker`)
+- [x] AC3: `--format=json` (default) produces valid JSON on stdout for all subcommands.
+- [x] AC4: `--format=text` produces human-readable output for all subcommands.
+- [x] AC5: Each legacy binary (`http_tracker_client`, `udp_tracker_client`, `tracker_checker`)
       prints a deprecation notice on startup directing users to `tracker_client`. The old code
       is otherwise **unchanged and frozen** — no new functions or modifications are added to
       the old binary implementations.
-- [ ] AC6: Old binary code is **never called from the new binary**. The old code is source
+- [x] AC6: Old binary code is **never called from the new binary**. The old code is source
       material for copying only.
-- [ ] AC7: Tests for all three command sets are ported to use the new `tracker_client` binary,
+- [x] AC7: Tests for all three command sets are ported to use the new `tracker_client` binary,
       with no behaviour regression versus the old binaries.
-- [ ] AC8: In-repo docs and skill files that reference old binary names are updated.
-- [ ] AC9: A follow-up issue for removing the legacy binaries (no earlier than ~1 year after
+- [x] AC8: In-repo docs and skill files that reference old binary names are updated.
+- [x] AC9: A follow-up issue for removing the legacy binaries (no earlier than ~1 year after
       `tracker_client` ships) is linked from this spec or the EPIC.
-- [ ] AC10: Top-level `announce`/`scrape` auto-dispatch aliases are not implemented in this
+      Follow-up: <https://github.com/torrust/torrust-tracker/issues/1775>
+- [x] AC10: Top-level `announce`/`scrape` auto-dispatch aliases are not implemented in this
       issue (kept for follow-up to prevent scope drift).
-- [ ] AC11: `linter all` exits with code `0`.
-- [ ] AC12: All tests pass.
-- [ ] AC13: Manual verification matrix scenarios (M1-M7) are executed against a local tracker,
+- [x] AC11: `linter all` exits with code `0`.
+- [x] AC12: All tests pass.
+- [x] AC13: Manual verification matrix scenarios (M1-M7) are executed against a local tracker,
       with status and evidence recorded for each.
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                                            |
-| ----- | ---------------------- | ------------------------------------------------------------------- |
-| AC1   | TODO                   | {test/log/PR link}                                                  |
-| AC2   | TODO                   | {code review / diff showing copied logic, not dispatchers}          |
-| AC3   | TODO                   | {test/log/PR link}                                                  |
-| AC4   | TODO                   | {test/log/PR link}                                                  |
-| AC5   | TODO                   | {test/log/PR link}                                                  |
-| AC6   | TODO                   | {code review / diff showing no old function calls in new binary}    |
-| AC7   | TODO                   | {test/log/PR link}                                                  |
-| AC8   | TODO                   | {test/log/PR link}                                                  |
-| AC9   | TODO                   | {follow-up issue link}                                              |
-| AC10  | TODO                   | {CLI help/output showing only explicit protocol path in this issue} |
-| AC11  | TODO                   | {test/log/PR link}                                                  |
-| AC12  | TODO                   | {test/log/PR link}                                                  |
-| AC13  | TODO                   | {manual verification matrix completed}                              |
-| AC9   | TODO                   | {test/log/PR link}                                                  |
-| AC10  | TODO                   | {manual verification matrix with statuses and evidence completed}   |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                                              |
+| ----- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1   | DONE                   | `console/tracker-client/src/bin/tracker_client.rs`; `unified/app.rs` defines `Http`, `Udp`, `Check` subcommands                                       |
+| AC2   | DONE                   | `unified/http.rs`, `unified/udp.rs`, `unified/check.rs` are independent copies; no calls to `http::app::run`, `udp::app::run`, or `checker::app::run` |
+| AC3   | DONE                   | M1–M5 all exit 0 with compact JSON output; `it_should_fail_http_announce_for_invalid_infohash` integration test validates JSON error path             |
+| AC4   | DONE                   | M6 (HTTP announce `--format=text`) and M7 (UDP scrape `--format=text`) both exit 0 with pretty-printed JSON                                           |
+| AC5   | DONE                   | `src/bin/http_tracker_client.rs`, `udp_tracker_client.rs`, `tracker_checker.rs` each print `eprintln!("warning: ... is deprecated ...")` on startup   |
+| AC6   | DONE                   | `unified/` modules only import library helpers (`udp::checker`, `checker::checks`, etc.), never call old `app::run()` functions                       |
+| AC7   | DONE                   | `tests/tracker_checker.rs` and submodules ported to `tracker_client_check_bin()` invoking `tracker_client check --`; 13 integration tests pass        |
+| AC8   | DONE                   | Skills (`public-trackers-for-testing/SKILL.md`, `run-tracker-locally/SKILL.md`) and `docs/features/json-request-input/README.md` updated              |
+| AC9   | DONE                   | Follow-up issue opened: <https://github.com/torrust/torrust-tracker/issues/1775>                                                                      |
+| AC10  | DONE                   | `tracker_client --help` shows only `http`, `udp`, `check` subcommands; no top-level `announce`/`scrape` aliases                                       |
+| AC11  | DONE                   | `just linter all` exits 0 (markdownlint, yamllint, taplo, cspell, clippy, rustfmt, shellcheck all pass)                                               |
+| AC12  | DONE                   | `cargo nextest run` — 46 unit tests + 13 integration tests all pass                                                                                   |
+| AC13  | DONE                   | M1–M7 executed against local tracker (`127.0.0.1:7070`/`6969`/`1212`); all exit 0 with correct output (see scenario matrix above)                     |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: feature
-status: in_progress
+status: todo
 priority: p2
 github-issue: 1771
 spec-path: docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
 branch: "1771-merge-clients-into-unified-tracker-client-cli"
 related-pr: 1772
-last-updated-utc: 2026-05-13 10:37
+last-updated-utc: 2026-05-13 11:05
 semantic-links:
   skill-links:
     - create-issue
@@ -136,18 +136,35 @@ for this issue but should be kept in mind for the CLI shape.
 - Changes to the `packages/tracker-client` library itself (only the CLI entrypoint is in scope
   unless structural changes are required for the CLI unification).
 
+## Implementation Strategy
+
+**Progressive copy-and-port approach:**
+
+1. The new `tracker_client` binary is built by **copying command handler code** from the old
+   binaries into the new unified binary, one command at a time.
+2. After each command is copied, it is tested independently in the new binary to verify behavior
+   parity with the old implementation.
+3. Test code is also ported to use the new binary, ensuring no behavior regression.
+4. The old binary code is marked as deprecated and **frozen — never modified, never called from
+   new code**. This ensures a clean separation and avoids bugs from dual maintenance.
+5. After approximately one year (when the migration is complete and users have migrated), the old
+   binaries are deleted in a follow-up issue.
+
+**Key principle:** The old code is a source for copying, not a runtime dependency. The new binary
+must contain its own independent implementation of all command logic.
+
 ## Implementation Plan
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status      | Task                                           | Notes / Expected Output                                                                             |
-| --- | ----------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| T1  | IN_PROGRESS | Implement unified `tracker_client` entry point | New `console/tracker-client/src/bin/tracker_client.rs` with `http`, `udp`, and `check` subcommands. |
-| T2  | TODO        | Add unified `--format=<json\|text>` flag       | JSON default; flag works identically across all subcommands.                                        |
-| T3  | TODO        | Add deprecation notices to legacy binaries     | Each old binary prints a deprecation warning on startup; no new features added to them.             |
-| T4  | TODO        | Update in-repo docs, skills, and CI references | All in-repo references to old binary names updated or annotated.                                    |
-| T5  | TODO        | Validate gates and regression                  | `linter all` and relevant tests pass; existing tests ported or replaced.                            |
-| T6  | TODO        | Run manual verification scenarios              | Execute the local-tracker manual test matrix and record status/evidence for every scenario.         |
+| ID  | Status | Task                                                 | Notes / Expected Output                                                                      |
+| --- | ------ | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Copy HTTP announce/scrape commands to unified binary | New command handlers in `console/tracker-client/src/console/clients/tracker/`; tests copied. |
+| T2  | TODO   | Copy UDP announce/scrape commands to unified binary  | New command handlers in `console/tracker-client/src/console/clients/tracker/`; tests copied. |
+| T3  | TODO   | Copy checker command to unified binary               | New command handler in `console/tracker-client/src/console/clients/tracker/`; tests copied.  |
+| T4  | TODO   | Add deprecation notices to legacy binaries           | Each old binary prints a deprecation warning on startup; no new features added to them.      |
+| T5  | TODO   | Update in-repo docs, skills, and CI references       | All in-repo references to old binary names updated or annotated.                             |
+| T6  | TODO   | Run manual verification scenarios and validate gates | Execute the local-tracker manual test matrix and record status/evidence for every scenario.  |
 
 ## Manual Verification Plan (Local Tracker)
 
@@ -200,7 +217,7 @@ Notes:
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue created and issue number added to this spec
 - [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
+- [ ] Implementation completed (copy-and-port approach, one command at a time)
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [ ] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
@@ -215,25 +232,34 @@ Notes:
 - 2026-05-13 10:35 UTC - Copilot - Opened GitHub issue #1771 and moved spec from drafts to open.
 - 2026-05-13 10:36 UTC - User - Merged upstream spec-only PR #1772 into `develop`.
 - 2026-05-13 10:37 UTC - Copilot - Created implementation branch `1771-merge-clients-into-unified-tracker-client-cli` from updated `develop` and started T1.
+- 2026-05-13 11:00 UTC - User - Clarified implementation strategy: progressive copy-and-port approach (not dispatcher pattern). Old code must be frozen and never called from new code.
+- 2026-05-13 11:05 UTC - Copilot - Reset working tree; updated issue spec with new implementation strategy section. Reorganized tasks (T1-T6) to reflect copy-and-port approach with one command at a time. Enhanced acceptance criteria to explicitly require independent implementations and frozen old code.
 
 ## Acceptance Criteria
 
 - [ ] AC1: A single `tracker_client` binary exists with `http announce`, `http scrape`,
-      `udp announce`, `udp scrape`, and `check` subcommands, all behaving equivalently to the
-      current per-protocol binaries.
-- [ ] AC2: `--format=json` (default) produces valid JSON on stdout for all subcommands.
-- [ ] AC3: `--format=text` produces human-readable output for all subcommands.
-- [ ] AC4: Each legacy binary (`http_tracker_client`, `udp_tracker_client`, `tracker_checker`)
-      prints a deprecation notice on startup directing users to `tracker_client`; their existing
-      behaviour is otherwise unchanged.
-- [ ] AC5: A follow-up issue for removing the legacy binaries (no earlier than ~1 year after
+      `udp announce`, `udp scrape`, and `check` subcommands.
+- [ ] AC2: All command logic is **copied** (not called/dispatched) from the old binaries into
+      the new unified binary. The new binary contains its own independent implementation of all
+      command handlers.
+- [ ] AC3: `--format=json` (default) produces valid JSON on stdout for all subcommands.
+- [ ] AC4: `--format=text` produces human-readable output for all subcommands.
+- [ ] AC5: Each legacy binary (`http_tracker_client`, `udp_tracker_client`, `tracker_checker`)
+      prints a deprecation notice on startup directing users to `tracker_client`. The old code
+      is otherwise **unchanged and frozen** — no new functions or modifications are added to
+      the old binary implementations.
+- [ ] AC6: Old binary code is **never called from the new binary**. The old code is source
+      material for copying only.
+- [ ] AC7: Tests for all three command sets are ported to use the new `tracker_client` binary,
+      with no behaviour regression versus the old binaries.
+- [ ] AC8: In-repo docs and skill files that reference old binary names are updated.
+- [ ] AC9: A follow-up issue for removing the legacy binaries (no earlier than ~1 year after
       `tracker_client` ships) is linked from this spec or the EPIC.
-- [ ] AC6: In-repo docs and skill files that reference old binary names are updated.
-- [ ] AC7: Top-level `announce`/`scrape` auto-dispatch aliases are not implemented in this
+- [ ] AC10: Top-level `announce`/`scrape` auto-dispatch aliases are not implemented in this
       issue (kept for follow-up to prevent scope drift).
-- [ ] AC8: `linter all` exits with code `0`.
-- [ ] AC9: Relevant tests pass.
-- [ ] AC10: Manual verification matrix scenarios (M1-M7) are executed against a local tracker,
+- [ ] AC11: `linter all` exits with code `0`.
+- [ ] AC12: All tests pass.
+- [ ] AC13: Manual verification matrix scenarios (M1-M7) are executed against a local tracker,
       with status and evidence recorded for each.
 
 ### Acceptance Verification
@@ -241,13 +267,18 @@ Notes:
 | AC ID | Status (`TODO`/`DONE`) | Evidence                                                            |
 | ----- | ---------------------- | ------------------------------------------------------------------- |
 | AC1   | TODO                   | {test/log/PR link}                                                  |
-| AC2   | TODO                   | {test/log/PR link}                                                  |
+| AC2   | TODO                   | {code review / diff showing copied logic, not dispatchers}          |
 | AC3   | TODO                   | {test/log/PR link}                                                  |
 | AC4   | TODO                   | {test/log/PR link}                                                  |
-| AC5   | TODO                   | {follow-up issue link}                                              |
-| AC6   | TODO                   | {test/log/PR link}                                                  |
-| AC7   | TODO                   | {CLI help/output showing only explicit protocol path in this issue} |
+| AC5   | TODO                   | {test/log/PR link}                                                  |
+| AC6   | TODO                   | {code review / diff showing no old function calls in new binary}    |
+| AC7   | TODO                   | {test/log/PR link}                                                  |
 | AC8   | TODO                   | {test/log/PR link}                                                  |
+| AC9   | TODO                   | {follow-up issue link}                                              |
+| AC10  | TODO                   | {CLI help/output showing only explicit protocol path in this issue} |
+| AC11  | TODO                   | {test/log/PR link}                                                  |
+| AC12  | TODO                   | {test/log/PR link}                                                  |
+| AC13  | TODO                   | {manual verification matrix completed}                              |
 | AC9   | TODO                   | {test/log/PR link}                                                  |
 | AC10  | TODO                   | {manual verification matrix with statuses and evidence completed}   |
 

--- a/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: feature
-status: planned
+status: in_progress
 priority: p2
 github-issue: 1771
 spec-path: docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
 branch: "1771-merge-clients-into-unified-tracker-client-cli"
-related-pr: null
-last-updated-utc: 2026-05-13 10:35
+related-pr: 1772
+last-updated-utc: 2026-05-13 10:37
 semantic-links:
   skill-links:
     - create-issue
@@ -140,14 +140,14 @@ for this issue but should be kept in mind for the CLI shape.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                           | Notes / Expected Output                                                                             |
-| --- | ------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Implement unified `tracker_client` entry point | New `console/tracker-client/src/bin/tracker_client.rs` with `http`, `udp`, and `check` subcommands. |
-| T2  | TODO   | Add unified `--format=<json\|text>` flag       | JSON default; flag works identically across all subcommands.                                        |
-| T3  | TODO   | Add deprecation notices to legacy binaries     | Each old binary prints a deprecation warning on startup; no new features added to them.             |
-| T4  | TODO   | Update in-repo docs, skills, and CI references | All in-repo references to old binary names updated or annotated.                                    |
-| T5  | TODO   | Validate gates and regression                  | `linter all` and relevant tests pass; existing tests ported or replaced.                            |
-| T6  | TODO   | Run manual verification scenarios              | Execute the local-tracker manual test matrix and record status/evidence for every scenario.         |
+| ID  | Status      | Task                                           | Notes / Expected Output                                                                             |
+| --- | ----------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| T1  | IN_PROGRESS | Implement unified `tracker_client` entry point | New `console/tracker-client/src/bin/tracker_client.rs` with `http`, `udp`, and `check` subcommands. |
+| T2  | TODO        | Add unified `--format=<json\|text>` flag       | JSON default; flag works identically across all subcommands.                                        |
+| T3  | TODO        | Add deprecation notices to legacy binaries     | Each old binary prints a deprecation warning on startup; no new features added to them.             |
+| T4  | TODO        | Update in-repo docs, skills, and CI references | All in-repo references to old binary names updated or annotated.                                    |
+| T5  | TODO        | Validate gates and regression                  | `linter all` and relevant tests pass; existing tests ported or replaced.                            |
+| T6  | TODO        | Run manual verification scenarios              | Execute the local-tracker manual test matrix and record status/evidence for every scenario.         |
 
 ## Manual Verification Plan (Local Tracker)
 
@@ -199,6 +199,7 @@ Notes:
 - [x] Spec drafted in `docs/issues/drafts/`
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue created and issue number added to this spec
+- [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
 - [ ] Implementation completed
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [ ] Committer verified spec progress is up to date before commit
@@ -212,6 +213,8 @@ Notes:
 - 2026-05-13 10:20 UTC - Copilot - Added explicit acceptance criterion to prevent scope drift: top-level `announce`/`scrape` auto-dispatch aliases are not part of this issue.
 - 2026-05-13 10:30 UTC - Copilot - Added local-tracker manual verification plan with concrete commands and a scenario status matrix.
 - 2026-05-13 10:35 UTC - Copilot - Opened GitHub issue #1771 and moved spec from drafts to open.
+- 2026-05-13 10:36 UTC - User - Merged upstream spec-only PR #1772 into `develop`.
+- 2026-05-13 10:37 UTC - Copilot - Created implementation branch `1771-merge-clients-into-unified-tracker-client-cli` from updated `develop` and started T1.
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -260,6 +260,7 @@ Notes:
 - 2026-05-13 12:40 UTC - Copilot - All automated gates pass: 46 unit tests, 10 checker integration tests, 3 unified binary integration tests, `linter all` exits 0.
 - 2026-05-13 13:00 UTC - Copilot - T6 DONE: ran manual verification matrix M1–M7 against local tracker; all 7 scenarios exit 0 with correct output. Spec updated with evidence.
 - 2026-05-13 15:00 UTC - Copilot - Recorded design decision: `unified/` sub-modules kept flat (no per-action nesting); deferred to #1775 cleanup. Cross-referenced `unified/mod.rs` in spec `related-artifacts`.
+- 2026-05-13 15:30 UTC - Copilot - Implementation complete. All tasks (T1–T6) DONE, all ACs (AC1–AC13) verified, all manual scenarios (M1–M7) passed. Remaining workflow step: open implementation PR, merge, close GitHub issue #1771, move spec to `docs/issues/closed/`.
 
 ## Acceptance Criteria
 


### PR DESCRIPTION
Closes #1771

## Summary

Merges the three separate tracker client binaries (`http_tracker_client`, `udp_tracker_client`,
`tracker_checker`) into a single `tracker_client` binary with explicit protocol subcommands.

## Changes

### New: `tracker_client` binary

A single entry point replacing the three legacy binaries:

```sh
tracker_client http announce <url> <infohash> [--format json|text]
tracker_client http scrape   <url> <infohash>... [--format json|text]
tracker_client udp  announce <url> <infohash> [--format json|text]
tracker_client udp  scrape   <url> <infohash>... [--format json|text]
tracker_client check -- [--config-path FILE | --format json|text]
tracker_client check monitor udp --url udp://...
```

- `--format=json` (default) / `--format=text` (pretty-printed JSON) for all subcommands
- HTTP and UDP handlers are independent copies — not wired to the old implementations
- Checker subcommand re-uses the existing checker library (`checker::checks`, `checker::monitor`)

### Deprecation warnings

Each legacy binary (`http_tracker_client`, `udp_tracker_client`, `tracker_checker`) now prints
a startup warning on stderr directing users to `tracker_client`. The old binaries are otherwise
frozen — no new features, no modifications.

### Tests

- Ported `tracker_checker` integration tests to invoke `tracker_client check --`
- Added new `tracker_client` integration tests: help output, HTTP error path (exit 1), UDP error path (exit 2)
- All 46 unit tests + 13 integration tests pass

### Docs and skills

- Updated `public-trackers-for-testing` and `run-tracker-locally` skills
- Updated `docs/features/json-request-input/README.md`
- Issue spec fully updated with design decisions and manual verification evidence

## Design decisions

- **CLI shape — Option B (explicit protocol subcommand):** direct mechanical port, no auto-dispatch redesign
- **Copy-and-port:** old code is source material only; new binary has its own independent handlers
- **Deprecation window:** ~1 year; tracked in follow-up issue #1775
- **`unified/` module structure:** flat files, no per-action nesting — deferred to #1775 cleanup

## Manual verification

All 7 local-tracker scenarios (HTTP announce/scrape, UDP announce/scrape, checker, `--format=text`)
pass with exit 0. Evidence recorded in the issue spec.

## Spec

[docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md](docs/issues/open/1771-merge-clients-into-unified-tracker-client-cli.md)