### PR TITLE
refactor(udp-server): relocate test environment to src/testing/environment.rs

### DIFF
--- a/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
+++ b/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
@@ -7,7 +7,7 @@ epic: 1669
 github-issue: 1906
 spec-path: docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
 branch: 1906-relocate-udp-server-test-environment
-related-pr: null
+related-pr: 4
 last-updated-utc: 2026-06-17
 semantic-links:
   skill-links:

--- a/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
+++ b/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
@@ -6,9 +6,9 @@ priority: p2
 epic: 1669
 github-issue: 1906
 spec-path: docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
-branch: null
+branch: 1906-relocate-udp-server-test-environment
 related-pr: null
-last-updated-utc: 2026-06-11
+last-updated-utc: 2026-06-17
 semantic-links:
   skill-links:
     - create-issue
@@ -70,8 +70,8 @@ runtime dependencies.
 
 ## Verification
 
-- [ ] `environment.rs` moved to `src/testing/environment.rs`
-- [ ] External consumers updated
-- [ ] `cargo test --workspace` — pass
-- [ ] `cargo machete` — pass
-- [ ] `linter all` — pass
+- [x] `environment.rs` moved to `src/testing/environment.rs`
+- [x] External consumers updated
+- [x] `cargo test --workspace` — pass
+- [x] `cargo machete` — pass
+- [x] `linter all` — pass

--- a/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
+++ b/docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
@@ -7,7 +7,7 @@ epic: 1669
 github-issue: 1906
 spec-path: docs/issues/open/1906-1669-si-25-relocate-udp-server-test-environment.md
 branch: 1906-relocate-udp-server-test-environment
-related-pr: 4
+related-pr: 1916
 last-updated-utc: 2026-06-17
 semantic-links:
   skill-links:

--- a/packages/axum-health-check-api-server/tests/server/contract.rs
+++ b/packages/axum-health-check-api-server/tests/server/contract.rs
@@ -263,7 +263,7 @@ mod udp {
         let core_config = Arc::new(configuration.core.clone());
         let udp_tracker_config = Arc::new(configuration.udp_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let service = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let registar = service.registar.clone();
 
@@ -308,7 +308,7 @@ mod udp {
         let core_config = Arc::new(configuration.core.clone());
         let udp_tracker_config = Arc::new(configuration.udp_trackers.clone().unwrap()[0].clone());
 
-        let service = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let service = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let binding = service.bind_address();
 

--- a/packages/udp-server/examples/udp_only_public_tracker.rs
+++ b/packages/udp-server/examples/udp_only_public_tracker.rs
@@ -38,7 +38,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use torrust_tracker_configuration::{Core, UdpTracker};
-use torrust_tracker_udp_server::environment::Started;
+use torrust_tracker_udp_server::testing::environment::Started;
 
 #[tokio::main]
 async fn main() {

--- a/packages/udp-server/src/lib.rs
+++ b/packages/udp-server/src/lib.rs
@@ -636,12 +636,12 @@
 //! taken from the [libtorrent](https://www.rasterbar.com/products/libtorrent/udp_tracker_protocol.html).
 pub mod banning;
 pub mod container;
-pub mod environment;
 pub mod error;
 pub mod event;
 pub mod handlers;
 pub mod server;
 pub mod statistics;
+pub mod testing;
 
 use std::net::SocketAddr;
 

--- a/packages/udp-server/src/testing/environment.rs
+++ b/packages/udp-server/src/testing/environment.rs
@@ -218,7 +218,7 @@ mod tests {
     use tokio::time::sleep;
     use torrust_tracker_test_helpers::{configuration, logging};
 
-    use crate::environment::Started;
+    use super::Started;
 
     #[tokio::test]
     async fn it_should_make_and_stop_udp_server() {

--- a/packages/udp-server/src/testing/mod.rs
+++ b/packages/udp-server/src/testing/mod.rs
@@ -1,0 +1,11 @@
+//! Test-only infrastructure for `udp-server`.
+//!
+//! This module provides convenience setup code (wiring containers, starting/stopping
+//! the server) for integration tests in this crate and external consumers such as
+//! `axum-health-check-api-server`.
+//!
+//! > **Note**: This module is exported unconditionally from `lib.rs` so that external
+//! > test packages can import it. It is primarily intended for test use, but is
+//! > compiled in all build profiles.
+
+pub mod environment;

--- a/packages/udp-server/tests/server/contract.rs
+++ b/packages/udp-server/tests/server/contract.rs
@@ -46,7 +46,7 @@ async fn should_return_a_bad_request_response_when_the_client_sends_an_empty_req
     let cfg = configuration::ephemeral();
     let core_config = Arc::new(cfg.core.clone());
     let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-    let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+    let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
     let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
         Ok(udp_client) => udp_client,
@@ -91,7 +91,7 @@ mod receiving_a_connection_request {
         let cfg = configuration::ephemeral();
         let core_config = Arc::new(cfg.core.clone());
         let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -195,7 +195,7 @@ mod receiving_an_announce_request {
         let cfg = configuration::ephemeral();
         let core_config = Arc::new(cfg.core.clone());
         let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -220,7 +220,7 @@ mod receiving_an_announce_request {
         let cfg = configuration::ephemeral();
         let core_config = Arc::new(cfg.core.clone());
         let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,
@@ -248,7 +248,7 @@ mod receiving_an_announce_request {
         let cfg = configuration::ephemeral();
         let core_config = Arc::new(cfg.core.clone());
         let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
         let ban_service = env.container.udp_tracker_core_container.ban_service.clone();
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
@@ -343,7 +343,7 @@ mod receiving_an_scrape_request {
         let cfg = configuration::ephemeral();
         let core_config = Arc::new(cfg.core.clone());
         let udp_tracker_config = Arc::new(cfg.udp_trackers.unwrap()[0].clone());
-        let env = torrust_tracker_udp_server::environment::Started::new(&core_config, &udp_tracker_config).await;
+        let env = torrust_tracker_udp_server::testing::environment::Started::new(&core_config, &udp_tracker_config).await;
 
         let client = match UdpTrackerClient::new(env.bind_address(), DEFAULT_UDP_TIMEOUT).await {
             Ok(udp_tracker_client) => udp_tracker_client,


### PR DESCRIPTION
## Description

Relocates `packages/udp-server/src/environment.rs` into `packages/udp-server/src/testing/environment.rs`, matching the pattern established by SI-23 (axum-rest-api-server) and SI-24 (axum-http-server).

This test-only infrastructure was living in the production module tree but is only consumed by tests and examples, forcing unnecessary runtime dependencies.

## Changes

- **Moved**: `packages/udp-server/src/environment.rs` → `packages/udp-server/src/testing/environment.rs`
- **Created**: `packages/udp-server/src/testing/mod.rs` to export the test-only module
- **Updated** `lib.rs`: exported `pub mod testing` instead of `pub mod environment`
- **Updated consumers**:
  - `packages/udp-server/tests/server/contract.rs` (6 imports)
  - `packages/udp-server/examples/udp_only_public_tracker.rs` (1 import)
  - `packages/axum-health-check-api-server/tests/server/contract.rs` (2 imports)

## Verification

- [x] `cargo test --workspace` — 129+ tests pass
- [x] `cargo machete` — pass
- [x] `linter all` — pass
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

Closes #1906
