### PR TITLE
chore(issues): archive closed issue #1671 spec and update cleanup skill

### DIFF
--- a/.github/skills/dev/planning/cleanup-completed-issues/SKILL.md
+++ b/.github/skills/dev/planning/cleanup-completed-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cleanup-completed-issues
-description: Guide for archiving closed issue specification files from docs/issues/open/ to docs/issues/closed/. Covers verifying closure on GitHub, moving files, updating frontmatter, creating a branch, and opening a PR. Does NOT cover permanent deletion of closed specs — that is a manual user-driven action. Use when cleaning up closed issue specs, archiving issue docs, or maintaining the docs/issues/ folder. Triggers on "cleanup issue", "archive issue", "move closed issue", "clean completed issues", or "maintain issue docs".
+description: Guide for archiving closed issue specification files from docs/issues/open/ to docs/issues/closed/. Covers verifying closure on GitHub, moving files, updating frontmatter, creating a branch, and opening a PR. Permanent deletion of closed specs is not automated — the user must explicitly request it. Use when cleaning up closed issue specs, archiving issue docs, or maintaining the docs/issues/ folder. Triggers on "cleanup issue", "archive issue", "move closed issue", "clean completed issues", or "maintain issue docs".
 metadata:
   author: torrust
   version: "1.3"
@@ -10,12 +10,13 @@ metadata:
 
 ## Lifecycle
 
-Closed issue specs follow a single automated stage:
+Closed issue specs follow this lifecycle:
 
-1. **Archive**: When an issue is closed, move its spec file from `docs/issues/open/` to
-   `docs/issues/closed/`. The file stays in the closed buffer as a reference.
-2. **Permanent deletion**: Not part of this skill. If the user wants specs permanently
-   deleted, they will explicitly ask for it.
+1. **Archive** (automated by this skill): When an issue is closed, move its spec file from
+   `docs/issues/open/` to `docs/issues/closed/`. The file stays in the closed buffer as a
+   reference for ongoing and upcoming work.
+2. **Permanent deletion** (user-driven): If the user wants specs permanently deleted, they
+   will explicitly ask for it. This skill does not automate deletion.
 
 See [`docs/issues/closed/README.md`](../../../../docs/issues/closed/README.md) for the purpose
 of the closed buffer folder.
@@ -41,9 +42,12 @@ Related lifecycle docs:
 
 Always create a new branch for this work. Never commit directly to `develop`.
 
+Start from an up-to-date `develop`:
+
 ```bash
+UPSTREAM_REMOTE="${UPSTREAM_REMOTE:-torrust}"
 git checkout develop
-git pull torrust develop
+git pull --ff-only "$UPSTREAM_REMOTE" develop
 git checkout -b chore/cleanup-completed-issues
 ```
 
@@ -102,7 +106,9 @@ After moving, update the spec's YAML frontmatter to reflect the closed state:
 
 For directories with multiple files, update at minimum the main `ISSUE.md` plus any
 supplementary files whose frontmatter references the `docs/issues/open/` path (e.g.,
-`related-artifacts` links to the open spec).
+`related-artifacts` links to the open spec). For supplementary docs without existing
+frontmatter, add a minimal block with `spec-path`, `last-updated-utc`, and a
+`sematic-links` section linking back to the parent issue spec.
 
 Also check the spec's **Workflow Checkpoints** section and tick any checkboxes that
 reflect completed work (manual verification, acceptance criteria review, etc.) based
@@ -136,7 +142,8 @@ Run the pre-commit hooks before finishing:
 ### Step 6: Push and Open a Pull Request
 
 ```bash
-git push {your-fork-remote} chore/cleanup-completed-issues
+FORK_REMOTE="${FORK_REMOTE:-josecelano}"
+git push "$FORK_REMOTE" chore/cleanup-completed-issues
 ```
 
 Open a PR targeting `develop`:
@@ -145,11 +152,12 @@ Open a PR targeting `develop`:
 gh pr create \
   --repo torrust/torrust-tracker \
   --base develop \
-  --head {your-fork-remote}:chore/cleanup-completed-issues \
-  --title "chore(issues): archive closed issue #{N} spec to docs/issues/closed" \
+  --head "${FORK_REMOTE}:chore/cleanup-completed-issues" \
+  --title "chore(issues): archive closed issue #${N} spec to docs/issues/closed" \
   --body "Archives the spec for issue #${N} (closed on GitHub) from \`docs/issues/open/\` to \`docs/issues/closed/\`.
 
 - Verified issue #${N} is \`CLOSED\` on GitHub
 - Updated frontmatter (\`status: done\`, \`spec-path\`, \`last-updated-utc\`)
 - Updated workflow checkboxes where applicable
 - Pre-commit hooks passed"
+```

--- a/.github/skills/dev/planning/cleanup-completed-issues/SKILL.md
+++ b/.github/skills/dev/planning/cleanup-completed-issues/SKILL.md
@@ -1,58 +1,50 @@
 ---
 name: cleanup-completed-issues
-description: Guide for cleaning up completed and closed issues in the torrust-tracker project. Covers moving closed issue documentation files from docs/issues/open/ to docs/issues/closed/ and eventually deleting them. Supports single issue cleanup or batch cleanup. Use when cleaning up closed issues, archiving issue docs, or maintaining the docs/issues/ folder. Triggers on "cleanup issue", "archive issue", "move closed issue", "clean completed issues", "delete closed issue", or "maintain issue docs".
+description: Guide for archiving closed issue specification files from docs/issues/open/ to docs/issues/closed/. Covers verifying closure on GitHub, moving files, updating frontmatter, creating a branch, and opening a PR. Does NOT cover permanent deletion of closed specs — that is a manual user-driven action. Use when cleaning up closed issue specs, archiving issue docs, or maintaining the docs/issues/ folder. Triggers on "cleanup issue", "archive issue", "move closed issue", "clean completed issues", or "maintain issue docs".
 metadata:
   author: torrust
-  version: "1.2"
+  version: "1.3"
 ---
 
 # Cleaning Up Completed Issues
 
-## Two-Stage Lifecycle
+## Lifecycle
 
-Closed issue specs are **not deleted immediately**. They go through a two-stage lifecycle:
+Closed issue specs follow a single automated stage:
 
-1. **Stage 1 — Archive**: When an issue is closed, move its spec file from `docs/issues/open/` to
-   `docs/issues/closed/`. The file stays here as a reference buffer while adjacent issues are
-   still in progress.
-2. **Stage 2 — Delete**: Once the spec is no longer referenced by active work (typically after
-   the next one or two related issues are also closed), delete it permanently.
+1. **Archive**: When an issue is closed, move its spec file from `docs/issues/open/` to
+   `docs/issues/closed/`. The file stays in the closed buffer as a reference.
+2. **Permanent deletion**: Not part of this skill. If the user wants specs permanently
+   deleted, they will explicitly ask for it.
 
 See [`docs/issues/closed/README.md`](../../../../docs/issues/closed/README.md) for the purpose
-of the buffer folder.
+of the closed buffer folder.
 
 Related lifecycle docs:
 
 - Open issue specs: [`docs/issues/open/README.md`](../../../../docs/issues/open/README.md)
 - Closed issue buffer: [`docs/issues/closed/README.md`](../../../../docs/issues/closed/README.md)
 
-## When to Archive (Stage 1)
+## When to Archive
 
-- **After PR merge**: Move the issue file when its PR is merged and the issue is closed.
+- **After PR merge**: Move the issue file when its PR is merged and the issue is closed on GitHub.
 - **Batch archive**: Periodically move multiple closed issue files during maintenance.
 - **Before releases**: Tidy `docs/issues/` before major releases.
 
-## When to Delete (Stage 2)
+## Prerequisites
 
-- The spec is no longer referenced by any open issue or active work.
-- The related issue series has progressed far enough that the context is no longer needed.
+- GitHub CLI (`gh`) must be authenticated and have access to the `torrust/torrust-tracker` repository.
 
 ## Step-by-Step Process
 
-### Step 0: Create a Working Branch
+### Step 0: Create a Working Branch (Mandatory)
 
-This cleanup task may not have a dedicated GitHub issue. Use a descriptive branch name
-without an issue prefix:
-
-```bash
-git checkout -b chore/cleanup-completed-issues-from-open
-```
-
-If there is a linked issue (e.g., automating this process), prefix the branch accordingly:
+Always create a new branch for this work. Never commit directly to `develop`.
 
 ```bash
-# When automating this process uses a tracking issue
-git checkout -b 1774-automate-cleanup-completed-issues
+git checkout develop
+git pull torrust develop
+git checkout -b chore/cleanup-completed-issues
 ```
 
 ### Step 1: Verify Issue is Closed on GitHub
@@ -76,16 +68,16 @@ done
 
 ### Step 2: Move Issue File to `docs/issues/closed/`
 
-**Single file:**
-
-```bash
-git mv docs/issues/open/42-add-peer-expiry-grace-period.md docs/issues/closed/
-```
-
 **Directory (multi-file subissue spec):**
 
 ```bash
 git mv docs/issues/open/42-my-subissue-folder/ docs/issues/closed/
+```
+
+**Single file:**
+
+```bash
+git mv docs/issues/open/42-add-peer-expiry-grace-period.md docs/issues/closed/
 ```
 
 **Batch files:**
@@ -93,14 +85,14 @@ git mv docs/issues/open/42-my-subissue-folder/ docs/issues/closed/
 ```bash
 git mv docs/issues/open/21-some-old-issue.md \
   docs/issues/open/22-another-old-issue.md \
-       docs/issues/closed/
+  docs/issues/closed/
 ```
 
 Note: `git mv` on a directory moves all files inside it atomically.
 
 ### Step 3: Update Frontmatter of Moved Files
 
-After moving, the spec's YAML frontmatter fields must reflect the closed state:
+After moving, update the spec's YAML frontmatter to reflect the closed state:
 
 | Field                 | Before                   | After                     |
 | --------------------- | ------------------------ | ------------------------- |
@@ -112,6 +104,11 @@ For directories with multiple files, update at minimum the main `ISSUE.md` plus 
 supplementary files whose frontmatter references the `docs/issues/open/` path (e.g.,
 `related-artifacts` links to the open spec).
 
+Also check the spec's **Workflow Checkpoints** section and tick any checkboxes that
+reflect completed work (manual verification, acceptance criteria review, etc.) based
+on the actual content of the spec body. Add a progress log entry documenting the
+archival action.
+
 ### Step 4: Update Any Parent Epic Spec
 
 If the closed issue was a subissue of an EPIC, update the epic's spec to reflect the
@@ -120,7 +117,7 @@ new `docs/issues/closed/` path and `DONE` status in its subissue table.
 Example: if `docs/issues/open/EPIC.md` has a table row referencing a subissue at
 `docs/issues/open/...` with `TODO` status, update both the path and status after archiving.
 
-### Step 5: Commit and Push
+### Step 5: Commit
 
 ```bash
 # Single issue
@@ -128,21 +125,31 @@ git commit -S -m "chore(issues): archive closed issue #42 spec to docs/issues/cl
 
 # Batch
 git commit -S -m "chore(issues): archive closed issue specs #21, #22, #23 to docs/issues/closed"
-
-git push {your-fork-remote} {branch}
 ```
 
-### Step 6 (Stage 2): Delete When No Longer Needed
+Run the pre-commit hooks before finishing:
 
 ```bash
-git rm docs/issues/closed/42-add-peer-expiry-grace-period.md
-git commit -S -m "chore(issues): remove closed issue #42 spec (no longer referenced)"
+./contrib/dev-tools/git/hooks/pre-commit.sh
 ```
 
-## Determining File Placement
+### Step 6: Push and Open a Pull Request
 
-| Condition                               | Action                        |
-| --------------------------------------- | ----------------------------- |
-| Issue still open                        | Keep in `docs/issues/open/`   |
-| Issue closed, related work still active | Move to `docs/issues/closed/` |
-| Issue closed, no longer referenced      | Delete permanently            |
+```bash
+git push {your-fork-remote} chore/cleanup-completed-issues
+```
+
+Open a PR targeting `develop`:
+
+```bash
+gh pr create \
+  --repo torrust/torrust-tracker \
+  --base develop \
+  --head {your-fork-remote}:chore/cleanup-completed-issues \
+  --title "chore(issues): archive closed issue #{N} spec to docs/issues/closed" \
+  --body "Archives the spec for issue #${N} (closed on GitHub) from \`docs/issues/open/\` to \`docs/issues/closed/\`.
+
+- Verified issue #${N} is \`CLOSED\` on GitHub
+- Updated frontmatter (\`status: done\`, \`spec-path\`, \`last-updated-utc\`)
+- Updated workflow checkboxes where applicable
+- Pre-commit hooks passed"

--- a/docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
+++ b/docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: feature
-status: open
+status: done
 priority: p2
 github-issue: 1671
-spec-path: docs/issues/open/1671-ipv4-ipv6-client-metrics/ISSUE.md
+spec-path: docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
 branch: "1671-ipv4-ipv6-client-metrics"
 related-pr: null
-last-updated-utc: 2026-06-20 10:00
+last-updated-utc: 2026-06-21 10:00
 semantic-links:
   skill-links:
     - create-issue
@@ -111,11 +111,11 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
 - [x] Implementation completed
 - [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
-- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+- [x] Committer verified spec progress is up to date before commit
+- [x] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
 
@@ -125,6 +125,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-06-20 UTC - Copilot - Updated spec verification table with experiment evidence, added UDP unit tests for client address labels, ran linter all
 - 2026-06-20 UTC - Copilot - Removed duplicate UDP server tests (derivation tested once in udp-core), added cross-fingerprint cookie rejection test for AC5, fixed linter issues, updated spec
 - 2026-06-20 UTC - Copilot - Added UDP integration test for `ipv6_v6only` config propagation (T17)
+- 2026-06-21 UTC - Copilot - Archived spec to `docs/issues/closed/` after issue closure on GitHub
 
 ## Acceptance Criteria
 

--- a/docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
+++ b/docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
@@ -1,6 +1,9 @@
 ---
 spec-path: docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
 last-updated-utc: 2026-06-21 10:00
+semantic-links:
+  related-artifacts:
+    - docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
 ---
 
 # Research: `IPV6_V6ONLY` Defaults and Dual-Stack Portability

--- a/docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
+++ b/docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
@@ -1,3 +1,8 @@
+---
+spec-path: docs/issues/closed/1671-ipv4-ipv6-client-metrics/research-dual-stack-portability.md
+last-updated-utc: 2026-06-21 10:00
+---
+
 # Research: `IPV6_V6ONLY` Defaults and Dual-Stack Portability
 
 > Related to [#1671](https://github.com/torrust/torrust-tracker/issues/1671) — IPv4/IPv6 client metrics.


### PR DESCRIPTION
Archives the spec for issue #1671 (IPv4/IPv6 client metrics) from `docs/issues/open/` to `docs/issues/closed/`.

### Changes

- **#1671 spec archived**: Verified issue is `CLOSED` on GitHub, moved via `git mv`
- **Frontmatter updated**: `status: done`, `spec-path` → closed path, `last-updated-utc` → today
- **Workflow checkboxes ticked**: manual verification, acceptance criteria review, committer verification, spec moved
- **Progress log entry**: archiving action documented
- **Skill updated**: `cleanup-completed-issues/SKILL.md` v1.3 — clarified branch/PR workflow, removed premature stage-2 deletion logic, added mandatory branch creation step, added PR step

### Verification

- [x] Pre-commit hooks passed (cargo machete, linter all, cargo test --doc --workspace)
- [x] Files moved with `git mv`
