### PR TITLE
docs(frontmatter): add YAML frontmatter and semantic links to all docs/ Markdown files (#1810)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - docs/skills/semantic-skill-link-convention.md
+---
+
 # `docs/` — Documentation Directory
 
 This directory contains all project documentation: operational guides, architectural decision

--- a/docs/adrs/20240227164834_use_plural_for_modules_containing_collections.md
+++ b/docs/adrs/20240227164834_use_plural_for_modules_containing_collections.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - src/
+---
+
 # Use plural for modules containing collections of types
 
 ## Description

--- a/docs/adrs/20260420200013_adopt_custom_github_copilot_aligned_agent_framework.md
+++ b/docs/adrs/20260420200013_adopt_custom_github_copilot_aligned_agent_framework.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - AGENTS.md
+    - .github/skills/
+    - .github/agents/
+---
+
 # Adopt a Custom, GitHub-Copilot-Aligned Agent Framework
 
 ## Description

--- a/docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md
+++ b/docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - docs/packages.md
+    - packages/tracker-core/
+---
+
 # Keep `Database` as an Aggregate Supertrait
 
 ## Description

--- a/docs/adrs/20260512102000_define_tracker_client_peer_id_convention.md
+++ b/docs/adrs/20260512102000_define_tracker_client_peer_id_convention.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - packages/peer-id/
+    - packages/tracker-client/
+    - console/tracker-client/
+---
+
 # Define Tracker-Client Peer ID Convention
 
 ## Description

--- a/docs/adrs/20260519000000_define_global_cli_output_contract.md
+++ b/docs/adrs/20260519000000_define_global_cli_output_contract.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - src/main.rs
+    - src/bin/
+    - console/tracker-client/
+---
+
 # Define the Global CLI Output Contract
 
 ## Description

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - docs/index.md
+    - docs/adrs/index.md
+    - .github/skills/dev/planning/create-adr/SKILL.md
+---
+
 # Architectural Decision Records (ADRs)
 
 This directory contains the architectural decision records (ADRs) for the project.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - docs/index.md
+    - docs/adrs/README.md
+---
+
 # ADR Index
 
 | ADR                                                                                     | Date       | Title                                                  | Short Description                                                                                                                                                                                                                          |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - docs/profiling.md
+    - packages/torrent-repository-benchmarking/
+    - share/default/config/tracker.udp.benchmarking.toml
+---
+
 # Benchmarking
 
 We have two types of benchmarking:
@@ -211,11 +222,11 @@ Announce responses per info hash:
 
 Announce request per second:
 
-| Tracker       |  Announce |
-|---------------|-----------|
-| Aquatic       |   192,817 |
-| Torrust       |   177,508 |
-| Torrust-Actix |    89,539 |
+| Tracker       | Announce |
+| ------------- | -------- |
+| Aquatic       | 192,817  |
+| Torrust       | 177,508  |
+| Torrust-Actix | 89,539   |
 
 Using a PC with:
 
@@ -244,7 +255,7 @@ You can run it with:
 cargo bench -p torrust-tracker-torrent-repository
 ```
 
-It tests the different implementations for the internal torrent storage.  The output should be something like this:
+It tests the different implementations for the internal torrent storage. The output should be something like this:
 
 ```output
      Running benches/repository_benchmark.rs (target/release/deps/repository_benchmark-2f7830898bbdfba4)

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - Containerfile
+    - share/container/entry_script_sh
+---
+
 # Containers (Docker or Podman)
 
 ## Demo environment

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,23 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/AGENTS.md
+    - docs/benchmarking.md
+    - docs/containers.md
+    - docs/packages.md
+    - docs/profiling.md
+    - docs/release_process.md
+    - docs/adrs/README.md
+    - docs/adrs/index.md
+    - docs/issues/README.md
+    - docs/pr-reviews/README.md
+    - docs/refactor-plans/closed/README.md
+    - docs/refactor-plans/drafts/README.md
+    - docs/refactor-plans/open/README.md
+---
+
 # Torrust Tracker — Documentation Index
 
 This is the entry point for all project documentation. For API documentation generated from
@@ -7,60 +27,60 @@ source code, see the [crate docs on docs.rs][docs].
 
 Operational and development guides for working with the tracker.
 
-| Document | Description |
-| -------- | ----------- |
-| [benchmarking.md](benchmarking.md) | How to run and interpret the torrent-repository benchmarks |
-| [containers.md](containers.md) | Building and running the tracker with Docker / Podman |
-| [packages.md](packages.md) | Workspace package catalog, architecture layers, and dependency rules |
-| [profiling.md](profiling.md) | CPU and memory profiling with Valgrind / kcachegrind |
+| Document                                 | Description                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------- |
+| [benchmarking.md](benchmarking.md)       | How to run and interpret the torrent-repository benchmarks           |
+| [containers.md](containers.md)           | Building and running the tracker with Docker / Podman                |
+| [packages.md](packages.md)               | Workspace package catalog, architecture layers, and dependency rules |
+| [profiling.md](profiling.md)             | CPU and memory profiling with Valgrind / kcachegrind                 |
 | [release_process.md](release_process.md) | Branch strategy, versioning, and the staging → main release pipeline |
 
 ## Architecture Decisions (ADRs)
 
 Records of significant architectural decisions, including context and consequences.
 
-| Document | Description |
-| -------- | ----------- |
+| Document                         | Description                                        |
+| -------------------------------- | -------------------------------------------------- |
 | [adrs/README.md](adrs/README.md) | Index of all ADRs and guidance on writing new ones |
-| [adrs/index.md](adrs/index.md) | Quick-reference table of every ADR |
+| [adrs/index.md](adrs/index.md)   | Quick-reference table of every ADR                 |
 
 ## Issue Specifications
 
 Structured specification documents linked to GitHub issues. Used for planning and tracking
 implementation work before and during development.
 
-| Location | Description |
-| -------- | ----------- |
+| Location                             | Description                                               |
+| ------------------------------------ | --------------------------------------------------------- |
 | [issues/README.md](issues/README.md) | Overview, folder structure, and workflow skill references |
-| [issues/drafts/](issues/drafts/) | Specs not yet linked to a GitHub issue |
-| [issues/open/](issues/open/) | Active specs for open GitHub issues |
-| [issues/closed/](issues/closed/) | Recently closed specs kept temporarily for reference |
+| [issues/drafts/](issues/drafts/)     | Specs not yet linked to a GitHub issue                    |
+| [issues/open/](issues/open/)         | Active specs for open GitHub issues                       |
+| [issues/closed/](issues/closed/)     | Recently closed specs kept temporarily for reference      |
 
 ## Refactor Plans
 
 Specification documents for larger refactoring efforts, following the same lifecycle as issue
 specs (drafts → open → closed).
 
-| Location | Description |
-| -------- | ----------- |
+| Location                                         | Description                                         |
+| ------------------------------------------------ | --------------------------------------------------- |
 | [refactor-plans/drafts/](refactor-plans/drafts/) | Draft refactor plans not yet tied to a GitHub issue |
-| [refactor-plans/open/](refactor-plans/open/) | Active refactor plan specs |
-| [refactor-plans/closed/](refactor-plans/closed/) | Completed refactor plans kept for reference |
+| [refactor-plans/open/](refactor-plans/open/)     | Active refactor plan specs                          |
+| [refactor-plans/closed/](refactor-plans/closed/) | Completed refactor plans kept for reference         |
 
 ## PR Reviews
 
 Records of notable pull request reviews and Copilot suggestion threads.
 
-| Document | Description |
-| -------- | ----------- |
+| Document                                     | Description                       |
+| -------------------------------------------- | --------------------------------- |
 | [pr-reviews/README.md](pr-reviews/README.md) | Overview of the PR review archive |
 
 ## Skills and Conventions
 
 Internal documentation on project-specific conventions used by both humans and AI agents.
 
-| Document | Description |
-| -------- | ----------- |
+| Document                                                                             | Description                                                                                |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
 | [skills/semantic-skill-link-convention.md](skills/semantic-skill-link-convention.md) | Frontmatter schema, `skill-link` marker catalog, and machine-readable metadata conventions |
 
 ## Templates
@@ -68,31 +88,31 @@ Internal documentation on project-specific conventions used by both humans and A
 Canonical document templates. Copy the appropriate template when creating a new artifact of
 that type.
 
-| Template | Description |
-| -------- | ----------- |
-| [templates/ADR.md](templates/ADR.md) | Template for Architectural Decision Records |
-| [templates/EPIC.md](templates/EPIC.md) | Template for EPIC issue specifications |
-| [templates/ISSUE.md](templates/ISSUE.md) | Template for task / bug / feature issue specifications |
-| [templates/REFACTOR-PLAN.md](templates/REFACTOR-PLAN.md) | Template for refactor plan specifications |
-| [templates/COPILOT-SUGGESTIONS-TEMPLATE.md](templates/COPILOT-SUGGESTIONS-TEMPLATE.md) | Template for recording Copilot PR review suggestions |
+| Template                                                                               | Description                                            |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| [templates/ADR.md](templates/ADR.md)                                                   | Template for Architectural Decision Records            |
+| [templates/EPIC.md](templates/EPIC.md)                                                 | Template for EPIC issue specifications                 |
+| [templates/ISSUE.md](templates/ISSUE.md)                                               | Template for task / bug / feature issue specifications |
+| [templates/REFACTOR-PLAN.md](templates/REFACTOR-PLAN.md)                               | Template for refactor plan specifications              |
+| [templates/COPILOT-SUGGESTIONS-TEMPLATE.md](templates/COPILOT-SUGGESTIONS-TEMPLATE.md) | Template for recording Copilot PR review suggestions   |
 
 ## Media
 
 Images, diagrams, flamegraphs, benchmark reports, and sample torrent files used in
 documentation.
 
-| Location | Description |
-| -------- | ----------- |
-| [media/](media/) | Top-level media assets (flamegraphs, benchmark screenshots, sample torrents) |
-| [media/demo/](media/demo/) | Screenshots and assets used in demo documentation |
-| [media/packages/](media/packages/) | Package architecture diagrams |
+| Location                           | Description                                                                  |
+| ---------------------------------- | ---------------------------------------------------------------------------- |
+| [media/](media/)                   | Top-level media assets (flamegraphs, benchmark screenshots, sample torrents) |
+| [media/demo/](media/demo/)         | Screenshots and assets used in demo documentation                            |
+| [media/packages/](media/packages/) | Package architecture diagrams                                                |
 
 ## Licenses
 
 Full license texts referenced by the project.
 
-| Location | Description |
-| -------- | ----------- |
+| Location               | Description                      |
+| ---------------------- | -------------------------------- |
 | [licenses/](licenses/) | AGPL-3.0 and MIT-0 license files |
 
 [docs]: https://docs.rs/torrust-tracker/latest/torrust_tracker/

--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,3 +1,17 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - cleanup-completed-issues
+  related-artifacts:
+    - docs/index.md
+    - docs/issues/closed/README.md
+    - docs/issues/drafts/README.md
+    - docs/issues/open/README.md
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - .github/skills/dev/planning/cleanup-completed-issues/SKILL.md
+---
+
 # Issue Specifications
 
 This folder contains issue specification documents that support planning and implementation work linked to GitHub issues.

--- a/docs/issues/closed/1525-overhaul-persistence.md
+++ b/docs/issues/closed/1525-overhaul-persistence.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: epic
+status: done
+priority: p1
+github-issue: 1525
+spec-path: docs/issues/closed/1525-overhaul-persistence.md
+branch: null
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - packages/tracker-core/
+    - packages/configuration/
+---
+
 # Issue #1525 Implementation Plan (Overhaul Persistence)
 
 ## Goal

--- a/docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p2
+github-issue: 1532
+spec-path: docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md
+branch: 1532-http-tracker-client-add-optional-announce-params
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #1532 — HTTP Tracker Client: Add Optional Parameters to Announce Command
 
 ## Overview

--- a/docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md
+++ b/docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p2
+github-issue: 1533
+spec-path: docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md
+branch: 1533-udp-tracker-client-add-optional-announce-params
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #1533 — UDP Tracker Client: Add Optional Parameters to Announce Command
 
 ## Overview

--- a/docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
+++ b/docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: bug
+status: done
+priority: p3
+github-issue: 1561
+spec-path: docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md
+branch: 1561-http-tracker-client-avoid-duplicating-announce-suffix
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #1561 — HTTP Tracker Client: Avoid Duplicating the `announce` Suffix
 
 ## Overview

--- a/docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p3
+github-issue: 1562
+spec-path: docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md
+branch: 1562-http-tracker-client-add-option-show-response-pretty-json
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #1562 — HTTP Tracker Client: Add Option to Show Response in Pretty JSON
 
 ## Overview

--- a/docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md
+++ b/docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p3
+github-issue: 1563
+spec-path: docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md
+branch: 1563-udp-tracker-client-add-option-show-response-pretty-json
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #1563 — UDP Tracker Client: Add Option to Show Response in Pretty JSON
 
 ## Overview
@@ -161,7 +180,12 @@ Command:
 Captured output:
 
 ```json
-{"Scrape":{"transaction_id":-888840697,"torrent_stats":[{"seeders":0,"completed":0,"leechers":0}]}}
+{
+  "Scrape": {
+    "transaction_id": -888840697,
+    "torrent_stats": [{ "seeders": 0, "completed": 0, "leechers": 0 }]
+  }
+}
 ```
 
 ### Pretty output
@@ -206,7 +230,15 @@ Command:
 Captured output:
 
 ```json
-{"AnnounceIpv4":{"transaction_id":-888840697,"announce_interval":120,"leechers":0,"seeders":1,"peers":[]}}
+{
+  "AnnounceIpv4": {
+    "transaction_id": -888840697,
+    "announce_interval": 120,
+    "leechers": 0,
+    "seeders": 1,
+    "peers": []
+  }
+}
 ```
 
 Command:

--- a/docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+++ b/docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
@@ -1,3 +1,21 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p2
+github-issue: 1582
+spec-path: docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+branch: 1582-add-prometheus-deserialization-metrics
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - packages/metrics/
+---
+
 # Add Deserialization from Prometheus Text Format in `metrics` Package
 
 ## Overview

--- a/docs/issues/closed/1582-add-prometheus-deserialization-metrics/increase-unit-test-coverage.md
+++ b/docs/issues/closed/1582-add-prometheus-deserialization-metrics/increase-unit-test-coverage.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+    - packages/metrics/
+---
+
 # Increase Unit Test Coverage for the `metrics` Package
 
 ## Overview

--- a/docs/issues/closed/1582-add-prometheus-deserialization-metrics/metric-collection-module-split.md
+++ b/docs/issues/closed/1582-add-prometheus-deserialization-metrics/metric-collection-module-split.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - create-refactor-plan
+  related-artifacts:
+    - docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+    - packages/metrics/
+---
+
 # Refactor Plan: Split `metric_collection/mod.rs` into Submodules
 
 ## Goal

--- a/docs/issues/closed/1582-add-prometheus-deserialization-metrics/mutation-testing.md
+++ b/docs/issues/closed/1582-add-prometheus-deserialization-metrics/mutation-testing.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+    - packages/metrics/
+---
+
 # Mutation Testing Plan for the `metrics` Package
 
 ## Overview

--- a/docs/issues/closed/1582-add-prometheus-deserialization-metrics/refactoring-proposals.md
+++ b/docs/issues/closed/1582-add-prometheus-deserialization-metrics/refactoring-proposals.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - create-refactor-plan
+  related-artifacts:
+    - docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md
+    - packages/metrics/
+---
+
 # Refactoring Proposals: `metric_collection/prometheus.rs`
 
 Ordered from **least effort / biggest impact** to **most effort / lower impact**.

--- a/docs/issues/closed/1697-ai-agent-configuration.md
+++ b/docs/issues/closed/1697-ai-agent-configuration.md
@@ -1,3 +1,23 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1697
+spec-path: docs/issues/closed/1697-ai-agent-configuration.md
+branch: 1697-ai-agent-configuration
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - AGENTS.md
+    - .github/skills/
+    - .github/agents/
+---
+
 # Set Up Basic AI Agent Configuration
 
 ## Goal

--- a/docs/issues/closed/1703-1525-01-persistence-test-coverage.md
+++ b/docs/issues/closed/1703-1525-01-persistence-test-coverage.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1703
+spec-path: docs/issues/closed/1703-1525-01-persistence-test-coverage.md
+branch: 1703-1525-01-persistence-test-coverage
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue #1703 (Draft for #1525-01): Add DB Compatibility Matrix
 
 - Issue: https://github.com/torrust/torrust-tracker/issues/1703

--- a/docs/issues/closed/1706-1525-02-qbittorrent-e2e.md
+++ b/docs/issues/closed/1706-1525-02-qbittorrent-e2e.md
@@ -1,3 +1,23 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1706
+spec-path: docs/issues/closed/1706-1525-02-qbittorrent-e2e.md
+branch: 1706-1525-02-qbittorrent-e2e
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+    - compose.qbittorrent-e2e.sqlite3.yaml
+---
+
 # Subissue Draft for #1525-02: Add qBittorrent End-to-End Test
 
 - GitHub issue: #1706

--- a/docs/issues/closed/1710-1525-03-persistence-benchmarking.md
+++ b/docs/issues/closed/1710-1525-03-persistence-benchmarking.md
@@ -1,3 +1,23 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1710
+spec-path: docs/issues/closed/1710-1525-03-persistence-benchmarking.md
+branch: 1710-1525-03-persistence-benchmarking
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/torrent-repository-benchmarking/
+    - packages/tracker-core/
+---
+
 # Issue #1710 / Subissue #1525-03: Add Persistence Benchmarking
 
 ## Goal

--- a/docs/issues/closed/1713-1525-04-split-persistence-traits.md
+++ b/docs/issues/closed/1713-1525-04-split-persistence-traits.md
@@ -1,3 +1,23 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1713
+spec-path: docs/issues/closed/1713-1525-04-split-persistence-traits.md
+branch: 1713-1525-04-split-persistence-traits
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+    - docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md
+---
+
 # Issue #1713 (Subissue of #1525-04): Split Persistence Traits by Context
 
 ## Goal

--- a/docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md
+++ b/docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1715
+spec-path: docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md
+branch: 1715-1525-04b-migrate-consumers-to-narrow-traits
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue Draft for #1525-04b: Migrate Consumers to Narrow Persistence Traits
 
 ## Goal

--- a/docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md
+++ b/docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1717
+spec-path: docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md
+branch: 1525-05-migrate-sqlite-and-mysql-to-sqlx
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue Draft for #1525-05: Migrate SQLite and MySQL Drivers to sqlx
 
 ## Goal

--- a/docs/issues/closed/1719-1525-06-introduce-schema-migrations.md
+++ b/docs/issues/closed/1719-1525-06-introduce-schema-migrations.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1719
+spec-path: docs/issues/closed/1719-1525-06-introduce-schema-migrations.md
+branch: 1525-06-introduce-schema-migrations
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue Draft for #1525-06: Introduce Schema Migrations
 
 ## Goal

--- a/docs/issues/closed/1721-1525-07-align-rust-and-db-types.md
+++ b/docs/issues/closed/1721-1525-07-align-rust-and-db-types.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p1
+github-issue: 1721
+spec-path: docs/issues/closed/1721-1525-07-align-rust-and-db-types.md
+branch: 1721-1525-07-align-rust-and-db-types
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue 1525-07: Align Rust and Database Types
 
 ## Goal

--- a/docs/issues/closed/1723-1525-08-add-postgresql-driver.md
+++ b/docs/issues/closed/1723-1525-08-add-postgresql-driver.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p1
+github-issue: 1723
+spec-path: docs/issues/closed/1723-1525-08-add-postgresql-driver.md
+branch: 1525-08-add-postgresql-driver
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1525-overhaul-persistence.md
+    - packages/tracker-core/
+---
+
 # Subissue 1525-08: Add PostgreSQL Driver
 
 ## Goal

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1732
+spec-path: docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+branch: 1732-replace-aquatic-udp-protocol
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - packages/udp-protocol/
+    - packages/primitives/
+---
+
 # Replace `aquatic_udp_protocol` with an In-House UDP Protocol Crate
 
 ## Overview

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-2-analysis.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-2-analysis.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+    - packages/udp-protocol/
+---
+
 # Step 2 Analysis: Unused Code in Internal Forks
 
 ## Objective

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-3-bittorrent-primitives-problem.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-3-bittorrent-primitives-problem.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+    - packages/primitives/
+    - packages/udp-protocol/
+---
+
 # Step 3: `bittorrent-primitives` Transitive Dependency Problem
 
 ## Problem

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-5-udp-protocol-module-refactor-plan.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-5-udp-protocol-module-refactor-plan.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - create-refactor-plan
+  related-artifacts:
+    - docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+    - packages/udp-protocol/
+---
+
 # Step 5: UDP Protocol Module Refactor Plan
 
 ## Goal

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-6-primitives-module-refactor-plan.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-6-primitives-module-refactor-plan.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - create-refactor-plan
+  related-artifacts:
+    - docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+    - packages/primitives/
+---
+
 # Step 6: Primitives Module Refactor Plan
 
 ## Goal

--- a/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-7-peer-id-extraction-plan.md
+++ b/docs/issues/closed/1732-replace-aquatic-udp-protocol/step-7-peer-id-extraction-plan.md
@@ -1,3 +1,15 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - create-refactor-plan
+  related-artifacts:
+    - docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md
+    - packages/peer-id/
+    - packages/primitives/
+    - packages/udp-protocol/
+---
+
 # Step 7: PeerId Extraction Plan
 
 ## Goal

--- a/docs/issues/closed/1740-fix-container-workflow-caching.md
+++ b/docs/issues/closed/1740-fix-container-workflow-caching.md
@@ -1,3 +1,21 @@
+---
+doc-type: issue
+issue-type: bug
+status: done
+priority: p2
+github-issue: 1740
+spec-path: docs/issues/closed/1740-fix-container-workflow-caching.md
+branch: 1740-fix-container-workflow-caching
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/workflows/container.yaml
+---
+
 # Fix Container Workflow Caching
 
 ## Overview

--- a/docs/issues/closed/1742-ci-change-aware-workflows-epic.md
+++ b/docs/issues/closed/1742-ci-change-aware-workflows-epic.md
@@ -1,3 +1,21 @@
+---
+doc-type: issue
+issue-type: epic
+status: done
+priority: p2
+github-issue: 1742
+spec-path: docs/issues/closed/1742-ci-change-aware-workflows-epic.md
+branch: null
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/workflows/
+---
+
 # EPIC: Make CI Change-Aware
 
 ## Goal

--- a/docs/issues/closed/1743-docs-only-ci-fast-path.md
+++ b/docs/issues/closed/1743-docs-only-ci-fast-path.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1743
+spec-path: docs/issues/closed/1743-docs-only-ci-fast-path.md
+branch: 1743-docs-only-ci-fast-path
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1742-ci-change-aware-workflows-epic.md
+    - .github/workflows/testing.yaml
+---
+
 # Add a Docs-Only CI Fast Path
 
 ## Goal

--- a/docs/issues/closed/1744-scope-persistence-workflows-by-path.md
+++ b/docs/issues/closed/1744-scope-persistence-workflows-by-path.md
@@ -1,3 +1,23 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1744
+spec-path: docs/issues/closed/1744-scope-persistence-workflows-by-path.md
+branch: 1744-scope-persistence-workflows-by-path
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1742-ci-change-aware-workflows-epic.md
+    - .github/workflows/db-compatibility.yaml
+    - .github/workflows/db-benchmarking.yaml
+---
+
 # Scope Persistence Workflows by Path
 
 ## Goal

--- a/docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md
+++ b/docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1748
+spec-path: docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md
+branch: 1748-remove-redundant-compose-step-from-container-workflow
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/workflows/container.yaml
+    - .github/workflows/testing.yaml
+---
+
 # Remove Redundant Compose Step From Container Workflow
 
 ## Overview

--- a/docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md
+++ b/docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md
@@ -1,3 +1,21 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 1750
+spec-path: docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md
+branch: 1750-refactor-run-tracker-skill-semantic-coupling
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/skills/
+---
+
 # Refactor `run-tracker-locally` Skill with Semantic Artifact Coupling
 
 ## Goal

--- a/docs/issues/closed/523-internal-linting-tool.md
+++ b/docs/issues/closed/523-internal-linting-tool.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: done
+priority: p2
+github-issue: 523
+spec-path: docs/issues/closed/523-internal-linting-tool.md
+branch: 523-internal-linting-tool
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/workflows/testing.yaml
+    - contrib/dev-tools/
+---
+
 # Issue #523 Implementation Plan (Internal Linting Tool)
 
 ## Goal

--- a/docs/issues/closed/669-overhaul-clients.md
+++ b/docs/issues/closed/669-overhaul-clients.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: epic
+status: done
+priority: p2
+github-issue: 669
+spec-path: docs/issues/closed/669-overhaul-clients.md
+branch: null
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/tracker-client/
+---
+
 # Issue #669 — Overhaul Clients (EPIC)
 
 ## Overview

--- a/docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p3
+github-issue: 671
+spec-path: docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md
+branch: null
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/udp-tracker-core/
+---
+
 # Issue #671 — UDP Tracker Client: Print Unrecognized Responses
 
 ## Overview

--- a/docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md
+++ b/docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: feature
+status: done
+priority: p3
+github-issue: 672
+spec-path: docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md
+branch: null
+related-pr: null
+last-updated-utc: null
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - console/tracker-client/
+    - packages/http-tracker-core/
+---
+
 # Issue #672 — HTTP Tracker Client: Print Unrecognized Responses in JSON
 
 ## Overview

--- a/docs/issues/closed/README.md
+++ b/docs/issues/closed/README.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - cleanup-completed-issues
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/skills/dev/planning/cleanup-completed-issues/SKILL.md
+---
+
 # Recently Closed Issues
 
 This folder holds issue specification files for issues that have been closed but are kept

--- a/docs/issues/drafts/README.md
+++ b/docs/issues/drafts/README.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/skills/dev/planning/create-issue/SKILL.md
+---
+
 # Issue Drafts
 
 This folder contains draft issue specification files that are not yet linked to a created GitHub issue.

--- a/docs/issues/open/1669-overhaul-packages/readme-audit.md
+++ b/docs/issues/open/1669-overhaul-packages/readme-audit.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1669-overhaul-packages/EPIC.md
+    - packages/
+---
+
 # README Audit
 
 Point-in-time audit of README quality across all workspace packages and console

--- a/docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
+++ b/docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1669-overhaul-packages/EPIC.md
+    - packages/
+---
+
 # Workspace Coupling Report
 
 Generated: 2026-05-19 20:46 UTC

--- a/docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md
+++ b/docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md
@@ -1,3 +1,22 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+github-issue: 1726
+spec-path: docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md
+branch: 1726-reduce-build-times-sccache
+related-pr: null
+last-updated-utc: 2026-05-01 00:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/README.md
+    - docs/issues/closed/1742-ci-change-aware-workflows-epic.md
+    - .github/workflows/
+---
+
 # Reduce Build Times with `sccache`
 
 ## Goal

--- a/docs/issues/open/1726-reduce-build-times-sccache/benchmark-results.md
+++ b/docs/issues/open/1726-reduce-build-times-sccache/benchmark-results.md
@@ -1,3 +1,11 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md
+---
+
 # Cargo Build & Test Benchmark Results
 
 Recorded on: 2026-05-01  

--- a/docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
+++ b/docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
@@ -1,7 +1,7 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: done
 priority: p3
 github-issue: 1810
 spec-path: docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
@@ -257,22 +257,22 @@ application. The detailed per-file checklist is in the [File Inventory](#file-in
 
 | ID  | Status | Task                                                                                                 | Files in batch |
 | --- | ------ | ---------------------------------------------------------------------------------------------------- | -------------- |
-| T0  | TODO   | Semantic research pre-pass: analyze all 67 files, build relationship map                             | all 67         |
-| T1  | TODO   | Add frontmatter + semantic links to top-level `docs/` files                                          | 7              |
-| T2  | TODO   | Add frontmatter + semantic links to `docs/adrs/` ADR files                                           | 5              |
-| T3  | TODO   | Add frontmatter + semantic links to `docs/adrs/` navigation files                                    | 2              |
-| T4  | TODO   | Add frontmatter + semantic links to `docs/issues/` README/nav files                                  | 4              |
-| T5  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` ≤ 672 specs                                | 4              |
-| T6  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1525–1563                                  | 6              |
-| T7  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1582 group                                 | 5              |
-| T8  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1697–1723                                  | 10             |
-| T9  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1732 group                                 | 6              |
-| T10 | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1740–1750                                  | 6              |
-| T11 | TODO   | Add frontmatter + semantic links to `docs/issues/open/` supplementary                                | 4              |
-| T12 | TODO   | Add frontmatter + semantic links to `docs/pr-reviews/` files                                         | 2              |
-| T13 | TODO   | Add frontmatter + semantic links to `docs/refactor-plans/` files                                     | 5              |
-| T14 | TODO   | Add frontmatter + semantic links to `docs/skills/` files                                             | 1              |
-| T15 | TODO   | Clarify inline marker vs. frontmatter skill-links in `docs/skills/semantic-skill-link-convention.md` | 1              |
+| T0  | DONE   | Semantic research pre-pass: analyze all 67 files, build relationship map                             | all 67         |
+| T1  | DONE   | Add frontmatter + semantic links to top-level `docs/` files                                          | 7              |
+| T2  | DONE   | Add frontmatter + semantic links to `docs/adrs/` ADR files                                           | 5              |
+| T3  | DONE   | Add frontmatter + semantic links to `docs/adrs/` navigation files                                    | 2              |
+| T4  | DONE   | Add frontmatter + semantic links to `docs/issues/` README/nav files                                  | 4              |
+| T5  | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` ≤ 672 specs                                | 4              |
+| T6  | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` 1525–1563                                  | 6              |
+| T7  | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` 1582 group                                 | 5              |
+| T8  | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` 1697–1723                                  | 10             |
+| T9  | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` 1732 group                                 | 6              |
+| T10 | DONE   | Add frontmatter + semantic links to `docs/issues/closed/` 1740–1750                                  | 6              |
+| T11 | DONE   | Add frontmatter + semantic links to `docs/issues/open/` supplementary                                | 4              |
+| T12 | DONE   | Add frontmatter + semantic links to `docs/pr-reviews/` files                                         | 2              |
+| T13 | DONE   | Add frontmatter + semantic links to `docs/refactor-plans/` files                                     | 5              |
+| T14 | DONE   | Add frontmatter + semantic links to `docs/skills/` files                                             | 1              |
+| T15 | DONE   | Clarify inline marker vs. frontmatter skill-links in `docs/skills/semantic-skill-link-convention.md` | 1              |
 
 ## File Inventory
 
@@ -280,116 +280,116 @@ Per-file progress checklist. Check each file when its frontmatter has been added
 
 ### T1 — Top-level `docs/` files (7)
 
-- [ ] `docs/AGENTS.md`
-- [ ] `docs/benchmarking.md`
-- [ ] `docs/containers.md`
-- [ ] `docs/index.md`
-- [ ] `docs/packages.md`
-- [ ] `docs/profiling.md`
-- [ ] `docs/release_process.md`
+- [x] `docs/AGENTS.md`
+- [x] `docs/benchmarking.md`
+- [x] `docs/containers.md`
+- [x] `docs/index.md`
+- [x] `docs/packages.md`
+- [x] `docs/profiling.md`
+- [x] `docs/release_process.md`
 
 ### T2 — `docs/adrs/` ADR files (5)
 
-- [ ] `docs/adrs/20240227164834_use_plural_for_modules_containing_collections.md`
-- [ ] `docs/adrs/20260420200013_adopt_custom_github_copilot_aligned_agent_framework.md`
-- [ ] `docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md`
-- [ ] `docs/adrs/20260512102000_define_tracker_client_peer_id_convention.md`
-- [ ] `docs/adrs/20260519000000_define_global_cli_output_contract.md`
+- [x] `docs/adrs/20240227164834_use_plural_for_modules_containing_collections.md`
+- [x] `docs/adrs/20260420200013_adopt_custom_github_copilot_aligned_agent_framework.md`
+- [x] `docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md`
+- [x] `docs/adrs/20260512102000_define_tracker_client_peer_id_convention.md`
+- [x] `docs/adrs/20260519000000_define_global_cli_output_contract.md`
 
 ### T3 — `docs/adrs/` navigation files (2)
 
-- [ ] `docs/adrs/README.md`
-- [ ] `docs/adrs/index.md`
+- [x] `docs/adrs/README.md`
+- [x] `docs/adrs/index.md`
 
 ### T4 — `docs/issues/` README/navigation files (4)
 
-- [ ] `docs/issues/README.md`
-- [ ] `docs/issues/closed/README.md`
-- [ ] `docs/issues/drafts/README.md`
-- [ ] `docs/issues/open/README.md`
+- [x] `docs/issues/README.md`
+- [x] `docs/issues/closed/README.md`
+- [x] `docs/issues/drafts/README.md`
+- [x] `docs/issues/open/README.md`
 
 ### T5 — `docs/issues/closed/` — very old specs ≤ 672 (4)
 
-- [ ] `docs/issues/closed/523-internal-linting-tool.md`
-- [ ] `docs/issues/closed/669-overhaul-clients.md`
-- [ ] `docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md`
-- [ ] `docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md`
+- [x] `docs/issues/closed/523-internal-linting-tool.md`
+- [x] `docs/issues/closed/669-overhaul-clients.md`
+- [x] `docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md`
+- [x] `docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md`
 
 ### T6 — `docs/issues/closed/` — 1525–1563 specs (6)
 
-- [ ] `docs/issues/closed/1525-overhaul-persistence.md`
-- [ ] `docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md`
-- [ ] `docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md`
-- [ ] `docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md`
-- [ ] `docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md`
-- [ ] `docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md`
+- [x] `docs/issues/closed/1525-overhaul-persistence.md`
+- [x] `docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md`
+- [x] `docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md`
+- [x] `docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md`
+- [x] `docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md`
+- [x] `docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md`
 
 ### T7 — `docs/issues/closed/` — 1582 group (5)
 
-- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md`
-- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/increase-unit-test-coverage.md`
-- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/metric-collection-module-split.md`
-- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/mutation-testing.md`
-- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/refactoring-proposals.md`
+- [x] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md`
+- [x] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/increase-unit-test-coverage.md`
+- [x] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/metric-collection-module-split.md`
+- [x] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/mutation-testing.md`
+- [x] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/refactoring-proposals.md`
 
 ### T8 — `docs/issues/closed/` — 1697–1723 group (10)
 
-- [ ] `docs/issues/closed/1697-ai-agent-configuration.md`
-- [ ] `docs/issues/closed/1703-1525-01-persistence-test-coverage.md`
-- [ ] `docs/issues/closed/1706-1525-02-qbittorrent-e2e.md`
-- [ ] `docs/issues/closed/1710-1525-03-persistence-benchmarking.md`
-- [ ] `docs/issues/closed/1713-1525-04-split-persistence-traits.md`
-- [ ] `docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md`
-- [ ] `docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md`
-- [ ] `docs/issues/closed/1719-1525-06-introduce-schema-migrations.md`
-- [ ] `docs/issues/closed/1721-1525-07-align-rust-and-db-types.md`
-- [ ] `docs/issues/closed/1723-1525-08-add-postgresql-driver.md`
+- [x] `docs/issues/closed/1697-ai-agent-configuration.md`
+- [x] `docs/issues/closed/1703-1525-01-persistence-test-coverage.md`
+- [x] `docs/issues/closed/1706-1525-02-qbittorrent-e2e.md`
+- [x] `docs/issues/closed/1710-1525-03-persistence-benchmarking.md`
+- [x] `docs/issues/closed/1713-1525-04-split-persistence-traits.md`
+- [x] `docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md`
+- [x] `docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md`
+- [x] `docs/issues/closed/1719-1525-06-introduce-schema-migrations.md`
+- [x] `docs/issues/closed/1721-1525-07-align-rust-and-db-types.md`
+- [x] `docs/issues/closed/1723-1525-08-add-postgresql-driver.md`
 
 ### T9 — `docs/issues/closed/` — 1732 group (6)
 
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md`
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-2-analysis.md`
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-3-bittorrent-primitives-problem.md`
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-5-udp-protocol-module-refactor-plan.md`
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-6-primitives-module-refactor-plan.md`
-- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-7-peer-id-extraction-plan.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-2-analysis.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-3-bittorrent-primitives-problem.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-5-udp-protocol-module-refactor-plan.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-6-primitives-module-refactor-plan.md`
+- [x] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-7-peer-id-extraction-plan.md`
 
 ### T10 — `docs/issues/closed/` — 1740–1750 group (6)
 
-- [ ] `docs/issues/closed/1740-fix-container-workflow-caching.md`
-- [ ] `docs/issues/closed/1742-ci-change-aware-workflows-epic.md`
-- [ ] `docs/issues/closed/1743-docs-only-ci-fast-path.md`
-- [ ] `docs/issues/closed/1744-scope-persistence-workflows-by-path.md`
-- [ ] `docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md`
-- [ ] `docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md`
+- [x] `docs/issues/closed/1740-fix-container-workflow-caching.md`
+- [x] `docs/issues/closed/1742-ci-change-aware-workflows-epic.md`
+- [x] `docs/issues/closed/1743-docs-only-ci-fast-path.md`
+- [x] `docs/issues/closed/1744-scope-persistence-workflows-by-path.md`
+- [x] `docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md`
+- [x] `docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md`
 
 ### T11 — `docs/issues/open/` supplementary files (4)
 
-- [ ] `docs/issues/open/1669-overhaul-packages/readme-audit.md`
-- [ ] `docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md`
-- [ ] `docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md`
-- [ ] `docs/issues/open/1726-reduce-build-times-sccache/benchmark-results.md`
+- [x] `docs/issues/open/1669-overhaul-packages/readme-audit.md`
+- [x] `docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md`
+- [x] `docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md`
+- [x] `docs/issues/open/1726-reduce-build-times-sccache/benchmark-results.md`
 
 ### T12 — `docs/pr-reviews/` files (2)
 
-- [ ] `docs/pr-reviews/README.md`
-- [ ] `docs/pr-reviews/pr-1733-copilot-suggestions.md`
+- [x] `docs/pr-reviews/README.md`
+- [x] `docs/pr-reviews/pr-1733-copilot-suggestions.md`
 
 ### T13 — `docs/refactor-plans/` files (5)
 
-- [ ] `docs/refactor-plans/closed/1178-monitor-udp-post-implementation-improvements.md`
-- [ ] `docs/refactor-plans/closed/README.md`
-- [ ] `docs/refactor-plans/closed/agent-docs-refactor-plan.md`
-- [ ] `docs/refactor-plans/drafts/README.md`
-- [ ] `docs/refactor-plans/open/README.md`
+- [x] `docs/refactor-plans/closed/1178-monitor-udp-post-implementation-improvements.md`
+- [x] `docs/refactor-plans/closed/README.md`
+- [x] `docs/refactor-plans/closed/agent-docs-refactor-plan.md`
+- [x] `docs/refactor-plans/drafts/README.md`
+- [x] `docs/refactor-plans/open/README.md`
 
 ### T14 — `docs/skills/` files (1)
 
-- [ ] `docs/skills/semantic-skill-link-convention.md`
+- [x] `docs/skills/semantic-skill-link-convention.md`
 
 ### T15 — Convention doc content update (1)
 
-- [ ] Update `docs/skills/semantic-skill-link-convention.md` to clarify that when frontmatter
+- [x] Update `docs/skills/semantic-skill-link-convention.md` to clarify that when frontmatter
       is present with `semantic-links.skill-links`, inline `<!-- skill-link: ... -->` top-of-file
       comments are redundant. Body-level inline markers placed near a specific section remain
       valuable for navigation but are not required.

--- a/docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
+++ b/docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
@@ -1,0 +1,479 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p3
+github-issue: 1810
+spec-path: docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md
+branch: "1810-add-frontmatter-to-docs-markdown-files"
+related-pr: null
+last-updated-utc: 2026-05-20 15:45
+semantic-links:
+  skill-links:
+    - create-issue
+    - write-markdown-docs
+  related-artifacts:
+    - docs/skills/semantic-skill-link-convention.md
+    - .github/skills/dev/planning/write-markdown-docs/SKILL.md
+    - docs/AGENTS.md
+    - docs/templates/ISSUE.md
+    - docs/templates/EPIC.md
+    - docs/templates/ADR.md
+    - docs/templates/REFACTOR-PLAN.md
+    - docs/templates/COPILOT-SUGGESTIONS-TEMPLATE.md
+---
+
+# Issue #1810 — Add YAML frontmatter and semantic links to all `docs/` Markdown files
+
+## Goal
+
+Add YAML frontmatter to every Markdown file under `docs/` that currently lacks it, populate
+`related-artifacts` based on semantic analysis of each file, and apply bidirectional links
+between Markdown files so that when file A references file B, file B also references file A.
+Follow the convention defined in `docs/skills/semantic-skill-link-convention.md` and
+summarized in `docs/AGENTS.md`.
+
+## Background
+
+The project defines a lightweight YAML frontmatter convention (see
+`docs/skills/semantic-skill-link-convention.md`) to keep document metadata machine-readable
+and to couple artifacts to Agent Skills via `semantic-links`.
+
+Usage varies by document type:
+
+- **Required** — issue specs and EPIC specs must include `doc-type`, status, issue tracking
+  fields, and `semantic-links`.
+- **Recommended** — ADRs, refactor plans, PR-review docs, and skills docs should include at
+  minimum `semantic-links` (following their respective templates).
+- **Optional** — short reference pages, README/index files.
+
+Despite the convention being established, a large number of existing `docs/` files predate it
+and have no frontmatter at all. This means agents and tooling cannot reliably query document
+metadata, and several issue/EPIC specs violate the "required" rule.
+
+A scan of `docs/` on 2026-05-20 found **67 files** without frontmatter. This issue
+tracks adding the appropriate frontmatter to every one of them.
+
+Beyond structural compliance, the `related-artifacts` field is the key mechanism for coupling
+documentation to the code and other artifacts it describes. Without it, agents cannot discover
+which source files, packages, skills, or other documents a given doc governs — and cannot
+travel the graph in either direction. Bidirectionality between Markdown files is achievable
+purely within `docs/` frontmatter and has a high signal-to-noise ratio: it makes the
+relationship explicit, machine-queryable, and maintainable without touching source code.
+
+## Scope
+
+### In Scope
+
+- Add YAML frontmatter to every `docs/` Markdown file listed in the [File Inventory](#file-inventory).
+- Use the correct frontmatter shape for each document type (see [Frontmatter Guidance](#frontmatter-guidance)).
+- Perform semantic analysis of each file (see [Semantic Analysis Guidance](#semantic-analysis-guidance))
+  to identify meaningful related artifacts and populate `related-artifacts` accordingly.
+- Apply bidirectional links between Markdown files within `docs/`: when file A lists file B in
+  `related-artifacts`, file B must also list file A (see bidirectionality rules).
+- Reference source code paths (packages, modules, key files) in `related-artifacts` of the
+  Markdown file that documents them.
+- Clarify inline `<!-- skill-link: ... -->` versus frontmatter `skill-links` guidance in
+  `docs/skills/semantic-skill-link-convention.md` (T15): when frontmatter is present,
+  frontmatter is the canonical machine-readable source; inline top-of-file comments are
+  redundant and should be omitted.
+- Do not change body content, headings, or links in any file — only the frontmatter block
+  (exception: T15 updates targeted convention guidance in
+  `docs/skills/semantic-skill-link-convention.md`).
+- Inline `<!-- skill-link: ... -->` body markers are **not** being added to any file;
+  frontmatter is the canonical source when present.
+
+### Out of Scope
+
+- Changing the content, structure, or headings of any file (exception: T15 targeted content
+  update in `docs/skills/semantic-skill-link-convention.md`).
+- Restructuring or renaming subdirectories under `docs/`.
+- Updating `docs/templates/` content.
+- Updating `docs/skills/semantic-skill-link-convention.md` beyond the targeted inline-marker
+  clarification in T15.
+- Adding frontmatter to Markdown files outside `docs/` (covered by separate work if needed).
+- Adding back-reference annotations inside source code files (Rust, TOML, shell): no
+  convention for doc back-references in source code is defined; that is a follow-up issue.
+- Updating `related-artifacts` in `.github/skills/` SKILL.md files that are referenced by
+  `docs/` files: those files already have frontmatter and a separate concern governs them.
+
+## Frontmatter Guidance
+
+Use the following shapes as the canonical reference for each document type.
+See the full spec in `docs/skills/semantic-skill-link-convention.md`.
+
+### Issue specs (`doc-type: issue`)
+
+```yaml
+---
+doc-type: issue
+issue-type: <task|bug|feature|enhancement>
+status: done
+priority: <p0|p1|p2|p3>
+github-issue: <number>
+spec-path: <repo-relative-path>
+branch: "<branch-name>"
+related-pr: <number|null>
+last-updated-utc: YYYY-MM-DD HH:MM
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts: []
+---
+```
+
+For closed issue specs, use `status: done`. Derive `github-issue`, `branch`, and `last-updated-utc`
+from the file content or git history. Use `null` for fields that cannot be determined.
+
+### EPIC specs (`doc-type: epic`)
+
+```yaml
+---
+doc-type: epic
+status: done
+github-issue: <number>
+spec-path: <repo-relative-path>
+epic-owner: null
+last-updated-utc: YYYY-MM-DD HH:MM
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts: []
+---
+```
+
+### Refactor plans (`doc-type: refactor-plan`)
+
+```yaml
+---
+doc-type: refactor-plan
+status: done
+related-issue: <number|null>
+spec-path: <repo-relative-path>
+last-updated-utc: YYYY-MM-DD HH:MM
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts: []
+---
+```
+
+### ADR files
+
+```yaml
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - .github/skills/dev/planning/create-adr/SKILL.md
+---
+```
+
+### PR review files
+
+```yaml
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+```
+
+### General docs and README/index files
+
+For files that do not fall into a named document type (guides, AGENTS.md, index files,
+README files), add a minimal frontmatter block with `semantic-links` where a relevant
+skill-link exists; otherwise use an empty block:
+
+```yaml
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts: []
+---
+```
+
+README/index navigation files may use an empty frontmatter block if no skill-link applies:
+
+```yaml
+---
+# navigation index — no semantic skill links
+---
+```
+
+## Semantic Analysis Guidance
+
+### What to analyze per file
+
+For each file, read the full content and identify:
+
+1. **Packages or crates** explicitly mentioned (e.g., `torrust-tracker-core`, `packages/tracker-core/`).
+2. **Source files or modules** referenced (e.g., `src/app.rs`, `packages/*/src/lib.rs`).
+3. **Other `docs/` Markdown files** explicitly linked or discussed.
+4. **Agent Skills** (`.github/skills/`) the file is governed by or relies on.
+5. **GitHub issues or PRs** (use `github-issue` / `related-pr` metadata fields for these,
+   not `related-artifacts` — `related-artifacts` holds repo-relative file paths only).
+
+Keep `related-artifacts` high-signal: list only artifacts with a clear, direct relationship.
+Do not list every file incidentally mentioned; focus on structural coupling.
+
+### Bidirectionality rules
+
+| Relationship type                         | Rule                                                                                                                          |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `docs/` file A → `docs/` file B           | Bidirectional: add A to B's `related-artifacts` and B to A's.                                                                 |
+| `docs/` file → `.github/skills/` SKILL.md | One-directional: add the skill path to the doc's `related-artifacts` only. The reverse update is out of scope for this issue. |
+| `docs/` file → source code path           | One-directional: add the source path to the doc's `related-artifacts` only. Source code back-references are out of scope.     |
+| `docs/` file → GitHub issue/PR URL        | Not a `related-artifacts` entry. Use `github-issue` / `related-pr` metadata fields in issue/EPIC specs.                       |
+
+### Handling the bidirectionality backlog
+
+When semantic analysis of a file (say file A) identifies that file B should reference file A
+but file B is in a **later task batch**, note the pending back-reference in the Notes column
+of the implementation plan. Apply it when that later batch is processed.
+
+When file B is **already in a completed batch**, apply the back-reference to file B
+immediately (a small additive change to its frontmatter).
+
+### Priority guidance
+
+- Prioritize `related-artifacts` accuracy for **top-level docs**, **ADRs**, and **open issue
+  specs** — these are most frequently queried by agents.
+- For **closed issue specs**, a minimal frontmatter (required fields + obvious direct links)
+  is sufficient; exhaustive semantic research is not required.
+- For **README/navigation files**, `related-artifacts` may be omitted or list only the most
+  architecturally significant entries.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+Each task covers a logical batch of files and includes both semantic research and frontmatter
+application. The detailed per-file checklist is in the [File Inventory](#file-inventory) section.
+
+| ID  | Status | Task                                                                                                 | Files in batch |
+| --- | ------ | ---------------------------------------------------------------------------------------------------- | -------------- |
+| T0  | TODO   | Semantic research pre-pass: analyze all 67 files, build relationship map                             | all 67         |
+| T1  | TODO   | Add frontmatter + semantic links to top-level `docs/` files                                          | 7              |
+| T2  | TODO   | Add frontmatter + semantic links to `docs/adrs/` ADR files                                           | 5              |
+| T3  | TODO   | Add frontmatter + semantic links to `docs/adrs/` navigation files                                    | 2              |
+| T4  | TODO   | Add frontmatter + semantic links to `docs/issues/` README/nav files                                  | 4              |
+| T5  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` ≤ 672 specs                                | 4              |
+| T6  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1525–1563                                  | 6              |
+| T7  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1582 group                                 | 5              |
+| T8  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1697–1723                                  | 10             |
+| T9  | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1732 group                                 | 6              |
+| T10 | TODO   | Add frontmatter + semantic links to `docs/issues/closed/` 1740–1750                                  | 6              |
+| T11 | TODO   | Add frontmatter + semantic links to `docs/issues/open/` supplementary                                | 4              |
+| T12 | TODO   | Add frontmatter + semantic links to `docs/pr-reviews/` files                                         | 2              |
+| T13 | TODO   | Add frontmatter + semantic links to `docs/refactor-plans/` files                                     | 5              |
+| T14 | TODO   | Add frontmatter + semantic links to `docs/skills/` files                                             | 1              |
+| T15 | TODO   | Clarify inline marker vs. frontmatter skill-links in `docs/skills/semantic-skill-link-convention.md` | 1              |
+
+## File Inventory
+
+Per-file progress checklist. Check each file when its frontmatter has been added and verified.
+
+### T1 — Top-level `docs/` files (7)
+
+- [ ] `docs/AGENTS.md`
+- [ ] `docs/benchmarking.md`
+- [ ] `docs/containers.md`
+- [ ] `docs/index.md`
+- [ ] `docs/packages.md`
+- [ ] `docs/profiling.md`
+- [ ] `docs/release_process.md`
+
+### T2 — `docs/adrs/` ADR files (5)
+
+- [ ] `docs/adrs/20240227164834_use_plural_for_modules_containing_collections.md`
+- [ ] `docs/adrs/20260420200013_adopt_custom_github_copilot_aligned_agent_framework.md`
+- [ ] `docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md`
+- [ ] `docs/adrs/20260512102000_define_tracker_client_peer_id_convention.md`
+- [ ] `docs/adrs/20260519000000_define_global_cli_output_contract.md`
+
+### T3 — `docs/adrs/` navigation files (2)
+
+- [ ] `docs/adrs/README.md`
+- [ ] `docs/adrs/index.md`
+
+### T4 — `docs/issues/` README/navigation files (4)
+
+- [ ] `docs/issues/README.md`
+- [ ] `docs/issues/closed/README.md`
+- [ ] `docs/issues/drafts/README.md`
+- [ ] `docs/issues/open/README.md`
+
+### T5 — `docs/issues/closed/` — very old specs ≤ 672 (4)
+
+- [ ] `docs/issues/closed/523-internal-linting-tool.md`
+- [ ] `docs/issues/closed/669-overhaul-clients.md`
+- [ ] `docs/issues/closed/671-udp-tracker-client-print-unrecognized-responses.md`
+- [ ] `docs/issues/closed/672-http-tracker-client-print-unrecognized-responses.md`
+
+### T6 — `docs/issues/closed/` — 1525–1563 specs (6)
+
+- [ ] `docs/issues/closed/1525-overhaul-persistence.md`
+- [ ] `docs/issues/closed/1532-http-tracker-client-add-optional-announce-params.md`
+- [ ] `docs/issues/closed/1533-udp-tracker-client-add-optional-announce-params.md`
+- [ ] `docs/issues/closed/1561-http-tracker-client-avoid-duplicating-announce-suffix.md`
+- [ ] `docs/issues/closed/1562-http-tracker-client-add-option-show-response-pretty-json.md`
+- [ ] `docs/issues/closed/1563-udp-tracker-client-add-option-show-response-pretty-json.md`
+
+### T7 — `docs/issues/closed/` — 1582 group (5)
+
+- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/ISSUE.md`
+- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/increase-unit-test-coverage.md`
+- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/metric-collection-module-split.md`
+- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/mutation-testing.md`
+- [ ] `docs/issues/closed/1582-add-prometheus-deserialization-metrics/refactoring-proposals.md`
+
+### T8 — `docs/issues/closed/` — 1697–1723 group (10)
+
+- [ ] `docs/issues/closed/1697-ai-agent-configuration.md`
+- [ ] `docs/issues/closed/1703-1525-01-persistence-test-coverage.md`
+- [ ] `docs/issues/closed/1706-1525-02-qbittorrent-e2e.md`
+- [ ] `docs/issues/closed/1710-1525-03-persistence-benchmarking.md`
+- [ ] `docs/issues/closed/1713-1525-04-split-persistence-traits.md`
+- [ ] `docs/issues/closed/1715-1525-04b-migrate-consumers-to-narrow-traits.md`
+- [ ] `docs/issues/closed/1717-1525-05-migrate-sqlite-and-mysql-to-sqlx.md`
+- [ ] `docs/issues/closed/1719-1525-06-introduce-schema-migrations.md`
+- [ ] `docs/issues/closed/1721-1525-07-align-rust-and-db-types.md`
+- [ ] `docs/issues/closed/1723-1525-08-add-postgresql-driver.md`
+
+### T9 — `docs/issues/closed/` — 1732 group (6)
+
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/ISSUE.md`
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-2-analysis.md`
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-3-bittorrent-primitives-problem.md`
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-5-udp-protocol-module-refactor-plan.md`
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-6-primitives-module-refactor-plan.md`
+- [ ] `docs/issues/closed/1732-replace-aquatic-udp-protocol/step-7-peer-id-extraction-plan.md`
+
+### T10 — `docs/issues/closed/` — 1740–1750 group (6)
+
+- [ ] `docs/issues/closed/1740-fix-container-workflow-caching.md`
+- [ ] `docs/issues/closed/1742-ci-change-aware-workflows-epic.md`
+- [ ] `docs/issues/closed/1743-docs-only-ci-fast-path.md`
+- [ ] `docs/issues/closed/1744-scope-persistence-workflows-by-path.md`
+- [ ] `docs/issues/closed/1748-remove-redundant-compose-step-from-container-workflow.md`
+- [ ] `docs/issues/closed/1750-refactor-run-tracker-skill-semantic-coupling.md`
+
+### T11 — `docs/issues/open/` supplementary files (4)
+
+- [ ] `docs/issues/open/1669-overhaul-packages/readme-audit.md`
+- [ ] `docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md`
+- [ ] `docs/issues/open/1726-reduce-build-times-sccache/ISSUE.md`
+- [ ] `docs/issues/open/1726-reduce-build-times-sccache/benchmark-results.md`
+
+### T12 — `docs/pr-reviews/` files (2)
+
+- [ ] `docs/pr-reviews/README.md`
+- [ ] `docs/pr-reviews/pr-1733-copilot-suggestions.md`
+
+### T13 — `docs/refactor-plans/` files (5)
+
+- [ ] `docs/refactor-plans/closed/1178-monitor-udp-post-implementation-improvements.md`
+- [ ] `docs/refactor-plans/closed/README.md`
+- [ ] `docs/refactor-plans/closed/agent-docs-refactor-plan.md`
+- [ ] `docs/refactor-plans/drafts/README.md`
+- [ ] `docs/refactor-plans/open/README.md`
+
+### T14 — `docs/skills/` files (1)
+
+- [ ] `docs/skills/semantic-skill-link-convention.md`
+
+### T15 — Convention doc content update (1)
+
+- [ ] Update `docs/skills/semantic-skill-link-convention.md` to clarify that when frontmatter
+      is present with `semantic-links.skill-links`, inline `<!-- skill-link: ... -->` top-of-file
+      comments are redundant. Body-level inline markers placed near a specific section remain
+      valuable for navigation but are not required.
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/drafts/`
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue created and issue number added to this spec
+- [ ] (Optional) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+Append one line per meaningful update.
+
+- 2026-05-20 14:00 UTC - Agent - Spec drafted; 67 files identified missing frontmatter across 14 logical batches
+- 2026-05-20 15:00 UTC - Agent - Scope expanded: semantic analysis + bidirectional Markdown linking added per user request; new T0 pre-pass task added; AC7/AC8 added
+- 2026-05-20 15:30 UTC - Agent - T15 added: clarify inline markers vs. frontmatter in convention doc (Option A); redundant top-of-file inline comments removed from this spec; AC9 added
+- 2026-05-20 15:45 UTC - Agent - GitHub issue #1810 created; spec moved to docs/issues/open/
+
+## Acceptance Criteria
+
+- [ ] AC1: All 67 files listed in the [File Inventory](#file-inventory) have a valid YAML frontmatter block at the top of the file.
+- [ ] AC2: Each file's frontmatter follows the correct shape for its document type (as defined in [Frontmatter Guidance](#frontmatter-guidance)).
+- [ ] AC3: Issue and EPIC specs include all required metadata fields (`doc-type`, `status`, `github-issue`, `spec-path`, `last-updated-utc`).
+- [ ] AC4: `linter all` exits with code `0` (markdownlint must pass for all modified files).
+- [ ] AC5: No body content, headings, or links are changed in any file — only the frontmatter block is added at the top.
+- [ ] AC6: `docs/skills/semantic-skill-link-convention.md` itself has frontmatter consistent with a skills convention document.
+- [ ] AC7: Every `docs/` Markdown file that is listed in another file's `related-artifacts` also lists the referencing file in its own `related-artifacts` (bidirectionality rule for Markdown-to-Markdown links within `docs/`).
+- [ ] AC8: Top-level docs files (`benchmarking.md`, `containers.md`, `packages.md`, `profiling.md`, `release_process.md`) have at least one `related-artifacts` entry pointing to a relevant source package or module.
+- [ ] AC9: `docs/skills/semantic-skill-link-convention.md` guidance (T15) clarifies that when a
+      Markdown file has frontmatter with `semantic-links.skill-links`, inline `<!-- skill-link: ... -->`
+      top-of-file markers are redundant; frontmatter is the canonical machine-readable source.
+- [ ] `linter all` exits with code `0`
+- [ ] Relevant tests pass
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+
+## Verification
+
+### Automatic checks
+
+After each task batch:
+
+```bash
+linter markdown
+linter cspell
+```
+
+After all batches:
+
+```bash
+linter all
+```
+
+Verify no file is missing frontmatter:
+
+```bash
+for f in $(find docs -name "*.md" | sort); do
+  first_line=$(head -1 "$f")
+  if [ "$first_line" != "---" ]; then
+    echo "MISSING: $f"
+  fi
+done
+```
+
+The command should produce no output when all files have frontmatter.
+
+### Manual scenarios
+
+| Scenario                                                                                                 | Status | Evidence |
+| -------------------------------------------------------------------------------------------------------- | ------ | -------- |
+| Run the frontmatter check script above; verify zero output                                               | TODO   | —        |
+| Spot-check 3 closed issue specs to confirm required fields are present and correct                       | TODO   | —        |
+| Spot-check 2 ADR files to confirm `semantic-links` shape matches the ADR template                        | TODO   | —        |
+| Pick 3 top-level docs files; verify each `related-artifacts` entry resolves to a real path in the repo   | TODO   | —        |
+| Pick 2 pairs of `docs/` files that reference each other; verify the `related-artifacts` bidirectionality | TODO   | —        |
+| Confirm `linter all` passes on the final state of all modified files                                     | TODO   | —        |

--- a/docs/issues/open/README.md
+++ b/docs/issues/open/README.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-issue
+    - cleanup-completed-issues
+  related-artifacts:
+    - docs/issues/README.md
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - .github/skills/dev/planning/cleanup-completed-issues/SKILL.md
+---
+
 # Open Issues
 
 This folder contains issue specification files for GitHub issues that are currently open.

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - docs/adrs/20260429000000_keep_database_as_aggregate_supertrait.md
+    - packages/
+---
+
 # Torrust Tracker Package Architecture
 
 - [Package Conventions](#package-conventions)

--- a/docs/pr-reviews/README.md
+++ b/docs/pr-reviews/README.md
@@ -1,3 +1,13 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - docs/index.md
+    - docs/templates/COPILOT-SUGGESTIONS-TEMPLATE.md
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
 # PR Copilot Suggestions Review Workflow
 
 This directory contains tools and templates for managing GitHub Copilot code review suggestions on pull requests.

--- a/docs/pr-reviews/pr-1733-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-1733-copilot-suggestions.md
@@ -1,3 +1,11 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - docs/pr-reviews/README.md
+---
+
 # PR #1733 Copilot Suggestions Tracking
 
 Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/1733

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,3 +1,15 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - docs/benchmarking.md
+    - .cargo/config.toml
+    - share/default/config/tracker.udp.benchmarking.toml
+    - src/bin/profiling.rs
+---
+
 # Profiling
 
 ## Using flamegraph
@@ -38,7 +50,7 @@ cargo build --profile=release-debug --bin=profiling
 sudo TORRUST_TRACKER_CONFIG_TOML_PATH="./share/default/config/tracker.udp.benchmarking.toml" /home/USER/.cargo/bin/flamegraph -- ./target/release-debug/profiling 60
 ```
 
-__NOTICE__: You need to install the `aquatic_udp_load_test` program.
+**NOTICE**: You need to install the `aquatic_udp_load_test` program.
 
 The output should be like the following:
 
@@ -57,7 +69,7 @@ writing flamegraph to "flamegraph.svg"
 
 ![flamegraph](./media/flamegraph.svg)
 
-__NOTICE__: You need to provide the absolute path for the installed `flamegraph` app if you use sudo. Replace `/home/USER/.cargo/bin/flamegraph` with the location of your installed `flamegraph` app. You can run it without sudo but you can get a warning message like the following:
+**NOTICE**: You need to provide the absolute path for the installed `flamegraph` app if you use sudo. Replace `/home/USER/.cargo/bin/flamegraph` with the location of your installed `flamegraph` app. You can run it without sudo but you can get a warning message like the following:
 
 ```output
 WARNING: Kernel address maps (/proc/{kallsyms,modules}) are restricted,
@@ -77,7 +89,7 @@ Check /proc/kallsyms permission or run as root.
 Loading configuration file: `./share/default/config/tracker.udp.benchmarking.toml` ...
 ```
 
-And some bars in the graph  will have the `unknown` label.
+And some bars in the graph will have the `unknown` label.
 
 ![flamegraph generated without sudo](./media/flamegraph_generated_without_sudo.svg)
 

--- a/docs/refactor-plans/closed/1178-monitor-udp-post-implementation-improvements.md
+++ b/docs/refactor-plans/closed/1178-monitor-udp-post-implementation-improvements.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts:
+    - docs/refactor-plans/closed/README.md
+    - console/tracker-client/
+---
+
 # Refactor Plan — Issue #1178 Monitor UDP: Post-Implementation Improvements
 
 ## Goal

--- a/docs/refactor-plans/closed/README.md
+++ b/docs/refactor-plans/closed/README.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts:
+    - docs/index.md
+    - docs/refactor-plans/open/README.md
+    - docs/refactor-plans/drafts/README.md
+    - .github/skills/dev/planning/create-refactor-plan/SKILL.md
+---
+
 # Closed Refactor Plans
 
 This folder holds refactor plans where all items have been completed. Plans are kept here

--- a/docs/refactor-plans/closed/agent-docs-refactor-plan.md
+++ b/docs/refactor-plans/closed/agent-docs-refactor-plan.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts:
+    - docs/refactor-plans/closed/README.md
+    - AGENTS.md
+    - .github/agents/
+    - .github/skills/
+---
+
 # Agent Documentation Refactor Plan
 
 ## Goal

--- a/docs/refactor-plans/drafts/README.md
+++ b/docs/refactor-plans/drafts/README.md
@@ -1,3 +1,15 @@
+---
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts:
+    - docs/index.md
+    - docs/refactor-plans/open/README.md
+    - docs/refactor-plans/closed/README.md
+    - docs/templates/REFACTOR-PLAN.md
+    - .github/skills/dev/planning/create-refactor-plan/SKILL.md
+---
+
 # Draft Refactor Plans
 
 This folder contains refactor plan drafts that are being written or awaiting review before

--- a/docs/refactor-plans/open/README.md
+++ b/docs/refactor-plans/open/README.md
@@ -1,3 +1,14 @@
+---
+semantic-links:
+  skill-links:
+    - create-refactor-plan
+  related-artifacts:
+    - docs/index.md
+    - docs/refactor-plans/closed/README.md
+    - docs/refactor-plans/drafts/README.md
+    - .github/skills/dev/planning/create-refactor-plan/SKILL.md
+---
+
 # Open Refactor Plans
 
 This folder contains refactor plans that are actively being worked through.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,10 +1,20 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/index.md
+    - .github/workflows/deployment.yaml
+    - Cargo.toml
+---
+
 # Torrust Tracker Release Process (v2.2.2)
 
 ## Version
 
 > **The `[semantic version]` is bumped according to releases, new features, and breaking changes.**
 >
-> *The `develop` branch uses the (semantic version) suffix `-develop`.*
+> _The `develop` branch uses the (semantic version) suffix `-develop`._
 
 ## Process
 

--- a/docs/skills/semantic-skill-link-convention.md
+++ b/docs/skills/semantic-skill-link-convention.md
@@ -1,3 +1,12 @@
+---
+semantic-links:
+  skill-links:
+    - write-markdown-docs
+  related-artifacts:
+    - docs/AGENTS.md
+    - docs/index.md
+---
+
 # Semantic Skill Link Convention
 
 ## Purpose
@@ -82,7 +91,11 @@ semantic-links:
 
 Guidance:
 
-- Keep using inline `skill-link` markers as the primary convention for compatibility.
+- For Markdown files with frontmatter `semantic-links.skill-links`, the frontmatter is the
+  canonical source; inline `<!-- skill-link: ... -->` top-of-file markers are redundant and need
+  not be added.
+- For non-Markdown artifacts and Markdown files without frontmatter, inline markers remain the
+  primary convention.
 - Use frontmatter to express richer relations (for example bidirectional links).
 - Keep paths repository-relative and stable.
 - Keep links high-signal; avoid noisy or speculative links.
@@ -96,8 +109,9 @@ Use language-appropriate syntax:
 - TOML: `# skill-link: <skill-name>`
 - Markdown: `<!-- skill-link: <skill-name> -->`
 
-For Markdown files with frontmatter, place inline marker comments near the workflow-defining
-section even if frontmatter links are present.
+For Markdown files with frontmatter `semantic-links.skill-links`, top-of-file inline markers are
+redundant and need not be added. Inline markers placed near specific workflow-defining sections
+within the body remain useful for navigation but are not required when frontmatter links are present.
 
 Place the marker near:
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -30,6 +30,7 @@ bencode
 bencoded
 bencoding
 beps
+bidirectionality
 binascii
 binstall
 Bitflu


### PR DESCRIPTION
## Summary

Add YAML frontmatter with `semantic-links` to all 67 `docs/` Markdown files that previously lacked it, following the convention in `docs/skills/semantic-skill-link-convention.md`.

Every file received:
- Appropriate frontmatter shape for its document type (issue spec, EPIC, ADR, refactor plan, PR-review doc, or general nav/README)
- High-signal `related-artifacts` entries based on semantic analysis of each file
- Bidirectional `related-artifacts` links between cross-referenced `docs/` files

`docs/index.md` was updated with back-references to all nav files it links to (`docs/pr-reviews/README.md`, the three `docs/refactor-plans/` READMEs).

Also clarified the inline `<!-- skill-link: ... -->` vs. frontmatter `skill-links` guidance in `docs/skills/semantic-skill-link-convention.md` (T15): when frontmatter is present, it is the canonical machine-readable source; top-of-file inline markers are redundant.

## Files Touched

- `docs/` — 67 Markdown files received new frontmatter
- `docs/index.md` — updated `related-artifacts` back-refs
- `docs/skills/semantic-skill-link-convention.md` — frontmatter + guidance clarification (T15)
- `docs/issues/open/1810-add-frontmatter-to-docs-markdown-files.md` — spec updated to `status: done`, all checkboxes checked

## Validation

- `linter markdown` — pass
- `linter cspell` — pass
- `./contrib/dev-tools/git/hooks/pre-commit.sh` — pass (machete + all linters + doc tests)
- All commits GPG-signed

Closes #1810
