### PR TITLE
refactor(located-error): [#1823] rename torrust-tracker-located-error to torrust-located-error

### DIFF
--- a/.github/skills/dev/git-workflow/release-new-version/SKILL.md
+++ b/.github/skills/dev/git-workflow/release-new-version/SKILL.md
@@ -101,7 +101,7 @@ Check the
 ran successfully and the following crates were published:
 
 - `torrust-tracker-contrib-bencode`
-- `torrust-tracker-located-error`
+- `torrust-located-error`
 - `torrust-tracker-primitives`
 - `torrust-clock`
 - `torrust-tracker-configuration`

--- a/.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md
+++ b/.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md
@@ -69,7 +69,7 @@ For errors that benefit from source location tracking, use the `located-error` p
 
 ```toml
 [dependencies]
-torrust-located-error = { workspace = true }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 ```
 
 ```rust

--- a/.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md
+++ b/.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md
@@ -69,11 +69,11 @@ For errors that benefit from source location tracking, use the `located-error` p
 
 ```toml
 [dependencies]
-torrust-tracker-located-error = { workspace = true }
+torrust-located-error = { workspace = true }
 ```
 
 ```rust
-use torrust_tracker_located_error::Located;
+use torrust_located_error::Located;
 
 // Wraps any error with file and line information
 let err = Located(my_error).into();

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -74,7 +74,7 @@ jobs:
           cargo publish -p torrust-tracker-configuration
           cargo publish -p torrust-tracker-contrib-bencode
           cargo publish -p torrust-tracker-events
-          cargo publish -p torrust-tracker-located-error
+          cargo publish -p torrust-located-error
           cargo publish -p torrust-tracker-metrics
           cargo publish -p torrust-tracker-primitives
           cargo publish -p torrust-tracker-swarm-coordination-registry

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -55,6 +55,7 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: "${{ secrets.TORRUST_UPDATE_CARGO_REGISTRY_TOKEN }}"
         run: |
+          cargo publish -p torrust-located-error
           cargo publish -p bittorrent-http-tracker-core
           cargo publish -p bittorrent-http-tracker-protocol
           cargo publish -p bittorrent-tracker-client
@@ -74,7 +75,6 @@ jobs:
           cargo publish -p torrust-tracker-configuration
           cargo publish -p torrust-tracker-contrib-bencode
           cargo publish -p torrust-tracker-events
-          cargo publish -p torrust-located-error
           cargo publish -p torrust-tracker-metrics
           cargo publish -p torrust-tracker-primitives
           cargo publish -p torrust-tracker-swarm-coordination-registry

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,12 +64,12 @@ All packages live under `packages/`. The workspace version is `3.0.0-develop`.
 | `axum-http-tracker-server`        | `torrust-tracker-axum-http-server`                | `axum-*`       | BitTorrent HTTP tracker server (BEP 3/23)      |
 | `axum-rest-tracker-api-server`    | `torrust-tracker-axum-rest-api-server`            | `axum-*`       | Management REST API server                     |
 | `axum-server`                     | `torrust-tracker-axum-server`                     | `axum-*`       | Base Axum HTTP server infrastructure           |
-| `clock`                           | `torrust-clock`                           | utilities      | Mockable time source for deterministic testing |
+| `clock`                           | `torrust-clock`                                   | utilities      | Mockable time source for deterministic testing |
 | `configuration`                   | `torrust-tracker-configuration`                   | domain         | Config file parsing, environment variables     |
 | `events`                          | `torrust-tracker-events`                          | domain         | Domain event definitions                       |
 | `http-protocol`                   | `bittorrent-http-tracker-protocol`                | `*-protocol`   | HTTP tracker protocol (BEP 3/23) parsing       |
 | `http-tracker-core`               | `bittorrent-http-tracker-core`                    | `*-core`       | HTTP-specific tracker domain logic             |
-| `located-error`                   | `torrust-tracker-located-error`                   | utilities      | Diagnostic errors with source locations        |
+| `located-error`                   | `torrust-located-error`                           | utilities      | Diagnostic errors with source locations        |
 | `metrics`                         | `torrust-metrics`                                 | domain         | Prometheus metrics integration                 |
 | `peer-id`                         | `bittorrent-peer-id`                              | domain         | Peer ID parsing and formatting utilities       |
 | `primitives`                      | `torrust-tracker-primitives`                      | domain         | Core domain types (InfoHash, PeerId, ...)      |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,8 +496,8 @@ dependencies = [
  "serde_bencode",
  "thiserror 2.0.18",
  "torrust-clock",
+ "torrust-located-error",
  "torrust-tracker-contrib-bencode",
- "torrust-tracker-located-error",
  "torrust-tracker-primitives",
 ]
 
@@ -541,8 +541,8 @@ dependencies = [
  "serde_repr",
  "thiserror 2.0.18",
  "tokio",
+ "torrust-located-error",
  "torrust-net-primitives",
- "torrust-tracker-located-error",
  "torrust-tracker-primitives",
  "tracing",
  "zerocopy",
@@ -568,10 +568,10 @@ dependencies = [
  "tokio",
  "tokio-util",
  "torrust-clock",
+ "torrust-located-error",
  "torrust-metrics",
  "torrust-tracker-configuration",
  "torrust-tracker-events",
- "torrust-tracker-located-error",
  "torrust-tracker-primitives",
  "torrust-tracker-swarm-coordination-registry",
  "torrust-tracker-test-helpers",
@@ -5111,6 +5111,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "torrust-located-error"
+version = "3.0.0-develop"
+dependencies = [
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "torrust-metrics"
 version = "3.0.0-develop"
 dependencies = [
@@ -5311,9 +5319,9 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.18",
  "tokio",
+ "torrust-located-error",
  "torrust-server-lib",
  "torrust-tracker-configuration",
- "torrust-tracker-located-error",
  "tower",
  "tracing",
 ]
@@ -5355,7 +5363,7 @@ dependencies = [
  "serde_with",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
- "torrust-tracker-located-error",
+ "torrust-located-error",
  "torrust-tracker-primitives",
  "tracing",
  "tracing-subscriber",
@@ -5378,14 +5386,6 @@ dependencies = [
  "futures",
  "mockall",
  "tokio",
-]
-
-[[package]]
-name = "torrust-tracker-located-error"
-version = "3.0.0-develop"
-dependencies = [
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]

--- a/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
+++ b/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
@@ -6,8 +6,8 @@ priority: p2
 github-issue: 1823
 spec-path: docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
 branch: 1823-rename-torrust-tracker-located-error-to-torrust-located-error
-related-pr: null
-last-updated-utc: 2026-05-21 17:15
+related-pr: 1824
+last-updated-utc: 2026-05-22 08:09
 semantic-links:
   skill-links:
     - create-issue
@@ -173,20 +173,20 @@ only after T10 is complete.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                                                                                       | Notes / Expected Output                                                      |
-| --- | ------ | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| T1  | TODO   | Rename `name` in `packages/located-error/Cargo.toml`                                                       | `name = "torrust-located-error"`                                             |
-| T2  | TODO   | Update root `Cargo.toml` workspace dependency key                                                          | `torrust-located-error = { version = ..., path = "packages/located-error" }` |
-| T3  | TODO   | Update all 5 dependent package `Cargo.toml` files (excluding root — see T2)                                | Replace `torrust-tracker-located-error` key with `torrust-located-error`     |
-| T4  | TODO   | Update Rust source `use` / path references (`torrust_tracker_located_error::` → `torrust_located_error::`) | Affects package sources and integration tests                                |
-| T5  | TODO   | Update prose in `packages/AGENTS.md`, `AGENTS.md`, `docs/packages.md`, `packages/located-error/README.md`  | Crate name and any inline code snippets                                      |
-| T6  | TODO   | Run `cargo build --workspace` and `cargo test --workspace`                                                 | Clean build and all tests pass                                               |
-| T7  | TODO   | Run `linter all`                                                                                           | Exit code `0`                                                                |
-| T8  | TODO   | Publish `torrust-located-error` on crates.io                                                               | Successful `cargo publish -p torrust-located-error`                          |
-| T9  | TODO   | Add deprecation notice to `torrust-tracker-located-error` on crates.io                                     | README / description points to `torrust-located-error`; do **not** yank yet  |
-| T10 | TODO   | Check and migrate any downstream Torrust repositories using `torrust-tracker-located-error`                | Companion PRs in downstream repos merged; must be complete before T11        |
-| T11 | TODO   | Yank all versions of `torrust-tracker-located-error` on crates.io                                          | All versions yanked; T10 must be complete first                              |
-| T12 | TODO   | Update EPIC #1669 `Package Inventory` and `Desired Package State` tables                                   | Move `torrust-located-error` from `torrust-tracker-` to `torrust-` prefix    |
+| ID  | Status | Task                                                                                                       | Notes / Expected Output                                                     |
+| --- | ------ | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| T1  | DONE   | Rename `name` in `packages/located-error/Cargo.toml`                                                       | `name = "torrust-located-error"`                                            |
+| T2  | N/A    | Update root `Cargo.toml` workspace dependency key                                                          | No workspace-level dep existed; all 5 packages reference the crate directly |
+| T3  | DONE   | Update all 5 dependent package `Cargo.toml` files (excluding root — see T2)                                | Replace `torrust-tracker-located-error` key with `torrust-located-error`    |
+| T4  | DONE   | Update Rust source `use` / path references (`torrust_tracker_located_error::` → `torrust_located_error::`) | Affects package sources and integration tests                               |
+| T5  | DONE   | Update prose in `packages/AGENTS.md`, `AGENTS.md`, `docs/packages.md`, `packages/located-error/README.md`  | Crate name and any inline code snippets                                     |
+| T6  | DONE   | Run `cargo build --workspace` and `cargo test --workspace`                                                 | Clean build and all tests pass                                              |
+| T7  | DONE   | Run `linter all`                                                                                           | Exit code `0`                                                               |
+| T8  | TODO   | Publish `torrust-located-error` on crates.io                                                               | Successful `cargo publish -p torrust-located-error`                         |
+| T9  | TODO   | Add deprecation notice to `torrust-tracker-located-error` on crates.io                                     | README / description points to `torrust-located-error`; do **not** yank yet |
+| T10 | TODO   | Check and migrate any downstream Torrust repositories using `torrust-tracker-located-error`                | Companion PRs in downstream repos merged; must be complete before T11       |
+| T11 | TODO   | Yank all versions of `torrust-tracker-located-error` on crates.io                                          | All versions yanked; T10 must be complete first                             |
+| T12 | TODO   | Update EPIC #1669 `Package Inventory` and `Desired Package State` tables                                   | Move `torrust-located-error` from `torrust-tracker-` to `torrust-` prefix   |
 
 **Dependent packages to update in T3** (5 files; root `Cargo.toml` is handled in T2):
 
@@ -200,12 +200,12 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 ### Workflow Checkpoints
 
-- [ ] Spec drafted in `docs/issues/drafts/`
-- [ ] Spec reviewed and approved by user/maintainer
-- [ ] GitHub issue created and issue number added to this spec
-- [ ] Spec moved to `docs/issues/open/` with issue number prefix
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, `cargo test --workspace`)
+- [x] Spec drafted in `docs/issues/drafts/`
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue created and issue number added to this spec
+- [x] Spec moved to `docs/issues/open/` with issue number prefix
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, `cargo test --workspace`)
 - [ ] Manual verification scenarios executed and recorded
 - [ ] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] `torrust-located-error` published on crates.io; deprecation notice added to old name
@@ -219,6 +219,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-05-15 12:00 UTC - josecelano - Spec drafted as subissue of EPIC #1669
 - 2026-05-21 17:00 UTC - josecelano - GitHub issue #1823 created and linked as sub-issue of #1669; spec moved to `docs/issues/open/`
 - 2026-05-21 17:15 UTC - josecelano - Added pre-implementation "Keep vs. Delete" analysis; awaiting reviewer decision before T1 starts
+- 2026-05-22 08:09 UTC - josecelano - Rename implemented: T1 (Cargo.toml name), T3 (5 dependent Cargo.toml dep keys), T4 (10 Rust source use statements), T5 (README, AGENTS.md, deployment.yaml, release_process.md, 2 skills); T2 is N/A (no workspace-level dep existed). T6 (`cargo build --workspace`, `cargo test --workspace`) and T7 (`linter all`) all pass. Draft PR #1824 open.
 
 ## Acceptance Criteria
 
@@ -252,9 +253,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                              | Command / Steps                                                                                                | Expected Result                            | Status | Evidence |
-| --- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ | -------- |
-| M1  | No stale references to old crate name | `grep -r "torrust-tracker-located-error\|torrust_tracker_located_error" . --include="*.toml" --include="*.rs"` | Zero matches                               | TODO   |          |
-| M2  | New crate name visible on crates.io   | Visit `https://crates.io/crates/torrust-located-error`                                                         | Crate page exists and shows latest version | TODO   |          |
-| M3  | Old crate name yanked                 | Visit `https://crates.io/crates/torrust-tracker-located-error`                                                 | All versions show "yanked"                 | TODO   |          |
-| M4  | Downstream Torrust repositories clean | Check `torrust-index` and other Torrust repos for `torrust-tracker-located-error` dependency                   | No references found after T10              | TODO   |          |
+| ID  | Scenario                              | Command / Steps                                                                                                | Expected Result                            | Status | Evidence                          |
+| --- | ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ | --------------------------------- |
+| M1  | No stale references to old crate name | `grep -r "torrust-tracker-located-error\|torrust_tracker_located_error" . --include="*.toml" --include="*.rs"` | Zero matches                               | DONE   | Zero matches confirmed 2026-05-22 |
+| M2  | New crate name visible on crates.io   | Visit `https://crates.io/crates/torrust-located-error`                                                         | Crate page exists and shows latest version | TODO   |                                   |
+| M3  | Old crate name yanked                 | Visit `https://crates.io/crates/torrust-tracker-located-error`                                                 | All versions show "yanked"                 | TODO   |                                   |
+| M4  | Downstream Torrust repositories clean | Check `torrust-index` and other Torrust repos for `torrust-tracker-located-error` dependency                   | No references found after T10              | TODO   |                                   |

--- a/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
+++ b/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: draft
+status: open
 priority: p2
-github-issue: null
-spec-path: docs/issues/drafts/1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
-branch: null
+github-issue: 1823
+spec-path: docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
+branch: 1823-rename-torrust-tracker-located-error-to-torrust-located-error
 related-pr: null
-last-updated-utc: 2026-05-15 12:00
+last-updated-utc: 2026-05-21 17:00
 semantic-links:
   skill-links:
     - create-issue
@@ -21,7 +21,7 @@ semantic-links:
 
 <!-- skill-link: create-issue -->
 
-# Issue #[To be assigned] - Rename `torrust-tracker-located-error` to `torrust-located-error`
+# Issue #1823 - Rename `torrust-tracker-located-error` to `torrust-located-error`
 
 ## Goal
 
@@ -128,6 +128,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 ### Progress Log
 
 - 2026-05-15 12:00 UTC - josecelano - Spec drafted as subissue of EPIC #1669
+- 2026-05-21 17:00 UTC - josecelano - GitHub issue #1823 created and linked as sub-issue of #1669; spec moved to `docs/issues/open/`
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
+++ b/docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
@@ -7,7 +7,7 @@ github-issue: 1823
 spec-path: docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
 branch: 1823-rename-torrust-tracker-located-error-to-torrust-located-error
 related-pr: null
-last-updated-utc: 2026-05-21 17:00
+last-updated-utc: 2026-05-21 17:15
 semantic-links:
   skill-links:
     - create-issue
@@ -50,6 +50,95 @@ the old published name (deprecation notice, then yank after downstream migration
 
 This issue is a subissue of EPIC [#1669](../open/1669-overhaul-packages/EPIC.md)
 (Overhaul: Packages).
+
+## Pre-Implementation Review: Keep vs. Delete
+
+Before starting the rename, we reconsidered whether the package itself should exist or be
+removed. The conclusion below should be reviewed and confirmed in the PR before T1–T13 are
+executed.
+
+### Recommendation
+
+**Keep the package and proceed with the rename to `torrust-located-error`.**
+
+### What the package actually provides
+
+The crate is ~110 lines in a single file (`packages/located-error/src/lib.rs`) with one
+runtime dependency (`tracing`). It exports:
+
+- `Located<E>` — newtype wrapper used as the conversion entry point.
+- `LocatedError<'a, E>` — the decorated error: `Arc<E>` source + `Box<Location<'a>>`.
+- `DynError` — `Arc<dyn Error + Send + Sync>` type alias.
+- A `#[track_caller]` `Into` impl that captures `Location::caller()` and emits
+  `tracing::debug!` on construction.
+
+Non-trivial value vs. `std` / `thiserror` alone:
+
+1. `#[track_caller]` capture into a stored `Location` (std has no first-class equivalent).
+2. `Arc`-shared source making the error cheaply `Clone` even for `!Clone` inner errors.
+3. Automatic `tracing::debug!` log on construction (single attachment point for tracing).
+4. Works for both concrete `E: Error` and `dyn Error + Send + Sync`.
+
+### Current workspace usage
+
+Active in **5 packages**, ~20 call sites:
+
+| Package          | Files                                                                                                      | Usage                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `configuration`  | `src/lib.rs`                                                                                               | 3 error variants (dyn)         |
+| `axum-server`    | `src/tsl.rs`                                                                                               | TLS error variant (dyn)        |
+| `http-protocol`  | `src/v1/requests/announce.rs`, `src/v1/requests/scrape.rs`                                                 | info_hash / peer-id conversion |
+| `tracker-core`   | `src/error.rs`, `src/authentication/key/mod.rs`, `src/authentication/handler.rs`, `src/databases/error.rs` | many error variants            |
+| `tracker-client` | `src/udp/mod.rs`                                                                                           | uses `DynError` alias          |
+
+The package is also referenced from
+[`.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md`](../../../.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md)
+as the recommended pattern for diagnostics-rich errors.
+
+### Why keep it
+
+- **Real, non-trivial functionality.** The `#[track_caller]` + `Arc`-clone + auto-trace
+  combo is not a one-liner. Replacing it everywhere would either duplicate the pattern
+  across 5 packages or drop diagnostic features.
+- **Stable surface, near-zero maintenance cost.** Single file, one dep, hasn't changed
+  materially in a long time.
+- **Crates.io alternatives are worse fits.** `error-stack` / `eyre` / `anyhow` are heavier
+  and don't compose cleanly with the `thiserror`-enum policy. The error-handling skill
+  explicitly disallows `anyhow` in libraries.
+- **Removal cost is high, benefit is low.** Deleting would touch ~20 call sites across
+  core domain packages just to swap to a less expressive pattern.
+- **The rename premise still holds.** Nothing in the implementation is tracker-specific.
+  `torrust-located-error` correctly reflects scope and is reusable by `torrust-index`.
+
+### Why delete it (the alternative case)
+
+For completeness, reasons one might prefer deletion:
+
+- **Niche pattern.** Locating an error to a `Location` is most useful when the wrapped
+  error type is `!Display`/opaque (e.g. `Box<dyn Error>`). Where call sites use concrete
+  `thiserror` enums with `#[from]`, the `?` operator already propagates source-chain
+  information and the `Location` adds limited extra signal.
+- **Tracing overlap.** `tracing` spans / `instrument` can carry caller metadata; some of
+  the value of `Located` is already available from structured logging at error sites.
+- **Few real beneficiaries.** Of the ~20 call sites, several store `LocatedError<dyn ...>`
+  variants that are rarely matched on; a plain `Box<dyn Error + Send + Sync>` source
+  field plus a `tracing::error!` at construction may be sufficient.
+- **One less crate to publish/maintain** on crates.io if the value is mostly cosmetic.
+
+These points are weaker than the "keep" reasons above given the current usage, but they
+are why this question is worth confirming with a reviewer before committing to a rename
+
+- publish + downstream migration.
+
+### Decision needed before implementation
+
+If the reviewer agrees with **Keep**, T1–T13 proceed as planned.
+
+If the reviewer prefers **Delete**, this subissue is closed and replaced by a new
+subissue with scope: remove `packages/located-error`, migrate ~20 call sites to a
+simpler pattern (likely `Box<dyn Error + Send + Sync>` + explicit `tracing::error!` at
+construction sites), yank `torrust-tracker-located-error` from crates.io with a final
+deprecation note.
 
 ## Scope
 
@@ -129,6 +218,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 - 2026-05-15 12:00 UTC - josecelano - Spec drafted as subissue of EPIC #1669
 - 2026-05-21 17:00 UTC - josecelano - GitHub issue #1823 created and linked as sub-issue of #1669; spec moved to `docs/issues/open/`
+- 2026-05-21 17:15 UTC - josecelano - Added pre-implementation "Keep vs. Delete" analysis; awaiting reviewer decision before T1 starts
 
 ## Acceptance Criteria
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -80,7 +80,7 @@ git push --tags torrust
 Make sure the [deployment](https://github.com/torrust/torrust-tracker/actions/workflows/deployment.yaml) workflow was successfully executed and the new version for the following crates were published:
 
 - [torrust-tracker-contrib-bencode](https://crates.io/crates/torrust-tracker-contrib-bencode)
-- [torrust-tracker-located-error](https://crates.io/crates/torrust-tracker-located-error)
+- [torrust-located-error](https://crates.io/crates/torrust-located-error)
 - [torrust-tracker-primitives](https://crates.io/crates/torrust-tracker-primitives)
 - [torrust-clock](https://crates.io/crates/torrust-clock)
 - [torrust-tracker-configuration](https://crates.io/crates/torrust-tracker-configuration)

--- a/packages/axum-server/Cargo.toml
+++ b/packages/axum-server/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2"
 tokio = { version = "1", features = [ "macros", "net", "rt-multi-thread", "signal", "sync" ] }
 torrust-server-lib = { version = "3.0.0-develop", path = "../server-lib" }
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 tower = { version = "0", features = [ "timeout" ] }
 tracing = "0"
 

--- a/packages/axum-server/src/tsl.rs
+++ b/packages/axum-server/src/tsl.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use axum_server::tls_rustls::RustlsConfig;
 use thiserror::Error;
+use torrust_located_error::{DynError, LocatedError};
 use torrust_tracker_configuration::TslConfig;
-use torrust_tracker_located_error::{DynError, LocatedError};
 use tracing::instrument;
 
 /// Error returned by the Bootstrap Process.

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { version = "1", features = [ "preserve_order" ] }
 serde_with = "3"
 thiserror = "2"
 toml = "0"
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 tracing = "0"
 tracing-subscriber = { version = "0", features = [ "json" ] }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -17,7 +17,7 @@ use derive_more::{Constructor, Display};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
-use torrust_tracker_located_error::{DynError, LocatedError};
+use torrust_located_error::{DynError, LocatedError};
 
 /// The maximum number of returned peers for a torrent.
 pub const TORRENT_PEERS_LIMIT: usize = 74;

--- a/packages/http-protocol/Cargo.toml
+++ b/packages/http-protocol/Cargo.toml
@@ -26,5 +26,5 @@ serde_bencode = "0"
 thiserror = "2"
 torrust-clock = { version = "3.0.0-develop", path = "../clock" }
 torrust-tracker-contrib-bencode = { version = "3.0.0-develop", path = "../../contrib/bencode" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use bittorrent_primitives::info_hash::{self, InfoHash};
 use thiserror::Error;
 use torrust_clock::clock::Time;
-use torrust_tracker_located_error::{Located, LocatedError};
+use torrust_located_error::{Located, LocatedError};
 use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes, PeerId, peer};
 
 use crate::CurrentClock;

--- a/packages/http-protocol/src/v1/requests/scrape.rs
+++ b/packages/http-protocol/src/v1/requests/scrape.rs
@@ -5,7 +5,7 @@ use std::panic::Location;
 
 use bittorrent_primitives::info_hash::{self, InfoHash};
 use thiserror::Error;
-use torrust_tracker_located_error::{Located, LocatedError};
+use torrust_located_error::{Located, LocatedError};
 
 use crate::percent_encoding::percent_decode_info_hash;
 use crate::v1::query::Query;

--- a/packages/located-error/Cargo.toml
+++ b/packages/located-error/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "A library to provide error decorator with the location and the source of the original error."
 keywords = [ "errors", "helper", "library" ]
-name = "torrust-tracker-located-error"
+name = "torrust-located-error"
 readme = "README.md"
 
 authors.workspace = true

--- a/packages/located-error/README.md
+++ b/packages/located-error/README.md
@@ -1,10 +1,10 @@
-# Torrust Tracker Located Error
+# Torrust Located Error
 
 A library to provide an error decorator with the location and the source of the original error.
 
 ## Documentation
 
-[Crate documentation](https://docs.rs/torrust-tracker-located-error).
+[Crate documentation](https://docs.rs/torrust-located-error).
 
 ## License
 

--- a/packages/located-error/src/lib.rs
+++ b/packages/located-error/src/lib.rs
@@ -5,7 +5,7 @@
 //! use std::error::Error;
 //! use std::panic::Location;
 //! use std::sync::Arc;
-//! use torrust_tracker_located_error::{Located, LocatedError};
+//! use torrust_located_error::{Located, LocatedError};
 //!
 //! #[derive(thiserror::Error, Debug)]
 //! enum TestError {

--- a/packages/tracker-client/Cargo.toml
+++ b/packages/tracker-client/Cargo.toml
@@ -27,7 +27,7 @@ serde_bytes = "0"
 serde_repr = "0"
 thiserror = "2"
 tokio = { version = "1", features = [ "macros", "net", "rt-multi-thread", "signal", "sync" ] }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 torrust-net-primitives = { version = "3.0.0-develop", path = "../net-primitives" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 tracing = "0"

--- a/packages/tracker-client/src/udp/mod.rs
+++ b/packages/tracker-client/src/udp/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use bittorrent_udp_tracker_protocol::Request;
 use thiserror::Error;
-use torrust_tracker_located_error::DynError;
+use torrust_located_error::DynError;
 
 pub mod client;
 

--- a/packages/tracker-core/Cargo.toml
+++ b/packages/tracker-core/Cargo.toml
@@ -35,7 +35,7 @@ tokio-util = "0.7.15"
 torrust-clock = { version = "3.0.0-develop", path = "../clock" }
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
 torrust-tracker-events = { version = "3.0.0-develop", path = "../events" }
-torrust-tracker-located-error = { version = "3.0.0-develop", path = "../located-error" }
+torrust-located-error = { version = "3.0.0-develop", path = "../located-error" }
 torrust-metrics = { version = "3.0.0-develop", path = "../metrics" }
 torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }
 torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "../swarm-coordination-registry" }

--- a/packages/tracker-core/src/authentication/handler.rs
+++ b/packages/tracker-core/src/authentication/handler.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_clock::clock::Time;
-use torrust_tracker_located_error::Located;
+use torrust_located_error::Located;
 
 use super::key::repository::in_memory::InMemoryKeyRepository;
 use super::key::repository::persisted::DatabaseKeyRepository;

--- a/packages/tracker-core/src/authentication/key/mod.rs
+++ b/packages/tracker-core/src/authentication/key/mod.rs
@@ -50,7 +50,7 @@ use std::time::Duration;
 use thiserror::Error;
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_clock::clock::Time;
-use torrust_tracker_located_error::{DynError, LocatedError};
+use torrust_located_error::{DynError, LocatedError};
 
 use crate::CurrentClock;
 

--- a/packages/tracker-core/src/databases/error.rs
+++ b/packages/tracker-core/src/databases/error.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use sqlx::Error as SqlxError;
 use sqlx::migrate::MigrateError;
-use torrust_tracker_located_error::{DynError, LocatedError};
+use torrust_located_error::{DynError, LocatedError};
 
 use super::driver::Driver;
 

--- a/packages/tracker-core/src/error.rs
+++ b/packages/tracker-core/src/error.rs
@@ -10,7 +10,7 @@
 use std::panic::Location;
 
 use bittorrent_primitives::info_hash::InfoHash;
-use torrust_tracker_located_error::LocatedError;
+use torrust_located_error::LocatedError;
 
 use super::authentication::key::ParseKeyError;
 use super::databases;
@@ -146,7 +146,7 @@ mod tests {
     }
 
     mod peer_key_error {
-        use torrust_tracker_located_error::Located;
+        use torrust_located_error::Located;
 
         use crate::databases::driver::Driver;
         use crate::error::PeerKeyError;


### PR DESCRIPTION
## Summary

Implements #1823: rename the Cargo crate `torrust-tracker-located-error` → `torrust-located-error`.

## What changed

- **T1** — `packages/located-error/Cargo.toml`: `name = "torrust-located-error"`
- **T2** — N/A: no workspace-level dep existed in root `Cargo.toml`; all 5 dependent packages reference the crate directly
- **T3** — Dep key renamed in 5 `Cargo.toml` files:
  - `packages/configuration/Cargo.toml`
  - `packages/axum-server/Cargo.toml`
  - `packages/http-protocol/Cargo.toml`
  - `packages/tracker-core/Cargo.toml`
  - `packages/tracker-client/Cargo.toml`
- **T4** — 10 Rust source `use` statements updated (`torrust_tracker_located_error::` → `torrust_located_error::`) across 9 files
- **T5** — Prose updated in: `AGENTS.md`, `packages/located-error/README.md`, `.github/workflows/deployment.yaml`, `docs/release_process.md`, `.github/skills/dev/git-workflow/release-new-version/SKILL.md`, `.github/skills/dev/rust-code-quality/handle-errors-in-code/SKILL.md`
- **T6/T7** — `cargo build --workspace`, `cargo test --workspace`, and `linter all` all pass

## Pre-implementation analysis

The "Pre-Implementation Review: Keep vs. Delete" section in the spec records the analysis done before committing to the rename. Recommendation was **Keep + rename**, which was proceeded with. If a reviewer disagrees and prefers deletion, this PR can be closed and a replacement issue opened with delete-and-migrate scope.

## Spec

[docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md](docs/issues/open/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md)

## Out of scope (deferred)

- T8: Publish `torrust-located-error` on crates.io
- T9: Deprecation notice on old crates.io name
- T10: Downstream repos migration
- T11: Yank `torrust-tracker-located-error`
- T12: Update EPIC #1669 tables

Closes #1823. Related to #1669.