### PR TITLE
refactor(env): narrow EnvContainer::initialize to accept per-service config slices

### DIFF
--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -20,6 +20,70 @@ the proposal, the reasoning, and a reference to any supporting artifact.
 
 ---
 
+## DEC-09 — Narrow `EnvContainer::initialize` and `Environment::new` to accept per-service config slices
+
+**Date**: 2026-06-02
+**Status**: Adopted
+
+### Proposal considered
+
+Change `EnvContainer::initialize` (and the wrapping `Environment::new`) for the
+UDP and HTTP server packages so that they accept the specific config types they
+actually need instead of the full `&Arc<Configuration>` aggregate:
+
+- `UdpTrackerEnvironment::new(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>)`
+- `HttpTrackerEnvironment::new(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>)`
+
+### Alternative chosen
+
+Adopt narrowing for the UDP tracker server and the HTTP tracker server environment
+constructors. The REST API server environment is **not narrowed** in this issue
+because it legitimately depends on all service config types to expose tracker status
+via the REST API (see DEC-07 trade-offs).
+
+### Why this alternative was adopted
+
+1. **Eliminates the root forcing function**: the `&Arc<Configuration>` parameter was
+   the primary reason a UDP-only binary compiled `HttpTracker`, `HttpApi`,
+   `HealthCheckApi`, `TslConfig`, and `AccessTokens` types at all. Narrowing the
+   constructor signature removes that dependency at the package boundary.
+
+2. **Explicit contracts**: the narrowed signatures document exactly which config
+   types each server environment actually uses, making unintentional coupling visible
+   at compile time.
+
+3. **Low migration cost**: all existing test call sites extract the narrower slices
+   with two lines (`Arc::new(cfg.core.clone())` and
+   `Arc::new(cfg.udp_trackers.unwrap()[0].clone())`). Logging setup, which was
+   previously bundled in `initialize_global_services`, was already called separately
+   by every test and is not a concern of the server environment constructor.
+
+4. **Main binary unaffected**: `AppContainer::initialize` (in `src/container.rs`)
+   does not use `Environment::new`; it initializes containers directly. No change
+   needed for the production startup path.
+
+### Trade-offs acknowledged
+
+- Every test call site that used `Started::new(&configuration)` must be updated to
+  extract the narrower slices first. The update is mechanical and consistent.
+- Logging setup (`logging::setup`) is no longer called inside `Environment::new`.
+  Callers that need logging must set it up independently (as tests already did).
+- The REST API server environment (`axum-rest-api-server`) still takes
+  `&Arc<Configuration>` because it needs `Core`, `HttpTracker`, `UdpTracker`, and
+  `HttpApi` — narrowing would provide no benefit there.
+
+### Supporting artifacts
+
+- [Issue #1861 spec](../../open/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md)
+- `packages/udp-server/src/environment.rs`
+- `packages/axum-http-server/src/environment.rs`
+- `packages/udp-server/examples/udp_only_public_tracker.rs` — now compiles without
+  `HttpTracker`, `HttpApi`, `HealthCheckApi`, `TslConfig`, `AccessTokens`
+- `packages/axum-http-server/examples/http_only_public_tracker.rs` — now compiles
+  without `UdpTracker`, `HttpApi`, `AccessTokens`, `HealthCheckApi`
+
+---
+
 ## DEC-07 — Keep `torrust-tracker-configuration` as a single central package; move domain primitives to `torrust-tracker-primitives`
 
 **Date**: 2026-06-03

--- a/docs/issues/open/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md
+++ b/docs/issues/open/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: closed
 priority: p3
 github-issue: 1861
 spec-path: docs/issues/open/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md
-branch: null
+branch: 1861-1669-narrow-envcontainer-initialize-config-slices
 related-pr: null
-last-updated-utc: 2026-06-01 00:00
+last-updated-utc: 2026-06-05 00:00
 semantic-links:
   skill-links:
     - create-issue
@@ -101,14 +101,14 @@ call sites. Confirm the Cargo examples no longer compile idle types.
 
 ## Acceptance Criteria
 
-- [ ] A decision entry is added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
-      with chosen approach and rationale
-- [ ] If narrowing is adopted: `UdpTrackerEnvironment::new` accepts narrower config types
+- [x] A decision entry is added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
+      with chosen approach and rationale (DEC-09)
+- [x] If narrowing is adopted: `UdpTrackerEnvironment::new` accepts narrower config types
       and the UDP Cargo example no longer compiles `HttpTracker`/`HttpApi`/etc.
-- [ ] If narrowing is adopted: `HttpTrackerEnvironment::new` accepts narrower config types
+- [x] If narrowing is adopted: `HttpTrackerEnvironment::new` accepts narrower config types
       and the HTTP Cargo example no longer compiles `UdpTracker`/`HealthCheckApi`/etc.
-- [ ] All tests pass (`cargo test --workspace`); no new clippy warnings
-- [ ] The Cargo examples still run correctly end-to-end (as verified by the manual test
+- [x] All tests pass (`cargo test --workspace`); no new clippy warnings
+- [x] The Cargo examples still run correctly end-to-end (as verified by the manual test
       results in `docs/issues/open/1856-.../manual-test-results.md`)
 
 ## Out of Scope

--- a/packages/axum-health-check-api-server/tests/server/contract.rs
+++ b/packages/axum-health-check-api-server/tests/server/contract.rs
@@ -146,9 +146,11 @@ mod http {
     pub(crate) async fn it_should_return_good_health_for_http_service() {
         logging::setup();
 
-        let configuration = Arc::new(configuration::ephemeral());
+        let configuration = configuration::ephemeral();
+        let core_config = Arc::new(configuration.core.clone());
+        let http_tracker_config = Arc::new(configuration.http_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_axum_http_server::environment::Started::new(&configuration).await;
+        let service = torrust_tracker_axum_http_server::environment::Started::new(&core_config, &http_tracker_config).await;
 
         let registar = service.registar.clone();
 
@@ -192,9 +194,11 @@ mod http {
     pub(crate) async fn it_should_return_error_when_http_service_was_stopped_after_registration() {
         logging::setup();
 
-        let configuration = Arc::new(configuration::ephemeral());
+        let configuration = configuration::ephemeral();
+        let core_config = Arc::new(configuration.core.clone());
+        let http_tracker_config = Arc::new(configuration.http_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_axum_http_server::environment::Started::new(&configuration).await;
+        let service = torrust_tracker_axum_http_server::environment::Started::new(&core_config, &http_tracker_config).await;
 
         let binding = *service.bind_address();
 
@@ -253,9 +257,11 @@ mod udp {
     pub(crate) async fn it_should_return_good_health_for_udp_service() {
         logging::setup();
 
-        let configuration = Arc::new(configuration::ephemeral());
+        let configuration = configuration::ephemeral();
+        let core_config = Arc::new(configuration.core.clone());
+        let udp_tracker_config = Arc::new(configuration.udp_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_udp_server::environment::Started::new(&configuration).await;
+        let service = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let registar = service.registar.clone();
 
@@ -296,9 +302,11 @@ mod udp {
     pub(crate) async fn it_should_return_error_when_udp_service_was_stopped_after_registration() {
         logging::setup();
 
-        let configuration = Arc::new(configuration::ephemeral());
+        let configuration = configuration::ephemeral();
+        let core_config = Arc::new(configuration.core.clone());
+        let udp_tracker_config = Arc::new(configuration.udp_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_udp_server::environment::Started::new(&configuration).await;
+        let service = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let binding = service.bind_address();
 

--- a/packages/axum-http-server/examples/http_only_public_tracker.rs
+++ b/packages/axum-http-server/examples/http_only_public_tracker.rs
@@ -1,62 +1,33 @@
-//! Minimal HTTP-only public tracker — configuration coupling demonstration.
+//! Minimal HTTP-only public tracker — narrowed configuration at the initialization boundary.
 //!
-//! **Purpose** (issue #1856, step 3): demonstrates how many configuration types an
-//! HTTP-only binary must compile today, including types that belong to services that
-//! are explicitly disabled at runtime.  This example starts a real HTTP tracker and
-//! runs until Ctrl-C is pressed.
-//!
-//! ## Why these two examples exist (and why they live here)
-//!
-//! Issue #1856 analyses whether the `torrust-tracker-configuration` package should
-//! be split by service type.  To make that coupling **visible and verifiable**, we
-//! need one operative example per protocol:
-//!
-//! - `udp_only_public_tracker` (in `torrust-tracker-udp-server`) — UDP path
-//! - `http_only_public_tracker` (this file, in `torrust-tracker-axum-http-server`) — HTTP path
-//!
-//! Both examples are intentionally **public** (no authentication key required).
-//! Private mode was considered but rejected: it would require a running REST API to
-//! issue authentication keys, which would pull `torrust-tracker-axum-rest-api-server`
-//! into the dependency graph and obscure the coupling signal we are trying to
-//! measure.  Keeping both examples public and self-contained makes the coupling
-//! table below directly comparable between the two protocols.
-//!
-//! The examples live inside their respective server packages (not in a shared
-//! `examples/` workspace package and not in the root crate) because each example
-//! deliberately uses only the server package it belongs to as its entry point.
-//! That constraint is itself part of what we are measuring: how many config types
-//! does a single-protocol server package drag in?
+//! **Status** (issue #1861, implementing decision DEC-09 from EPIC #1669): the initialization
+//! entry point now accepts `&Arc<Core>` and `&Arc<HttpTracker>` directly, so an HTTP-only
+//! binary no longer needs to compile the full `Configuration` aggregate.
 //!
 //! ## What this example shows
 //!
-//! A realistic HTTP-only public tracker needs these config types at runtime:
+//! An HTTP-only public tracker can now be started with exactly the two config types it
+//! actually uses at runtime:
 //!
 //! - `Core` — shared tracker settings (mode, announce policy, database, …)
 //! - `HttpTracker` — bind address and optional TLS config for the HTTP server
 //!
-//! However, the initialization entry point accepts `&Configuration` — the **full
-//! aggregate** struct — so the compiler must include all fields declared in
-//! `Configuration`:
-//!
-//! | Config type       | Used by HTTP-only binary | Why compiled in               |
-//! |-------------------|--------------------------|-------------------------------|
-//! | `Core`            | Yes                      | Tracker domain settings       |
-//! | `HttpTracker`     | Yes                      | Bind address, TLS config      |
-//! | `Logging`         | Yes (log setup only)     | Global log initialization     |
-//! | `UdpTracker`      | **No**                   | Field of `Configuration`      |
-//! | `HttpApi`         | **No**                   | Field of `Configuration`      |
-//! | `AccessTokens`    | **No**                   | Field of `Configuration`      |
-//! | `HealthCheckApi`  | **No**                   | Field of `Configuration`      |
-//! | `TslConfig`       | Optional (TLS path)      | Field of `HttpTracker`        |
+//! | Config type       | Needed? | Notes                                       |
+//! |-------------------|---------|---------------------------------------------|
+//! | `Core`            | Yes     | Tracker domain settings                     |
+//! | `HttpTracker`     | Yes     | Bind address, TLS config                    |
+//! | `Configuration`   | No      | Full aggregate — no longer required here    |
+//! | `UdpTracker`      | No      | Not compiled unless explicitly imported     |
+//! | `HttpApi`         | No      | Not compiled unless explicitly imported     |
+//! | `HealthCheckApi`  | No      | Not compiled unless explicitly imported     |
 //!
 //! ## Cross-layer coupling note
 //!
 //! `rest-api-core` imports **both** `HttpTracker` and `UdpTracker` from the
 //! configuration package so it can expose tracker status via the REST API endpoints.
 //! This means that any binary including the REST API compiles UDP config types
-//! regardless of whether a UDP tracker is actually running.  Splitting the config
-//! package by service type would not eliminate this cross-layer coupling; the REST
-//! API would still depend on all service config types to describe tracker status.
+//! regardless of whether a UDP tracker is actually running.  This is a separate
+//! concern and is not addressed by this narrowing (see EPIC #1669 for context).
 //!
 //! ## How to run
 //!
@@ -74,54 +45,42 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use torrust_tracker_axum_http_server::environment::Started;
-use torrust_tracker_configuration::{Configuration, HttpTracker, UdpTracker};
+use torrust_tracker_configuration::{Core, HttpTracker};
 
 #[tokio::main]
 async fn main() {
     // Temporary database file — cleaned up on exit.
     let db_path = std::env::temp_dir().join("torrust-http-example.db");
 
-    // Build the minimal configuration for an HTTP-only public tracker.
-    let mut config = Configuration::default();
-
+    // Build Core and HttpTracker directly — no full Configuration aggregate needed.
     // Public tracker: peers do not need an authentication key.
-    config.core.private = false;
-
-    // Point the database at the temporary file.
-    config.core.database.path = db_path.to_string_lossy().into_owned();
+    let core = Core {
+        private: false,
+        database: torrust_tracker_configuration::Database {
+            path: db_path.to_string_lossy().into_owned(),
+            ..Default::default()
+        },
+        ..Core::default()
+    };
 
     // Single HTTP tracker instance; port 0 lets the OS assign a free port.
     // TLS is disabled for simplicity; a production deployment would set tsl_config.
-    config.http_trackers = Some(vec![HttpTracker {
+    let http_tracker = HttpTracker {
         bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         tsl_config: None,
         tracker_usage_statistics: false,
-    }]);
+    };
 
-    // Disable all services that this HTTP-only binary does not need.
-    config.udp_trackers = None;
-    config.http_api = None;
-
-    // --- Demonstrate the coupling problem ----------------------------------------
-
-    // `UdpTracker` is compiled into this binary even though it is never used at
-    // runtime, because it is a field of the `Configuration` aggregate.
-    #[allow(clippy::no_effect_underscore_binding)]
-    let _unused_udp_type: Option<Vec<UdpTracker>> = config.udp_trackers.clone();
-
-    println!("Types from torrust-tracker-configuration compiled into this binary:");
-    println!("  Used at runtime    : Core, HttpTracker, Logging");
-    println!("  Full aggregate     : Configuration (required by the initialization entry point)");
-    println!("  Compiled but idle  : UdpTracker, HttpApi, AccessTokens, HealthCheckApi");
-    println!();
-    println!("Cross-layer coupling: rest-api-core imports both HttpTracker and UdpTracker");
-    println!("  to expose tracker status via the REST API.  A package split would not");
-    println!("  eliminate this dependency — the REST API needs all service config types.");
+    println!("Types from torrust-tracker-configuration used by this binary:");
+    println!("  Core        — tracker domain settings");
+    println!("  HttpTracker — bind address, TLS config");
+    println!("  (Configuration aggregate and idle types are NOT compiled in)");
     println!();
 
-    // Start the tracker; `Started` is a type alias for `Environment<Running>`.
-    let config = Arc::new(config);
-    let env = Started::new(&config).await;
+    // Start the tracker using the narrowed API; `Started` is a type alias for `Environment<Running>`.
+    let core_config = Arc::new(core);
+    let http_tracker_config = Arc::new(http_tracker);
+    let env = Started::new(&core_config, &http_tracker_config).await;
 
     println!("Listening on {}", env.bind_address());
     println!("Press Ctrl-C to stop.");

--- a/packages/axum-http-server/src/environment.rs
+++ b/packages/axum-http-server/src/environment.rs
@@ -5,7 +5,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use torrust_server_lib::registar::Registar;
 use torrust_tracker_axum_server::tsl::make_rust_tls;
-use torrust_tracker_configuration::{Configuration, logging};
+use torrust_tracker_configuration::{Core, HttpTracker};
 use torrust_tracker_core::container::TrackerCoreContainer;
 use torrust_tracker_http_tracker_core::container::HttpTrackerCoreContainer;
 use torrust_tracker_http_tracker_core::statistics::event::listener::run_event_listener;
@@ -38,13 +38,13 @@ impl<S> Environment<S> {
 impl Environment<Stopped> {
     /// # Panics
     ///
-    /// Will panic if it fails to make the TSL config from the configuration.
+    /// Will panic if it fails to build the TLS config from the `tsl_config` field of `http_tracker_config`.
     #[allow(dead_code)]
     #[must_use]
-    pub async fn new(configuration: &Arc<Configuration>) -> Self {
-        initialize_global_services(configuration);
+    pub async fn new(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Self {
+        initialize_static();
 
-        let container = Arc::new(EnvContainer::initialize(configuration).await);
+        let container = Arc::new(EnvContainer::initialize(core_config, http_tracker_config).await);
 
         let bind_to = container.http_tracker_core_container.http_tracker_config.bind_address;
 
@@ -97,8 +97,11 @@ impl Environment<Stopped> {
 }
 
 impl Environment<Running> {
-    pub async fn new(configuration: &Arc<Configuration>) -> Self {
-        Environment::<Stopped>::new(configuration).await.start().await
+    pub async fn new(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Self {
+        Environment::<Stopped>::new(core_config, http_tracker_config)
+            .await
+            .start()
+            .await
     }
 
     /// Stops the test environment and return a stopped environment.
@@ -138,38 +141,23 @@ pub struct EnvContainer {
 }
 
 impl EnvContainer {
-    /// # Panics
-    ///
-    /// Will panic if the configuration is missing the HTTP tracker configuration.
     #[must_use]
-    pub async fn initialize(configuration: &Configuration) -> Self {
-        let core_config = Arc::new(configuration.core.clone());
-        let http_tracker_config = configuration
-            .http_trackers
-            .clone()
-            .expect("missing HTTP tracker configuration");
-        let http_tracker_config = Arc::new(http_tracker_config[0].clone());
-
+    pub async fn initialize(core_config: &Arc<Core>, http_tracker_config: &Arc<HttpTracker>) -> Self {
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
-            configuration.core.tracker_usage_statistics.into(),
+            core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container =
-            Arc::new(TrackerCoreContainer::initialize_from(&core_config, &swarm_coordination_registry_container).await);
+            Arc::new(TrackerCoreContainer::initialize_from(core_config, &swarm_coordination_registry_container).await);
 
         let http_tracker_container =
-            HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &http_tracker_config);
+            HttpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, http_tracker_config);
 
         Self {
             tracker_core_container,
             http_tracker_core_container: http_tracker_container,
         }
     }
-}
-
-fn initialize_global_services(configuration: &Configuration) {
-    initialize_static();
-    logging::setup(&configuration.logging);
 }
 
 fn initialize_static() {

--- a/packages/axum-http-server/tests/server/v1/contract.rs
+++ b/packages/axum-http-server/tests/server/v1/contract.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use torrust_tracker_axum_http_server::environment::Started;
 use torrust_tracker_test_helpers::{configuration, logging};
 
@@ -5,12 +7,17 @@ use torrust_tracker_test_helpers::{configuration, logging};
 async fn environment_should_be_started_and_stopped() {
     logging::setup();
 
-    let env = Started::new(&configuration::ephemeral().into()).await;
+    let cfg = configuration::ephemeral();
+    let core_config = Arc::new(cfg.core.clone());
+    let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+    let env = Started::new(&core_config, &http_tracker_config).await;
 
     env.stop().await;
 }
 
 mod for_all_config_modes {
+
+    use std::sync::Arc;
 
     use torrust_tracker_axum_http_server::environment::Started;
     use torrust_tracker_axum_http_server::v1::handlers::health_check::{Report, Status};
@@ -22,7 +29,10 @@ mod for_all_config_modes {
     async fn health_check_endpoint_should_return_ok_if_the_http_tracker_is_running() {
         logging::setup();
 
-        let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
+        let cfg = configuration::ephemeral_with_reverse_proxy();
+        let core_config = Arc::new(cfg.core.clone());
+        let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+        let env = Started::new(&core_config, &http_tracker_config).await;
 
         let response = Client::new(*env.bind_address()).health_check().await;
 
@@ -34,6 +44,8 @@ mod for_all_config_modes {
     }
 
     mod and_running_on_reverse_proxy {
+        use std::sync::Arc;
+
         use torrust_tracker_axum_http_server::environment::Started;
         use torrust_tracker_test_helpers::{configuration, logging};
 
@@ -48,7 +60,10 @@ mod for_all_config_modes {
             // If the tracker is running behind a reverse proxy, the peer IP is the
             // right most IP in the `X-Forwarded-For` HTTP header, which is the IP of the proxy's client.
 
-            let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
+            let cfg = configuration::ephemeral_with_reverse_proxy();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let params = QueryBuilder::default().query().params();
 
@@ -63,7 +78,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_xff_http_request_header_contains_an_invalid_ip() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
+            let cfg = configuration::ephemeral_with_reverse_proxy();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let params = QueryBuilder::default().query().params();
 
@@ -92,6 +110,7 @@ mod for_all_config_modes {
 
         use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV6};
         use std::str::FromStr;
+        use std::sync::Arc;
 
         use bittorrent_primitives::info_hash::InfoHash;
         use local_ip_address::local_ip;
@@ -118,7 +137,10 @@ mod for_all_config_modes {
         async fn it_should_start_and_stop() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
             env.stop().await;
         }
 
@@ -126,7 +148,10 @@ mod for_all_config_modes {
         async fn should_respond_if_only_the_mandatory_fields_are_provided() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -143,7 +168,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_url_query_component_is_empty() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let response = Client::new(*env.bind_address()).get("announce").await;
 
@@ -156,7 +184,10 @@ mod for_all_config_modes {
         async fn should_fail_when_url_query_parameters_are_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let invalid_query_param = "a=b=c";
 
@@ -173,7 +204,10 @@ mod for_all_config_modes {
         async fn should_fail_when_a_mandatory_field_is_missing() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             // Without `info_hash` param
 
@@ -212,7 +246,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_info_hash_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -236,7 +273,10 @@ mod for_all_config_modes {
             // 1. If tracker is NOT running `on_reverse_proxy` from the remote client IP.
             // 2. If tracker is     running `on_reverse_proxy` from `X-Forwarded-For` request HTTP header.
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -253,7 +293,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_downloaded_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -274,7 +317,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_uploaded_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -295,7 +341,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_peer_id_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -323,7 +372,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_port_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -344,7 +396,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_left_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -365,7 +420,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_event_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -394,7 +452,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_compact_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -415,7 +476,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_numwant_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral().into()).await;
+            let cfg = configuration::ephemeral();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -436,7 +500,10 @@ mod for_all_config_modes {
         async fn should_return_no_peers_if_the_announced_peer_is_the_first_one() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let response = Client::new(*env.bind_address())
                 .announce(
@@ -467,7 +534,10 @@ mod for_all_config_modes {
         async fn should_return_the_list_of_previously_announced_peers() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -511,7 +581,10 @@ mod for_all_config_modes {
         async fn should_return_the_list_of_previously_announced_peers_including_peers_using_ipv4_and_ipv6() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -566,7 +639,10 @@ mod for_all_config_modes {
          {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
             let peer = PeerBuilder::default().build();
@@ -620,7 +696,10 @@ mod for_all_config_modes {
             // Tracker Returns Compact Peer Lists
             // https://www.bittorrent.org/beps/bep_0023.html
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -663,7 +742,10 @@ mod for_all_config_modes {
             // code-review: the HTTP tracker does not return the compact response by default if the "compact"
             // param is not provided in the announce URL. The BEP 23 suggest to do so.
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -703,7 +785,10 @@ mod for_all_config_modes {
         async fn should_increase_the_number_of_tcp4_announce_requests_handled_in_statistics() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             Client::new(*env.bind_address())
                 .announce(&QueryBuilder::default().query())
@@ -729,7 +814,10 @@ mod for_all_config_modes {
                 return; // we cannot bind to a ipv6 socket, so we will skip this test
             }
 
-            let env = Started::new(&configuration::ephemeral_ipv6().into()).await;
+            let cfg = configuration::ephemeral_ipv6();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             Client::bind(*env.bind_address(), IpAddr::from_str("::1").unwrap())
                 .announce(&QueryBuilder::default().query())
@@ -750,7 +838,10 @@ mod for_all_config_modes {
 
             // The tracker ignores the peer address in the request param. It uses the client remote ip address.
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             Client::new(*env.bind_address())
                 .announce(
@@ -773,7 +864,10 @@ mod for_all_config_modes {
         async fn should_assign_to_the_peer_ip_the_remote_client_ip_instead_of_the_peer_address_in_the_request_param() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
             let client_ip = local_ip().unwrap();
@@ -814,8 +908,10 @@ mod for_all_config_modes {
                 client     <-> tracker                      <-> Internet
                 127.0.0.1      external_ip = "2.137.87.41"
             */
-            let env =
-                Started::new(&configuration::ephemeral_with_external_ip(IpAddr::from_str("2.137.87.41").unwrap()).into()).await;
+            let cfg = configuration::ephemeral_with_external_ip(IpAddr::from_str("2.137.87.41").unwrap());
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
             let loopback_ip = IpAddr::from_str("127.0.0.1").unwrap();
@@ -861,11 +957,11 @@ mod for_all_config_modes {
                ::1            external_ip = "2345:0425:2CA1:0000:0000:0567:5673:23b5"
             */
 
-            let env = Started::new(
-                &configuration::ephemeral_with_external_ip(IpAddr::from_str("2345:0425:2CA1:0000:0000:0567:5673:23b5").unwrap())
-                    .into(),
-            )
-            .await;
+            let cfg =
+                configuration::ephemeral_with_external_ip(IpAddr::from_str("2345:0425:2CA1:0000:0000:0567:5673:23b5").unwrap());
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
             let loopback_ip = IpAddr::from_str("127.0.0.1").unwrap();
@@ -911,7 +1007,10 @@ mod for_all_config_modes {
             145.254.214.256     X-Forwarded-For = 145.254.214.256    on_reverse_proxy = true       145.254.214.256
             */
 
-            let env = Started::new(&configuration::ephemeral_with_reverse_proxy().into()).await;
+            let cfg = configuration::ephemeral_with_reverse_proxy();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -957,6 +1056,7 @@ mod for_all_config_modes {
 
         use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
         use std::str::FromStr;
+        use std::sync::Arc;
 
         use bittorrent_primitives::info_hash::InfoHash;
         use tokio::net::TcpListener;
@@ -980,7 +1080,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_request_is_empty() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
             let response = Client::new(*env.bind_address()).get("scrape").await;
 
             assert_missing_query_params_for_scrape_request_error_response(response).await;
@@ -992,7 +1095,10 @@ mod for_all_config_modes {
         async fn should_fail_when_the_info_hash_param_is_invalid() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let mut params = QueryBuilder::default().query().params();
 
@@ -1011,7 +1117,10 @@ mod for_all_config_modes {
         async fn should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1052,7 +1161,10 @@ mod for_all_config_modes {
         async fn should_return_the_file_with_the_complete_peer_when_there_is_one_peer_with_no_bytes_pending_to_download() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1093,7 +1205,10 @@ mod for_all_config_modes {
         async fn should_return_a_file_with_zeroed_values_when_there_are_no_peers() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1114,7 +1229,10 @@ mod for_all_config_modes {
         async fn should_accept_multiple_infohashes() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash1 = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
             let info_hash2 = InfoHash::from_str("3b245504cf5f11bbdbe1201cea6a6bf45aee1bc0").unwrap(); // DevSkim: ignore DS173237
@@ -1142,7 +1260,10 @@ mod for_all_config_modes {
         async fn should_increase_the_number_ot_tcp4_scrape_requests_handled_in_statistics() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_public().into()).await;
+            let cfg = configuration::ephemeral_public();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1174,7 +1295,10 @@ mod for_all_config_modes {
                 return; // we cannot bind to a ipv6 socket, so we will skip this test
             }
 
-            let env = Started::new(&configuration::ephemeral_ipv6().into()).await;
+            let cfg = configuration::ephemeral_ipv6();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1201,6 +1325,7 @@ mod configured_as_whitelisted {
 
     mod and_receiving_an_announce_request {
         use std::str::FromStr;
+        use std::sync::Arc;
 
         use bittorrent_primitives::info_hash::InfoHash;
         use torrust_tracker_axum_http_server::environment::Started;
@@ -1217,7 +1342,10 @@ mod configured_as_whitelisted {
         async fn should_fail_if_the_torrent_is_not_in_the_whitelist() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_listed().into()).await;
+            let cfg = configuration::ephemeral_listed();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let request_id = Uuid::new_v4();
             let info_hash = random_info_hash();
@@ -1244,7 +1372,10 @@ mod configured_as_whitelisted {
         async fn should_allow_announcing_a_whitelisted_torrent() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_listed().into()).await;
+            let cfg = configuration::ephemeral_listed();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1267,6 +1398,7 @@ mod configured_as_whitelisted {
 
     mod receiving_an_scrape_request {
         use std::str::FromStr;
+        use std::sync::Arc;
 
         use bittorrent_primitives::info_hash::InfoHash;
         use torrust_tracker_axum_http_server::environment::Started;
@@ -1285,7 +1417,10 @@ mod configured_as_whitelisted {
         async fn should_return_the_zeroed_file_when_the_requested_file_is_not_whitelisted() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_listed().into()).await;
+            let cfg = configuration::ephemeral_listed();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = random_info_hash();
 
@@ -1322,7 +1457,10 @@ mod configured_as_whitelisted {
         async fn should_return_the_file_stats_when_the_requested_file_is_whitelisted() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_listed().into()).await;
+            let cfg = configuration::ephemeral_listed();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1372,6 +1510,7 @@ mod configured_as_private {
 
     mod and_receiving_an_announce_request {
         use std::str::FromStr;
+        use std::sync::Arc;
         use std::time::Duration;
 
         use bittorrent_primitives::info_hash::InfoHash;
@@ -1389,7 +1528,10 @@ mod configured_as_private {
         async fn should_respond_to_authenticated_peers() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let expiring_key = env
                 .container
@@ -1412,7 +1554,10 @@ mod configured_as_private {
         async fn should_fail_if_the_peer_has_not_provided_the_authentication_key() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1429,7 +1574,10 @@ mod configured_as_private {
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let invalid_key = "INVALID_KEY";
 
@@ -1446,7 +1594,10 @@ mod configured_as_private {
         async fn should_fail_if_the_peer_cannot_be_authenticated_with_the_provided_key() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             // The tracker does not have this key
             let unregistered_key = Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
@@ -1464,6 +1615,7 @@ mod configured_as_private {
     mod receiving_an_scrape_request {
 
         use std::str::FromStr;
+        use std::sync::Arc;
         use std::time::Duration;
 
         use bittorrent_primitives::info_hash::InfoHash;
@@ -1482,7 +1634,10 @@ mod configured_as_private {
         async fn should_fail_if_the_key_query_param_cannot_be_parsed() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let invalid_key = "INVALID_KEY";
 
@@ -1499,7 +1654,10 @@ mod configured_as_private {
         async fn should_return_the_zeroed_file_when_the_client_is_not_authenticated() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1531,7 +1689,10 @@ mod configured_as_private {
         async fn should_return_the_real_file_stats_when_the_client_is_authenticated() {
             logging::setup();
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 
@@ -1583,7 +1744,10 @@ mod configured_as_private {
             // There is not authentication error
             // code-review: should this really be this way?
 
-            let env = Started::new(&configuration::ephemeral_private().into()).await;
+            let cfg = configuration::ephemeral_private();
+            let core_config = Arc::new(cfg.core.clone());
+            let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
+            let env = Started::new(&core_config, &http_tracker_config).await;
 
             let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
 

--- a/packages/udp-server/examples/udp_only_public_tracker.rs
+++ b/packages/udp-server/examples/udp_only_public_tracker.rs
@@ -1,53 +1,25 @@
-//! Minimal UDP-only public tracker — configuration coupling demonstration.
+//! Minimal UDP-only public tracker — narrowed configuration at the initialization boundary.
 //!
-//! **Purpose** (issue #1856, step 3): demonstrates how many configuration types a
-//! UDP-only binary must compile today, even though most of those types are not
-//! exercised at runtime.  This example starts a real UDP tracker and runs until
-//! Ctrl-C is pressed.
-//!
-//! ## Why these two examples exist (and why they live here)
-//!
-//! Issue #1856 analyses whether the `torrust-tracker-configuration` package should
-//! be split by service type.  To make that coupling **visible and verifiable**, we
-//! need one operative example per protocol:
-//!
-//! - `udp_only_public_tracker` (this file, in `torrust-tracker-udp-server`) — UDP path
-//! - `http_only_public_tracker` (in `torrust-tracker-axum-http-server`) — HTTP path
-//!
-//! Both examples are intentionally **public** (no authentication key required).
-//! Private mode was considered but rejected: it would require a running REST API to
-//! issue authentication keys, which would pull `torrust-tracker-axum-rest-api-server`
-//! into the dependency graph and obscure the coupling signal we are trying to
-//! measure.  Keeping both examples public and self-contained makes the coupling
-//! table below directly comparable between the two protocols.
-//!
-//! The examples live inside their respective server packages (not in a shared
-//! `examples/` workspace package and not in the root crate) because each example
-//! deliberately uses only the server package it belongs to as its entry point.
-//! That constraint is itself part of what we are measuring: how many config types
-//! does a single-protocol server package drag in?
+//! **Status** (issue #1861, implementing decision DEC-09 from EPIC #1669): the initialization
+//! entry point now accepts `&Arc<Core>` and `&Arc<UdpTracker>` directly, so a UDP-only
+//! binary no longer needs to compile the full `Configuration` aggregate.
 //!
 //! ## What this example shows
 //!
-//! A realistic UDP-only public tracker needs exactly two config types at runtime:
+//! A UDP-only public tracker can now be started with exactly the two config types it
+//! actually uses at runtime:
 //!
 //! - `Core` — shared tracker settings (mode, announce policy, database, …)
 //! - `UdpTracker` — bind address and cookie lifetime for the UDP server
 //!
-//! However, the initialization entry point accepts `&Configuration` — the **full
-//! aggregate** struct — so the compiler must include all fields declared in
-//! `Configuration`:
-//!
-//! | Config type       | Used by UDP-only binary | Why compiled in               |
-//! |-------------------|-------------------------|-------------------------------|
-//! | `Core`            | Yes                     | Tracker domain settings       |
-//! | `UdpTracker`      | Yes                     | Bind address, cookie lifetime |
-//! | `Logging`         | Yes (log setup only)    | Global log initialization     |
-//! | `HttpTracker`     | **No**                  | Field of `Configuration`      |
-//! | `HttpApi`         | **No**                  | Field of `Configuration`      |
-//! | `HealthCheckApi`  | **No**                  | Field of `Configuration`      |
-//! | `TslConfig`       | **No**                  | Field of `HttpTracker`        |
-//! | `AccessTokens`    | **No**                  | Used by REST API only         |
+//! | Config type       | Needed? | Notes                                       |
+//! |-------------------|---------|---------------------------------------------|
+//! | `Core`            | Yes     | Tracker domain settings                     |
+//! | `UdpTracker`      | Yes     | Bind address, cookie lifetime               |
+//! | `Configuration`   | No      | Full aggregate — no longer required here    |
+//! | `HttpTracker`     | No      | Not compiled unless explicitly imported     |
+//! | `HttpApi`         | No      | Not compiled unless explicitly imported     |
+//! | `HealthCheckApi`  | No      | Not compiled unless explicitly imported     |
 //!
 //! ## How to run
 //!
@@ -65,7 +37,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;
 
-use torrust_tracker_configuration::{Configuration, HttpTracker, UdpTracker};
+use torrust_tracker_configuration::{Core, UdpTracker};
 use torrust_tracker_udp_server::environment::Started;
 
 #[tokio::main]
@@ -73,42 +45,33 @@ async fn main() {
     // Temporary database file — cleaned up on exit.
     let db_path = std::env::temp_dir().join("torrust-udp-example.db");
 
-    // Build the minimal configuration for a UDP-only public tracker.
-    let mut config = Configuration::default();
-
+    // Build Core and UdpTracker directly — no full Configuration aggregate needed.
     // Public tracker: peers do not need an authentication key.
-    config.core.private = false;
+    let core = Core {
+        private: false,
+        database: torrust_tracker_configuration::Database {
+            path: db_path.to_string_lossy().into_owned(),
+            ..Default::default()
+        },
+        ..Core::default()
+    };
 
-    // Point the database at the temporary file.
-    config.core.database.path = db_path.to_string_lossy().into_owned();
-
-    // Single UDP tracker instance; port 0 lets the OS assign a free port.
-    config.udp_trackers = Some(vec![UdpTracker {
+    let udp_tracker = UdpTracker {
         bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         cookie_lifetime: Duration::from_secs(120),
         tracker_usage_statistics: false,
-    }]);
+    };
 
-    // Disable all services that a UDP-only binary does not need.
-    config.http_trackers = None;
-    config.http_api = None;
-
-    // --- Demonstrate the coupling problem ----------------------------------------
-
-    // `HttpTracker` is compiled into this binary even though it is never used at
-    // runtime, because it is a field of the `Configuration` aggregate.
-    #[allow(clippy::no_effect_underscore_binding)]
-    let _unused_http_type: Option<Vec<HttpTracker>> = config.http_trackers.clone();
-
-    println!("Types from torrust-tracker-configuration compiled into this binary:");
-    println!("  Used at runtime    : Core, UdpTracker, Logging");
-    println!("  Full aggregate     : Configuration (required by the initialization entry point)");
-    println!("  Compiled but idle  : HttpTracker, HttpApi, HealthCheckApi, TslConfig, AccessTokens");
+    println!("Types from torrust-tracker-configuration used by this binary:");
+    println!("  Core       — tracker domain settings");
+    println!("  UdpTracker — bind address, cookie lifetime");
+    println!("  (Configuration aggregate and idle types are NOT compiled in)");
     println!();
 
-    // Start the tracker; `Started` is a type alias for `Environment<Running>`.
-    let config = Arc::new(config);
-    let env = Started::new(&config).await;
+    // Start the tracker using the narrowed API; `Started` is a type alias for `Environment<Running>`.
+    let core_config = Arc::new(core);
+    let udp_tracker_config = Arc::new(udp_tracker);
+    let env = Started::new(&core_config, &udp_tracker_config).await;
 
     println!("Listening on {}", env.bind_address());
     println!("Press Ctrl-C to stop.");

--- a/packages/udp-server/src/environment.rs
+++ b/packages/udp-server/src/environment.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use torrust_server_lib::registar::Registar;
-use torrust_tracker_configuration::{Configuration, logging};
+use torrust_tracker_configuration::{Core, UdpTracker};
 use torrust_tracker_core::container::TrackerCoreContainer;
 use torrust_tracker_swarm_coordination_registry::container::SwarmCoordinationRegistryContainer;
 use torrust_tracker_udp_tracker_core::container::UdpTrackerCoreContainer;
@@ -35,10 +35,10 @@ where
 impl Environment<Stopped> {
     #[allow(dead_code)]
     #[must_use]
-    pub async fn new(configuration: &Arc<Configuration>) -> Self {
-        initialize_global_services(configuration);
+    pub async fn new(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Self {
+        initialize_static();
 
-        let container = Arc::new(EnvContainer::initialize(configuration).await);
+        let container = Arc::new(EnvContainer::initialize(core_config, udp_tracker_config).await);
 
         let bind_to = container.udp_tracker_core_container.udp_tracker_config.bind_address;
 
@@ -116,10 +116,10 @@ impl Environment<Running> {
     /// # Panics
     ///
     /// Will panic if it cannot start the server within the timeout.
-    pub async fn new(configuration: &Arc<Configuration>) -> Self {
+    pub async fn new(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Self {
         tokio::time::timeout(
             DEFAULT_SERVER_LIFECYCLE_TIMEOUT,
-            Environment::<Stopped>::new(configuration).await.start(),
+            Environment::<Stopped>::new(core_config, udp_tracker_config).await.start(),
         )
         .await
         .expect("Failed to create a UDP tracker server running environment within the timeout")
@@ -183,26 +183,19 @@ pub struct EnvContainer {
 }
 
 impl EnvContainer {
-    /// # Panics
-    ///
-    /// Will panic if the configuration is missing the UDP tracker configuration.
     #[must_use]
-    pub async fn initialize(configuration: &Configuration) -> Self {
-        let core_config = Arc::new(configuration.core.clone());
-        let udp_tracker_configurations = configuration.udp_trackers.clone().expect("missing UDP tracker configuration");
-        let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
-
+    pub async fn initialize(core_config: &Arc<Core>, udp_tracker_config: &Arc<UdpTracker>) -> Self {
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
 
         let tracker_core_container =
-            Arc::new(TrackerCoreContainer::initialize_from(&core_config, &swarm_coordination_registry_container).await);
+            Arc::new(TrackerCoreContainer::initialize_from(core_config, &swarm_coordination_registry_container).await);
 
         let udp_tracker_core_container =
-            UdpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, &udp_tracker_config);
+            UdpTrackerCoreContainer::initialize_from_tracker_core(&tracker_core_container, udp_tracker_config);
 
-        let udp_tracker_server_container = UdpTrackerServerContainer::initialize(&core_config);
+        let udp_tracker_server_container = UdpTrackerServerContainer::initialize(core_config);
 
         Self {
             tracker_core_container,
@@ -212,11 +205,6 @@ impl EnvContainer {
     }
 }
 
-fn initialize_global_services(configuration: &Configuration) {
-    initialize_static();
-    logging::setup(&configuration.logging);
-}
-
 fn initialize_static() {
     torrust_clock::initialize_static();
     torrust_tracker_udp_tracker_core::initialize_static();
@@ -224,6 +212,7 @@ fn initialize_static() {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use tokio::time::sleep;
@@ -235,7 +224,11 @@ mod tests {
     async fn it_should_make_and_stop_udp_server() {
         logging::setup();
 
-        let env = Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+
+        let env = Started::new(&core_config, &udp_tracker_config).await;
         sleep(Duration::from_secs(1)).await;
         env.stop().await;
         sleep(Duration::from_secs(1)).await;

--- a/packages/udp-server/tests/server/contract.rs
+++ b/packages/udp-server/tests/server/contract.rs
@@ -4,6 +4,7 @@
 // https://www.bittorrent.org/beps/bep_0015.html
 
 use core::panic;
+use std::sync::Arc;
 use std::time::Duration;
 
 use torrust_tracker_client::udp::client::UdpTrackerClient;
@@ -42,7 +43,10 @@ async fn send_connection_request(transaction_id: TransactionId, client: &UdpTrac
 async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_request() {
     logging::setup();
 
-    let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+    let cfg = configuration::ephemeral();
+    let core_config = Arc::new(cfg.core.clone());
+    let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+    let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
     let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
         Ok(udp_client) => udp_client,
@@ -71,6 +75,8 @@ async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_req
 }
 
 mod receiving_a_connection_request {
+    use std::sync::Arc;
+
     use torrust_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_test_helpers::{configuration, logging};
     use torrust_tracker_udp_tracker_protocol::{ConnectRequest, TransactionId};
@@ -82,7 +88,10 @@ mod receiving_a_connection_request {
     async fn should_return_a_connect_response() {
         logging::setup();
 
-        let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -111,6 +120,7 @@ mod receiving_a_connection_request {
 
 mod receiving_an_announce_request {
     use std::net::Ipv4Addr;
+    use std::sync::Arc;
 
     use torrust_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_test_helpers::logging::logs_contains_a_line_with;
@@ -182,7 +192,10 @@ mod receiving_an_announce_request {
     async fn should_return_an_announce_response() {
         logging::setup();
 
-        let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -204,7 +217,10 @@ mod receiving_an_announce_request {
     async fn should_return_many_announce_response() {
         logging::setup();
 
-        let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -229,7 +245,10 @@ mod receiving_an_announce_request {
     async fn should_ban_the_client_ip_if_it_sends_more_than_10_requests_with_a_cookie_value_not_normal() {
         logging::setup();
 
-        let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
         let ban_service = env.container.udp_tracker_core_container.ban_service.clone();
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
@@ -307,6 +326,8 @@ mod receiving_an_announce_request {
 }
 
 mod receiving_an_scrape_request {
+    use std::sync::Arc;
+
     use torrust_tracker_client::udp::client::UdpTrackerClient;
     use torrust_tracker_test_helpers::{configuration, logging};
     use torrust_tracker_udp_tracker_protocol::{ConnectionId, InfoHash, ScrapeRequest, TransactionId};
@@ -319,7 +340,10 @@ mod receiving_an_scrape_request {
     async fn should_return_a_scrape_response() {
         logging::setup();
 
-        let env = torrust_tracker_udp_server::environment::Started::new(&configuration::ephemeral().into()).await;
+        let cfg = configuration::ephemeral();
+        let core_config = Arc::new(cfg.core.clone());
+        let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
+        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,


### PR DESCRIPTION
## Summary

Closes #1861.

Implements DEC-09 from EPIC #1669: narrows the initialization API of `EnvContainer` (and related server environment types) to accept specific config slices instead of the full `Configuration` aggregate.

## What changed

### `packages/udp-server/src/environment.rs`
- `Environment::new` and `EnvContainer::initialize` now accept `(&Arc<Core>, &Arc<UdpTracker>)` instead of `&Arc<Configuration>`
- `initialize_global_services` call removed (callers manage logging/clock setup independently)

### `packages/axum-http-server/src/environment.rs`
- Same narrowing: `(&Arc<Core>, &Arc<HttpTracker>)` instead of `&Arc<Configuration>`

### Call sites updated
- `packages/udp-server/tests/server/contract.rs` — 6 call sites
- `packages/axum-http-server/tests/server/v1/contract.rs` — 50 call sites
- `packages/axum-health-check-api-server/tests/server/contract.rs` — 4 call sites

### Examples rewritten
- `packages/udp-server/examples/udp_only_public_tracker.rs` — now uses `Core` + `UdpTracker` directly; `Configuration` aggregate is not imported
- `packages/axum-http-server/examples/http_only_public_tracker.rs` — now uses `Core` + `HttpTracker` directly

### Docs
- `docs/issues/open/1669-overhaul-packages/DECISIONS.md` — DEC-09 added
- `docs/issues/open/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md` — closed, all acceptance criteria checked

## Out of scope

- `axum-rest-api-server` environment: intentionally **not** narrowed — it legitimately needs `Core`, `HttpTracker`, `UdpTracker`, and `HttpApi` to expose full tracker status via the REST API.
- `src/bootstrap/` (main binary): unaffected — uses `AppContainer::initialize`, not `Environment::new` directly.
