### PR TITLE
docs(skills): clarify upstream remote and rebase requirements in git-workflow skills

### DIFF
--- a/.github/skills/dev/git-workflow/create-feature-branch/SKILL.md
+++ b/.github/skills/dev/git-workflow/create-feature-branch/SKILL.md
@@ -17,6 +17,8 @@ conventions.
 - To merge into `develop` or `main`, you must open a PR in `torrust/torrust-tracker`.
 - That PR must come from a branch in a fork (`<fork-owner>:<branch>`), not a branch in the same repository.
 - Remote names are contributor-specific. Do not assume `origin` or `torrust`; identify remotes from `git remote -v`.
+- The upstream repository is `https://github.com/torrust/torrust-tracker`. Its remote is commonly named `torrust`, but verify with `git remote -v`.
+- Before branching, always fetch and pull the latest `develop` from the upstream remote to ensure the branch starts from an up-to-date base.
 
 ## Branch Naming Convention
 
@@ -40,9 +42,14 @@ Alternative formats (no tracked issue):
 ### Standard Workflow
 
 ```bash
-# Ensure you're on latest develop
+# Identify the upstream remote (points to https://github.com/torrust/torrust-tracker)
+# It is commonly named "torrust"; verify with: git remote -v
+UPSTREAM_REMOTE=torrust  # replace if your remote has a different name
+
+# Ensure you're on the latest develop from upstream
 git checkout develop
-git pull --ff-only
+git fetch $UPSTREAM_REMOTE
+git pull --ff-only $UPSTREAM_REMOTE develop
 
 # Create and checkout branch for issue #42
 git checkout -b 42-add-peer-expiry-grace-period
@@ -76,8 +83,12 @@ git checkout -b 42-add-peer-expiry-grace-period
 ### 1. Create Branch from `develop`
 
 ```bash
+# Identify the upstream remote (commonly "torrust"; verify with git remote -v)
+UPSTREAM_REMOTE=torrust  # replace if your remote has a different name
+
 git checkout develop
-git pull --ff-only
+git fetch $UPSTREAM_REMOTE
+git pull --ff-only $UPSTREAM_REMOTE develop
 git checkout -b 42-add-peer-expiry-grace-period
 ```
 

--- a/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
+++ b/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
@@ -19,11 +19,33 @@ Before opening a PR:
 
 - [ ] Working tree is clean (`git status`)
 - [ ] Upstream target repository confirmed from workspace metadata (`Cargo.toml` → `repository`)
+- [ ] Branch is rebased on the latest `develop` from upstream (`<upstream-remote>/develop`); verify with `git log --oneline <upstream-remote>/develop..HEAD` and rebase if behind
 - [ ] Branch is pushed to your fork remote
 - [ ] Commits are GPG signed (`git log --show-signature -n 1`)
 - [ ] All pre-commit checks passed (`linter all`, `cargo machete`, tests)
 - [ ] PR body claims are aligned with the actual commit range (`<upstream-remote>/develop..HEAD`)
 - [ ] If manual verification used temporary local-only patches, PR body explicitly says they are not included
+
+### Keeping the branch up to date
+
+Always rebase your branch on the latest upstream `develop` before pushing — both when opening
+a PR for the first time and when pushing updates to an existing PR:
+
+```bash
+# Identify the upstream remote (commonly "torrust"; verify with git remote -v)
+UPSTREAM_REMOTE=torrust  # replace if your remote has a different name
+
+git fetch $UPSTREAM_REMOTE
+git rebase $UPSTREAM_REMOTE/develop
+
+# Then push (use --force-with-lease when rewriting history)
+git push --force-with-lease <fork-remote> <branch-name>
+```
+
+> In general, every PR targeting `develop` should sit on top of the latest commit in
+> `<upstream-remote>/develop`. Check this whenever you push or re-push.
+
+<!-- markdownlint-disable-next-line MD028 -->
 
 > Important:
 >

--- a/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
+++ b/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
@@ -19,7 +19,7 @@ Before opening a PR:
 
 - [ ] Working tree is clean (`git status`)
 - [ ] Upstream target repository confirmed from workspace metadata (`Cargo.toml` → `repository`)
-- [ ] Branch is rebased on the latest `develop` from upstream (`<upstream-remote>/develop`); verify with `git log --oneline <upstream-remote>/develop..HEAD` and rebase if behind
+- [ ] Branch is rebased on the latest `develop` from upstream (`<upstream-remote>/develop`); verify with `git log --oneline HEAD..<upstream-remote>/develop` (empty output means up to date) and rebase if behind
 - [ ] Branch is pushed to your fork remote
 - [ ] Commits are GPG signed (`git log --show-signature -n 1`)
 - [ ] All pre-commit checks passed (`linter all`, `cargo machete`, tests)


### PR DESCRIPTION
## Summary

Clarifies two important workflow points in the git-workflow skills that were implicit or missing.

### Changes

**`.github/skills/dev/git-workflow/create-feature-branch/SKILL.md`**

- Added to Delivery Policy: the upstream remote is `https://github.com/torrust/torrust-tracker`, commonly named `torrust`; always fetch and pull from it before branching.
- Updated both the Standard Workflow and Complete Branch Lifecycle snippets to use an explicit `UPSTREAM_REMOTE` variable, `git fetch $UPSTREAM_REMOTE`, and `git pull --ff-only $UPSTREAM_REMOTE develop` before creating the branch.

**`.github/skills/dev/git-workflow/open-pull-request/SKILL.md`**

- Added a pre-flight checklist item: branch must be rebased on the latest `<upstream-remote>/develop`.
- Added a dedicated "Keeping the branch up to date" section with the explicit fetch + rebase + force-with-lease push workflow to use both when opening a PR and when pushing updates to an existing one.

## Validation

- Pre-commit checks pass (`cargo machete`, `linter all`, doc tests).

Related to #1750