### PR TITLE
feat(primitives): replace TORRENT_PEERS_LIMIT with AnnouncePolicy::max_peers_per_announce

### DIFF
--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -20,6 +20,52 @@ the proposal, the reasoning, and a reference to any supporting artifact.
 
 ---
 
+## DEC-10 — Move peer-count cap from a global constant to `AnnouncePolicy::max_peers_per_announce`
+
+**Date**: 2026-06-09
+**Status**: Adopted
+**Related issue**: [#1864](https://github.com/torrust/torrust-tracker/issues/1864)
+
+### Proposal considered
+
+The hardcoded constant `TORRENT_PEERS_LIMIT = 74` in `torrust-tracker-primitives` was
+the sole compile-time control over how many peers the tracker returns per announce
+response. The options evaluated were:
+
+1. **Keep the constant** but expose it as a public API so callers can pass it explicitly.
+2. **Add a runtime field** `max_peers_per_announce: usize` to `AnnouncePolicy` and remove
+   the constant entirely.
+3. **Move the cap to `TrackerPolicy`** alongside the existing cleanup policy fields.
+
+### Alternative chosen
+
+Option 2: add `max_peers_per_announce: usize` (default `74`) to `AnnouncePolicy` and
+remove `TORRENT_PEERS_LIMIT`. The cap is applied inside `AnnounceHandler::build_announce_data`
+via `PeersWanted::limit(max_peers)` at call time, not at `PeersWanted` construction time.
+
+### Why this alternative was adopted
+
+1. **Semantic fit**: `AnnouncePolicy` already governs announce-response behaviour
+   (`interval`, `interval_min`). The peer count cap belongs in the same bucket.
+2. **Runtime configurability**: operators can tune the cap per deployment without
+   recompiling. The previous constant made that impossible.
+3. **Cleaner type boundaries**: `PeersWanted` no longer needs to know about a global
+   limit when constructed; the limit is injected once at the point of use
+   (`build_announce_data`), keeping the type simple and context-free.
+4. **Avoiding `TrackerPolicy` scope creep**: `TrackerPolicy` is about data-retention
+   behaviour (persistence, ghost peers, etc.). Mixing in a response-size limit there
+   would blur its responsibility.
+5. **No `From<i32/u32>` impls**: the old `From` impls baked in the compile-time constant.
+   Replacing them with `PeersWanted::from_client_request(i32)` makes the cap injection
+   point explicit and removes hidden global state from the type system.
+
+### Tradeoffs accepted
+
+- `AnnouncePolicy::new()` now takes a third argument; callers were updated.
+- A small scope increase to `AnnouncePolicy` (previously two fields, now three).
+
+---
+
 ## DEC-08 — Keep `TslConfig` in tracker configuration and keep `torrust-tracker-axum-server` tracker-scoped
 
 **Date**: 2026-06-03

--- a/docs/issues/open/1864-1669-review-torrent-peers-limit/ISSUE.md
+++ b/docs/issues/open/1864-1669-review-torrent-peers-limit/ISSUE.md
@@ -90,9 +90,9 @@ global value shared across multiple packages.
 
 ## Acceptance Criteria
 
-- [ ] A decision (ADR or `DECISIONS.md` entry under EPIC #1669) recording the chosen
+- [x] A decision (ADR or `DECISIONS.md` entry under EPIC #1669) recording the chosen
       approach and the rationale.
-- [ ] If the decision is to change the current design: implementation is complete,
+- [x] If the decision is to change the current design: implementation is complete,
       all tests pass, and the doc reference in `axum-http-server/src/lib.rs` is updated.
-- [ ] `cargo test --workspace` passes.
-- [ ] `linter all` passes.
+- [x] `cargo test --workspace` passes.
+- [x] `linter all` passes.

--- a/packages/axum-http-server/src/lib.rs
+++ b/packages/axum-http-server/src/lib.rs
@@ -70,10 +70,11 @@
 //! > request or the right-most-ip in the `X-Forwarded-For` header if the tracker
 //! > is behind a reverse proxy.
 //!
-//! > **NOTICE**: the maximum number of peers that the tracker can return is
-//! > `74`. Defined with a hardcoded const [`TORRENT_PEERS_LIMIT`](torrust_tracker_primitives::TORRENT_PEERS_LIMIT).
-//! > Refer to [issue 262](https://github.com/torrust/torrust-tracker/issues/262)
-//! > for more information about this limitation.
+//! > **NOTICE**: the maximum number of peers that the tracker can return per
+//! > announce response is controlled by the `max_peers_per_announce` field in
+//! > the `[core.announce_policy]` configuration section (default: `74`).
+//! > Refer to [`AnnouncePolicy::max_peers_per_announce`](torrust_tracker_primitives::AnnouncePolicy)
+//! > for more information.
 //!
 //! > **NOTICE**: the `info_hash` parameter is NOT a `URL` encoded string param.
 //! > It is percent encode of the raw `info_hash` bytes (40 bytes). URL `GET` params

--- a/packages/axum-http-server/src/lib.rs
+++ b/packages/axum-http-server/src/lib.rs
@@ -73,7 +73,7 @@
 //! > **NOTICE**: the maximum number of peers that the tracker can return per
 //! > announce response is controlled by the `max_peers_per_announce` field in
 //! > the `[core.announce_policy]` configuration section (default: `74`).
-//! > Refer to [`AnnouncePolicy::max_peers_per_announce`](torrust_tracker_primitives::AnnouncePolicy)
+//! > Refer to [`AnnouncePolicy::max_peers_per_announce`](torrust_tracker_primitives::AnnouncePolicy::max_peers_per_announce)
 //! > for more information.
 //!
 //! > **NOTICE**: the `info_hash` parameter is NOT a `URL` encoded string param.

--- a/packages/axum-http-server/tests/server/v1/contract.rs
+++ b/packages/axum-http-server/tests/server/v1/contract.rs
@@ -888,7 +888,7 @@ mod for_all_config_modes {
                 .container
                 .tracker_core_container
                 .in_memory_torrent_repository
-                .get_torrent_peers(&info_hash)
+                .get_torrent_peers(&info_hash, usize::MAX)
                 .await;
             let peer_addr = peers[0].peer_addr;
 
@@ -933,7 +933,7 @@ mod for_all_config_modes {
                 .container
                 .tracker_core_container
                 .in_memory_torrent_repository
-                .get_torrent_peers(&info_hash)
+                .get_torrent_peers(&info_hash, usize::MAX)
                 .await;
             let peer_addr = peers[0].peer_addr;
 
@@ -983,7 +983,7 @@ mod for_all_config_modes {
                 .container
                 .tracker_core_container
                 .in_memory_torrent_repository
-                .get_torrent_peers(&info_hash)
+                .get_torrent_peers(&info_hash, usize::MAX)
                 .await;
             let peer_addr = peers[0].peer_addr;
 
@@ -1034,7 +1034,7 @@ mod for_all_config_modes {
                 .container
                 .tracker_core_container
                 .in_memory_torrent_repository
-                .get_torrent_peers(&info_hash)
+                .get_torrent_peers(&info_hash, usize::MAX)
                 .await;
             let peer_addr = peers[0].peer_addr;
 

--- a/packages/configuration/src/v2_0_0/mod.rs
+++ b/packages/configuration/src/v2_0_0/mod.rs
@@ -207,6 +207,7 @@
 //! [core.announce_policy]
 //! interval = 120
 //! interval_min = 120
+//! max_peers_per_announce = 74
 //!
 //! [core.database]
 //! driver = "sqlite3"
@@ -455,6 +456,7 @@ mod tests {
                                 [core.announce_policy]
                                 interval = 120
                                 interval_min = 120
+                                max_peers_per_announce = 74
 
                                 [core.database]
                                 driver = "sqlite3"

--- a/packages/primitives/src/announce.rs
+++ b/packages/primitives/src/announce.rs
@@ -38,6 +38,18 @@ pub struct AnnouncePolicy {
     /// the tracker for not adhering to the rules.
     #[serde(default = "AnnouncePolicy::default_interval_min")]
     pub interval_min: u32,
+
+    /// Maximum number of peers returned in a single announce response.
+    ///
+    /// When a client requests peers (via the `numwant` parameter or by
+    /// omitting it), the tracker caps the response at this value. Clients
+    /// requesting more peers than this limit will still receive at most
+    /// `max_peers_per_announce` peers. Clients that omit `numwant` (asking
+    /// for "as many as possible") also receive at most this many peers.
+    ///
+    /// Defaults to `74` (the standard `BitTorrent` peer-list size).
+    #[serde(default = "AnnouncePolicy::default_max_peers_per_announce")]
+    pub max_peers_per_announce: usize,
 }
 
 impl Default for AnnouncePolicy {
@@ -45,6 +57,7 @@ impl Default for AnnouncePolicy {
         Self {
             interval: Self::default_interval(),
             interval_min: Self::default_interval_min(),
+            max_peers_per_announce: Self::default_max_peers_per_announce(),
         }
     }
 }
@@ -56,6 +69,10 @@ impl AnnouncePolicy {
 
     fn default_interval_min() -> u32 {
         120
+    }
+
+    fn default_max_peers_per_announce() -> usize {
+        74
     }
 }
 

--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -21,7 +21,7 @@ use bittorrent_primitives::info_hash::InfoHash;
 pub use mode::PrivateMode;
 pub use number_of_bytes::NumberOfBytes;
 pub use peer_id::{PeerClient, PeerId};
-pub use policy::{TORRENT_PEERS_LIMIT, TrackerPolicy};
+pub use policy::TrackerPolicy;
 pub use scrape::ScrapeData;
 /// Duration since the Unix Epoch.
 ///

--- a/packages/primitives/src/policy.rs
+++ b/packages/primitives/src/policy.rs
@@ -1,13 +1,9 @@
 //! Tracker policy types.
 //!
-//! This module contains the [`TrackerPolicy`] struct and the
-//! [`TORRENT_PEERS_LIMIT`] constant that govern tracker-wide retention
-//! and cleanup behaviour.
+//! This module contains the [`TrackerPolicy`] struct that governs
+//! tracker-wide retention and cleanup behaviour.
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize};
-
-/// The maximum number of returned peers for a torrent.
-pub const TORRENT_PEERS_LIMIT: usize = 74;
 
 /// Policy settings that control tracker-wide torrent and peer retention.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Constructor)]

--- a/packages/swarm-coordination-registry/src/swarm/registry.rs
+++ b/packages/swarm-coordination-registry/src/swarm/registry.rs
@@ -198,7 +198,7 @@ impl Registry {
     ///
     /// This method filters out the client making the request (based on its
     /// network address) and returns up to a maximum number of peers, defined by
-    /// the greater of the provided limit or the global `TORRENT_PEERS_LIMIT`.
+    /// the greater of the provided limit or the configured max peers per announce.
     ///
     /// # Returns
     ///
@@ -226,7 +226,7 @@ impl Registry {
 
     /// Retrieves the list of peers for a given torrent.
     ///
-    /// This method returns up to `TORRENT_PEERS_LIMIT` peers for the torrent
+    /// This method returns up to the provided limit of peers for the torrent
     /// specified by the info-hash.
     ///
     /// # Returns
@@ -676,7 +676,9 @@ mod tests {
 
                 use torrust_clock::DurationSinceUnixEpoch;
                 use torrust_tracker_primitives::peer::Peer;
-                use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes, TORRENT_PEERS_LIMIT};
+                use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes};
+
+                const MAX_PEERS: usize = 74;
 
                 use crate::swarm::registry::Registry;
                 use crate::swarm::registry::tests::the_swarm_repository::numeric_peer_id;
@@ -687,7 +689,7 @@ mod tests {
                     let swarms = Arc::new(Registry::default());
 
                     let peers = swarms
-                        .get_peers_peers_excluding(&sample_info_hash(), &sample_peer(), TORRENT_PEERS_LIMIT)
+                        .get_peers_peers_excluding(&sample_info_hash(), &sample_peer(), MAX_PEERS)
                         .await
                         .unwrap();
 
@@ -703,10 +705,7 @@ mod tests {
 
                     swarms.handle_announcement(&info_hash, &peer, None).await.unwrap();
 
-                    let peers = swarms
-                        .get_peers_peers_excluding(&info_hash, &peer, TORRENT_PEERS_LIMIT)
-                        .await
-                        .unwrap();
+                    let peers = swarms.get_peers_peers_excluding(&info_hash, &peer, MAX_PEERS).await.unwrap();
 
                     assert_eq!(peers, vec![]);
                 }
@@ -737,7 +736,7 @@ mod tests {
                     }
 
                     let peers = swarms
-                        .get_peers_peers_excluding(&info_hash, &excluded_peer, TORRENT_PEERS_LIMIT)
+                        .get_peers_peers_excluding(&info_hash, &excluded_peer, MAX_PEERS)
                         .await
                         .unwrap();
 

--- a/packages/swarm-coordination-registry/src/swarm/registry.rs
+++ b/packages/swarm-coordination-registry/src/swarm/registry.rs
@@ -197,8 +197,7 @@ impl Registry {
     /// requesting client.
     ///
     /// This method filters out the client making the request (based on its
-    /// network address) and returns up to a maximum number of peers, defined by
-    /// the greater of the provided limit or the configured max peers per announce.
+    /// network address) and returns up to `limit` peers.
     ///
     /// # Returns
     ///

--- a/packages/torrent-repository-benchmarking/tests/entry/mod.rs
+++ b/packages/torrent-repository-benchmarking/tests/entry/mod.rs
@@ -405,7 +405,7 @@ async fn it_should_limit_the_number_of_peers_returned(
 
     let peers = torrent.get_peers(Some(MAX_PEERS)).await;
 
-    assert_eq!(peers.len(), 74);
+    assert_eq!(peers.len(), MAX_PEERS);
 }
 
 #[rstest]

--- a/packages/torrent-repository-benchmarking/tests/entry/mod.rs
+++ b/packages/torrent-repository-benchmarking/tests/entry/mod.rs
@@ -5,7 +5,9 @@ use rstest::{fixture, rstest};
 use torrust_clock::clock::stopped::Stopped as _;
 use torrust_clock::clock::{self, Time as _};
 use torrust_tracker_primitives::peer::Peer;
-use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes, TORRENT_PEERS_LIMIT, TrackerPolicy, peer};
+use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes, TrackerPolicy, peer};
+
+const MAX_PEERS: usize = 74;
 use torrust_tracker_torrent_repository_benchmarking::{
     EntryMutexParkingLot, EntryMutexStd, EntryMutexTokio, EntryRwLockParkingLot, EntrySingle,
 };
@@ -401,7 +403,7 @@ async fn it_should_limit_the_number_of_peers_returned(
         torrent.upsert_peer(&peer).await;
     }
 
-    let peers = torrent.get_peers(Some(TORRENT_PEERS_LIMIT)).await;
+    let peers = torrent.get_peers(Some(MAX_PEERS)).await;
 
     assert_eq!(peers.len(), 74);
 }

--- a/packages/tracker-core/src/announce_handler.rs
+++ b/packages/tracker-core/src/announce_handler.rs
@@ -95,7 +95,7 @@ use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use torrust_tracker_configuration::Core;
-use torrust_tracker_primitives::{AnnounceData, NumberOfDownloads, TORRENT_PEERS_LIMIT, peer};
+use torrust_tracker_primitives::{AnnounceData, NumberOfDownloads, peer};
 
 use super::torrent::repository::in_memory::InMemoryTorrentRepository;
 use crate::databases;
@@ -189,7 +189,11 @@ impl AnnounceHandler {
     async fn build_announce_data(&self, info_hash: &InfoHash, peer: &peer::Peer, peers_wanted: &PeersWanted) -> AnnounceData {
         let peers = self
             .in_memory_torrent_repository
-            .get_peers_for(info_hash, peer, peers_wanted.limit())
+            .get_peers_for(
+                info_hash,
+                peer,
+                peers_wanted.limit(self.config.announce_policy.max_peers_per_announce),
+            )
             .await;
 
         let swarm_metadata = self
@@ -217,46 +221,38 @@ pub enum PeersWanted {
 }
 
 impl PeersWanted {
-    /// Request a specific number of peers.
+    /// Request a specific number of peers, without applying the tracker-side cap.
+    ///
+    /// The cap is applied when [`limit`](PeersWanted::limit) is called.
     #[must_use]
-    pub fn only(limit: u32) -> Self {
-        limit.into()
+    pub fn only(amount: u32) -> Self {
+        PeersWanted::Only { amount: amount as usize }
     }
 
-    /// Returns the maximum number of peers allowed based on the request and tracker limit.
-    fn limit(&self) -> usize {
-        match self {
-            PeersWanted::AsManyAsPossible => TORRENT_PEERS_LIMIT,
-            PeersWanted::Only { amount } => *amount,
-        }
-    }
-}
-
-impl From<i32> for PeersWanted {
-    fn from(value: i32) -> Self {
+    /// Constructs a `PeersWanted` from a raw client-supplied value.
+    ///
+    /// A value of `0` or negative means "as many as possible";
+    /// any positive value is stored as-is and capped at the tracker limit
+    /// when [`limit`](PeersWanted::limit) is called.
+    #[must_use]
+    pub fn from_client_request(value: i32) -> Self {
         if value <= 0 {
-            return PeersWanted::AsManyAsPossible;
-        }
-
-        // This conversion is safe because `value > 0`
-        let amount = usize::try_from(value).unwrap();
-
-        PeersWanted::Only {
-            amount: amount.min(TORRENT_PEERS_LIMIT),
+            PeersWanted::AsManyAsPossible
+        } else {
+            // Safe: value > 0, so casting to usize is lossless on all supported platforms.
+            #[allow(clippy::cast_sign_loss)]
+            PeersWanted::Only { amount: value as usize }
         }
     }
-}
 
-impl From<u32> for PeersWanted {
-    fn from(value: u32) -> Self {
-        if value == 0 {
-            return PeersWanted::AsManyAsPossible;
-        }
-
-        let amount = value as usize;
-
-        PeersWanted::Only {
-            amount: amount.min(TORRENT_PEERS_LIMIT),
+    /// Returns the effective number of peers to return, capped at `max_peers`.
+    ///
+    /// - `AsManyAsPossible` resolves to `max_peers`.
+    /// - `Only { amount }` resolves to `amount.min(max_peers)`.
+    pub(crate) fn limit(&self, max_peers: usize) -> usize {
+        match self {
+            PeersWanted::AsManyAsPossible => max_peers,
+            PeersWanted::Only { amount } => (*amount).min(max_peers),
         }
     }
 }
@@ -597,91 +593,91 @@ mod tests {
 
         mod should_allow_the_client_peers_to_specified_the_number_of_peers_wanted {
 
-            use torrust_tracker_primitives::TORRENT_PEERS_LIMIT;
-
             use crate::announce_handler::PeersWanted;
+
+            const MAX_PEERS: usize = 74;
 
             #[test]
             fn it_should_return_the_maximin_number_of_peers_by_default() {
                 let peers_wanted = PeersWanted::default();
 
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
             }
 
             #[test]
             fn it_should_return_74_at_the_most_if_the_client_wants_them_all() {
                 let peers_wanted = PeersWanted::AsManyAsPossible;
 
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
             }
 
             #[test]
             fn it_should_allow_limiting_the_peer_list() {
                 let peers_wanted = PeersWanted::only(10);
 
-                assert_eq!(peers_wanted.limit(), 10);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), 10);
             }
 
             fn maximum_as_u32() -> u32 {
-                u32::try_from(TORRENT_PEERS_LIMIT).unwrap()
+                u32::try_from(MAX_PEERS).unwrap()
             }
 
             fn maximum_as_i32() -> i32 {
-                i32::try_from(TORRENT_PEERS_LIMIT).unwrap()
+                i32::try_from(MAX_PEERS).unwrap()
             }
 
             #[test]
             fn it_should_return_the_maximum_when_wanting_more_than_the_maximum() {
                 let peers_wanted = PeersWanted::only(maximum_as_u32() + 1);
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
             }
 
             #[test]
-            fn it_should_return_the_maximum_when_wanting_only_zero() {
+            fn it_should_return_zero_when_wanting_only_zero() {
                 let peers_wanted = PeersWanted::only(0);
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), 0);
             }
 
             #[test]
-            fn it_should_convert_the_peers_wanted_number_from_i32() {
-                // Negative. It should return the maximum
-                let peers_wanted: PeersWanted = (-1i32).into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+            fn it_should_convert_the_peers_wanted_number_from_i32_via_from_client_request() {
+                // Negative. It should return the maximum (AsManyAsPossible)
+                let peers_wanted = PeersWanted::from_client_request(-1i32);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
-                // Zero. It should return the maximum
-                let peers_wanted: PeersWanted = 0i32.into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                // Zero. It should return the maximum (AsManyAsPossible)
+                let peers_wanted = PeersWanted::from_client_request(0i32);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
-                // Greater than the maximum. It should return the maximum
-                let peers_wanted: PeersWanted = (maximum_as_i32() + 1).into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                // Greater than the maximum. It should be capped at limit time
+                let peers_wanted = PeersWanted::from_client_request(maximum_as_i32() + 1);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
                 // The maximum
-                let peers_wanted: PeersWanted = (maximum_as_i32()).into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                let peers_wanted = PeersWanted::from_client_request(maximum_as_i32());
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
                 // Smaller than the maximum
-                let peers_wanted: PeersWanted = (maximum_as_i32() - 1).into();
-                assert_eq!(i32::try_from(peers_wanted.limit()).unwrap(), maximum_as_i32() - 1);
+                let peers_wanted = PeersWanted::from_client_request(maximum_as_i32() - 1);
+                assert_eq!(i32::try_from(peers_wanted.limit(MAX_PEERS)).unwrap(), maximum_as_i32() - 1);
             }
 
             #[test]
-            fn it_should_convert_the_peers_wanted_number_from_u32() {
-                // Zero. It should return the maximum
-                let peers_wanted: PeersWanted = 0u32.into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+            fn it_should_cap_only_peers_wanted_at_limit_time() {
+                // Zero — returns 0 (explicit request for zero peers)
+                let peers_wanted = PeersWanted::only(0u32);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), 0);
 
-                // Greater than the maximum. It should return the maximum
-                let peers_wanted: PeersWanted = (maximum_as_u32() + 1).into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                // Greater than the maximum — capped at limit time
+                let peers_wanted = PeersWanted::only(maximum_as_u32() + 1);
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
                 // The maximum
-                let peers_wanted: PeersWanted = (maximum_as_u32()).into();
-                assert_eq!(peers_wanted.limit(), TORRENT_PEERS_LIMIT);
+                let peers_wanted = PeersWanted::only(maximum_as_u32());
+                assert_eq!(peers_wanted.limit(MAX_PEERS), MAX_PEERS);
 
                 // Smaller than the maximum
-                let peers_wanted: PeersWanted = (maximum_as_u32() - 1).into();
-                assert_eq!(i32::try_from(peers_wanted.limit()).unwrap(), maximum_as_i32() - 1);
+                let peers_wanted = PeersWanted::only(maximum_as_u32() - 1);
+                assert_eq!(i32::try_from(peers_wanted.limit(MAX_PEERS)).unwrap(), maximum_as_i32() - 1);
             }
         }
     }

--- a/packages/tracker-core/src/torrent/repository/in_memory.rs
+++ b/packages/tracker-core/src/torrent/repository/in_memory.rs
@@ -1,12 +1,11 @@
 //! In-memory torrents repository.
-use std::cmp::max;
 use std::sync::Arc;
 
 use bittorrent_primitives::info_hash::InfoHash;
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_tracker_primitives::pagination::Pagination;
 use torrust_tracker_primitives::swarm_metadata::{AggregateActiveSwarmMetadata, SwarmMetadata};
-use torrust_tracker_primitives::{NumberOfDownloads, NumberOfDownloadsBTreeMap, TORRENT_PEERS_LIMIT, TrackerPolicy, peer};
+use torrust_tracker_primitives::{NumberOfDownloads, NumberOfDownloadsBTreeMap, TrackerPolicy, peer};
 use torrust_tracker_swarm_coordination_registry::{CoordinatorHandle, Registry};
 
 /// In-memory repository for torrent entries.
@@ -161,8 +160,7 @@ impl InMemoryTorrentRepository {
     /// requesting client.
     ///
     /// This method filters out the client making the request (based on its
-    /// network address) and returns up to a maximum number of peers, defined by
-    /// the greater of the provided limit or the global `TORRENT_PEERS_LIMIT`.
+    /// network address) and returns up to `limit` peers.
     ///
     /// # Arguments
     ///
@@ -181,19 +179,20 @@ impl InMemoryTorrentRepository {
     #[must_use]
     pub(crate) async fn get_peers_for(&self, info_hash: &InfoHash, peer: &peer::Peer, limit: usize) -> Vec<Arc<peer::Peer>> {
         self.swarms
-            .get_peers_peers_excluding(info_hash, peer, max(limit, TORRENT_PEERS_LIMIT))
+            .get_peers_peers_excluding(info_hash, peer, limit)
             .await
             .expect("Failed to get other peers in swarm")
     }
 
     /// Retrieves the list of peers for a given torrent.
     ///
-    /// This method returns up to `TORRENT_PEERS_LIMIT` peers for the torrent
+    /// This method returns up to `max_peers` peers for the torrent
     /// specified by the info-hash.
     ///
     /// # Arguments
     ///
     /// * `info_hash` - The info hash of the torrent.
+    /// * `max_peers` - The maximum number of peers to return.
     ///
     /// # Returns
     ///
@@ -204,10 +203,9 @@ impl InMemoryTorrentRepository {
     ///
     /// This function panics if the underling swarms return an error.
     #[must_use]
-    pub async fn get_torrent_peers(&self, info_hash: &InfoHash) -> Vec<Arc<peer::Peer>> {
-        // todo: pass the limit as an argument like `get_peers_for`
+    pub async fn get_torrent_peers(&self, info_hash: &InfoHash, max_peers: usize) -> Vec<Arc<peer::Peer>> {
         self.swarms
-            .get_swarm_peers(info_hash, TORRENT_PEERS_LIMIT)
+            .get_swarm_peers(info_hash, max_peers)
             .await
             .expect("Failed to get other peers in swarm")
     }

--- a/packages/tracker-core/tests/integration.rs
+++ b/packages/tracker-core/tests/integration.rs
@@ -24,7 +24,8 @@ async fn it_should_handle_the_announce_request() {
             },
             policy: AnnouncePolicy {
                 interval: 120,
-                interval_min: 120
+                interval_min: 120,
+                max_peers_per_announce: 74,
             }
         }
     );

--- a/packages/udp-server/src/handlers/announce.rs
+++ b/packages/udp-server/src/handlers/announce.rs
@@ -266,7 +266,7 @@ pub(crate) mod tests {
 
                 let peers = core_tracker_services
                     .in_memory_torrent_repository
-                    .get_torrent_peers(&info_hash.0.into())
+                    .get_torrent_peers(&info_hash.0.into(), usize::MAX)
                     .await;
 
                 let expected_peer = PeerBuilder::default()
@@ -361,7 +361,7 @@ pub(crate) mod tests {
 
                 let peers = core_tracker_services
                     .in_memory_torrent_repository
-                    .get_torrent_peers(&info_hash.0.into())
+                    .get_torrent_peers(&info_hash.0.into(), usize::MAX)
                     .await;
 
                 assert_eq!(peers[0].peer_addr, SocketAddr::new(IpAddr::V4(remote_client_ip), client_port));
@@ -523,7 +523,7 @@ pub(crate) mod tests {
 
                     let peers = core_tracker_services
                         .in_memory_torrent_repository
-                        .get_torrent_peers(&info_hash.0.into())
+                        .get_torrent_peers(&info_hash.0.into(), usize::MAX)
                         .await;
 
                     let external_ip_in_tracker_configuration = core_tracker_services.core_config.net.external_ip.unwrap();
@@ -608,7 +608,7 @@ pub(crate) mod tests {
 
                 let peers = core_tracker_services
                     .in_memory_torrent_repository
-                    .get_torrent_peers(&info_hash.0.into())
+                    .get_torrent_peers(&info_hash.0.into(), usize::MAX)
                     .await;
 
                 let expected_peer = PeerBuilder::default()
@@ -706,7 +706,7 @@ pub(crate) mod tests {
 
                 let peers = core_tracker_services
                     .in_memory_torrent_repository
-                    .get_torrent_peers(&info_hash.0.into())
+                    .get_torrent_peers(&info_hash.0.into(), usize::MAX)
                     .await;
 
                 // When using IPv6 the tracker converts the remote client ip into a IPv4 address
@@ -969,7 +969,9 @@ pub(crate) mod tests {
                     .await
                     .unwrap();
 
-                    let peers = in_memory_torrent_repository.get_torrent_peers(&info_hash.0.into()).await;
+                    let peers = in_memory_torrent_repository
+                        .get_torrent_peers(&info_hash.0.into(), usize::MAX)
+                        .await;
 
                     let external_ip_in_tracker_configuration = core_config.net.external_ip.unwrap();
 

--- a/packages/udp-tracker-core/src/services/announce.rs
+++ b/packages/udp-tracker-core/src/services/announce.rs
@@ -74,7 +74,7 @@ impl AnnounceService {
 
         let mut peer = peer_builder::from_request(request, &remote_client_ip);
 
-        let peers_wanted: PeersWanted = i32::from(request.peers_wanted.0).into();
+        let peers_wanted = PeersWanted::from_client_request(i32::from(request.peers_wanted.0));
 
         let announce_data = self
             .announce_handler


### PR DESCRIPTION
## Summary

Closes #1864 — sub-task of EPIC #1669.

Move the peer-count cap from a global compile-time constant (`TORRENT_PEERS_LIMIT = 74`) to a configurable field `AnnouncePolicy::max_peers_per_announce` (default 74, serialized via serde). This makes the limit observable in the configuration file and overridable at runtime without recompilation.

## Changes

- **Remove** `TORRENT_PEERS_LIMIT` from `primitives::policy` and its re-export from `primitives::lib`
- **Add** `AnnouncePolicy::max_peers_per_announce: usize` (serde default = 74, stored in `[core.announce_policy]` config section)
- **Refactor** `PeersWanted` in `tracker-core`:
  - Remove `From<i32>` and `From<u32>` impls (were silently applying the global cap at construction time)
  - Add `PeersWanted::from_client_request(i32)` — `≤0` → `AsManyAsPossible`, positive → `Only { amount }`
  - `PeersWanted::limit()` now takes an explicit `max_peers: usize` argument, applied at announce time from `announce_policy.max_peers_per_announce`
- **Fix** `get_torrent_peers` — now takes `max_peers: usize` instead of using the global constant (old implementation had a bug: `max(limit, TORRENT_PEERS_LIMIT)` returned _more_ than requested)
- Update all call sites, tests, configuration fixtures, and docs
- Record decision as **DEC-10** in `docs/issues/open/1669-overhaul-packages/DECISIONS.md`

## Configuration

The new field appears in `[core.announce_policy]`:

```toml
[core.announce_policy]
interval = 120
interval_min = 120
max_peers_per_announce = 74
```

Existing configs without the field continue to work (serde default = 74).

## Testing

- All workspace tests pass (`cargo test --workspace`)
- Pre-push checks pass (nightly format, nightly check, nightly docs, full stable test suite)