### PR TITLE
docs: improve docs/ folder navigation (#1803)

### DIFF
--- a/.github/skills/dev/planning/write-markdown-docs/SKILL.md
+++ b/.github/skills/dev/planning/write-markdown-docs/SKILL.md
@@ -61,10 +61,40 @@ abc1234 (SHA) → links to commit (useful for references)
 owner/repo#42 → cross-repo issue link
 ```
 
+## Frontmatter
+
+All Markdown files in `docs/` should include YAML frontmatter.
+
+It is **required** for issue specs and EPIC specs. It is **recommended** for all other
+`.md` files in the repository.
+
+Follow the frontmatter convention defined in
+[`docs/skills/semantic-skill-link-convention.md`](../../../../docs/skills/semantic-skill-link-convention.md),
+which specifies the required fields for each document type and the shape of
+`semantic-links` entries.
+
+## Repo Markdown vs. GitHub Markdown
+
+The `.markdownlint.json` configuration at the repository root applies **only to `.md` files
+tracked in the repository**. It does not apply to Markdown written on GitHub surfaces such
+as issue descriptions, PR descriptions, PR review comments, or discussion posts.
+
+**Do not wrap lines when writing GitHub issue or PR body text.** Hard-wrapping lines in issue
+or PR descriptions produces visually broken paragraphs on GitHub's web UI and is harder for
+human readers to follow. Write each paragraph as a single continuous line and let GitHub's
+rendering handle the wrapping.
+
+| Surface                | Governed by `.markdownlint.json` | Line wrapping                                                |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------ |
+| `.md` files in repo    | Yes                              | Follow repo config (MD013 disabled, but keep lines readable) |
+| GitHub issue / PR body | No                               | Do **not** hard-wrap lines                                   |
+| GitHub review comments | No                               | Do **not** hard-wrap lines                                   |
+
 ## Checklist Before Committing Docs
 
 - [ ] No `#NUMBER` patterns used for enumeration or step numbering
 - [ ] Ordered lists use Markdown syntax (`1.` `2.` `3.`)
 - [ ] Any `#NUMBER` present is an intentional issue/PR reference
 - [ ] Tables are consistently formatted
+- [ ] Frontmatter is present and follows `docs/skills/semantic-skill-link-convention.md`
 - [ ] `linter markdown` and `linter cspell` pass

--- a/.github/skills/dev/planning/write-markdown-docs/SKILL.md
+++ b/.github/skills/dev/planning/write-markdown-docs/SKILL.md
@@ -63,13 +63,12 @@ owner/repo#42 → cross-repo issue link
 
 ## Frontmatter
 
-All Markdown files in `docs/` should include YAML frontmatter.
-
-It is **required** for issue specs and EPIC specs. It is **recommended** for all other
-`.md` files in the repository.
+Frontmatter use in `docs/` varies by document type: **required** for issue specs and
+EPIC specs, **recommended** for ADRs and refactor plans, and **optional** for short
+reference pages and README files.
 
 Follow the frontmatter convention defined in
-[`docs/skills/semantic-skill-link-convention.md`](../../../../docs/skills/semantic-skill-link-convention.md),
+[`docs/skills/semantic-skill-link-convention.md`](../../../../../docs/skills/semantic-skill-link-convention.md),
 which specifies the required fields for each document type and the shape of
 `semantic-links` entries.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -38,7 +38,7 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 
 ## Markdown Frontmatter
 
-All `.md` files in this directory tree should include YAML frontmatter.
+Frontmatter use varies by document type:
 
 - **Required** for issue specs and EPIC specs — see the required field schema in
   [`docs/skills/semantic-skill-link-convention.md`](skills/semantic-skill-link-convention.md).
@@ -75,7 +75,7 @@ See the `write-markdown-docs` skill for the full checklist and GFM pitfalls.
 
 ## Key Skills
 
-| Skill                                                                                   | When to use                                                                             |
-| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| [`write-markdown-docs`](../../.github/skills/dev/planning/write-markdown-docs/SKILL.md) | Writing or editing any `.md` file — covers GFM pitfalls, frontmatter, and linting scope |
-| [`create-issue`](../../.github/skills/dev/planning/create-issue/SKILL.md)               | Drafting and creating issue specifications                                              |
+| Skill                                                                                | When to use                                                                             |
+| ------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| [`write-markdown-docs`](../.github/skills/dev/planning/write-markdown-docs/SKILL.md) | Writing or editing any `.md` file — covers GFM pitfalls, frontmatter, and linting scope |
+| [`create-issue`](../.github/skills/dev/planning/create-issue/SKILL.md)               | Drafting and creating issue specifications                                              |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,81 @@
+# `docs/` — Documentation Directory
+
+This directory contains all project documentation: operational guides, architectural decision
+records, issue and refactor-plan specifications, templates, and supporting media.
+
+For the full project context see the [root AGENTS.md](../AGENTS.md).
+
+## Directory Map
+
+| Path                 | Purpose                                                           |
+| -------------------- | ----------------------------------------------------------------- |
+| `index.md`           | Entry point — structured index of every document and subdirectory |
+| `benchmarking.md`    | How to run and interpret torrent-repository benchmarks            |
+| `containers.md`      | Running the tracker with Docker / Podman                          |
+| `packages.md`        | Workspace package catalog, architecture layers, dependency rules  |
+| `profiling.md`       | CPU and memory profiling with Valgrind / kcachegrind              |
+| `release_process.md` | Branch strategy, versioning, and the release pipeline             |
+| `adrs/`              | Architectural Decision Records (ADRs)                             |
+| `issues/`            | Issue specification documents linked to GitHub issues             |
+| `refactor-plans/`    | Refactor plan specifications (same lifecycle as issue specs)      |
+| `pr-reviews/`        | Notable PR review records and Copilot suggestion threads          |
+| `skills/`            | Internal conventions used by humans and AI agents                 |
+| `templates/`         | Canonical document templates (ADR, EPIC, issue, refactor plan)    |
+| `media/`             | Images, diagrams, flamegraphs, benchmark reports, sample torrents |
+| `licenses/`          | Full license texts (AGPL-3.0, MIT-0)                              |
+
+### Where to place a new artifact
+
+| Artifact type                                  | Target location                                                  |
+| ---------------------------------------------- | ---------------------------------------------------------------- |
+| New ADR                                        | `docs/adrs/` — filename format: `YYYYMMDDHHMMSS_<short-slug>.md` |
+| New issue spec (before GitHub issue exists)    | `docs/issues/drafts/`                                            |
+| New issue spec (after GitHub issue created)    | `docs/issues/open/<number>-<short-slug>.md`                      |
+| New refactor plan (before GitHub issue exists) | `docs/refactor-plans/drafts/`                                    |
+| New refactor plan (after GitHub issue created) | `docs/refactor-plans/open/<number>-<short-slug>.md`              |
+| New document template                          | `docs/templates/`                                                |
+| New diagram or screenshot                      | `docs/media/` (or the relevant subdirectory)                     |
+
+## Markdown Frontmatter
+
+All `.md` files in this directory tree should include YAML frontmatter.
+
+- **Required** for issue specs and EPIC specs — see the required field schema in
+  [`docs/skills/semantic-skill-link-convention.md`](skills/semantic-skill-link-convention.md).
+- **Recommended** for ADRs, refactor plans, and other specification documents.
+- **Optional** for short reference pages and README files.
+
+Use `semantic-links` in frontmatter to couple a document to the Agent Skills it affects:
+
+```yaml
+---
+semantic-links:
+  skill-links:
+    - <skill-name>
+  related-artifacts:
+    - <repo-relative-path>
+---
+```
+
+## Markdown Linting
+
+Repository `.md` files are linted by markdownlint using the configuration in
+[`.markdownlint.json`](../.markdownlint.json).
+
+**GitHub surfaces are a different context.** Issue descriptions, PR descriptions, and review
+comments are rendered by GitHub and are **not** governed by `.markdownlint.json`. In
+particular:
+
+- Do **not** hard-wrap lines in GitHub issue or PR body text. Wrapping produces broken
+  paragraphs on GitHub's web UI. Write each paragraph as a single continuous line.
+- The `MD013` line-length rule is disabled in the repo config, but repo files should still be
+  kept readable. GitHub surfaces have no such constraint at all.
+
+See the `write-markdown-docs` skill for the full checklist and GFM pitfalls.
+
+## Key Skills
+
+| Skill                                                                                   | When to use                                                                             |
+| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [`write-markdown-docs`](../../.github/skills/dev/planning/write-markdown-docs/SKILL.md) | Writing or editing any `.md` file — covers GFM pitfalls, frontmatter, and linting scope |
+| [`create-issue`](../../.github/skills/dev/planning/create-issue/SKILL.md)               | Drafting and creating issue specifications                                              |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,98 @@
-# Torrust Tracker Documentation
+# Torrust Tracker — Documentation Index
 
-For more detailed instructions, please view our [crate documentation][docs].
+This is the entry point for all project documentation. For API documentation generated from
+source code, see the [crate docs on docs.rs][docs].
 
-- [Benchmarking](benchmarking.md)
-- [Containers](containers.md)
-- [Issue Specs](issues/README.md)
-- [Packages](packages.md)
-- [Profiling](profiling.md)
-- [Releases process](release_process.md)
+## Guides
+
+Operational and development guides for working with the tracker.
+
+| Document | Description |
+| -------- | ----------- |
+| [benchmarking.md](benchmarking.md) | How to run and interpret the torrent-repository benchmarks |
+| [containers.md](containers.md) | Building and running the tracker with Docker / Podman |
+| [packages.md](packages.md) | Workspace package catalog, architecture layers, and dependency rules |
+| [profiling.md](profiling.md) | CPU and memory profiling with Valgrind / kcachegrind |
+| [release_process.md](release_process.md) | Branch strategy, versioning, and the staging → main release pipeline |
+
+## Architecture Decisions (ADRs)
+
+Records of significant architectural decisions, including context and consequences.
+
+| Document | Description |
+| -------- | ----------- |
+| [adrs/README.md](adrs/README.md) | Index of all ADRs and guidance on writing new ones |
+| [adrs/index.md](adrs/index.md) | Quick-reference table of every ADR |
+
+## Issue Specifications
+
+Structured specification documents linked to GitHub issues. Used for planning and tracking
+implementation work before and during development.
+
+| Location | Description |
+| -------- | ----------- |
+| [issues/README.md](issues/README.md) | Overview, folder structure, and workflow skill references |
+| [issues/drafts/](issues/drafts/) | Specs not yet linked to a GitHub issue |
+| [issues/open/](issues/open/) | Active specs for open GitHub issues |
+| [issues/closed/](issues/closed/) | Recently closed specs kept temporarily for reference |
+
+## Refactor Plans
+
+Specification documents for larger refactoring efforts, following the same lifecycle as issue
+specs (drafts → open → closed).
+
+| Location | Description |
+| -------- | ----------- |
+| [refactor-plans/drafts/](refactor-plans/drafts/) | Draft refactor plans not yet tied to a GitHub issue |
+| [refactor-plans/open/](refactor-plans/open/) | Active refactor plan specs |
+| [refactor-plans/closed/](refactor-plans/closed/) | Completed refactor plans kept for reference |
+
+## PR Reviews
+
+Records of notable pull request reviews and Copilot suggestion threads.
+
+| Document | Description |
+| -------- | ----------- |
+| [pr-reviews/README.md](pr-reviews/README.md) | Overview of the PR review archive |
+
+## Skills and Conventions
+
+Internal documentation on project-specific conventions used by both humans and AI agents.
+
+| Document | Description |
+| -------- | ----------- |
+| [skills/semantic-skill-link-convention.md](skills/semantic-skill-link-convention.md) | Frontmatter schema, `skill-link` marker catalog, and machine-readable metadata conventions |
+
+## Templates
+
+Canonical document templates. Copy the appropriate template when creating a new artifact of
+that type.
+
+| Template | Description |
+| -------- | ----------- |
+| [templates/ADR.md](templates/ADR.md) | Template for Architectural Decision Records |
+| [templates/EPIC.md](templates/EPIC.md) | Template for EPIC issue specifications |
+| [templates/ISSUE.md](templates/ISSUE.md) | Template for task / bug / feature issue specifications |
+| [templates/REFACTOR-PLAN.md](templates/REFACTOR-PLAN.md) | Template for refactor plan specifications |
+| [templates/COPILOT-SUGGESTIONS-TEMPLATE.md](templates/COPILOT-SUGGESTIONS-TEMPLATE.md) | Template for recording Copilot PR review suggestions |
+
+## Media
+
+Images, diagrams, flamegraphs, benchmark reports, and sample torrent files used in
+documentation.
+
+| Location | Description |
+| -------- | ----------- |
+| [media/](media/) | Top-level media assets (flamegraphs, benchmark screenshots, sample torrents) |
+| [media/demo/](media/demo/) | Screenshots and assets used in demo documentation |
+| [media/packages/](media/packages/) | Package architecture diagrams |
+
+## Licenses
+
+Full license texts referenced by the project.
+
+| Location | Description |
+| -------- | ----------- |
+| [licenses/](licenses/) | AGPL-3.0 and MIT-0 license files |
 
 [docs]: https://docs.rs/torrust-tracker/latest/torrust_tracker/

--- a/docs/issues/open/1803-improve-docs-folder-navigation.md
+++ b/docs/issues/open/1803-improve-docs-folder-navigation.md
@@ -1,7 +1,7 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: in-progress
 priority: p2
 github-issue: 1803
 spec-path: docs/issues/open/1803-improve-docs-folder-navigation.md
@@ -193,9 +193,9 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 ## References
 
-- Current index: [`docs/index.md`](../index.md)
-- Frontmatter convention: [`docs/skills/semantic-skill-link-convention.md`](../skills/semantic-skill-link-convention.md)
-- Markdown linting configuration: [`.markdownlint.json`](../../.markdownlint.json)
-- Write markdown docs skill: [`.github/skills/dev/planning/write-markdown-docs/SKILL.md`](../../.github/skills/dev/planning/write-markdown-docs/SKILL.md)
-- Existing `packages/AGENTS.md` (pattern reference): [`packages/AGENTS.md`](../../packages/AGENTS.md)
-- Existing `src/AGENTS.md` (pattern reference): [`src/AGENTS.md`](../../src/AGENTS.md)
+- Current index: [`docs/index.md`](../../index.md)
+- Frontmatter convention: [`docs/skills/semantic-skill-link-convention.md`](../../skills/semantic-skill-link-convention.md)
+- Markdown linting configuration: [`.markdownlint.json`](../../../.markdownlint.json)
+- Write markdown docs skill: [`.github/skills/dev/planning/write-markdown-docs/SKILL.md`](../../../.github/skills/dev/planning/write-markdown-docs/SKILL.md)
+- Existing `packages/AGENTS.md` (pattern reference): [`packages/AGENTS.md`](../../../packages/AGENTS.md)
+- Existing `src/AGENTS.md` (pattern reference): [`src/AGENTS.md`](../../../src/AGENTS.md)

--- a/docs/issues/open/1803-improve-docs-folder-navigation.md
+++ b/docs/issues/open/1803-improve-docs-folder-navigation.md
@@ -1,0 +1,200 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+github-issue: 1803
+spec-path: docs/issues/open/1803-improve-docs-folder-navigation.md
+branch: "1803-improve-docs-folder-navigation"
+related-pr: null
+last-updated-utc: 2026-05-20 11:00
+semantic-links:
+  skill-links:
+    - create-issue
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - docs/AGENTS.md
+    - .github/skills/dev/planning/write-markdown-docs/SKILL.md
+    - docs/skills/semantic-skill-link-convention.md
+    - .markdownlint.json
+---
+
+<!-- skill-link: create-issue -->
+<!-- skill-link: write-markdown-docs -->
+
+# Issue #1803 - Improve `docs/` folder navigation
+
+## Goal
+
+Make the `docs/` folder easier to navigate for both human readers and AI agents by expanding
+the existing `docs/index.md` with structured sections and descriptions, adding a
+`docs/AGENTS.md` with AI-agent guidance, and updating the `write-markdown-docs` skill with
+missing rules about frontmatter and GitHub-vs-repo markdown.
+
+## Background
+
+The current `docs/index.md` is a minimal flat list of links with no descriptions and no
+entries for several subdirectories (`adrs/`, `refactor-plans/`, `pr-reviews/`, `skills/`,
+`templates/`, `licenses/`, `media/`). A reader cannot tell from the index alone what each
+section covers or where to look for a specific type of artifact.
+
+There is also no `docs/AGENTS.md` file, while the project already has directory-scoped
+`AGENTS.md` files for `packages/` and `src/`. Without one, AI agents asked to write, find, or
+update documentation artifacts must infer the correct subdirectory and conventions from
+context instead of having explicit guidance.
+
+Finally, the `write-markdown-docs` skill does not mention:
+
+- The frontmatter convention described in `docs/skills/semantic-skill-link-convention.md`.
+- The difference between repo Markdown files (linted by `.markdownlint.json`) and GitHub
+  Markdown surfaces (issues, PRs) that are not subject to the repo lint configuration.
+
+## Scope
+
+### In Scope
+
+- Expand `docs/index.md` with organized sections, short descriptions for each entry, and
+  links to all subdirectories currently missing from the index.
+- Create `docs/AGENTS.md` covering: directory map, frontmatter convention, Markdown linting
+  rules (repo files vs. GitHub surfaces), and a reference to the `write-markdown-docs` skill.
+- Update `.github/skills/dev/planning/write-markdown-docs/SKILL.md` to add a frontmatter
+  section and a section distinguishing repo Markdown from GitHub Markdown.
+
+### Out of Scope
+
+- Restructuring or renaming any subdirectory under `docs/`.
+- Writing or updating content of individual documentation files.
+- Changing the `.markdownlint.json` configuration.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                                  | Notes / Expected Output                                                                                    |
+| --- | ------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Expand `docs/index.md` with sections and descriptions | Organized sections with one-line descriptions for every entry, including previously missing subdirectories |
+| T2  | TODO   | Create `docs/AGENTS.md`                               | Directory map, frontmatter rules, linting scope (repo vs. GitHub), skill reference                         |
+| T3  | TODO   | Update `write-markdown-docs` skill                    | New "Frontmatter" section and new "Repo Markdown vs. GitHub Markdown" section (see proposed content below) |
+
+### Proposed additions to `write-markdown-docs` skill (T3)
+
+Add the following two sections before the existing "Checklist Before Committing Docs" section:
+
+```markdown
+## Frontmatter
+
+All Markdown files in `docs/` should include YAML frontmatter.
+
+It is **required** for issue specs and EPIC specs. It is **recommended** for all other
+`.md` files in the repository.
+
+Follow the frontmatter convention defined in
+[`docs/skills/semantic-skill-link-convention.md`](../../../../docs/skills/semantic-skill-link-convention.md),
+which specifies the required fields for each document type and the shape of
+`semantic-links` entries.
+
+## Repo Markdown vs. GitHub Markdown
+
+The `.markdownlint.json` configuration at the repository root applies **only to `.md` files
+tracked in the repository**. It does not apply to Markdown written on GitHub surfaces such
+as issue descriptions, PR descriptions, PR review comments, or discussion posts.
+
+**Do not wrap lines when writing GitHub issue or PR body text.** Hard-wrapping lines in issue
+or PR descriptions produces visually broken paragraphs on GitHub's web UI and is harder for
+human readers to follow. Write each paragraph as a single continuous line and let GitHub's
+rendering handle the wrapping.
+
+| Surface                | Governed by `.markdownlint.json` | Line wrapping                                                |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------ |
+| `.md` files in repo    | Yes                              | Follow repo config (MD013 disabled, but keep lines readable) |
+| GitHub issue / PR body | No                               | Do **not** hard-wrap lines                                   |
+| GitHub review comments | No                               | Do **not** hard-wrap lines                                   |
+```
+
+Also add a frontmatter item to the existing checklist:
+
+```markdown
+- [ ] Frontmatter is present and follows `docs/skills/semantic-skill-link-convention.md`
+```
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/drafts/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] GitHub issue created and issue number added to this spec
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-05-20 10:00 UTC - Agent - Spec drafted based on user discussion
+
+## Acceptance Criteria
+
+- [ ] AC1: `docs/index.md` contains a section for every subdirectory and top-level file in
+      `docs/`, each with a short description of its purpose.
+- [ ] AC2: `docs/AGENTS.md` exists and covers the directory map, frontmatter convention,
+      Markdown linting scope distinction (repo files vs. GitHub surfaces), and a reference to the
+      `write-markdown-docs` skill.
+- [ ] AC3: `write-markdown-docs` skill includes a "Frontmatter" section referencing
+      `docs/skills/semantic-skill-link-convention.md` and a section explaining that GitHub
+      Markdown surfaces (issues, PRs) are not subject to `.markdownlint.json` rules, and that
+      line wrapping must not be applied to issue or PR body text.
+- [ ] AC4: `linter all` exits with code `0`.
+- [ ] AC5: Manual verification scenarios are executed and documented (status + evidence).
+- [ ] AC6: Acceptance criteria are re-reviewed after implementation and reflect actual
+      behavior.
+- [ ] AC7: Documentation is updated when behavior or workflow changes.
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter all`
+- `linter markdown` (targeted check on changed `.md` files)
+- `linter cspell`
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                            | Command/Steps                                                                                | Expected Result                                                                                                      | Status | Evidence |
+| --- | ----------------------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------ | -------- |
+| M1  | Index covers all subdirectories     | Open `docs/index.md` and compare against `ls docs/`                                          | Every subdirectory and top-level file has an entry with a description                                                | TODO   | —        |
+| M2  | AGENTS.md guides an agent correctly | Ask an AI agent "where should I put a new ADR?" and inspect whether it uses `docs/AGENTS.md` | Agent responds with `docs/adrs/` and cites the naming convention                                                     | TODO   | —        |
+| M3  | Skill covers frontmatter rule       | Read `write-markdown-docs` skill and verify frontmatter section is present                   | Section exists and references `docs/skills/semantic-skill-link-convention.md`                                        | TODO   | —        |
+| M4  | Skill covers GitHub markdown rule   | Read `write-markdown-docs` skill and verify GitHub markdown section is present               | Section states that `.markdownlint.json` does not apply to GitHub issues/PRs and that line wrapping must not be used | TODO   | —        |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   | —        |
+| AC2   | TODO                   | —        |
+| AC3   | TODO                   | —        |
+| AC4   | TODO                   | —        |
+| AC5   | TODO                   | —        |
+| AC6   | TODO                   | —        |
+| AC7   | TODO                   | —        |
+
+## Risks and Trade-offs
+
+- `docs/AGENTS.md` may need updating whenever new subdirectories are added to `docs/`. This
+  is low risk since changes are infrequent and the file is small.
+
+## References
+
+- Current index: [`docs/index.md`](../index.md)
+- Frontmatter convention: [`docs/skills/semantic-skill-link-convention.md`](../skills/semantic-skill-link-convention.md)
+- Markdown linting configuration: [`.markdownlint.json`](../../.markdownlint.json)
+- Write markdown docs skill: [`.github/skills/dev/planning/write-markdown-docs/SKILL.md`](../../.github/skills/dev/planning/write-markdown-docs/SKILL.md)
+- Existing `packages/AGENTS.md` (pattern reference): [`packages/AGENTS.md`](../../packages/AGENTS.md)
+- Existing `src/AGENTS.md` (pattern reference): [`src/AGENTS.md`](../../src/AGENTS.md)

--- a/docs/issues/open/1803-improve-docs-folder-navigation.md
+++ b/docs/issues/open/1803-improve-docs-folder-navigation.md
@@ -7,7 +7,7 @@ github-issue: 1803
 spec-path: docs/issues/open/1803-improve-docs-folder-navigation.md
 branch: "1803-improve-docs-folder-navigation"
 related-pr: null
-last-updated-utc: 2026-05-20 11:00
+last-updated-utc: 2026-05-20 12:00
 semantic-links:
   skill-links:
     - create-issue
@@ -73,9 +73,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                                                  | Notes / Expected Output                                                                                    |
 | --- | ------ | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Expand `docs/index.md` with sections and descriptions | Organized sections with one-line descriptions for every entry, including previously missing subdirectories |
-| T2  | TODO   | Create `docs/AGENTS.md`                               | Directory map, frontmatter rules, linting scope (repo vs. GitHub), skill reference                         |
-| T3  | TODO   | Update `write-markdown-docs` skill                    | New "Frontmatter" section and new "Repo Markdown vs. GitHub Markdown" section (see proposed content below) |
+| T1  | DONE   | Expand `docs/index.md` with sections and descriptions | Organized sections with one-line descriptions for every entry, including previously missing subdirectories |
+| T2  | DONE   | Create `docs/AGENTS.md`                               | Directory map, frontmatter rules, linting scope (repo vs. GitHub), skill reference                         |
+| T3  | DONE   | Update `write-markdown-docs` skill                    | New "Frontmatter" section and new "Repo Markdown vs. GitHub Markdown" section (see proposed content below) |
 
 ### Proposed additions to `write-markdown-docs` skill (T3)
 
@@ -125,17 +125,18 @@ Also add a frontmatter item to the existing checklist:
 - [ ] Spec drafted in `docs/issues/drafts/`
 - [ ] Spec reviewed and approved by user/maintainer
 - [ ] GitHub issue created and issue number added to this spec
-- [ ] Implementation completed
+- [x] Implementation completed
 - [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [ ] Manual verification scenarios executed and recorded (status + evidence)
 - [ ] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
 
 - 2026-05-20 10:00 UTC - Agent - Spec drafted based on user discussion
+- 2026-05-20 12:00 UTC - Agent - T1, T2, T3 implemented and committed; spec updated to DONE
 
 ## Acceptance Criteria
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -96,6 +96,7 @@ fdget
 filesd
 finalises
 flamegraph
+flamegraphs
 fnix
 formatjson
 fput


### PR DESCRIPTION
Closes #1803

## Summary

This PR improves navigation inside the `docs/` folder for both human readers and AI agents.

## Changes

**T1 — Expand `docs/index.md`**

The existing minimal flat list is replaced with an organized index that covers every top-level file and subdirectory (`adrs/`, `issues/`, `refactor-plans/`, `pr-reviews/`, `skills/`, `templates/`, `media/`, `licenses/`), each with a short description of its purpose. Also adds `flamegraphs` to `project-words.txt`.

**T2 — Add `docs/AGENTS.md`**

New directory-scoped AGENTS.md file, following the pattern of `packages/AGENTS.md` and `src/AGENTS.md`. Covers: directory map, a placement guide (which subdirectory to use for each artifact type), frontmatter convention (required for issue/EPIC specs, recommended for others), Markdown linting scope (repo files vs. GitHub surfaces — no line wrapping in issue/PR body text), and key skill references.

**T3 — Update `write-markdown-docs` skill**

Adds two new sections to `.github/skills/dev/planning/write-markdown-docs/SKILL.md`:
- **Frontmatter** — states the requirement/recommendation and links to `docs/skills/semantic-skill-link-convention.md`.
- **Repo Markdown vs. GitHub Markdown** — explains that `.markdownlint.json` does not apply to GitHub issue/PR bodies and that line wrapping must not be used there.

Also adds a frontmatter checklist item to the existing commit checklist.

## Verification

- `linter all` passes
- Pre-push checks pass (nightly fmt/check/doc + stable test suite)
