### PR TITLE
refactor(http-protocol): decouple from udp-protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5342,7 +5342,6 @@ dependencies = [
  "torrust-located-error",
  "torrust-tracker-contrib-bencode",
  "torrust-tracker-primitives",
- "torrust-tracker-udp-tracker-protocol",
 ]
 
 [[package]]

--- a/docs/issues/open/1669-overhaul-packages/EPIC.md
+++ b/docs/issues/open/1669-overhaul-packages/EPIC.md
@@ -239,7 +239,7 @@ The following crates remain in `torrust/torrust-tracker` for now:
 - `torrust-tracker-core`
 
 Rationale: current dependencies indicate unresolved layering/coupling. In particular,
-`torrust-http-tracker-protocol` currently depends on
+`torrust-tracker-http-tracker-protocol` currently depends on
 `torrust-tracker-primitives`. The move can be
 revisited after these dependencies are clarified and reduced.
 

--- a/docs/issues/open/1669-overhaul-packages/EPIC.md
+++ b/docs/issues/open/1669-overhaul-packages/EPIC.md
@@ -240,7 +240,7 @@ The following crates remain in `torrust/torrust-tracker` for now:
 
 Rationale: current dependencies indicate unresolved layering/coupling. In particular,
 `torrust-http-tracker-protocol` currently depends on
-`torrust-tracker-primitives` and `torrust-udp-tracker-protocol`. The move can be
+`torrust-tracker-primitives`. The move can be
 revisited after these dependencies are clarified and reduced.
 
 > **Naming policy**: prefix reflects ownership and release identity, not estimated
@@ -352,7 +352,6 @@ This section lists direct crate dependencies that have a `torrust*` prefix.
   - `torrust-clock`
   - `torrust-located-error`
   - `torrust-tracker-primitives`
-  - `torrust-tracker-udp-tracker-protocol`
 - `torrust-tracker-udp-tracker-core`
   - `torrust-clock`
   - `torrust-metrics`
@@ -534,7 +533,7 @@ Status: TODO unless noted.
 
 #### 3. Numbered Subissues (GitHub Issues Open)
 
-- [ ] [#1834](https://github.com/torrust/torrust-tracker/issues/1834) SI-13: Decouple `http-protocol` from `udp-protocol` _(Rule M; remove cross-protocol dependency edge)_
+- [x] [#1834](https://github.com/torrust/torrust-tracker/issues/1834) SI-13: Decouple `http-protocol` from `udp-protocol` _(Rule M; remove cross-protocol dependency edge)_
 - [ ] [#1835](https://github.com/torrust/torrust-tracker/issues/1835) SI-14: Decouple `http-protocol` from `torrust-tracker-primitives` _(Rule M; remove protocol -> domain coupling as step 2)_
 
 #### 4. Draft Specs (No Subissue Number, No GitHub Issue)
@@ -571,7 +570,7 @@ Details:
 | REST API architecture      | #TBD — Define REST API contract-first package architecture                                                                                                                       | [docs/issues/drafts/1669-define-rest-api-contract-first-package-architecture.md](../../drafts/1669-define-rest-api-contract-first-package-architecture.md)                                     | TODO   | Policy reminder only in this EPIC; validate via PoC, then execute migration in a dedicated API EPIC; defer API package extraction/publication |
 | Rename-to-desired-state    | [#1829](https://github.com/torrust/torrust-tracker/issues/1829) — Rename crates and folder names to match desired `torrust-tracker` workspace state                              | [docs/issues/closed/1829-1669-11-rename-crates-and-folders-to-match-desired-tracker-workspace.md](../../closed/1829-1669-11-rename-crates-and-folders-to-match-desired-tracker-workspace.md)   | DONE   | SI-11 complete; spec archived to `docs/issues/closed/` after issue closure                                                                    |
 | HTTP protocol decoupling   | [#1830](https://github.com/torrust/torrust-tracker/issues/1830) — Decouple `http-protocol` from `tracker-core`                                                                   | [docs/issues/closed/1830-1669-12-decouple-http-protocol-from-tracker-core.md](../../closed/1830-1669-12-decouple-http-protocol-from-tracker-core.md)                                           | DONE   | SI-12 complete; removed `http-protocol -> tracker-core` edge and moved mapping to higher layer                                                |
-| HTTP/UDP decoupling        | [#1834](https://github.com/torrust/torrust-tracker/issues/1834) — Decouple `http-protocol` from `udp-protocol`                                                                   | [docs/issues/open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md](../../open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md)                                               | TODO   | SI-13. Rule M; remove cross-protocol dependency edge                                                                                          |
+| HTTP/UDP decoupling        | [#1834](https://github.com/torrust/torrust-tracker/issues/1834) — Decouple `http-protocol` from `udp-protocol`                                                                   | [docs/issues/open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md](../../open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md)                                               | DONE   | SI-13 complete; removed `http-protocol -> udp-protocol` edge                                                                                  |
 | HTTP/primitives decoupling | [#1835](https://github.com/torrust/torrust-tracker/issues/1835) — Decouple `http-protocol` from `torrust-tracker-primitives`                                                     | [docs/issues/open/1835-1669-14-decouple-http-protocol-from-tracker-primitives.md](../../open/1835-1669-14-decouple-http-protocol-from-tracker-primitives.md)                                   | TODO   | SI-14. Rule M; execute after SI-13; remove protocol -> domain coupling in step 2                                                              |
 
 ### Draft issues
@@ -688,7 +687,7 @@ against this constraint (verified May 2026).
 | `torrust-tracker-metrics` (→ `torrust-metrics`) | No               | `torrust-tracker-clock` (published ✅; was `torrust-tracker-primitives` — removed by SI-02 #1790)                                                       | ✅ After rename                 | See [extract metrics subissue](../../drafts/1669-extract-torrust-metrics-to-standalone-repo.md)                                         |
 | `torrust-tracker-udp-tracker-protocol`          | No               | `bittorrent-peer-id` (not published)                                                                                                                    | ❌                              | After `bittorrent-peer-id`                                                                                                              |
 | `torrust-tracker-core`                          | No               | `torrust-tracker-events`, `torrust-tracker-metrics`, `torrust-tracker-swarm-coordination-registry`, `torrust-tracker-rest-api-client` (all unpublished) | ❌ Very deep chain              | After all four above; also has `torrust-tracker-rest-api-client` as a runtime dep — a layer violation worth resolving before extraction |
-| `torrust-tracker-http-tracker-protocol`         | No               | `torrust-tracker-udp-tracker-protocol`, `torrust-tracker-core` (both unpublished)                                                                       | ❌                              | After `torrust-tracker-udp-tracker-protocol` and `torrust-tracker-core`                                                                 |
+| `torrust-tracker-http-tracker-protocol`         | No               | `torrust-tracker-core` (unpublished)                                                                                                                    | ❌                              | After `torrust-tracker-core`                                                                                                            |
 
 **Practical extraction order for `bittorrent-*` crates** (once decided):
 
@@ -697,7 +696,7 @@ against this constraint (verified May 2026).
 3. `torrust-tracker-core` — needs the four unpublished deps above + clock rename; complex
    chain; the layer violation (`torrust-tracker-rest-api-client` runtime dep) should be
    resolved before or during this step.
-4. `torrust-tracker-http-tracker-protocol` — needs #2 and #3 done.
+4. `torrust-tracker-http-tracker-protocol` — needs #3 done.
 
 > Workspace renames (this EPIC's current subissues) are independent of extraction ordering —
 > a crate can be renamed in-workspace before it is published or extracted.

--- a/docs/issues/open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md
+++ b/docs/issues/open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md
@@ -5,7 +5,7 @@ status: planned
 priority: p1
 github-issue: 1834
 spec-path: docs/issues/open/1834-1669-13-decouple-http-protocol-from-udp-protocol.md
-branch: null
+branch: 1834-decouple-http-protocol-from-udp-protocol
 related-pr: null
 last-updated-utc: 2026-05-27 00:00
 semantic-links:
@@ -103,27 +103,27 @@ Additional context:
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                                                                                   | Notes / Expected Output                                                                                                                  |
-| --- | ------ | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Confirm all UDP protocol usage in `http-protocol` is limited to one conversion impl                    | Evidence recorded in PR description                                                                                                      |
-| T2  | TODO   | Remove UDP `AnnounceEvent` conversion impl from `packages/http-protocol/src/v1/requests/announce.rs`   | No direct references to `torrust_tracker_udp_tracker_protocol::` remain                                                                  |
-| T3  | TODO   | Remove `torrust-tracker-udp-tracker-protocol` from `packages/http-protocol/Cargo.toml`                 | `cargo tree -p torrust-tracker-http-tracker-protocol --depth 1` shows no UDP protocol edge                                               |
-| T4  | TODO   | Update tests to use supported conversion paths (`Event <-> torrust-tracker-primitives::AnnounceEvent`) | Tests compile and pass without UDP protocol types                                                                                        |
-| T5  | TODO   | Run verification commands                                                                              | Build/tests/lints pass                                                                                                                   |
-| T6  | TODO   | Update EPIC tracking rows and draft list as needed                                                     | Active Subissues remain consistent                                                                                                       |
-| T7  | TODO   | Update EPIC after implementation                                                                       | Update Active Subissues progress and EPIC sections: Package Inventory, Desired Package State, Torrust Dependency Lists (Direct, Non-dev) |
+| ID  | Status | Task                                                                                                   | Notes / Expected Output                                                                                      |
+| --- | ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE   | Confirm all UDP protocol usage in `http-protocol` is limited to one conversion impl                    | Confirmed by `rg` before edits (`torrust_tracker_udp_tracker_protocol::*` only in announce conversion impl)  |
+| T2  | DONE   | Remove UDP `AnnounceEvent` conversion impl from `packages/http-protocol/src/v1/requests/announce.rs`   | Removed `impl From<torrust_tracker_udp_tracker_protocol::AnnounceEvent> for Event`                           |
+| T3  | DONE   | Remove `torrust-tracker-udp-tracker-protocol` from `packages/http-protocol/Cargo.toml`                 | Removed dependency; `cargo tree -p torrust-tracker-http-tracker-protocol --depth 1` has no UDP protocol edge |
+| T4  | DONE   | Update tests to use supported conversion paths (`Event <-> torrust-tracker-primitives::AnnounceEvent`) | No test fixtures used UDP event types; existing tests passed without changes                                 |
+| T5  | DONE   | Run verification commands                                                                              | `cargo build --workspace`, targeted HTTP protocol/core/server tests, and `linter all` passed                 |
+| T6  | DONE   | Update EPIC tracking rows and draft list as needed                                                     | Updated Active Subissues and details table status for SI-13                                                  |
+| T7  | DONE   | Update EPIC after implementation                                                                       | Updated dependency narrative and direct dependency lists for `torrust-tracker-http-tracker-protocol`         |
 
 ## Acceptance Criteria
 
-- [ ] `packages/http-protocol/Cargo.toml` has no `torrust-tracker-udp-tracker-protocol` dependency.
-- [ ] `packages/http-protocol` has no source-level references to
+- [x] `packages/http-protocol/Cargo.toml` has no `torrust-tracker-udp-tracker-protocol` dependency.
+- [x] `packages/http-protocol` has no source-level references to
       `torrust_tracker_udp_tracker_protocol::`.
-- [ ] HTTP protocol announce event behavior remains unchanged for
+- [x] HTTP protocol announce event behavior remains unchanged for
       `started/stopped/completed/none` mappings.
-- [ ] `cargo build --workspace` passes.
-- [ ] `cargo test -p torrust-tracker-http-tracker-protocol` passes.
-- [ ] `linter all` exits with code `0`.
-- [ ] EPIC tracking includes this subissue.
+- [x] `cargo build --workspace` passes.
+- [x] `cargo test -p torrust-tracker-http-tracker-protocol` passes.
+- [x] `linter all` exits with code `0`.
+- [x] EPIC tracking includes this subissue.
 
 ## Verification Plan
 
@@ -139,11 +139,11 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                               | Command / Steps                                                      | Expected Result                                              | Status | Evidence |
-| --- | -------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------ | ------ | -------- |
-| M1  | No cross-protocol edge remains         | `cargo tree -p torrust-tracker-http-tracker-protocol --depth 1`      | No dependency on `torrust-tracker-udp-tracker-protocol`      | TODO   |          |
-| M2  | No UDP symbols in HTTP protocol source | `rg "torrust_tracker_udp_tracker_protocol::" packages/http-protocol` | No matches                                                   | TODO   |          |
-| M3  | Event conversion behavior preserved    | Run existing announce request parsing/unit tests                     | Mappings for `started/stopped/completed/none` remain correct | TODO   |          |
+| ID  | Scenario                               | Command / Steps                                                      | Expected Result                                              | Status | Evidence                                                     |
+| --- | -------------------------------------- | -------------------------------------------------------------------- | ------------------------------------------------------------ | ------ | ------------------------------------------------------------ |
+| M1  | No cross-protocol edge remains         | `cargo tree -p torrust-tracker-http-tracker-protocol --depth 1`      | No dependency on `torrust-tracker-udp-tracker-protocol`      | DONE   | Tree output shows no UDP protocol dependency                 |
+| M2  | No UDP symbols in HTTP protocol source | `rg "torrust_tracker_udp_tracker_protocol::" packages/http-protocol` | No matches                                                   | DONE   | `rg` returned no output                                      |
+| M3  | Event conversion behavior preserved    | Run existing announce request parsing/unit tests                     | Mappings for `started/stopped/completed/none` remain correct | DONE   | `cargo test -p torrust-tracker-http-tracker-protocol` passed |
 
 ## Risks and Trade-offs
 

--- a/packages/http-protocol/Cargo.toml
+++ b/packages/http-protocol/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
-torrust-tracker-udp-tracker-protocol = { version = "3.0.0-develop", path = "../udp-protocol" }
 bittorrent-primitives = "0.2.0"
 derive_more = { version = "2", features = [ "as_ref", "constructor", "from" ] }
 multimap = "0"

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -190,17 +190,6 @@ impl fmt::Display for Event {
     }
 }
 
-impl From<torrust_tracker_udp_tracker_protocol::AnnounceEvent> for Event {
-    fn from(event: torrust_tracker_udp_tracker_protocol::AnnounceEvent) -> Self {
-        match event {
-            torrust_tracker_udp_tracker_protocol::AnnounceEvent::Started => Self::Started,
-            torrust_tracker_udp_tracker_protocol::AnnounceEvent::Stopped => Self::Stopped,
-            torrust_tracker_udp_tracker_protocol::AnnounceEvent::Completed => Self::Completed,
-            torrust_tracker_udp_tracker_protocol::AnnounceEvent::None => Self::Empty,
-        }
-    }
-}
-
 impl From<AnnounceEvent> for Event {
     fn from(event: AnnounceEvent) -> Self {
         match event {


### PR DESCRIPTION
## Summary
- remove the `torrust-tracker-udp-tracker-protocol` dependency from `packages/http-protocol`
- remove `From<torrust_tracker_udp_tracker_protocol::AnnounceEvent> for Event` from HTTP announce request parsing
- keep HTTP announce event mappings via `torrust-tracker-primitives::AnnounceEvent`
- update issue/EPIC tracking docs for SI-13 completion

## Verification
- cargo tree -p torrust-tracker-http-tracker-protocol --depth 1
- rg "torrust_tracker_udp_tracker_protocol::" packages/http-protocol
- cargo test -p torrust-tracker-http-tracker-protocol
- cargo test -p torrust-tracker-http-tracker-core
- cargo test -p torrust-tracker-axum-http-server
- cargo build --workspace
- linter all

## Issue
- Closes #1834
