### PR TITLE
chore: mark closed issues as completed and bump actions/checkout from v6 to v7

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup-buildx
         name: Setup Buildx
@@ -176,7 +176,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: meta
         name: Docker Meta
@@ -224,7 +224,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: meta
         name: Docker Meta

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm

--- a/.github/workflows/db-benchmarking.yaml
+++ b/.github/workflows/db-benchmarking.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -60,7 +60,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -90,7 +90,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/db-compatibility.yaml
+++ b/.github/workflows/db-compatibility.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -71,7 +71,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -42,7 +42,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install LLVM tools
         run: sudo apt-get update && sudo apt-get install -y llvm

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: sync
         name: Apply Labels from File

--- a/.github/workflows/os-compatibility.yaml
+++ b/.github/workflows/os-compatibility.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -104,7 +104,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain
@@ -140,7 +140,7 @@ jobs:
     steps:
       - id: checkout
         name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - id: setup
         name: Setup Toolchain

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -96,7 +96,7 @@ jobs:
           echo "override_commit=$(<commit_sha.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.parse_previous_artifacts.outputs.override_commit || '' }}
           path: repo_root

--- a/docs/issues/open/1924-1669-si-30-decouple-rest-api-core-from-udp-internals.md
+++ b/docs/issues/open/1924-1669-si-30-decouple-rest-api-core-from-udp-internals.md
@@ -1,12 +1,12 @@
 ---
 doc-type: spec
 issue-type: task
-status: open
+status: completed
 priority: p2
 epic: 1669
 github-issue: 1924
 spec-path: docs/issues/open/1924-1669-si-30-decouple-rest-api-core-from-udp-internals.md
-last-updated-utc: 2026-06-22
+last-updated-utc: 2026-06-23
 semantic-links:
   skill-links:
     - create-issue

--- a/docs/issues/open/1925-1669-si-31-configure-cargo-deny-for-layer-boundary-enforcement.md
+++ b/docs/issues/open/1925-1669-si-31-configure-cargo-deny-for-layer-boundary-enforcement.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: completed
 priority: p2
 github-issue: 1925
 spec-path: docs/issues/open/1925-1669-si-31-configure-cargo-deny-for-layer-boundary-enforcement.md
 branch: 1925-configure-cargo-deny-for-layer-boundary-enforcement
 related-pr: 1932
-last-updated-utc: 2026-06-22
+last-updated-utc: 2026-06-23
 semantic-links:
   skill-links:
     - create-issue


### PR DESCRIPTION
**Closed issue specs:**
- Updated frontmatter `status` from `open` → `completed` for issues #1924 (SI-30) and #1925 (SI-31)
- Updated `last-updated-utc` to 2026-06-23

**Dependabot PR #1920 follow-up:**
- Bumped `actions/checkout` from v6 to v7 across all 12 workflow files

**Pre-merge checks:**
- [x] `cargo machete --with-metadata` — pass
- [x] `cargo deny check bans` — pass
- [x] `linter all` — pass
- [x] `cargo test --doc --workspace` — pass
