### PR TITLE
feat(container): narrow build target scope to tracker image needs (closes #1853)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,8 +44,10 @@
 
 # ── Dev tooling (not needed in any build stage) ───────────────────────────────
 # su-exec is compiled in the gcc stage: COPY ./contrib/dev-tools/su-exec/
+# workspace-coupling/Cargo.toml is copied in the recipe stage for cargo chef prepare
 /contrib/dev-tools/
 !/contrib/dev-tools/su-exec/
+!/contrib/dev-tools/analysis/workspace-coupling/Cargo.toml
 
 # ── Build artifacts and runtime state ─────────────────────────────────────────
 /bin/

--- a/Containerfile
+++ b/Containerfile
@@ -185,34 +185,34 @@ RUN cargo chef prepare --recipe-path /build/recipe.json
 FROM chef AS dependencies_debug
 WORKDIR /build/src
 COPY --from=recipe /build/recipe.json /build/recipe.json
-RUN cargo chef cook --tests --benches --examples --workspace --all-targets --all-features --recipe-path /build/recipe.json
+RUN cargo chef cook --tests --workspace --all-features --recipe-path /build/recipe.json
 # Pre-link warm-up: Create and discard a nextest archive to warm up the linker
 # before final compilation. This improves incremental build cache efficiency
 # by pre-faulting the linker phases, avoiding redundant linking work in later stages.
-RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/temp.tar.zst ; rm -f /build/temp.tar.zst
+RUN cargo nextest archive --tests --workspace --all-features --archive-file /build/temp.tar.zst && rm -f /build/temp.tar.zst
 
 ## Cook (release)
 FROM chef AS dependencies
 WORKDIR /build/src
 COPY --from=recipe /build/recipe.json /build/recipe.json
-RUN cargo chef cook --tests --benches --examples --workspace --all-targets --all-features --recipe-path /build/recipe.json --release
+RUN cargo chef cook --tests --workspace --all-features --recipe-path /build/recipe.json --release
 # Pre-link warm-up: Create and discard a nextest archive to warm up the linker
 # before final compilation. This improves incremental build cache efficiency
 # by pre-faulting the linker phases, avoiding redundant linking work in later stages.
-RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/temp.tar.zst --release  ; rm -f /build/temp.tar.zst
+RUN cargo nextest archive --tests --workspace --all-features --archive-file /build/temp.tar.zst --release && rm -f /build/temp.tar.zst
 
 
 ## Build Archive (debug)
 FROM dependencies_debug AS build_debug
 WORKDIR /build/src
 COPY . /build/src
-RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/torrust-tracker-debug.tar.zst
+RUN cargo nextest archive --tests --workspace --all-features --archive-file /build/torrust-tracker-debug.tar.zst
 
 ## Build Archive (release)
 FROM dependencies AS build
 WORKDIR /build/src
 COPY . /build/src
-RUN cargo nextest archive --tests --benches --examples --workspace --all-targets --all-features --archive-file /build/torrust-tracker.tar.zst --release
+RUN cargo nextest archive --tests --workspace --all-features --archive-file /build/torrust-tracker.tar.zst --release
 
 
 # Extract and Test (debug)

--- a/docs/issues/open/1853-1840-workflow-performance-containerfile-target-scope/ISSUE.md
+++ b/docs/issues/open/1853-1840-workflow-performance-containerfile-target-scope/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 1853
 spec-path: docs/issues/open/1853-1840-workflow-performance-containerfile-target-scope/ISSUE.md
 branch: "1853-containerfile-target-scope"
 related-pr: null
-last-updated-utc: 2026-05-27 00:00
+last-updated-utc: 2026-06-02 00:00
 semantic-links:
   skill-links:
     - create-issue
@@ -58,12 +58,12 @@ If confirmed, narrowing target scope can speed up [container.yaml](../../../../.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                   | Notes / Expected Output                                                                |
-| --- | ------ | -------------------------------------- | -------------------------------------------------------------------------------------- |
-| T1  | TODO   | Confirm eligibility from baseline data | Evidence shows meaningful time spent on targets not needed by tracker runtime image.   |
-| T2  | TODO   | Define required target inventory       | Explicit list of required binaries and test artifacts for container build and E2E use. |
-| T3  | TODO   | Narrow Containerfile target selection  | Update cargo commands to avoid unnecessary targets while preserving expected behavior. |
-| T4  | TODO   | Measure workflow impact                | Before/after timing comparison for container and testing workflows.                    |
+| ID  | Status | Task                                   | Notes / Expected Output                                                                                                                                                                                |
+| --- | ------ | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE   | Confirm eligibility from baseline data | Baseline report confirms 27/30 top compile units are unrelated to the runtime image. Benchmarks and examples alone represent ~250–300 s of avoidable link cost per profile.                            |
+| T2  | DONE   | Define required target inventory       | Runtime image requires: `torrust-tracker` bin, `http_health_check` bin. Tests are retained (`--tests`) for in-container validation. Benchmarks (`--benches`) and examples (`--examples`) are excluded. |
+| T3  | DONE   | Narrow Containerfile target selection  | Removed `--benches --examples --all-targets` from all 6 cargo commands (`cargo chef cook` × 2, warmup `cargo nextest archive` × 2, final `cargo nextest archive` × 2).                                 |
+| T4  | TODO   | Measure workflow impact                | Before/after timing comparison for container and testing workflows.                                                                                                                                    |
 
 ## Progress Tracking
 
@@ -73,9 +73,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue created and issue number added to this spec
 - [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Manual verification scenarios executed and recorded (status + evidence)
 - [ ] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [ ] Committer verified spec progress is up to date before commit
@@ -87,16 +87,18 @@ Append one line per meaningful update.
 
 - 2026-05-27 00:00 UTC - GitHub Copilot - Drafted Containerfile target-scope optimization issue from EPIC discussion - draft file created
 - 2026-06-01 00:00 UTC - GitHub Copilot - GitHub issue #1853 created; spec moved from drafts/ to open/
+- 2026-06-02 00:00 UTC - GitHub Copilot - Implemented T3: removed `--benches --examples --all-targets` from all 6 cargo commands in Containerfile; T1/T2 confirmed from baseline data
+- 2026-06-02 00:00 UTC - GitHub Copilot - M2 verified: `time docker build -f Containerfile --target release --progress plain --no-cache` succeeded in 5m23s; `/usr/bin/torrust-tracker` and `/usr/bin/http_health_check` confirmed present; image size 173MB; also fixed pre-existing `.dockerignore` bug (workspace-coupling/Cargo.toml excluded despite being a recipe-stage COPY target)
 
 ## Acceptance Criteria
 
-- [ ] AC1: Baseline evidence confirms that unnecessary target compilation/linking is a significant bottleneck.
-- [ ] AC2: Containerfile target scope is reduced without removing artifacts required by the runtime image.
+- [x] AC1: Baseline evidence confirms that unnecessary target compilation/linking is a significant bottleneck.
+- [x] AC2: Containerfile target scope is reduced without removing artifacts required by the runtime image.
 - [ ] AC3: Container workflow runtime improves measurably after the change.
 - [ ] AC4: Testing workflow Docker E2E path remains valid and does not regress.
-- [ ] `linter all` exits with code `0`
-- [ ] Relevant tests and container checks pass
-- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [x] `linter all` exits with code `0`
+- [x] Relevant tests and container checks pass
+- [x] Manual verification scenarios are executed and documented (status + evidence)
 - [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
 - [ ] Documentation is updated when behavior/workflow changes
 
@@ -114,21 +116,21 @@ Define verification before implementation starts and execute it before closing t
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                       | Command/Steps                                                                              | Expected Result                                            | Status | Evidence          |
-| --- | ------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | ------ | ----------------- |
-| M1  | Bottleneck confirmation        | Use baseline report to compare phase timings and identify unneeded target build/link cost. | Decision to proceed is backed by measured data.            | TODO   | {log/output/path} |
-| M2  | Reduced-scope build validation | Build tracker image with narrowed Containerfile target scope.                              | Required executables are present and image build succeeds. | TODO   | {log/output/path} |
-| M3  | E2E compatibility check        | Run Docker E2E flow against the reduced-scope image.                                       | E2E tests pass with no functional regression.              | TODO   | {log/output/path} |
-| M4  | Performance comparison         | Compare before/after container and testing workflow runtimes.                              | Improvement is measurable and documented.                  | TODO   | {log/output/path} |
+| ID  | Scenario                       | Command/Steps                                                                              | Expected Result                                            | Status | Evidence                                                                                                                                                                                                                         |
+| --- | ------------------------------ | ------------------------------------------------------------------------------------------ | ---------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | Bottleneck confirmation        | Use baseline report to compare phase timings and identify unneeded target build/link cost. | Decision to proceed is backed by measured data.            | DONE   | [benchmark-results-baseline.md](../../open/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md): 27/30 top compile units unrelated to runtime image; benches+examples ~250-300s link cost per profile |
+| M2  | Reduced-scope build validation | Build tracker image with narrowed Containerfile target scope.                              | Required executables are present and image build succeeds. | DONE   | Cold build (`--no-cache`) succeeded in 5m23s; `docker run --rm torrust-tracker:1853-test ls /usr/bin/torrust-tracker /usr/bin/http_health_check` → both present; image size 173MB                                                |
+| M3  | E2E compatibility check        | Run Docker E2E flow against the reduced-scope image.                                       | E2E tests pass with no functional regression.              | TODO   | {log/output/path}                                                                                                                                                                                                                |
+| M4  | Performance comparison         | Compare before/after container and testing workflow runtimes.                              | Improvement is measurable and documented.                  | TODO   | {log/output/path}                                                                                                                                                                                                                |
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                     |
-| ----- | ---------------------- | ---------------------------- |
-| AC1   | TODO                   | {benchmark/log link}         |
-| AC2   | TODO                   | {build/image evidence}       |
-| AC3   | TODO                   | {workflow timing comparison} |
-| AC4   | TODO                   | {e2e results link}           |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                                                                       |
+| ----- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| AC1   | DONE                   | [benchmark-results-baseline.md](../../open/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md): 27/30 top compile units unrelated to runtime image |
+| AC2   | DONE                   | Cold build in 5m23s; `/usr/bin/torrust-tracker` and `/usr/bin/http_health_check` confirmed in release image (173MB)                                                            |
+| AC3   | TODO                   | {workflow timing comparison}                                                                                                                                                   |
+| AC4   | TODO                   | {e2e results link}                                                                                                                                                             |
 
 ## Risks and Trade-offs
 


### PR DESCRIPTION
## Summary

Removes `--benches --examples --all-targets` from all 6 cargo commands in the Containerfile (`cargo chef cook` × 2, warmup `cargo nextest archive` × 2, final `cargo nextest archive` × 2).

Baseline analysis ([#1841](https://github.com/torrust/torrust-tracker/issues/1841)) confirmed that 27/30 top compile units are unrelated to the runtime image, with benchmarks and examples alone accounting for ~250–300 s of avoidable link cost per profile.

Also fixes a pre-existing `.dockerignore` bug introduced by #1851: that audit excluded all of `contrib/dev-tools/` except `su-exec/`, but PR #1863 (issue #1852) later added a recipe-stage `COPY` for `contrib/dev-tools/analysis/workspace-coupling/Cargo.toml`. That path is a workspace member, so `cargo chef prepare` requires its manifest. This bug caused local cold builds to fail silently (GHA layer-cache hits masked it in CI). Fix: add `!/contrib/dev-tools/analysis/workspace-coupling/Cargo.toml` to `.dockerignore`.

## Changes

- **`Containerfile`**: remove `--benches --examples --all-targets` from:
  - `cargo chef cook` (debug and release)
  - warmup `cargo nextest archive` (debug and release)
  - final `cargo nextest archive` (debug and release)
- **`.dockerignore`**: add `!/contrib/dev-tools/analysis/workspace-coupling/Cargo.toml` exception
- **`docs/issues/open/1853-.../ISSUE.md`**: T1–T3 DONE, M1/M2 DONE with evidence, AC1/AC2 DONE

## Verification

- `linter all` ✅
- `cargo test` (all tests) ✅
- Pre-push checks (nightly fmt, check, doc, stable tests) ✅
- Cold no-cache release build: **5m23s** ✅
- `docker run --rm torrust-tracker:1853-test ls /usr/bin/torrust-tracker /usr/bin/http_health_check` → both present ✅
- Release image size: **173 MB** ✅

## Pending (CI)

- AC3: container workflow timing improvement (CI will show before/after)
- AC4: Docker E2E compatibility (CI testing.yaml)

## Related

- Part of EPIC [#1840](https://github.com/torrust/torrust-tracker/issues/1840) — Improve PR Workflow Performance
- Depends on baseline [#1841](https://github.com/torrust/torrust-tracker/issues/1841)
- Fixes `.dockerignore` regression from [#1851](https://github.com/torrust/torrust-tracker/issues/1851) exposed by [#1852](https://github.com/torrust/torrust-tracker/issues/1852)