### PR TITLE
feat(deps): use cargo machete --with-metadata and remove unused dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,39 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,92 +171,6 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.5.0",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
- "tokio",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener 5.4.1",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-attributes",
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -311,14 +192,8 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -328,7 +203,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -486,7 +361,7 @@ checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -590,11 +465,9 @@ dependencies = [
  "bittorrent-primitives",
  "bittorrent-tracker-core",
  "criterion 0.5.1",
- "formatjson",
  "futures",
  "mockall",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -634,7 +507,6 @@ version = "3.0.0-develop"
 dependencies = [
  "compact_str",
  "hex",
- "pretty_assertions",
  "quickcheck",
  "regex",
  "serde",
@@ -686,7 +558,6 @@ dependencies = [
  "chrono",
  "clap",
  "derive_more 2.1.1",
- "local-ip-address",
  "mockall",
  "rand 0.10.1",
  "serde",
@@ -696,7 +567,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
- "torrust-rest-tracker-api-client",
  "torrust-tracker-clock",
  "torrust-tracker-configuration",
  "torrust-tracker-events",
@@ -734,7 +604,6 @@ dependencies = [
  "torrust-tracker-metrics",
  "torrust-tracker-primitives",
  "torrust-tracker-swarm-coordination-registry",
- "torrust-tracker-test-helpers",
  "tracing",
  "zerocopy",
 ]
@@ -768,19 +637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel 2.5.0",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1069,7 +925,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1424,7 +1280,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1437,7 +1293,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1448,7 +1304,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1459,7 +1315,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1515,7 +1371,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1525,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1554,7 +1410,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1568,7 +1424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-xid",
 ]
 
@@ -1610,7 +1466,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1725,28 +1581,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.1",
  "pin-project-lite",
 ]
 
@@ -1961,19 +1801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,7 +1808,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2079,7 +1906,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2093,18 +1920,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -2653,7 +2468,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2672,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2695,15 +2510,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -2793,9 +2599,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2852,7 +2655,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2915,7 +2718,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2976,7 +2779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3150,7 +2953,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3238,7 +3041,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "structmeta",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3271,7 +3074,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3319,7 +3122,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3387,7 +3190,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3395,23 +3198,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
 
 [[package]]
 name = "pkcs1"
@@ -3472,20 +3258,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3570,7 +3342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3601,7 +3373,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3621,7 +3393,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "version_check",
  "yansi",
 ]
@@ -3646,7 +3418,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3677,7 +3449,7 @@ checksum = "a9a28b8493dd664c8b171dd944da82d933f7d456b829bfb236738e1fe06c5ba4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3888,7 +3660,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4057,7 +3829,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-ident",
 ]
 
@@ -4075,7 +3847,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.117",
+ "syn",
  "unicode-ident",
 ]
 
@@ -4326,7 +4098,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4375,7 +4147,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4437,7 +4209,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4615,7 +4387,7 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.4.1",
+ "event-listener",
  "futures-core",
  "futures-intrusive",
  "futures-io",
@@ -4649,7 +4421,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4672,7 +4444,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn",
  "tokio",
  "url",
 ]
@@ -4818,7 +4590,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4829,7 +4601,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4861,17 +4633,6 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4898,7 +4659,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5035,7 +4796,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5046,7 +4807,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5148,7 +4909,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5365,7 +5126,6 @@ dependencies = [
  "torrust-udp-tracker-server",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -5399,7 +5159,6 @@ dependencies = [
  "torrust-server-lib",
  "torrust-tracker-clock",
  "torrust-tracker-configuration",
- "torrust-tracker-events",
  "torrust-tracker-primitives",
  "torrust-tracker-swarm-coordination-registry",
  "torrust-tracker-test-helpers",
@@ -5407,7 +5166,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "uuid",
- "zerocopy",
 ]
 
 [[package]]
@@ -5424,8 +5182,6 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "hyper",
- "local-ip-address",
- "mockall",
  "reqwest",
  "serde",
  "serde_json",
@@ -5516,7 +5272,6 @@ name = "torrust-server-lib"
 version = "3.0.0-develop"
 dependencies = [
  "derive_more 2.1.1",
- "rstest 0.25.0",
  "tokio",
  "torrust-net-primitives",
  "tower-http",
@@ -5537,8 +5292,6 @@ dependencies = [
  "bittorrent-udp-tracker-core",
  "chrono",
  "clap",
- "local-ip-address",
- "mockall",
  "pbkdf2",
  "rand 0.10.1",
  "regex",
@@ -5673,7 +5426,6 @@ dependencies = [
  "bittorrent-peer-id",
  "bittorrent-primitives",
  "derive_more 2.1.1",
- "rstest 0.25.0",
  "serde",
  "tdyne-peer-id",
  "tdyne-peer-id-registry",
@@ -5686,14 +5438,11 @@ dependencies = [
 name = "torrust-tracker-swarm-coordination-registry"
 version = "3.0.0-develop"
 dependencies = [
- "async-std",
  "bittorrent-primitives",
  "chrono",
- "criterion 0.8.2",
  "crossbeam-skiplist",
  "futures",
  "mockall",
- "rand 0.10.1",
  "rstest 0.26.1",
  "serde",
  "thiserror 2.0.18",
@@ -5704,7 +5453,6 @@ dependencies = [
  "torrust-tracker-events",
  "torrust-tracker-metrics",
  "torrust-tracker-primitives",
- "torrust-tracker-test-helpers",
  "tracing",
 ]
 
@@ -5722,7 +5470,6 @@ dependencies = [
 name = "torrust-tracker-torrent-repository-benchmarking"
 version = "3.0.0-develop"
 dependencies = [
- "async-std",
  "bittorrent-primitives",
  "criterion 0.8.2",
  "crossbeam-skiplist",
@@ -5748,7 +5495,6 @@ dependencies = [
  "derive_more 2.1.1",
  "futures",
  "futures-util",
- "local-ip-address",
  "mockall",
  "rand 0.10.1",
  "ringbuf",
@@ -5846,7 +5592,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6069,12 +5815,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6177,7 +5917,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -6315,7 +6055,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6326,7 +6066,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6640,7 +6380,7 @@ dependencies = [
  "heck",
  "indexmap 2.14.0",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6656,7 +6396,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6749,7 +6489,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6770,7 +6510,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6790,7 +6530,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6830,7 +6570,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,6 @@ tracing-subscriber = { version = "0", features = [ "json" ] }
 [dev-dependencies]
 bittorrent-primitives = "0.2.0"
 bittorrent-tracker-client = { version = "3.0.0-develop", path = "packages/tracker-client" }
-local-ip-address = "0"
-mockall = "0"
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "packages/test-helpers" }
 
 [workspace]

--- a/contrib/dev-tools/git/hooks/pre-commit.sh
+++ b/contrib/dev-tools/git/hooks/pre-commit.sh
@@ -18,7 +18,7 @@ set -uo pipefail
 # Each step: "description|command"
 
 declare -a STEPS=(
-    "Checking for unused dependencies (cargo machete)|cargo machete"
+    "Checking for unused dependencies (cargo machete)|cargo machete --with-metadata"
     "Running all linters|linter all"
     "Running documentation tests|cargo test --doc --workspace"
 )

--- a/contrib/dev-tools/git/hooks/pre-commit.sh
+++ b/contrib/dev-tools/git/hooks/pre-commit.sh
@@ -18,7 +18,7 @@ set -uo pipefail
 # Each step: "description|command"
 
 declare -a STEPS=(
-    "Checking for unused dependencies (cargo machete)|cargo machete --with-metadata"
+    "Checking for unused dependencies (cargo machete --with-metadata)|cargo machete --with-metadata"
     "Running all linters|linter all"
     "Running documentation tests|cargo test --doc --workspace"
 )

--- a/docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
+++ b/docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: implemented
 priority: p2
 github-issue: 1804
 spec-path: docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
 branch: "1804-use-cargo-machete-with-metadata"
 related-pr: null
-last-updated-utc: 2026-05-20 00:00
+last-updated-utc: 2026-05-20 12:30
 semantic-links:
   skill-links:
     - create-issue
@@ -78,29 +78,29 @@ files across the workspace.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                                                                      | Notes / Expected Output                                        |
-| --- | ------ | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| T1  | TODO   | Run `cargo machete --with-metadata` and record the full list of flagged dependencies      | Baseline list; confirm each is genuinely unused before removal |
-| T2  | TODO   | Update `contrib/dev-tools/git/hooks/pre-commit.sh` to use `cargo machete --with-metadata` | Hook passes with the new flag                                  |
-| T3  | TODO   | Update CI workflow(s) that call `cargo machete` without `--with-metadata`                 | CI step passes with the new flag                               |
-| T4  | TODO   | Remove flagged unused dependencies from all `Cargo.toml` files                            | `cargo machete --with-metadata` reports clean after removals   |
-| T5  | TODO   | Run `cargo build --workspace` and `cargo test --workspace`                                | Clean build; all tests pass                                    |
-| T6  | TODO   | Run `linter all`                                                                          | Exit code `0`                                                  |
+| ID  | Status | Task                                                                                      | Notes / Expected Output                                                                               |
+| --- | ------ | ----------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Run `cargo machete --with-metadata` and record the full list of flagged dependencies      | 22 unused deps found across 13 packages; 1 false-positive (`serde_bytes`) handled via ignore list     |
+| T2  | DONE   | Update `contrib/dev-tools/git/hooks/pre-commit.sh` to use `cargo machete --with-metadata` | Hook passes with the new flag                                                                         |
+| T3  | DONE   | Update CI workflow(s) that call `cargo machete` without `--with-metadata`                 | N/A — only `copilot-setup-steps.yml` exists in this repo and only installs the tool; does not call it |
+| T4  | DONE   | Remove flagged unused dependencies from all `Cargo.toml` files                            | `cargo machete --with-metadata` reports clean after removals                                          |
+| T5  | DONE   | Run `cargo build --workspace` and `cargo test --workspace`                                | Clean build; all tests pass                                                                           |
+| T6  | DONE   | Run `linter all`                                                                          | Exit code `0`                                                                                         |
 
 ## Progress Tracking
 
 ### Workflow Checkpoints
 
 - [x] Spec drafted in `docs/issues/drafts/`
-- [ ] Spec reviewed and approved by user/maintainer
-- [ ] GitHub issue created and issue number added to this spec
-- [ ] Spec moved to `docs/issues/open/` with issue number prefix
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, `cargo test --workspace`)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue created and issue number added to this spec
+- [x] Spec moved to `docs/issues/open/` with issue number prefix
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, `cargo test --workspace`)
+- [x] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
@@ -108,17 +108,22 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-05-20 00:00 UTC - josecelano - Spec drafted. Root cause identified: plain `cargo machete`
   has false negatives for dev dependencies; `--with-metadata` mode is accurate. Full list of
   unused deps generated by running `cargo machete --with-metadata` in the workspace.
+- 2026-05-20 12:30 UTC - josecelano - Implementation complete. Removed 21 genuine unused
+  dev-deps across 13 `Cargo.toml` files; 1 machete false-positive (`serde_bytes` in
+  `axum-http-tracker-server`, used via `#[serde(with = "serde_bytes")]` string attribute)
+  kept and suppressed via `[package.metadata.cargo-machete] ignored`. T3 is N/A — no CI
+  workflow in this repo calls plain `cargo machete`. Commit: `225e74fc`.
 
 ## Acceptance Criteria
 
-- [ ] AC1: The pre-commit hook calls `cargo machete --with-metadata` (not plain `cargo machete`).
-- [ ] AC2: All CI workflow steps that call `cargo machete` use `--with-metadata`.
-- [ ] AC3: `cargo machete --with-metadata` exits `0` across the entire workspace (no unused deps).
-- [ ] AC4: `cargo build --workspace` and `cargo test --workspace` pass cleanly after dep removals.
-- [ ] AC5: `linter all` exits with code `0`.
-- [ ] Manual verification scenarios are executed and documented (status + evidence).
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
-- [ ] Documentation is updated when behaviour or workflow changes.
+- [x] AC1: The pre-commit hook calls `cargo machete --with-metadata` (not plain `cargo machete`).
+- [x] AC2: All CI workflow steps that call `cargo machete` use `--with-metadata` (N/A — no CI step calls it in this repo).
+- [x] AC3: `cargo machete --with-metadata` exits `0` across the entire workspace (no unused deps).
+- [x] AC4: `cargo build --workspace` and `cargo test --workspace` pass cleanly after dep removals.
+- [x] AC5: `linter all` exits with code `0`.
+- [x] Manual verification scenarios are executed and documented (status + evidence).
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [x] Documentation is updated when behaviour or workflow changes.
 
 ## Verification Plan
 
@@ -133,21 +138,21 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                                           | Command/Steps                                            | Expected Result                                  | Status | Evidence |
-| --- | -------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------ | ------ | -------- |
-| M1  | Pre-commit hook uses `--with-metadata`             | `grep machete contrib/dev-tools/git/hooks/pre-commit.sh` | Output includes `--with-metadata`                | TODO   |          |
-| M2  | No unused deps remain after removals               | `cargo machete --with-metadata`                          | "didn't find any unused dependencies. Good job!" | TODO   |          |
-| M3  | Workspace builds and tests pass after dep removals | `cargo build --workspace && cargo test --workspace`      | Both commands exit `0`                           | TODO   |          |
+| ID  | Scenario                                           | Command/Steps                                            | Expected Result                                  | Status | Evidence                                                                         |
+| --- | -------------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------ | ------ | -------------------------------------------------------------------------------- |
+| M1  | Pre-commit hook uses `--with-metadata`             | `grep machete contrib/dev-tools/git/hooks/pre-commit.sh` | Output includes `--with-metadata`                | DONE   | Line confirms: `cargo machete --with-metadata`                                   |
+| M2  | No unused deps remain after removals               | `cargo machete --with-metadata`                          | "didn't find any unused dependencies. Good job!" | DONE   | `cargo-machete didn't find any unused dependencies in this directory. Good job!` |
+| M3  | Workspace builds and tests pass after dep removals | `cargo build --workspace && cargo test --workspace`      | Both commands exit `0`                           | DONE   | Both exit `0`; full test suite passes                                            |
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence |
-| ----- | ---------------------- | -------- |
-| AC1   | TODO                   |          |
-| AC2   | TODO                   |          |
-| AC3   | TODO                   |          |
-| AC4   | TODO                   |          |
-| AC5   | TODO                   |          |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                               |
+| ----- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| AC1   | DONE                   | `grep` on pre-commit.sh confirms `cargo machete --with-metadata`                                       |
+| AC2   | DONE                   | N/A — no CI workflow in this repo calls `cargo machete` directly                                       |
+| AC3   | DONE                   | `cargo machete --with-metadata` exits `0`: "didn't find any unused dependencies. Good job!"            |
+| AC4   | DONE                   | `cargo build --workspace` and `cargo test --workspace` both exit `0`                                   |
+| AC5   | DONE                   | `linter all` exits `0`: all linters (markdown, yaml, toml, cspell, clippy, rustfmt, shellcheck) passed |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
+++ b/docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
@@ -6,7 +6,7 @@ priority: p2
 github-issue: 1804
 spec-path: docs/issues/open/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
 branch: "1804-use-cargo-machete-with-metadata"
-related-pr: null
+related-pr: 1809
 last-updated-utc: 2026-05-20 12:30
 semantic-links:
   skill-links:

--- a/packages/axum-health-check-api-server/Cargo.toml
+++ b/packages/axum-health-check-api-server/Cargo.toml
@@ -37,4 +37,3 @@ torrust-axum-rest-tracker-api-server = { version = "3.0.0-develop", path = "../a
 torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 torrust-udp-tracker-server = { version = "3.0.0-develop", path = "../udp-tracker-server" }
-tracing-subscriber = { version = "0", features = [ "json" ] }

--- a/packages/axum-http-tracker-server/Cargo.toml
+++ b/packages/axum-http-tracker-server/Cargo.toml
@@ -48,7 +48,10 @@ serde_bencode = "0"
 serde_bytes = "0"
 serde_repr = "0"
 torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 uuid = { version = "1", features = [ "v4" ] }
-zerocopy = "0.8"
+
+# cargo-machete cannot detect `serde_bytes` usage via `#[serde(with = "serde_bytes")]`
+# string attributes in test code; suppress the false-positive.
+[package.metadata.cargo-machete]
+ignored = [ "serde_bytes" ]

--- a/packages/axum-rest-tracker-api-server/Cargo.toml
+++ b/packages/axum-rest-tracker-api-server/Cargo.toml
@@ -47,8 +47,6 @@ tracing = "0"
 url = "2"
 
 [dev-dependencies]
-local-ip-address = "0"
-mockall = "0"
 torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "../rest-tracker-api-client" }
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 url = { version = "2", features = [ "serde" ] }

--- a/packages/http-tracker-core/Cargo.toml
+++ b/packages/http-tracker-core/Cargo.toml
@@ -33,9 +33,7 @@ torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path 
 tracing = "0"
 
 [dev-dependencies]
-formatjson = "0.3.1"
 mockall = "0"
-serde_json = "1.0.140"
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 
 [[bench]]

--- a/packages/peer-id/Cargo.toml
+++ b/packages/peer-id/Cargo.toml
@@ -27,6 +27,3 @@ quickcheck = { version = "1", optional = true }
 regex = "1"
 serde = { version = "1", features = [ "derive" ], optional = true }
 zerocopy = { version = "0.8", features = [ "derive" ], optional = true }
-
-[dev-dependencies]
-pretty_assertions = "1"

--- a/packages/primitives/Cargo.toml
+++ b/packages/primitives/Cargo.toml
@@ -25,6 +25,3 @@ tdyne-peer-id-registry = "0"
 thiserror = "2"
 torrust-net-primitives = { version = "3.0.0-develop", path = "../net-primitives" }
 torrust-tracker-clock = { version = "3.0.0-develop", path = "../clock" }
-
-[dev-dependencies]
-rstest = "0.25.0"

--- a/packages/server-lib/Cargo.toml
+++ b/packages/server-lib/Cargo.toml
@@ -19,6 +19,3 @@ tokio = { version = "1", features = [ "macros", "net", "rt-multi-thread", "signa
 torrust-net-primitives = { version = "3.0.0-develop", path = "../net-primitives" }
 tower-http = { version = "0", features = [ "compression-full", "cors", "propagate-header", "request-id", "trace" ] }
 tracing = "0"
-
-[dev-dependencies]
-rstest = "0.25.0"

--- a/packages/swarm-coordination-registry/Cargo.toml
+++ b/packages/swarm-coordination-registry/Cargo.toml
@@ -32,9 +32,5 @@ torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives"
 tracing = "0"
 
 [dev-dependencies]
-async-std = { version = "1", features = [ "attributes", "tokio1" ] }
-criterion = { version = "0", features = [ "async_tokio" ] }
 mockall = "0"
-rand = "0"
 rstest = "0"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }

--- a/packages/torrent-repository-benchmarking/Cargo.toml
+++ b/packages/torrent-repository-benchmarking/Cargo.toml
@@ -27,7 +27,6 @@ torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configur
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 
 [dev-dependencies]
-async-std = { version = "1", features = [ "attributes", "tokio1" ] }
 criterion = { version = "0", features = [ "async_tokio" ] }
 rstest = "0"
 

--- a/packages/tracker-core/Cargo.toml
+++ b/packages/tracker-core/Cargo.toml
@@ -43,8 +43,6 @@ testcontainers = "0"
 tracing = "0"
 
 [dev-dependencies]
-local-ip-address = "0"
 mockall = "0"
-torrust-rest-tracker-api-client = { version = "3.0.0-develop", path = "../rest-tracker-api-client" }
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 url = "2.5.4"

--- a/packages/udp-tracker-core/Cargo.toml
+++ b/packages/udp-tracker-core/Cargo.toml
@@ -39,7 +39,6 @@ zerocopy = "0.8"
 
 [dev-dependencies]
 mockall = "0"
-torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }
 
 [[bench]]
 harness = false

--- a/packages/udp-tracker-server/Cargo.toml
+++ b/packages/udp-tracker-server/Cargo.toml
@@ -41,7 +41,6 @@ uuid = { version = "1", features = [ "v4" ] }
 zerocopy = "0.8"
 
 [dev-dependencies]
-local-ip-address = "0"
 mockall = "0"
 rand = "0"
 torrust-tracker-test-helpers = { version = "3.0.0-develop", path = "../test-helpers" }


### PR DESCRIPTION
## Summary

Fixes #1804.

Plain `cargo machete` uses text-scan which produces false negatives for dev-dependencies.
Switching to `cargo machete --with-metadata` (which uses `cargo metadata` for accurate
crate-name resolution) revealed 22 unused dev-dependencies that the old check was silently
missing.

## Changes

### Pre-commit hook

- `contrib/dev-tools/git/hooks/pre-commit.sh`: changed `cargo machete` → `cargo machete --with-metadata`

### Cargo.toml files cleaned up (21 genuine unused dev-deps removed across 13 files)

| Package | Removed dev-dependencies |
|---|---|
| root `Cargo.toml` | `local-ip-address`, `mockall` |
| `packages/axum-health-check-api-server` | `tracing-subscriber` |
| `packages/axum-http-tracker-server` | `torrust-tracker-events`, `zerocopy` |
| `packages/axum-rest-tracker-api-server` | `local-ip-address`, `mockall` |
| `packages/http-tracker-core` | `formatjson`, `serde_json` |
| `packages/peer-id` | `pretty_assertions` (entire `[dev-dependencies]` removed) |
| `packages/primitives` | `rstest` (entire `[dev-dependencies]` removed) |
| `packages/server-lib` | `rstest` (entire `[dev-dependencies]` removed) |
| `packages/swarm-coordination-registry` | `async-std`, `criterion`, `rand`, `torrust-tracker-test-helpers` |
| `packages/torrent-repository-benchmarking` | `async-std` |
| `packages/tracker-core` | `local-ip-address`, `torrust-rest-tracker-api-client` |
| `packages/udp-tracker-core` | `torrust-tracker-test-helpers` |
| `packages/udp-tracker-server` | `local-ip-address` |

### False-positive handled

`serde_bytes` in `packages/axum-http-tracker-server` is used via `#[serde(with = "serde_bytes")]`
string attributes in test code — `cargo machete` cannot detect this pattern. It is kept and
suppressed via:

```toml
[package.metadata.cargo-machete]
ignored = ["serde_bytes"]
# cargo-machete cannot detect serde_bytes usage via #[serde(with = "serde_bytes")] string
# attributes in test code; suppress the false-positive.
```

### CI note

Only `.github/workflows/copilot-setup-steps.yml` exists in this repo and it only _installs_
`cargo-machete` (no invocation) — no CI update was needed.

## Verification

- `cargo machete --with-metadata` → "didn't find any unused dependencies. Good job!"
- `cargo build --workspace` → exit 0
- `cargo test --workspace` → all tests pass
- `linter all` → exit 0 (markdownlint, yamllint, taplo, cspell, clippy, rustfmt, shellcheck)
- Pre-commit hook ran and passed before commit `225e74fc`
