### PR TITLE
docs(epic): record TslConfig decision

### DIFF
--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -65,7 +65,7 @@ tracker-scoped, and avoid creating a new package just for the TLS DTO.
 
 ### Supporting artifacts
 
-- [Issue #1860 spec](../open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md)
+- [Issue #1860 spec](../../open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md)
 - `packages/axum-server/README.md`
 - `packages/configuration/src/lib.rs`
 

--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -20,6 +20,57 @@ the proposal, the reasoning, and a reference to any supporting artifact.
 
 ---
 
+## DEC-08 — Keep `TslConfig` in tracker configuration and keep `torrust-tracker-axum-server` tracker-scoped
+
+**Date**: 2026-06-03
+**Status**: Adopted
+
+### Proposal considered
+
+Move `TslConfig` out of `torrust-tracker-configuration` and either:
+
+- place it in `torrust-tracker-axum-server`, or
+- extract it into a new generic package such as `torrust-server-lib` or a dedicated TLS
+  DTO crate.
+
+### Alternative chosen
+
+Keep `TslConfig` in `torrust-tracker-configuration`, keep `torrust-tracker-axum-server`
+tracker-scoped, and avoid creating a new package just for the TLS DTO.
+
+### Why this alternative was adopted
+
+1. **The configuration type is already the public DTO**: `HttpTracker` is now used as the
+   public configuration object for custom tracker composition, so `TslConfig` remains part
+   of the tracker-facing configuration contract.
+2. **Moving to `axum-server` would worsen the dependency story**: the configuration crate
+   would need to import a delivery-layer package to deserialize `HttpTracker.tsl_config`,
+   which inverts the desired layering.
+3. **A separate DTO/internal-type split is overkill here**: `TslConfig` is a two-field
+   struct with no business logic. Treating it like `SocketAddr` is reasonable and avoids
+   needless mapping boilerplate.
+4. **A generic home is premature**: `server-lib` is broader infrastructure for all Torrust
+   HTTP servers, and there is no current cross-project reuse requirement that justifies a
+   new TLS-specific package.
+5. **Tracker-scoped naming matches reality**: the package is now explicitly scoped to the
+   Torrust tracker HTTP services, so depending on tracker configuration types is acceptable
+   when it keeps the service API cohesive.
+
+### Trade-offs acknowledged
+
+- `TslConfig` remains coupled to the tracker supervisor configuration schema.
+- If the same TLS DTO is ever reused across other Torrust projects, a generic package can
+  be reconsidered then.
+- The current choice favors simplicity and cohesive tracker APIs over early abstraction.
+
+### Supporting artifacts
+
+- [Issue #1860 spec](../open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md)
+- `packages/axum-server/README.md`
+- `packages/configuration/src/lib.rs`
+
+---
+
 ## DEC-09 — Narrow `EnvContainer::initialize` and `Environment::new` to accept per-service config slices
 
 **Date**: 2026-06-02

--- a/docs/issues/open/1856-1669-analyse-configuration-package-coupling/ISSUE.md
+++ b/docs/issues/open/1856-1669-analyse-configuration-package-coupling/ISSUE.md
@@ -606,7 +606,10 @@ This decision is recorded in
   import sites. This is a code-change follow-up to be tracked as a new subissue
   of EPIC #1669.
 - **FU-2**: Evaluate whether `TslConfig` should move into `axum-server` (already
-  flagged in EPIC.md as a temporary coupling). This can be done independently.
+  flagged in EPIC.md as a temporary coupling). The current conclusion from issue
+  #1860 is to keep `TslConfig` in `torrust-tracker-configuration` and keep
+  `torrust-tracker-axum-server` tracker-scoped rather than creating a new package
+  just for the TLS DTO.
 - **FU-3**: Revisit whether `EnvContainer::initialize` should accept narrower
   config slices (`Arc<Core>`, `Arc<UdpTracker>`) instead of `&Configuration`,
   which would reduce the coupling forcing function at the initialisation boundary.

--- a/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
+++ b/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
@@ -38,7 +38,7 @@ This issue is a subissue of EPIC [#1669](../1669-overhaul-packages/EPIC.md).
 ## Background
 
 `TslConfig` is currently defined in `torrust-tracker-configuration`
-(`packages/configuration/src/v2_0_0/tls.rs`). Its only production consumer is
+(`packages/configuration/src/lib.rs`). Its only production consumer is
 `torrust-tracker-axum-server` (`packages/axum-server/src/tsl.rs`). No other production
 code in the workspace depends on `TslConfig` directly.
 
@@ -93,8 +93,8 @@ Move the type, update import sites, update Cargo manifests, run tests.
 
 - [x] A decision entry is added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
       with chosen approach and rationale
-- [x] Option C chosen: `TslConfig` stays in `torrust-tracker-configuration`, the
-      package boundary stays tracker-scoped, and no new TLS DTO package was added
+- [x] DEC-08 chosen approach: `TslConfig` stays in `torrust-tracker-configuration`,
+      the package boundary stays tracker-scoped, and no new TLS DTO package was added
 - [x] All tests pass; no new clippy warnings — not applicable because no code changes
       were required for the selected option
 

--- a/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
+++ b/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
@@ -152,7 +152,7 @@ the type lands — which would invert a dependency edge.
 | `make_rust_tls`              | `packages/axum-server/src/tsl.rs`                           | Uses `ssl_cert_path` / `ssl_key_path` to build `RustlsConfig` |
 | `axum-http-server` (2 sites) | `packages/axum-http-server/src/server.rs`, `environment.rs` | Passes `&tsl_config` to `make_rust_tls`                       |
 
-`make_rust_tls` in `axum-server` is the only **behavioural** consumer.
+`make_rust_tls` in `axum-server` is the only **behavioral** consumer.
 `HttpApi` and `HttpTracker` are **structural** consumers — they hold the type purely
 for deserialization.
 
@@ -222,14 +222,14 @@ This changes the shape of the decision in two ways:
 
    With a clean separation, a mapping step at the boundary converts the public DTO
    into the internal service config. This is the DEC-06 pattern applied to
-   configuration. The cost is the mapping boilerplate and the version synchronisation
+   configuration. The cost is the mapping boilerplate and the version synchronization
    discipline between the two representations.
 
    Without this separation (status quo), the configuration type _is_ the service
    config. Evolution is simpler (one type to change), but changing any field is
    immediately a public schema break.
 
-### The version-synchronisation problem
+### The version-synchronization problem
 
 If the service packages define their own internal config types, each change to a
 service's runtime behaviour that requires a new config option must be coordinated in

--- a/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
+++ b/docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: resolved
 priority: p3
 github-issue: 1860
 spec-path: docs/issues/open/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
 branch: null
 related-pr: null
-last-updated-utc: 2026-06-01 00:00
+last-updated-utc: 2026-06-03 00:00
 semantic-links:
   skill-links:
     - create-issue
@@ -91,12 +91,12 @@ Move the type, update import sites, update Cargo manifests, run tests.
 
 ## Acceptance Criteria
 
-- [ ] A decision entry is added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
+- [x] A decision entry is added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
       with chosen approach and rationale
-- [ ] If Option A or B chosen: `TslConfig` is moved, all import sites updated, and
-      `torrust-tracker-axum-server`'s `Cargo.toml` no longer depends on
-      `torrust-tracker-configuration`
-- [ ] All tests pass; no new clippy warnings
+- [x] Option C chosen: `TslConfig` stays in `torrust-tracker-configuration`, the
+      package boundary stays tracker-scoped, and no new TLS DTO package was added
+- [x] All tests pass; no new clippy warnings — not applicable because no code changes
+      were required for the selected option
 
 ## Out of Scope
 
@@ -113,7 +113,223 @@ pure framework-integration layer with no domain-level config coupling.
 ## Related
 
 - Parent EPIC: #1669 — [EPIC.md](../1669-overhaul-packages/EPIC.md)
-- Decision to be added: DECISIONS.md DEC-08
+- Decision recorded: DECISIONS.md DEC-08
 - Analysis: #1856 — [ISSUE.md](../1856-1669-analyse-configuration-package-coupling/ISSUE.md)
 - EPIC note: see "Note on `torrust-tracker-axum-server`" in EPIC.md
 - Follow-ups: FU-1 (#1859), FU-3 (#1861)
+
+---
+
+## Codebase Audit (2026-06-03)
+
+### `TslConfig` structural facts
+
+`TslConfig` is defined in `packages/configuration/src/lib.rs`:
+
+```rust
+#[serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+pub struct TslConfig {
+    #[serde(default = "TslConfig::default_ssl_cert_path")]
+    pub ssl_cert_path: Utf8PathBuf,
+    #[serde(default = "TslConfig::default_ssl_key_path")]
+    pub ssl_key_path: Utf8PathBuf,
+}
+```
+
+It carries `#[derive(Serialize, Deserialize)]` and `#[serde(...)]` on its fields.
+It is the TOML deserialization type, embedded in both `HttpApi.tsl_config` and
+`HttpTracker.tsl_config`. It therefore **cannot be moved out of `configuration`** without
+either (a) keeping a DTO copy there, or (b) making `configuration` import from wherever
+the type lands — which would invert a dependency edge.
+
+### Production consumers
+
+| Site                         | File                                                        | Role                                                          |
+| ---------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------- |
+| `HttpApi.tsl_config`         | `packages/configuration/src/v2_0_0/tracker_api.rs`          | TOML deserialization field                                    |
+| `HttpTracker.tsl_config`     | `packages/configuration/src/v2_0_0/http_tracker.rs`         | TOML deserialization field                                    |
+| `make_rust_tls`              | `packages/axum-server/src/tsl.rs`                           | Uses `ssl_cert_path` / `ssl_key_path` to build `RustlsConfig` |
+| `axum-http-server` (2 sites) | `packages/axum-http-server/src/server.rs`, `environment.rs` | Passes `&tsl_config` to `make_rust_tls`                       |
+
+`make_rust_tls` in `axum-server` is the only **behavioural** consumer.
+`HttpApi` and `HttpTracker` are **structural** consumers — they hold the type purely
+for deserialization.
+
+### Revised options
+
+The original option table in the spec above was written before confirming that `TslConfig`
+carries `Serialize`/`Deserialize` and is embedded in two config structs. The analysis below
+supersedes it.
+
+| Option                                                                                                                     | Description                                                                                                                                                                 | Dependency edge change                                                                                                                             | Verdict                                                 |
+| -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| **A — Move to `axum-server`**                                                                                              | Define `TslConfig` in `axum-server`; `configuration` imports it for deserialization.                                                                                        | `configuration → axum-server` introduced. Delivery layer ← config. **Inverted edge — not viable.**                                                 | ❌ Off the table                                        |
+| **B — Move to `server-lib`**                                                                                               | Define `TslConfig` in `torrust-server-lib`; both `configuration` and `axum-server` import from there.                                                                       | `configuration → server-lib`, `axum-server → server-lib`. No forbidden edges. Aligns with EPIC goal of extracting a generic `torrust-axum-server`. | ✅ Architecturally sound                                |
+| **C — Keep in `configuration`; change `make_rust_tls` to accept raw paths**                                                | `axum-server` stops importing `TslConfig` at all. Call sites extract `cert` and `key` individually before calling the function. No new type or package needed.              | `axum-server → configuration` removed.                                                                                                             | ✅ Minimal and clean                                    |
+| **D — Keep `TslConfig` in `configuration` as TOML DTO; define internal `TlsConfig` in `axum-server`; map at the boundary** | `configuration` owns the TOML DTO; `axum-server` owns its internal type; a one-line mapping converts between them at the call site. Aligns with DEC-06 (map at boundaries). | `axum-server → configuration` removed (no longer needs the type).                                                                                  | ✅ Principled but adds boilerplate for a 2-field struct |
+
+### Design tension
+
+You raised an important concern: exposing inner implementation details through the public
+configuration API couples the internals to the public contract. The configuration type is
+part of the public TOML schema — changing `TslConfig` would be a schema-breaking change.
+If `axum-server` has its own internal `TlsConfig`, the schema DTO and the runtime type
+evolve independently and the boundary between "what the user configures" and "what the code
+uses" is explicit.
+
+On the other hand, for a 2-field struct with no tracker-specific logic, the DTO and the
+internal type are identical in practice. The mapping is trivial, but every change to the
+schema still requires updating two types.
+
+### Constraint from the "build-your-own tracker" goal and DEC-09
+
+Issue #1861 (DEC-09, now closed) narrowed `HttpTrackerEnvironment::new` to accept
+`(&Arc<Core>, &Arc<HttpTracker>)` instead of `&Arc<Configuration>`. The HTTP-only
+example (`packages/axum-http-server/examples/http_only_public_tracker.rs`) now
+constructs an `HttpTracker` directly:
+
+```rust
+let http_tracker = HttpTracker {
+    bind_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+    tsl_config: None,
+    tracker_usage_statistics: false,
+};
+```
+
+This reveals an important constraint: **`TslConfig` is now part of the public API for
+building custom trackers**. A user composing an HTTP-only tracker must construct
+`HttpTracker`, which includes `tsl_config: Option<TslConfig>`. They will import and
+use `TslConfig` from whatever package it lives in.
+
+This changes the shape of the decision in two ways:
+
+1. **Moving `TslConfig` to `axum-server` (Option A) would be worse, not better**, in
+   this scenario. A user building a custom HTTP tracker would have to import
+   `HttpTracker` from `configuration` _and_ `TslConfig` from `axum-server` — two
+   separate packages for one config struct and one of its fields. That is a worse
+   developer experience than the current coupling.
+
+2. **The deeper architectural tension is now visible**: `HttpTracker` (defined in
+   `configuration`) is used both as the TOML deserialization DTO _and_ as the
+   runtime config passed directly to the HTTP tracker service. These two roles are
+   conflated. The question you are raising is whether there should be a clean
+   separation:
+   - **TOML DTO** (public schema contract, owned by `configuration`): what the user
+     writes in `tracker.toml` or constructs in application code.
+   - **Service config** (internal runtime contract, owned by the service package):
+     what the HTTP tracker server actually reads at runtime.
+
+   With a clean separation, a mapping step at the boundary converts the public DTO
+   into the internal service config. This is the DEC-06 pattern applied to
+   configuration. The cost is the mapping boilerplate and the version synchronisation
+   discipline between the two representations.
+
+   Without this separation (status quo), the configuration type _is_ the service
+   config. Evolution is simpler (one type to change), but changing any field is
+   immediately a public schema break.
+
+### The version-synchronisation problem
+
+If the service packages define their own internal config types, each change to a
+service's runtime behaviour that requires a new config option must be coordinated in
+two places:
+
+1. The service package's internal type (to add the field).
+2. The global `configuration` package's TOML DTO (to expose it in the schema).
+
+This means the global `configuration` package version must be bumped whenever any
+service adds a new config field — even if the change is entirely internal to that
+service. The version coupling is not eliminated; it is just made explicit through a
+mapping layer. The benefit is that the _shape_ of the coupling is controlled: the
+service's internal type can change freely as long as the mapping from the DTO
+handles the translation.
+
+---
+
+## Open Questions (awaiting answers)
+
+**Q1 — Is Option A off the table, and does the build-your-own constraint settle it?**
+
+The analysis concludes Option A is not viable for two independent reasons:
+
+1. Embedding `TslConfig` in `HttpApi` and `HttpTracker` for TOML deserialization would
+   require `configuration → axum-server`, inverting the layering.
+2. With DEC-09 in place, a user building a custom HTTP tracker constructs `HttpTracker`
+   directly. If `TslConfig` lived in `axum-server`, they would need to import from both
+   `configuration` (for `HttpTracker`) and `axum-server` (for `TslConfig`) — a worse
+   experience than today.
+
+Do you agree that Option A is off the table?
+
+> **Answer:**
+
+Yes, I agree.
+
+**Q2 — Should there be a clean DTO / service-config separation (DEC-06 pattern)?**
+
+The core architectural question is whether the configuration type (`HttpTracker`,
+`TslConfig`) should be both the TOML DTO _and_ the runtime service config, or whether
+the service should own its internal config and map from the DTO at the boundary.
+
+- **No separation (status quo / Path C)**: `HttpTracker` and `TslConfig` from
+  `configuration` flow all the way into the service. Simplest, no mapping boilerplate.
+  Any change to a field is immediately a schema change. `make_rust_tls` in `axum-server`
+  could be changed to accept `(cert: &Utf8PathBuf, key: &Utf8PathBuf)` directly,
+  removing the `TslConfig` import from `axum-server` with zero new types.
+- **Clean separation (Path D)**: `axum-server` defines its own `TlsConfig`; a mapping
+  converts `configuration::TslConfig` → `axum_server::TlsConfig` at the boundary.
+  Aligns with DEC-06. Adds a trivial `From` impl for a 2-field struct. Service internals
+  can evolve without touching the schema.
+
+For `TslConfig` specifically, there is no functional difference between the two today
+(same two fields, same types). The question is whether you want to establish the
+DTO-separation pattern now as a precedent, or whether you consider it premature given
+the type's simplicity. If we do not establish it here, the inconsistency with DEC-06
+is intentional and should be documented in the decision.
+
+> **Answer:**
+
+That looks overengineered for a 2-field struct that is unlikely to change. I see it more like the type `SocketAddr` from the standard library: it is both the deserialization type and the runtime type, and that is fine. If we had a more complex config with more fields and more complex logic, I would be more inclined to separate the DTO from the internal type, but for this case I think it's fine to keep them together.
+
+**Q3 — Does `TslConfig` belong in `server-lib` long-term (Path B)?**
+
+The EPIC mentions extracting `axum-server` as a generic `torrust-axum-server` reusable
+across the Torrust organisation. If the extraction is planned soon, moving `TslConfig`
+to `server-lib` now would give it a neutral home that neither `configuration` nor
+`axum-server` owns. If the extraction is far off, this is premature abstraction.
+
+Should we act on this now or defer? And if we defer, should the decision entry
+explicitly flag this as a deferred action so it is not forgotten?
+
+> **Answer:**
+
+Maybe, but for now that package has common functionality used in all Torrust servers, not only HTTP servers. What about "packages/axum-http-server"?
+
+**Q4 — Tests in `axum-server/src/tsl.rs` construct `TslConfig` directly.**
+
+If we go with Path C (`make_rust_tls` accepts raw paths), the tests would build
+`Utf8PathBuf` directly with no config type involved. If we go with Path D (internal
+`TlsConfig`), the tests would construct the new internal type. Either way the
+`axum-server → configuration` dependency is removed — including the dev-dependency.
+Is that acceptable, or do you want to keep the tests constructing `TslConfig` from
+`configuration` (e.g. as an integration check that the mapping is correct)?
+
+> **Answer:**
+
+It does not make sense not to use it, just to remove the dependency if that abstraction makes sense in the test.
+
+### Preferred choice from the discussion
+
+Based on the current answers, the preferred choice is **Option C** with the current
+tracker-scoped package boundary preserved:
+
+- keep `TslConfig` in `torrust-tracker-configuration`
+- keep `torrust-tracker-axum-server` as tracker-specific infrastructure rather than a
+  generic org-level wrapper
+- keep the `HttpTracker` public API self-contained for custom tracker composition
+- avoid introducing a new package only for `TslConfig`
+
+That preference keeps the build-your-own tracker story straightforward while avoiding a
+new abstraction layer for a two-field config DTO that is already part of the public
+tracker configuration contract.

--- a/packages/axum-server/README.md
+++ b/packages/axum-server/README.md
@@ -17,9 +17,8 @@ The TLS helper in `tsl.rs` currently depends on:
 
 - `TslConfig` from `torrust-tracker-configuration` — the tracker supervisor's public
   TLS configuration DTO
-- `LocatedError` / `DynError` from `torrust-tracker-located-error` — planned to be
-  renamed to `torrust-located-error` (a generic package) under EPIC
-  [#1669](https://github.com/torrust/torrust-tracker/issues/1669) SI-10
+- `LocatedError` / `DynError` from `torrust-located-error` — already extracted into a
+  generic package
 
 If this server wrapper is reused outside the tracker in the future, the package
 boundary can be revisited and a more generic home for `TslConfig` can be evaluated

--- a/packages/axum-server/README.md
+++ b/packages/axum-server/README.md
@@ -1,6 +1,6 @@
-# Torrust Axum Server
+# Torrust Tracker Axum Server
 
-A wrapper for the Axum server for Torrust HTTP servers to add timeouts.
+A wrapper for the Axum server used by Torrust tracker HTTP services to add timeouts.
 
 ## Documentation
 
@@ -8,22 +8,22 @@ A wrapper for the Axum server for Torrust HTTP servers to add timeouts.
 
 ## Notes
 
-This package is currently scoped under the `torrust-tracker-` prefix because `tsl.rs`
-depends on two tracker-specific items:
+This package is tracker-scoped infrastructure for HTTP services in the Torrust tracker.
+It is the base Axum server wrapper used by the tracker's HTTP service packages, so it
+is fine for it to depend on tracker configuration types when that keeps the service API
+cohesive.
 
-- `TslConfig` from `torrust-tracker-configuration` — a small two-field struct (SSL
-  certificate and key paths). It has no inherent tracker dependency and could be moved
-  to a generic package.
+The TLS helper in `tsl.rs` currently depends on:
+
+- `TslConfig` from `torrust-tracker-configuration` — the tracker supervisor's public
+  TLS configuration DTO
 - `LocatedError` / `DynError` from `torrust-tracker-located-error` — planned to be
-  renamed to `torrust-located-error` (a generic package) under
-  EPIC [#1669](https://github.com/torrust/torrust-tracker/issues/1669) SI-10.
+  renamed to `torrust-located-error` (a generic package) under EPIC
+  [#1669](https://github.com/torrust/torrust-tracker/issues/1669) SI-10
 
-Once `TslConfig` is extracted to a generic location and `torrust-tracker-located-error`
-is renamed, this package could become a generic `torrust-axum-server` reusable across
-the Torrust organisation. A near-identical module already exists in
-[torrust-index](https://github.com/torrust/torrust-index/blob/develop/src/web/api/server/custom_axum.rs),
-which confirms the generic utility of this pattern. This reorganization is tracked in
-EPIC [#1669](https://github.com/torrust/torrust-tracker/issues/1669).
+If this server wrapper is reused outside the tracker in the future, the package
+boundary can be revisited and a more generic home for `TslConfig` can be evaluated
+then.
 
 ## License
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -38,8 +38,8 @@ bools
 Bragilevsky
 bufs
 buildid
-Buildx
 BuildKit
+Buildx
 byteorder
 callgrind
 CALLSITE
@@ -187,6 +187,7 @@ multimap
 myacicontext
 mysqladmin
 mysqld
+ñaca
 Naim
 nanos
 newkey
@@ -211,6 +212,7 @@ openmetrics
 optimisations
 organisation
 ostr
+overengineered
 Pando
 parallelise
 parallelised
@@ -241,9 +243,9 @@ RAII
 Rakshasa
 randomised
 Rasterbar
+readelf
 realpath
 reannounce
-readelf
 recognised
 recompiles
 referer
@@ -319,7 +321,6 @@ tlnp
 tlsv
 toki
 toplevel
-tslconfig
 Torrentstorm
 torru
 torrust
@@ -330,6 +331,7 @@ triaging
 trixie
 trunc
 tryhackx
+tslconfig
 ttwu
 typenum
 udpv
@@ -349,8 +351,8 @@ unsync
 untuple
 unviable
 upcasting
-urlencode
 ureq
+urlencode
 uroot
 usize
 Vagaa
@@ -378,4 +380,3 @@ xxxxxxxxxxxxxxxxxxxxd
 yyyyyyyyyyyyyyyyyyyyd
 zerocopy
 zstd
-ñaca


### PR DESCRIPTION
Record DEC-08 for issue #1860 and align the tracker docs with the final conclusion.

Summary:
- keep TslConfig in torrust-tracker-configuration
- keep torrust-tracker-axum-server tracker-scoped
- update the parent analysis and the axum-server README to match
- resolve the follow-up issue spec with the chosen option and rationale

This is a docs-only change set; no code changes were required for the selected option.