### PR TITLE
SI-27: Move Driver enum from configuration to primitives, remove duplicate in tracker-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,6 +4868,7 @@ dependencies = [
  "torrust-tracker-configuration",
  "torrust-tracker-core",
  "torrust-tracker-http-tracker-core",
+ "torrust-tracker-primitives",
  "torrust-tracker-rest-api-client",
  "torrust-tracker-rest-api-core",
  "torrust-tracker-swarm-coordination-registry",
@@ -5177,6 +5178,7 @@ dependencies = [
  "torrust-info-hash",
  "torrust-tracker-configuration",
  "torrust-tracker-core",
+ "torrust-tracker-primitives",
 ]
 
 [[package]]
@@ -5186,6 +5188,7 @@ dependencies = [
  "binascii",
  "derive_more 2.1.1",
  "serde",
+ "serde_json",
  "tdyne-peer-id",
  "tdyne-peer-id-registry",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ torrust-tracker-rest-api-core = { version = "3.0.0-develop", path = "packages/re
 torrust-server-lib = { version = "3.0.0-develop", path = "packages/server-lib" }
 torrust-clock = "3.0.0"
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "packages/configuration" }
+torrust-tracker-primitives = { version = "3.0.0-develop", path = "packages/primitives" }
 torrust-tracker-swarm-coordination-registry = { version = "3.0.0-develop", path = "packages/swarm-coordination-registry" }
 torrust-tracker-udp-server = { version = "3.0.0-develop", path = "packages/udp-server" }
 tracing = "0"

--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -53,13 +53,14 @@ Move the `Driver` enum to `torrust-tracker-primitives`, eliminate the duplicate 
 4. **`tracker-core` no longer needs `configuration` just for `Driver`**: the dependency
    on `torrust-tracker-configuration` from `tracker-core` was partially due to `Driver`.
    After the move, only the `Core` config type remains as a dependency.
-5. **CLI parity**: `persistence-benchmark` gains `clap::ValueEnum` on the `primitives::Driver`,
-   making the CLI `--driver` argument natively supported without manual `FromStr`.
+5. **Shared parsing helpers**: `primitives::Driver` provides `FromStr` and `as_str()`,
+   making the CLI `--driver` argument easy to consume in `persistence-benchmark`
+   without manual string-to-enum mapping.
 
 ### Trade-offs accepted
 
-- `torrust-tracker-primitives` gains two new Cargo dependencies: `serde` (was already
-  present) and `clap` (for `ValueEnum` on the benchmark CLI).
+- `torrust-tracker-primitives` gains one new dev-dependency: `serde_json`
+  (for serialization tests on the `Driver` enum).
 - Breakage: all consumers that imported `torrust_tracker_configuration::Driver` or
   `torrust_tracker_core::databases::driver::Driver` must be updated.
 

--- a/docs/issues/open/1669-overhaul-packages/DECISIONS.md
+++ b/docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -20,6 +20,59 @@ the proposal, the reasoning, and a reference to any supporting artifact.
 
 ---
 
+## DEC-14 — Move `Driver` enum from `configuration` to `primitives`
+
+**Date**: 2026-06-18
+**Status**: Adopted
+**Related issue**: [#1908](https://github.com/torrust/torrust-tracker/issues/1908)
+
+### Proposal considered
+
+The `Driver` enum (`Sqlite3`, `MySQL`, `PostgreSQL`) was defined in
+`torrust-tracker-configuration` as a TOML deserialization type, with a duplicate
+copy living in `torrust-tracker-core::databases::driver`. The duplication required
+pointless mapping code between two semantically identical enums.
+
+### Alternative chosen
+
+Move the `Driver` enum to `torrust-tracker-primitives`, eliminate the duplicate in
+`tracker-core`, and remove the `configuration` re-export. All consumers import
+`torrust_tracker_primitives::Driver` directly.
+
+### Why this alternative was adopted
+
+1. **Cross-cutting domain concept**: `Driver` is used by `configuration` (deserialization),
+   `tracker-core` (database initialization), and `persistence-benchmark` (CLI argument).
+   Placement in `primitives` reflects that it is a shared domain type, not
+   configuration plumbing.
+2. **Eliminates duplication**: the `tracker-core` copy was a perfect duplicate of the
+   `configuration` enum. Removing it eliminates a maintenance hazard.
+3. **Eliminates mapping code**: `setup.rs` previously had a `match` that converted
+   `configuration::Driver` → `tracker_core::databases::driver::Driver` — a pointless
+   identity mapping.
+4. **`tracker-core` no longer needs `configuration` just for `Driver`**: the dependency
+   on `torrust-tracker-configuration` from `tracker-core` was partially due to `Driver`.
+   After the move, only the `Core` config type remains as a dependency.
+5. **CLI parity**: `persistence-benchmark` gains `clap::ValueEnum` on the `primitives::Driver`,
+   making the CLI `--driver` argument natively supported without manual `FromStr`.
+
+### Trade-offs accepted
+
+- `torrust-tracker-primitives` gains two new Cargo dependencies: `serde` (was already
+  present) and `clap` (for `ValueEnum` on the benchmark CLI).
+- Breakage: all consumers that imported `torrust_tracker_configuration::Driver` or
+  `torrust_tracker_core::databases::driver::Driver` must be updated.
+
+### Supporting artifacts
+
+- `packages/primitives/src/driver.rs` — new module with the unified `Driver` enum
+- `packages/tracker-core/src/databases/driver/mod.rs` — removed (duplicate)
+- `packages/configuration/src/lib.rs` — removed `pub type Driver` re-export
+- `packages/configuration/src/v2_0_0/database.rs` — `Driver` definition removed, now
+  imported from primitives
+
+---
+
 ## DEC-10 — Move peer-count cap from a global constant to `AnnouncePolicy::max_peers_per_announce`
 
 **Date**: 2026-06-09

--- a/docs/issues/open/1908-1669-si-27-move-driver-enum-to-primitives.md
+++ b/docs/issues/open/1908-1669-si-27-move-driver-enum-to-primitives.md
@@ -87,10 +87,10 @@ keep that dependency. But the coupling for `Driver` specifically is eliminated.
 
 ## Verification
 
-- [ ] DEC-XX added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
-- [ ] `Driver` defined in `primitives`, re-exported from `configuration`
-- [ ] Duplicate in `tracker-core` removed
-- [ ] Mapping in `setup.rs` simplified
-- [ ] `cargo test --workspace` — pass
-- [ ] `cargo machete` — pass
-- [ ] `linter all` — pass
+- [x] DEC-14 added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
+- [x] `Driver` defined in `primitives`, re-exported from `configuration` (as import via `torrust_tracker_primitives`)
+- [x] Duplicate in `tracker-core` removed
+- [x] Mapping in `setup.rs` simplified
+- [x] `cargo test --workspace` — pass
+- [x] `cargo machete` — pass (no new unused deps)
+- [x] `linter all` — pass

--- a/docs/issues/open/1908-1669-si-27-move-driver-enum-to-primitives.md
+++ b/docs/issues/open/1908-1669-si-27-move-driver-enum-to-primitives.md
@@ -88,7 +88,7 @@ keep that dependency. But the coupling for `Driver` specifically is eliminated.
 ## Verification
 
 - [x] DEC-14 added to `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
-- [x] `Driver` defined in `primitives`, re-exported from `configuration` (as import via `torrust_tracker_primitives`)
+- [x] `Driver` defined in `primitives`, all consumers import it directly
 - [x] Duplicate in `tracker-core` removed
 - [x] Mapping in `setup.rs` simplified
 - [x] `cargo test --workspace` — pass

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -36,7 +36,6 @@ pub type HttpApi = v2_0_0::tracker_api::HttpApi;
 pub type HttpTracker = v2_0_0::http_tracker::HttpTracker;
 pub type UdpTracker = v2_0_0::udp_tracker::UdpTracker;
 pub type Database = v2_0_0::database::Database;
-pub type Driver = v2_0_0::database::Driver;
 pub type Threshold = v2_0_0::logging::Threshold;
 
 pub type AccessTokens = HashMap<String, String>;

--- a/packages/configuration/src/v2_0_0/database.rs
+++ b/packages/configuration/src/v2_0_0/database.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use torrust_tracker_primitives::Driver;
 use url::Url;
 
 #[allow(clippy::struct_excessive_bools)]
@@ -57,18 +58,6 @@ impl Database {
             }
         }
     }
-}
-
-/// The database management system used by the tracker.
-#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
-#[serde(rename_all = "lowercase")]
-pub enum Driver {
-    /// The `Sqlite3` database driver.
-    Sqlite3,
-    /// The `MySQL` database driver.
-    MySQL,
-    /// The `PostgreSQL` database driver.
-    PostgreSQL,
 }
 
 #[cfg(test)]

--- a/packages/persistence-benchmark/Cargo.toml
+++ b/packages/persistence-benchmark/Cargo.toml
@@ -29,3 +29,4 @@ testcontainers = "0"
 tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 torrust-tracker-configuration = { version = "3.0.0-develop", path = "../configuration" }
 torrust-tracker-core = { path = "../tracker-core" }
+torrust-tracker-primitives = { version = "3.0.0-develop", path = "../primitives" }

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/mod.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/mod.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow};
 use testcontainers::{ContainerAsync, GenericImage};
 use torrust_tracker_core::databases::SchemaMigrator;
-use torrust_tracker_core::databases::driver::Driver;
 use torrust_tracker_core::databases::setup::DatabaseStores;
+use torrust_tracker_primitives::Driver;
 
 mod mysql;
 mod postgres;

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/mysql.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/mysql.rs
@@ -58,7 +58,7 @@ pub(super) async fn initialize(db_version: &str) -> Result<ActiveDatabase> {
         .context("mysql container did not accept connections in time")?;
 
     let mut config = configuration::Core::default();
-    config.database.driver = configuration::Driver::MySQL;
+    config.database.driver = torrust_tracker_primitives::Driver::MySQL;
     config.database.path = mysql_database_url;
     let database = initialize_database(&config).await;
 

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/postgres.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/postgres.rs
@@ -52,7 +52,7 @@ pub(super) async fn initialize(db_version: &str) -> Result<ActiveDatabase> {
         .context("postgres container did not accept connections in time")?;
 
     let mut config = configuration::Core::default();
-    config.database.driver = configuration::Driver::PostgreSQL;
+    config.database.driver = torrust_tracker_primitives::Driver::PostgreSQL;
     config.database.path = postgres_database_url;
     let database = initialize_database(&config).await;
 

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/sqlite.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/database/sqlite.rs
@@ -10,7 +10,7 @@ pub(super) async fn initialize() -> ActiveDatabase {
     ));
     let sqlite_db_path_as_string = sqlite_db_path.to_string_lossy().to_string();
     let mut config = configuration::Core::default();
-    config.database.driver = configuration::Driver::Sqlite3;
+    config.database.driver = torrust_tracker_primitives::Driver::Sqlite3;
     config.database.path = sqlite_db_path_as_string;
 
     let database = initialize_database(&config).await;

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/mod.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/driver_bench/mod.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use torrust_tracker_core::databases::driver::Driver;
+use torrust_tracker_primitives::Driver;
 
 use super::types::OpsCount;
 

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/operations.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/operations.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use torrust_tracker_core::databases::driver::Driver;
+use torrust_tracker_primitives::Driver;
 
 use super::types::{DbVersion, OpsCount};
 use super::{driver_bench, metrics};

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/reporting.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/reporting.rs
@@ -1,4 +1,4 @@
-use torrust_tracker_core::databases::driver::Driver;
+use torrust_tracker_primitives::Driver;
 
 use super::types::DbVersion;
 use super::{metrics, report};
@@ -30,7 +30,7 @@ mod tests {
     use std::str::FromStr;
     use std::time::Duration;
 
-    use torrust_tracker_core::databases::driver::Driver;
+    use torrust_tracker_primitives::Driver;
 
     use super::build_report;
     use crate::persistence_benchmark::metrics::OperationStats;

--- a/packages/persistence-benchmark/src/bin/persistence_benchmark/runner.rs
+++ b/packages/persistence-benchmark/src/bin/persistence_benchmark/runner.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use anyhow::Result;
 use clap::Parser;
-use torrust_tracker_core::databases::driver::Driver;
+use torrust_tracker_primitives::Driver;
 
 use super::types::{DbVersion, OpsCount};
 use super::{operations, report, reporting};

--- a/packages/primitives/Cargo.toml
+++ b/packages/primitives/Cargo.toml
@@ -18,10 +18,13 @@ version.workspace = true
 torrust-peer-id = "0.1.0"
 binascii = "0"
 torrust-info-hash = "=0.2.0"
-derive_more = { version = "2", features = [ "constructor" ] }
+derive_more = { version = "2", features = [ "constructor", "display" ] }
 serde = { version = "1", features = [ "derive" ] }
 tdyne-peer-id = "1"
 tdyne-peer-id-registry = "0"
 thiserror = "2"
 torrust-net-primitives = "0.1.0"
 torrust-clock = "3.0.0"
+
+[dev-dependencies]
+serde_json = "1"

--- a/packages/primitives/src/driver.rs
+++ b/packages/primitives/src/driver.rs
@@ -1,0 +1,125 @@
+//! Database driver types.
+//!
+//! This module defines the [`Driver`] enum which identifies the database
+//! management system used by the tracker. It is a cross-cutting domain
+//! concept shared by configuration deserialization, database initialization,
+//! and CLI tooling.
+
+use std::str::FromStr;
+
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+
+/// The database management system used by the tracker.
+#[derive(Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Display, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum Driver {
+    /// The `Sqlite3` database driver.
+    Sqlite3,
+    /// The `MySQL` database driver.
+    MySQL,
+    /// The `PostgreSQL` database driver.
+    PostgreSQL,
+}
+
+impl Driver {
+    /// Returns the stable lowercase identifier used by CLI and reports.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sqlite3 => "sqlite3",
+            Self::MySQL => "mysql",
+            Self::PostgreSQL => "postgresql",
+        }
+    }
+}
+
+impl FromStr for Driver {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "sqlite3" => Ok(Self::Sqlite3),
+            "mysql" => Ok(Self::MySQL),
+            "postgresql" => Ok(Self::PostgreSQL),
+            _ => Err("driver must be one of: sqlite3, mysql, postgresql".to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Driver;
+
+    #[test]
+    fn it_should_display_sqlite3() {
+        assert_eq!(Driver::Sqlite3.to_string(), "Sqlite3");
+    }
+
+    #[test]
+    fn it_should_display_mysql() {
+        assert_eq!(Driver::MySQL.to_string(), "MySQL");
+    }
+
+    #[test]
+    fn it_should_display_postgresql() {
+        assert_eq!(Driver::PostgreSQL.to_string(), "PostgreSQL");
+    }
+
+    #[test]
+    fn it_should_return_as_str_sqlite3() {
+        assert_eq!(Driver::Sqlite3.as_str(), "sqlite3");
+    }
+
+    #[test]
+    fn it_should_return_as_str_mysql() {
+        assert_eq!(Driver::MySQL.as_str(), "mysql");
+    }
+
+    #[test]
+    fn it_should_return_as_str_postgresql() {
+        assert_eq!(Driver::PostgreSQL.as_str(), "postgresql");
+    }
+
+    #[test]
+    fn it_should_parse_sqlite3() {
+        let driver: Result<Driver, _> = "sqlite3".parse();
+        assert_eq!(driver.unwrap(), Driver::Sqlite3);
+    }
+
+    #[test]
+    fn it_should_parse_mysql() {
+        let driver: Result<Driver, _> = "mysql".parse();
+        assert_eq!(driver.unwrap(), Driver::MySQL);
+    }
+
+    #[test]
+    fn it_should_parse_postgresql() {
+        let driver: Result<Driver, _> = "postgresql".parse();
+        assert_eq!(driver.unwrap(), Driver::PostgreSQL);
+    }
+
+    #[test]
+    fn it_should_fail_parsing_invalid_driver() {
+        let driver: Result<Driver, _> = "invalid".parse();
+        assert!(driver.is_err());
+    }
+
+    #[test]
+    fn it_should_serialize_sqlite3_to_lowercase() {
+        let serialized = serde_json::to_string(&Driver::Sqlite3).unwrap();
+        assert_eq!(serialized, "\"sqlite3\"");
+    }
+
+    #[test]
+    fn it_should_serialize_mysql_to_lowercase() {
+        let serialized = serde_json::to_string(&Driver::MySQL).unwrap();
+        assert_eq!(serialized, "\"mysql\"");
+    }
+
+    #[test]
+    fn it_should_serialize_postgresql_to_lowercase() {
+        let serialized = serde_json::to_string(&Driver::PostgreSQL).unwrap();
+        assert_eq!(serialized, "\"postgresql\"");
+    }
+}

--- a/packages/primitives/src/lib.rs
+++ b/packages/primitives/src/lib.rs
@@ -5,6 +5,7 @@
 //! by the tracker server crate, but also by other crates in the Torrust
 //! ecosystem.
 pub mod announce;
+pub mod driver;
 pub mod mode;
 pub mod number_of_bytes;
 pub mod pagination;
@@ -22,6 +23,7 @@ pub mod swarm_metadata;
 use std::collections::BTreeMap;
 
 pub use announce::{AnnounceData, AnnounceEvent, AnnouncePolicy};
+pub use driver::Driver;
 pub use mode::PrivateMode;
 pub use number_of_bytes::NumberOfBytes;
 pub use policy::TrackerPolicy;

--- a/packages/tracker-core/src/authentication/handler.rs
+++ b/packages/tracker-core/src/authentication/handler.rs
@@ -359,6 +359,7 @@ mod tests {
                 use mockall::predicate::function;
                 use torrust_clock::clock::stopped::Stopped;
                 use torrust_clock::clock::{self, Time};
+                use torrust_tracker_primitives::Driver;
 
                 use crate::CurrentClock;
                 use crate::authentication::PeerKey;
@@ -366,7 +367,6 @@ mod tests {
                 use crate::authentication::handler::tests::the_keys_handler_when_the_tracker_is_configured_as_private::{
                     instantiate_keys_handler, instantiate_keys_handler_with_database, mock_auth_key_store,
                 };
-                use crate::databases::driver::Driver;
                 use crate::databases::{self, AuthKeyStore};
                 use crate::error::PeerKeyError;
 
@@ -433,6 +433,7 @@ mod tests {
                 use mockall::predicate;
                 use torrust_clock::clock::stopped::Stopped;
                 use torrust_clock::clock::{self, Time};
+                use torrust_tracker_primitives::Driver;
 
                 use crate::CurrentClock;
                 use crate::authentication::handler::AddKeyRequest;
@@ -440,7 +441,6 @@ mod tests {
                     instantiate_keys_handler, instantiate_keys_handler_with_database, mock_auth_key_store,
                 };
                 use crate::authentication::{Key, PeerKey};
-                use crate::databases::driver::Driver;
                 use crate::databases::{self, AuthKeyStore};
                 use crate::error::PeerKeyError;
 
@@ -541,13 +541,13 @@ mod tests {
                 use std::sync::Arc;
 
                 use mockall::predicate::function;
+                use torrust_tracker_primitives::Driver;
 
                 use crate::authentication::PeerKey;
                 use crate::authentication::handler::AddKeyRequest;
                 use crate::authentication::handler::tests::the_keys_handler_when_the_tracker_is_configured_as_private::{
                     instantiate_keys_handler, instantiate_keys_handler_with_database, mock_auth_key_store,
                 };
-                use crate::databases::driver::Driver;
                 use crate::databases::{self, AuthKeyStore};
                 use crate::error::PeerKeyError;
 
@@ -611,13 +611,13 @@ mod tests {
                 use std::sync::Arc;
 
                 use mockall::predicate;
+                use torrust_tracker_primitives::Driver;
 
                 use crate::authentication::handler::AddKeyRequest;
                 use crate::authentication::handler::tests::the_keys_handler_when_the_tracker_is_configured_as_private::{
                     instantiate_keys_handler, instantiate_keys_handler_with_database, mock_auth_key_store,
                 };
                 use crate::authentication::{Key, PeerKey};
-                use crate::databases::driver::Driver;
                 use crate::databases::{self, AuthKeyStore};
                 use crate::error::PeerKeyError;
 

--- a/packages/tracker-core/src/databases/driver/mod.rs
+++ b/packages/tracker-core/src/databases/driver/mod.rs
@@ -1,55 +1,11 @@
 //! Database driver factory.
-use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use torrust_tracker_primitives::Driver;
 
 use super::error::Error;
 
 /// Metric name in DB for the total number of downloads across all torrents.
 pub(super) const TORRENTS_DOWNLOADS_TOTAL: &str = "torrents_downloads_total";
-
-/// The database management system used by the tracker.
-///
-/// Refer to:
-///
-/// - [Torrust Tracker Configuration](https://docs.rs/torrust-tracker-configuration).
-/// - [Torrust Tracker](https://docs.rs/torrust-tracker).
-///
-/// For more information about persistence.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, derive_more::Display, Clone)]
-pub enum Driver {
-    /// The Sqlite3 database driver.
-    Sqlite3,
-    /// The `MySQL` database driver.
-    MySQL,
-    /// The `PostgreSQL` database driver.
-    PostgreSQL,
-}
-
-impl Driver {
-    /// Returns the stable lowercase identifier used by CLI and reports.
-    #[must_use]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Sqlite3 => "sqlite3",
-            Self::MySQL => "mysql",
-            Self::PostgreSQL => "postgresql",
-        }
-    }
-}
-
-impl FromStr for Driver {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "sqlite3" => Ok(Self::Sqlite3),
-            "mysql" => Ok(Self::MySQL),
-            "postgresql" => Ok(Self::PostgreSQL),
-            _ => Err("driver must be one of: sqlite3, mysql, postgresql".to_string()),
-        }
-    }
-}
 
 pub mod mysql;
 pub mod postgres;

--- a/packages/tracker-core/src/databases/error.rs
+++ b/packages/tracker-core/src/databases/error.rs
@@ -14,8 +14,7 @@ use std::sync::Arc;
 use sqlx::Error as SqlxError;
 use sqlx::migrate::MigrateError;
 use torrust_located_error::{DynError, LocatedError};
-
-use super::driver::Driver;
+use torrust_tracker_primitives::Driver;
 
 /// Database error type that encapsulates various failures encountered during
 /// database operations.
@@ -149,7 +148,8 @@ impl From<(MigrateError, Driver)> for Error {
 
 #[cfg(test)]
 mod tests {
-    use crate::databases::driver::Driver;
+    use torrust_tracker_primitives::Driver;
+
     use crate::databases::error::Error;
 
     #[test]

--- a/packages/tracker-core/src/databases/setup.rs
+++ b/packages/tracker-core/src/databases/setup.rs
@@ -5,8 +5,8 @@
 use std::sync::Arc;
 
 use torrust_tracker_configuration::Core;
+use torrust_tracker_primitives::Driver;
 
-use super::driver::Driver;
 use super::driver::mysql::Mysql;
 use super::driver::postgres::Postgres;
 use super::driver::sqlite::Sqlite;
@@ -89,11 +89,7 @@ where
 /// ```
 #[must_use]
 pub async fn initialize_database(config: &Core) -> DatabaseStores {
-    let driver = match config.database.driver {
-        torrust_tracker_configuration::Driver::Sqlite3 => Driver::Sqlite3,
-        torrust_tracker_configuration::Driver::MySQL => Driver::MySQL,
-        torrust_tracker_configuration::Driver::PostgreSQL => Driver::PostgreSQL,
-    };
+    let driver = &config.database.driver;
 
     match driver {
         Driver::Sqlite3 => {

--- a/packages/tracker-core/src/error.rs
+++ b/packages/tracker-core/src/error.rs
@@ -147,8 +147,8 @@ mod tests {
 
     mod peer_key_error {
         use torrust_located_error::Located;
+        use torrust_tracker_primitives::Driver;
 
-        use crate::databases::driver::Driver;
         use crate::error::PeerKeyError;
         use crate::{authentication, databases};
 

--- a/src/console/ci/qbittorrent_e2e/tracker/config_builder.rs
+++ b/src/console/ci/qbittorrent_e2e/tracker/config_builder.rs
@@ -4,7 +4,8 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use torrust_tracker_configuration::{Configuration, Driver, HealthCheckApi, HttpApi, HttpTracker, UdpTracker};
+use torrust_tracker_configuration::{Configuration, HealthCheckApi, HttpApi, HttpTracker, UdpTracker};
+use torrust_tracker_primitives::Driver;
 
 const CONFIG_FILE_NAME: &str = "tracker-config.toml";
 const DEFAULT_SQLITE3_DATABASE_PATH: &str = "/var/lib/torrust/tracker/database/sqlite3.db";


### PR DESCRIPTION
## Description

Implements **SI-27** (sub-issue of EPIC #1669, issue #1908).

Moves the `Driver` enum (`Sqlite3`, `MySQL`, `PostgreSQL`) from `torrust-tracker-configuration`
to `torrust-tracker-primitives`, removes the duplicate copy in `torrust-tracker-core`, and
eliminates the pointless identity mapping between the two.

### Changes

| Package | Change |
|---------|--------|
| `primitives` | New `driver.rs` module with unified `Driver` enum (`Serialize`, `Deserialize`, `Display`, `Hash`, `Ord`, `as_str()`, `FromStr`) |
| `configuration` | Removed `Driver` enum definition and `pub type Driver` re-export; imports from primitives |
| `tracker-core` | Removed duplicate `Driver` enum (~60 lines); removed identity mapping in `setup.rs`; imports from primitives |
| `persistence-benchmark` | Added explicit `torrust-tracker-primitives` dep; updated all imports |
| `src/console` (root crate) | Updated E2E config builder import; added primitives dep |

### Acceptance criteria

- [x] `Driver` defined once in primitives, consumed by all packages
- [x] No duplicate in `tracker-core`
- [x] No mapping code between identical enums
- [x] `cargo test --workspace` — all 2232 tests pass
- [x] `cargo machete` — no new unused deps
- [x] `linter all` — pass
- [x] DEC-14 recorded in `DECISIONS.md`

Closes #1908
