### PR TITLE
feat(security): add security analysis process and catalog non-affecting Containerfile CVEs

### DIFF
--- a/.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md
+++ b/.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md
@@ -24,7 +24,7 @@ provides a quick reference.
 docs/security/analysis/
   README.md              ← Process + template
   non-affecting/         ← CVEs that do NOT affect us (catalog)
-  affecting/             ← CVEs that DO affect us (future)
+  affecting/             ← CVEs that DO affect us (create when needed)
 ```
 
 ## Process (3 Steps)
@@ -49,7 +49,7 @@ If the vulnerability is **not yet cataloged**:
 
 If a vulnerability **does** affect us (rare — the runtime is distroless):
 
-1. Create a file in `docs/security/analysis/affecting/` with the same template.
+1. Create the `docs/security/analysis/affecting/` directory if it does not exist, then create a file there with the same template.
 2. Open a GitHub issue with the `security` and `bug` labels.
 3. Notify maintainers — these are high priority.
 

--- a/.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md
+++ b/.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: catalog-security-vulnerabilities
+description: Guide for cataloging security vulnerability warnings (e.g. Docker DX CVEs) that do NOT affect the project. Covers the process of checking the existing catalog, creating a new analysis document with rationale, and escalating if a vulnerability is found to be affecting. Use when handling Docker DX warnings, CVE analysis, vulnerability scanning results, or security audit findings. Triggers on "Docker DX", "vulnerability warning", "CVE analysis", "security scan", "catalog vulnerability", "non-affecting CVE", or "container CVE".
+metadata:
+  author: torrust
+  version: "1.0"
+  semantic-links:
+    related-artifacts:
+      - docs/security/analysis/README.md
+---
+
+# Catalog Security Vulnerabilities
+
+This skill guides you through evaluating and documenting security vulnerability warnings
+(such as Docker DX extension flags or scanner output) that appear in the project's
+dependencies or infrastructure.
+
+The authoritative process document is `docs/security/analysis/README.md` — this skill
+provides a quick reference.
+
+## Quick Reference
+
+```text
+docs/security/analysis/
+  README.md              ← Process + template
+  non-affecting/         ← CVEs that do NOT affect us (catalog)
+  affecting/             ← CVEs that DO affect us (future)
+```
+
+## Process (3 Steps)
+
+### Step 1: Check the Catalog
+
+Before analyzing a new warning, check `docs/security/analysis/non-affecting/` to see if
+it has already been evaluated. Every file there documents why a set of CVEs is
+non-affecting. If found, the analysis is already done — link the existing document in
+any related issue or PR comment.
+
+### Step 2: Analyse and Document (if not cataloged)
+
+If the vulnerability is **not yet cataloged**:
+
+1. Determine whether it affects us (see criteria examples in the README).
+2. If **non-affecting**: create a dated file in `non-affecting/` following the template
+   in the README. Include rationale, future actions, and review cadence.
+3. If **affecting**: escalate immediately (see Step 3).
+
+### Step 3: Escalate if Affecting
+
+If a vulnerability **does** affect us (rare — the runtime is distroless):
+
+1. Create a file in `docs/security/analysis/affecting/` with the same template.
+2. Open a GitHub issue with the `security` and `bug` labels.
+3. Notify maintainers — these are high priority.
+
+## Review Cadence
+
+All analysis documents have a `review-cadence` field in their frontmatter. The default
+is `quarterly` — re-check whether upstream CVEs have been fixed and whether the
+assessment is still valid.
+
+## Policy
+
+- Never ignore a vulnerability warning without documenting why.
+- The runtime image (`gcr.io/distroless/cc-debian13:debug`) is the critical trust boundary.
+  Build-stage CVEs are generally non-affecting unless they involve code execution during
+  build that could compromise the output binary.

--- a/docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
+++ b/docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
@@ -6,6 +6,8 @@ semantic-links:
     - .github/skills/dev/planning/create-adr/SKILL.md
     - Containerfile
     - .github/workflows/container.yaml
+    - docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
+    - docs/security/analysis/README.md
 ---
 
 # Keep unit tests inside the container build process
@@ -60,13 +62,33 @@ The three-layer strategy is therefore:
 3. **E2E tests against the distroless `release` image** (`container.yaml` `test` job) —
    the only layer that proves the binary works in the actual production runtime.
 
+### Security Rationale
+
+Keeping unit tests inside the container build also provides a **security-in-depth** benefit:
+
+- The `tester` stage runs the **exact compiled binary** produced by `rust:trixie` — including
+  all its runtime dependencies — in an environment that shares the same Debian trixie glibc
+  as the production runtime. This acts as a **build-pipeline integrity check**: if a
+  maliciously compromised build tool or compromised dependency introduced unexpected
+  behavioural changes, unit test failures would likely surface them before the binary reaches
+  the runtime image.
+- The unit tests exercise code paths that would be exercised in production, providing a
+  baseline of expected behaviour against which anomalous test results could be detected.
+- This is a weaker guarantee than running in the distroless runtime itself (the unit tests
+  run in `rust:slim-trixie`, not `distroless/cc-debian13`), but it is a strictly stronger
+  guarantee than running tests on a separate GHA host with a different glibc and library set.
+
+For a full security analysis of the Containerfile's build-stage vulnerabilities, see
+`docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md`.
+
 ### Alternatives Considered
 
 **Move unit tests entirely to the GHA host and remove the `tester` stage.**
 This would make the container build significantly faster (eliminating ~50 fat-LTO binary
-compilations). However, it removes layer 2 above. The decision for now is to keep all three
-layers. If the build time becomes unacceptable, this option can be revisited as part of the
-LTO optimization work tracked in issue #1840.
+compilations), but would also remove the build-pipeline integrity check described in the
+Security Rationale above. The decision for now is to keep all three layers. If the build time
+becomes unacceptable, this option can be revisited as part of the LTO optimization work
+tracked in issue #1840.
 
 ### Consequences
 

--- a/docs/issues/open/1898-document-security-analysis-process.md
+++ b/docs/issues/open/1898-document-security-analysis-process.md
@@ -1,12 +1,12 @@
 ---
 doc-type: issue
 issue-type: task
-status: draft
+status: in-progress
 priority: p3
 github-issue: 1898
 spec-path: docs/issues/open/1898-document-security-analysis-process.md
 branch: "1898-document-security-analysis-process"
-related-pr: null
+related-pr: 1899
 last-updated-utc: 2026-06-10 16:30
 semantic-links:
   skill-links:
@@ -96,9 +96,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T5  | DONE   | Add semantic links between all related docs             | `semantic-links` updated in ADR, security analysis, and README                                           |
 | T6  | DONE   | Create security analysis skill                          | `.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md`                               |
 | T7  | DONE   | User reviews the draft issue spec                       | Approval before creating GitHub issue                                                                    |
-| T8  | TODO   | Create GitHub issue                                     | Using `gh` CLI or MCP tools                                                                              |
-| T9  | TODO   | Rename spec from `drafts/` to `open/` with issue number | `git mv` + update frontmatter                                                                            |
-| T10 | TODO   | Commit and push                                         | `git add`, `git commit -S`, push to fork                                                                 |
+| T8  | DONE   | Create GitHub issue                                     | Issue #1898 created with task+security labels                                                            |
+| T9  | DONE   | Rename spec from `drafts/` to `open/` with issue number | Moved to `docs/issues/open/1898-document-security-analysis-process.md`                                   |
+| T10 | DONE   | Commit and push                                         | Commit `fdee528f`, pushed, PR #1899 opened                                                               |
 
 ## Progress Tracking
 

--- a/docs/issues/open/1898-document-security-analysis-process.md
+++ b/docs/issues/open/1898-document-security-analysis-process.md
@@ -1,0 +1,149 @@
+---
+doc-type: issue
+issue-type: task
+status: draft
+priority: p3
+github-issue: 1898
+spec-path: docs/issues/open/1898-document-security-analysis-process.md
+branch: "1898-document-security-analysis-process"
+related-pr: null
+last-updated-utc: 2026-06-10 16:30
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/security/analysis/README.md
+    - docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
+    - docs/issues/README.md
+    - Containerfile
+    - docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
+    - docs/skills/semantic-skill-link-convention.md
+    - https://github.com/torrust/torrust-tracker/issues/1457
+    - https://github.com/torrust/torrust-tracker/issues/1460
+    - https://github.com/torrust/torrust-tracker/issues/1463
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1898 - Document security analysis process and catalog non-affecting Containerfile CVEs
+
+## Goal
+
+Establish a structured process for evaluating security warnings and create the initial
+catalog entry documenting why the trixie-based Containerfile image CVEs do not affect us.
+
+## Background
+
+The VS Code Docker DX extension flags vulnerabilities in the Containerfile's three
+trixie-based `FROM` images (`rust:trixie`, `rust:slim-trixie`, `gcc:trixie`). These are
+upstream CVEs in Docker Official Images. Before this issue, there was no documented process
+or central catalog to record such analyses, meaning every contributor seeing these warnings
+would need to re-do the same investigation.
+
+### Related prior work
+
+This issue builds on the **Docker Security Overhaul** EPIC
+([#1457](https://github.com/torrust/torrust-tracker/issues/1457)), which established
+a security baseline for the Containerfile and container workflows. Previous sub-issues
+include adding hadolint linting to CI
+([#1460](https://github.com/torrust/torrust-tracker/issues/1460)) and evaluating the
+`rust:slim-trixie` vs `rust:trixie` trade-off
+([#1463](https://github.com/torrust/torrust-tracker/issues/1463)). Issue #1463 already
+includes a Trivy scan of both the trixie build images and the distroless runtime,
+confirming the runtime has 0 critical/high CVEs.
+
+The current VS Code Docker DX warnings are a new signal that needs to be systematically
+analyzed and cataloged, which this issue addresses by creating a permanent analysis
+process and catalog.
+
+We need:
+
+1. A `docs/security/analysis/` folder structure with a process document.
+2. The initial analysis cataloging these CVEs as non-affecting, with rationale.
+3. A subfolder for non-affecting vulnerabilities so they can be looked up quickly.
+4. A `.github/skills/dev/maintenance/catalog-security-vulnerabilities/` skill so AI agents
+   auto-discover this process.
+
+## Scope
+
+### In Scope
+
+- Create `docs/security/analysis/README.md` — index and process description.
+- Create `docs/security/analysis/non-affecting/` — subfolder for non-affecting vulnerabilities.
+- Create `docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md` — actual analysis.
+- Create `.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md` — AI agent skill.
+- Update `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md` — add Security Rationale section.
+- Add semantic links between ADR, security analysis, and skill convention.
+- List notable CVEs, explain why non-affecting, define review cadence.
+
+### Out of Scope
+
+- Changing the Containerfile base images (separate concern if needed).
+- Fixing the upstream CVEs (they are in Docker Official Images, not our code).
+- Creating automation for vulnerability scanning (future enhancement).
+- Documenting affecting vulnerabilities (none found yet).
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                                    | Notes / Expected Output                                                                                  |
+| --- | ------ | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Create `docs/security/analysis/` folder structure       | `README.md` + `non-affecting/` subfolder                                                                 |
+| T2  | DONE   | Analyze trixie Containerfile CVEs                       | Document showing why they don't affect us                                                                |
+| T3  | DONE   | Write the non-affecting analysis document               | `2026-06-10_containerfile-trixie-cves.md` with full rationale                                            |
+| T4  | DONE   | Update ADR with security rationale                      | Added Security Rationale section to `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md` |
+| T5  | DONE   | Add semantic links between all related docs             | `semantic-links` updated in ADR, security analysis, and README                                           |
+| T6  | DONE   | Create security analysis skill                          | `.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md`                               |
+| T7  | DONE   | User reviews the draft issue spec                       | Approval before creating GitHub issue                                                                    |
+| T8  | TODO   | Create GitHub issue                                     | Using `gh` CLI or MCP tools                                                                              |
+| T9  | TODO   | Rename spec from `drafts/` to `open/` with issue number | `git mv` + update frontmatter                                                                            |
+| T10 | TODO   | Commit and push                                         | `git add`, `git commit -S`, push to fork                                                                 |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Spec drafted in `docs/issues/drafts/`
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue created and issue number added to this spec
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests)
+- [ ] Manual verification scenarios executed and recorded
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-06-10 16:30 UTC - GitHub Copilot - Created security analysis skill in `.github/skills/dev/maintenance/catalog-security-vulnerabilities/`
+- 2026-06-10 16:00 UTC - GitHub Copilot - Drafted issue spec and created analysis documents in `docs/security/analysis/`
+
+## Acceptance Criteria
+
+- [ ] AC1: `docs/security/analysis/README.md` exists with process description and template
+- [ ] AC2: `docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md` exists with full analysis
+- [ ] AC3: The analysis document includes: vulnerability summary, rationale for non-affecting status, future actions, and references
+- [ ] AC4: `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md` has a Security Rationale section
+- [ ] AC5: Semantic links are consistent between ADR, security analysis documents, and related artifacts
+- [ ] AC6: `linter all` exits with code `0`
+- [ ] AC7: New documents are spell-checked (no false positives)
+- [ ] AC8: Documentation is updated when behavior/workflow changes
+- [ ] AC9: `.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md` exists with process description and semantic-links
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter all`
+- Spell check on new documents
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                                   | Command/Steps                                                 | Expected Result                   | Status | Evidence |
+| --- | ------------------------------------------ | ------------------------------------------------------------- | --------------------------------- | ------ | -------- |
+| M1  | Verify README renders correctly            | Open `docs/security/analysis/README.md` in VS Code preview    | All sections readable, links work | TODO   |          |
+| M2  | Verify analysis document renders correctly | Open analysis doc in VS Code preview                          | Tables render, rationale clear    | TODO   |          |
+| M3  | Verify no broken internal links            | Check all `semantic-links` and references point to real files | All refs resolve                  | TODO   |          |
+| M4  | Run linters                                | `linter all`                                                  | Exit code 0                       | TODO   |          |

--- a/docs/security/analysis/README.md
+++ b/docs/security/analysis/README.md
@@ -1,0 +1,67 @@
+---
+semantic-links:
+  skill-links:
+    - catalog-security-vulnerabilities
+  related-artifacts:
+    - Containerfile
+    - docs/security/analysis/non-affecting/
+    - docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
+---
+
+# Security Analysis
+
+This folder contains security analysis documents for the Torrust Tracker project.
+
+## Purpose
+
+When a security issue is detected (e.g., by Docker Scout, dependabot, manual audit, or
+container image vulnerability scanning), we create an analysis document here to:
+
+1. **Evaluate** whether the vulnerability actually affects our project.
+2. **Document the decision** so other contributors seeing the same warning can quickly
+   determine whether it has been analyzed before.
+3. **Track periodic review** — even non-affecting vulnerabilities should be re-evaluated
+   periodically to check if the situation has changed.
+
+## Folder Structure
+
+```text
+docs/security/analysis/
+├── README.md                  # This file — index and process
+├── non-affecting/             # Vulnerabilities that do NOT affect us
+│   └── {date}_{descriptive-name}.md
+└── ...                        # (future) Affecting vulnerabilities go here
+```
+
+## Process
+
+### When a security warning appears
+
+1. **Check the catalog**: search `docs/security/analysis/non-affecting/` to see if this
+   vulnerability has already been analyzed. If it has, you're done — the document explains
+   why it doesn't affect us and what to watch for.
+
+2. **If not yet cataloged**: create a new analysis document in `non-affecting/` (or an
+   appropriate subfolder) following the template below.
+
+3. **If it DOES affect us**: escalate immediately. Create an issue and a fix. The analysis
+   document should describe the impact, affected components, and remediation plan.
+
+### Analysis Document Template
+
+Each analysis document should include:
+
+- **Date of analysis**
+- **Source of the warning** (tool, scanner, CVE database, etc.)
+- **Vulnerability summary** — what CVEs, what packages, what severity
+- **Why it does not affect us** — a clear rationale tied to our architecture
+- **Future actions** — periodic review cadence, conditions that would change the status
+- **References** — links to the original warning, Docker Hub layers, CVE entries, etc.
+
+### Review Cadence
+
+Non-affecting vulnerabilities should be reviewed:
+
+- At least **quarterly** (or when the relevant base image is updated).
+- Immediately if the affected image begins being used in a **different context** (e.g., if
+  a build-stage image becomes part of the runtime).

--- a/docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
+++ b/docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
@@ -123,7 +123,7 @@ the build image) could produce compromised binaries. However:
 - Docker Hub `gcc:trixie` (linux/amd64): <https://hub.docker.com/layers/library/gcc/trixie/images/sha256-74b6d3e67f73206d3474a9fd8ce21695de3816bbc52616169110460594d66c32>
 - ADR: Keep unit tests inside container build: `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md`
 
-  <!-- skill-link: create-adr -->
+  <!-- skill-link: catalog-security-vulnerabilities -->
 
 - Issue draft about pre-built base images: `docs/issues/drafts/1840-workflow-performance-prebuilt-base-images/ISSUE.md`
 

--- a/docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
+++ b/docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md
@@ -1,0 +1,142 @@
+---
+date-analyzed: 2026-06-10
+source: Docker DX (docker-language-server) / Docker Scout
+status: non-affecting
+review-cadence: quarterly
+image-digest: sha256:19dfb952582d0e17841fdb8cd70febfb6cb0761c4e0cd84f3cb1f07bb3281a8d
+semantic-links:
+  related-artifacts:
+    - Containerfile
+    - docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
+---
+
+# Containerfile trixie-based image vulnerabilities
+
+## Context
+
+The VS Code Docker DX extension (docker-language-server) flagged vulnerabilities in the
+`Containerfile` on the three `FROM` instructions that use Debian trixie-based base images.
+Line numbers drift as the file changes; the stages are the stable reference:
+
+| Line (approx.) | Image              | Stage    | Purpose                               |
+| -------------- | ------------------ | -------- | ------------------------------------- |
+| 6              | `rust:trixie`      | `chef`   | Install `cargo-chef`, `cargo-nextest` |
+| 15             | `rust:slim-trixie` | `tester` | Run unit tests inside container build |
+| 32             | `gcc:trixie`       | `gcc`    | Compile `su-exec` from source         |
+
+## Vulnerability Summary
+
+All three images are **upstream Docker Official Images** based on Debian trixie
+(Debian 13/testing). The scanner reports CVEs in the OS-level packages shipped by
+those images, not in anything we add.
+
+| Image              | C   | H   | M   | L   | Unspecified | Total |
+| ------------------ | --- | --- | --- | --- | ----------- | ----- |
+| `rust:trixie`      | 4   | 26  | 27  | 178 | 27          | 262   |
+| `rust:slim-trixie` | 1   | 6   | 6   | 84  | 1           | 98    |
+| `gcc:trixie`       | 4   | 31  | 27  | 182 | 27          | 271   |
+
+### Notable critical CVEs
+
+| CVE            | CVSS | Package   |
+| -------------- | ---- | --------- |
+| CVE-2026-20889 | 9.8  | `libraw`  |
+| CVE-2026-21413 | 9.8  | `libraw`  |
+| CVE-2026-45447 | 9.8  | `openssl` |
+| CVE-2026-33278 | 9.1  | `unbound` |
+
+### Notable high-severity CVEs
+
+| CVE            | CVSS | Package                 |
+| -------------- | ---- | ----------------------- |
+| CVE-2026-41142 | 8.8  | `openexr`               |
+| CVE-2026-42216 | 8.8  | `openexr`               |
+| CVE-2026-32740 | 8.8  | `libheif`               |
+| CVE-2026-42959 | 8.7  | `unbound`               |
+| CVE-2026-7383  | 8.1  | `openssl` (slim-trixie) |
+
+## Why This Does NOT Affect Us
+
+These vulnerabilities are **not exploitable in our deployment context** for the following
+reasons:
+
+### 1. Build-time-only stages
+
+The `chef`, `tester`, and `gcc` stages are **intermediate build stages**. They exist only
+during `docker build` and are never:
+
+- **Pushed to any registry** as a runnable image.
+- **Exposed to any network** — no ports are open, no services are listening.
+- **Accessible to any external actor** — they run ephemerally in the build process and are
+  discarded after the final `release` stage is assembled.
+
+| Stage       | Base image               | Exposed to traffic?   | Persisted after build? |
+| ----------- | ------------------------ | --------------------- | ---------------------- |
+| `chef`      | `rust:trixie`            | ❌ No                 | ❌ No                  |
+| `tester`    | `rust:slim-trixie`       | ❌ No                 | ❌ No                  |
+| `gcc`       | `gcc:trixie`             | ❌ No                 | ❌ No                  |
+| **Runtime** | `distroless/cc-debian13` | ✅ Yes (UDP/HTTP/API) | ✅ Yes                 |
+
+### 2. Runtime image is different
+
+The production runtime image is `gcr.io/distroless/cc-debian13:debug` (the `runtime` stage,
+near the end of the Containerfile). This is a Google distroless image based on Debian 13,
+which has a much smaller attack surface (~10 packages vs ~600 in the full Rust image). Any
+vulnerability scanner warnings on the runtime image would be treated as **high priority** —
+but those are not present in this warning.
+
+### 3. Upstream image trust boundary
+
+All three flagged images are **Docker Official Images** (`library/rust`, `library/gcc`).
+We pull them from Docker Hub's official repository, which is the same trust boundary as
+any `FROM` statement in any Dockerfile. The CVEs exist in the upstream images themselves;
+they are not introduced by our Containerfile.
+
+### 4. Supply-chain risk is acceptable
+
+The theoretical concern is that a compromised build tool (e.g., a vulnerable `openssl` in
+the build image) could produce compromised binaries. However:
+
+- The build stages are **ephemeral** — the vulnerability would need to be actively exploited
+  during the ~35-40 minute build window.
+- The final runtime image is **independently verified** by E2E tests running against the
+  distroless image.
+- The `tester` stage runs **unit tests** on the compiled binary produced by `rust:trixie`,
+  exercising the same code paths that would run in production. This provides a build-pipeline
+  integrity check: unexpected test failures could indicate anomalous behaviour from a
+  compromised build tool or dependency. See the Security Rationale section in the ADR
+  `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md` for more detail.
+
+## Future Actions
+
+| Action                                                               | Cadence                | Owner |
+| -------------------------------------------------------------------- | ---------------------- | ----- |
+| Monitor Docker Hub for updated `rust:trixie` and `gcc:trixie` images | Quarterly              | TBD   |
+| Rebuild container image and verify warning count decreases           | After upstream updates | TBD   |
+| Re-evaluate if these stages become part of the runtime image         | On architecture change | TBD   |
+| Check if Docker fixes these CVEs in fresh `trixie` tags              | Next quarterly review  | TBD   |
+
+## References
+
+- Docker Hub `rust:trixie` (linux/amd64): <https://hub.docker.com/layers/library/rust/trixie/images/sha256-19dfb952582d0e17841fdb8cd70febfb6cb0761c4e0cd84f3cb1f07bb3281a8d>
+- Docker Hub `rust:slim-trixie` (linux/amd64): <https://hub.docker.com/layers/library/rust/slim-trixie/images/sha256-7be7e62dbd0954a32c340afe3df951d75dde2859549b2b72fdd4a8c842b37534>
+- Docker Hub `gcc:trixie` (linux/amd64): <https://hub.docker.com/layers/library/gcc/trixie/images/sha256-74b6d3e67f73206d3474a9fd8ce21695de3816bbc52616169110460594d66c32>
+- ADR: Keep unit tests inside container build: `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md`
+
+  <!-- skill-link: create-adr -->
+
+- Issue draft about pre-built base images: `docs/issues/drafts/1840-workflow-performance-prebuilt-base-images/ISSUE.md`
+
+## Related GitHub Issues
+
+| Issue                                                           | Title                                        | Relationship                                                                                                            |
+| --------------------------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [#1457](https://github.com/torrust/torrust-tracker/issues/1457) | Docker Security Overhaul EPIC                | Parent EPIC covering all Docker security improvements                                                                   |
+| [#1460](https://github.com/torrust/torrust-tracker/issues/1460) | Add hadolint linter step to `container.yaml` | Related: Containerfile linting for best practices                                                                       |
+| [#1463](https://github.com/torrust/torrust-tracker/issues/1463) | Consider using `rust:slim-trixie`            | Related: Also analyzes trixie CVEs; found slim-trixie has same vulns; also scanned distroless runtime (0 critical/high) |
+
+## Changelog
+
+| Date       | Change                                           |
+| ---------- | ------------------------------------------------ |
+| 2026-06-10 | Initial analysis — CVEs determined non-affecting |

--- a/project-words.txt
+++ b/project-words.txt
@@ -28,6 +28,7 @@ Azureus
 backlinks
 bdecode
 behaviour
+behavioural
 bencode
 bencoded
 bencoding
@@ -71,6 +72,7 @@ Containerfile
 conv
 curr
 cvar
+cves
 Cyberneering
 cyclomatic
 dashmap
@@ -168,6 +170,8 @@ Laravel
 lcov
 leecher
 leechers
+libheif
+libraw
 libsqlite
 libtorrent
 libz
@@ -216,6 +220,7 @@ objcopy
 obra
 oneline
 oneshot
+openexr
 openmetrics
 optimisation
 optimisations
@@ -374,6 +379,7 @@ VARCHAR
 Vitaly
 vmlinux
 vtable
+vulns
 Vuze
 wakelist
 wakeup


### PR DESCRIPTION
## Description

Establish a structured security analysis process and create the initial catalog entry for non-affecting Containerfile CVEs flagged by Docker DX.

### Added

- `docs/security/analysis/README.md` — process document with template and review cadence
- `docs/security/analysis/non-affecting/2026-06-10_containerfile-trixie-cves.md` — CVE catalog entry for trixie build-stage warnings
- `.github/skills/dev/maintenance/catalog-security-vulnerabilities/SKILL.md` — AI agent skill for auto-discovery
- `docs/issues/open/1898-document-security-analysis-process.md` — issue specification

### Enhanced

- `docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md` — added Security Rationale section
- `project-words.txt` — new dictionary entries

### Related

Closes #1898
Related to #1457, #1460, #1463
