### PR TITLE
docs(1640): add issue spec for per-instance Network config

### DIFF
--- a/docs/issues/drafts/1417-add-public-service-url-to-configuration.md
+++ b/docs/issues/drafts/1417-add-public-service-url-to-configuration.md
@@ -1,0 +1,109 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: draft
+priority: p3
+github-issue: 1417
+spec-path: docs/issues/drafts/1417-add-public-service-url-to-configuration.md
+branch: "1417-add-public-service-url"
+related-pr: null
+last-updated-utc: 2026-06-23 18:45
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1640-move-network-to-per-instance-config.md
+    - github torrust/torrust-tracker-deployer
+    - github torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
+    - packages/configuration/src/v2_0_0/http_tracker.rs
+    - packages/configuration/src/v2_0_0/udp_tracker.rs
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1417 - Include public service URL in configuration
+
+## Goal
+
+Add an optional `public_url` field to each tracker instance (`HttpTracker`, `UdpTracker`) and API service (`HttpApi`, `HealthCheckApi`) so the application knows the public-facing URL for each service regardless of network topology, reverse proxies, or TLS termination.
+
+## Background
+
+The tracker configuration only specifies the **bind address** (the local IP:port where the service listens):
+
+```toml
+[[http_trackers]]
+bind_address = "0.0.0.0:7070"
+```
+
+The application has no way to know the **public URL** clients use to reach each service. This matters when:
+
+- The tracker runs behind a reverse proxy (Caddy, nginx) with TLS termination
+- Multiple tracker instances share the same IP but serve different domains
+- Metrics should be broken down by public URL, domain, or protocol
+
+For example, the [Torrust Tracker Deployer](https://github.com/torrust/torrust-tracker-deployer) already defines per-tracker `domain` and `use_tls_proxy` fields in its environment configs ([example](https://github.com/torrust/torrust-tracker-deployer/blob/main/docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json)), but these are deployer-internal and not propagated to the tracker itself.
+
+### Use cases
+
+1. **Metrics labels**: Prometheus metrics could include a `public_url` label to separate data per domain or protocol.
+2. **Logging**: Log entries could record which public URL served a request.
+3. **API discovery**: The health check endpoint could advertise service URLs.
+4. **Notifications**: Service notifications could reference the correct public URL.
+
+## Scope
+
+### In Scope
+
+- Add optional `public_url: Option<String>` field to `HttpTracker`, `UdpTracker`, `HttpApi`, and `HealthCheckApi`
+- Use a **single URL string** (e.g. `"https://tracker1.example.com/announce"`) — not decomposed into domain/path components, since consumers can parse those as needed
+- The URL protocol (`https://`) provides TLS status; the domain is extracted by consumers
+- Document the field in default config examples
+- No runtime behaviour change — the field is stored in config and available for use by consumers (metrics, logging, etc.)
+
+### Out of Scope
+
+- Adding runtime support for the URL in metrics/logging/API (separate issues)
+- URL validation beyond basic format checks
+- Changing the deployer's internal config format
+
+### Follow-up: Metrics Labels
+
+A follow-up issue would use the `public_url` field to add new labels to Prometheus metrics. The **domain** (parsed from the URL) is the most useful label, since:
+
+- Protocol is already captured in existing metrics labels.
+- The full URL would duplicate the information already available via the bind address socket label (each tracker instance has a unique bind address, so `url` and `bind_address` would always be 1:1).
+- A `domain` label, on the other hand, enables aggregation across tracker instances sharing the same domain behind different ports or protocols.
+
+No changes are needed in this issue — the field just needs to be present in the config for consumers to use.
+
+## Design Decisions
+
+**Single URL string vs decomposed fields**: The field is a single URL string. Consumers parse protocol, domain, and path as needed. This is the simplest user-facing form and avoids duplicating the deployer's `domain` + `use_tls_proxy` approach.
+
+**Where the field lives**: This field is about **public exposure** (how users reach the service), not **network topology** (how the service connects). It could stay flat on the config struct or join a `Network` block depending on future architecture decisions. For now, keep it flat — issue #1640 establishes the `Network` block, and this field can be placed accordingly.
+
+## Implementation Plan
+
+| ID  | Status | Task                                                        | Notes          |
+| --- | ------ | ----------------------------------------------------------- | -------------- |
+| T1  | TODO   | Add `public_url: Option<String>` to `HttpTracker` config    | Default `None` |
+| T2  | TODO   | Add `public_url: Option<String>` to `UdpTracker` config     | Default `None` |
+| T3  | TODO   | Add `public_url: Option<String>` to `HttpApi` config        | Default `None` |
+| T4  | TODO   | Add `public_url: Option<String>` to `HealthCheckApi` config | Default `None` |
+| T5  | TODO   | Document field in default config examples and crate docs    |                |
+| T6  | TODO   | Run `linter all` and tests                                  |                |
+
+## Progress Tracking
+
+### Progress Log
+
+- 2026-06-23 18:45 UTC - Copilot - Drafted from GitHub issue #1417 and discussions in issue #1640 spec review.
+
+## Acceptance Criteria
+
+- [ ] AC1: All config structs gain `public_url: Option<String>` field
+- [ ] AC2: Default config examples include the new field (commented or shown)
+- [ ] AC3: No runtime behaviour change — field is present for consumer use
+- [ ] `linter all` exits with code `0`
+- [ ] Relevant tests pass

--- a/docs/issues/drafts/1417-add-public-service-url-to-configuration.md
+++ b/docs/issues/drafts/1417-add-public-service-url-to-configuration.md
@@ -12,9 +12,9 @@ semantic-links:
   skill-links:
     - create-issue
   related-artifacts:
-    - docs/issues/open/1640-move-network-to-per-instance-config.md
-    - github torrust/torrust-tracker-deployer
-    - github torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
+    - issue #1640
+    - issue torrust/torrust-tracker-deployer
+    - issue torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
     - packages/configuration/src/v2_0_0/http_tracker.rs
     - packages/configuration/src/v2_0_0/udp_tracker.rs
 ---

--- a/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
+++ b/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
@@ -46,7 +46,6 @@ semantic-links:
     - src/lib.rs
     - share/default/config/
     - docs/containers.md
-    - issue #1417
 ---
 
 <!-- skill-link: create-issue -->

--- a/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
+++ b/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
@@ -1,0 +1,555 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: open
+priority: p2
+github-issue: 1640
+spec-path: docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
+branch: "1640-move-network-to-per-instance-config"
+related-pr: null
+last-updated-utc: 2026-06-23 18:30
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/adrs/20260617093046_reject_wildcard_external_ip.md
+    - github issues/1417 (public service URL)
+    - github issues/1671 (IPv4/IPv6 client metrics)
+    - github torrust/torrust-tracker-deployer
+    - github torrust/torrust-tracker-deployer pull/273
+    - github torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
+    - packages/configuration/src/v2_0_0/http_tracker.rs
+    - packages/configuration/src/v2_0_0/udp_tracker.rs
+    - packages/configuration/src/v2_0_0/network.rs
+    - packages/configuration/src/v2_0_0/core.rs
+    - packages/tracker-core/src/announce_handler.rs
+    - packages/tracker-core/src/lib.rs
+    - packages/http-core/src/container.rs
+    - packages/http-core/src/services/announce.rs
+    - packages/http-core/src/services/scrape.rs
+    - packages/http-core/benches/helpers/sync.rs
+    - packages/http-protocol/src/v1/services/peer_ip_resolver.rs
+    - packages/axum-http-server/src/v1/routes.rs
+    - packages/axum-http-server/src/v1/handlers/announce.rs
+    - packages/axum-http-server/src/v1/handlers/scrape.rs
+    - packages/axum-http-server/src/server.rs
+    - packages/axum-http-server/src/testing/environment.rs
+    - packages/axum-http-server/examples/http_only_public_tracker.rs
+    - packages/axum-rest-api-server/src/testing/environment.rs
+    - packages/udp-core/src/services/announce.rs
+    - packages/udp-server/src/server/launcher.rs
+    - packages/udp-server/src/handlers/announce.rs
+    - packages/udp-server/src/handlers/mod.rs
+    - packages/test-helpers/src/configuration.rs
+    - src/container.rs
+    - src/bootstrap/jobs/http_tracker.rs
+    - src/lib.rs
+    - share/default/config/
+    - docs/containers.md
+    - docs/issues/1417
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1640 - Move `on_reverse_proxy` to per-tracker config (and relocate `Network`)
+
+## Goal
+
+Give each tracker instance (`HttpTracker` and `UdpTracker`) its own `Network` config block containing `external_ip`, `on_reverse_proxy`, and `ipv6_v6only`. Remove the shared `[core.net]` section and make the domain-layer `AnnounceHandler` accept `external_ip` as a per-call parameter.
+
+**End state**: Every tracker instance has its own networking config — socket behaviour, proxy awareness, and peer-IP replacement are all per-instance concerns. The shared `Core` only holds truly cross-cutting settings (database, policy, private mode).
+
+## Background
+
+The issue was originally opened to allow per-HTTP-tracker `on_reverse_proxy` settings. During analysis we discovered a broader architectural problem: the entire `Network` struct (`external_ip`, `on_reverse_proxy`, `ipv6_v6only`) lived in `[core.net]` as a **global singleton** shared by all tracker instances. This caused three separate issues:
+
+| Current field      | Currently in                                | Problem                                                  |
+| ------------------ | ------------------------------------------- | -------------------------------------------------------- |
+| `on_reverse_proxy` | `core.net` (global)                         | HTTP proxy config shouldn't be global — servers differ   |
+| `external_ip`      | `core.net` (global)                         | Each tracker instance may have its own public IP         |
+| `ipv6_v6only`      | `HttpTracker` / `UdpTracker` (per-instance) | Correct placement, but field is duplicated in both types |
+
+**Final design**: `Network` becomes a per-instance struct placed inside `HttpTracker` and `UdpTracker`:
+
+```toml
+# BEFORE: Global shared config
+[core.net]
+external_ip = "203.0.113.5"
+on_reverse_proxy = true
+
+[[http_trackers]]
+bind_address = "0.0.0.0:7070"
+ipv6_v6only = false          # field directly in HttpTracker
+
+[[udp_trackers]]
+bind_address = "0.0.0.0:6969"
+ipv6_v6only = true           # field directly in UdpTracker
+
+# AFTER: Per-instance networking config
+[[http_trackers]]
+bind_address = "0.0.0.0:7070"
+
+[http_trackers.net]
+external_ip = "203.0.113.5"
+on_reverse_proxy = true
+ipv6_v6only = false
+
+[[udp_trackers]]
+bind_address = "0.0.0.0:6969"
+
+[udp_trackers.net]
+external_ip = "2001:db8::1"
+on_reverse_proxy = false
+ipv6_v6only = true
+```
+
+The JSON form makes the per-instance structure clearer:
+
+```json
+{
+  "http_trackers": [
+    {
+      "bind_address": "0.0.0.0:7070",
+      "net": {
+        "external_ip": "203.0.113.5",
+        "on_reverse_proxy": true,
+        "ipv6_v6only": false
+      }
+    }
+  ],
+  "udp_trackers": [
+    {
+      "bind_address": "0.0.0.0:6969",
+      "net": {
+        "external_ip": "2001:db8::1",
+        "on_reverse_proxy": false,
+        "ipv6_v6only": true
+      }
+    }
+  ]
+}
+```
+
+### Why `external_ip` moves too
+
+The `external_ip` is consumed by `AnnounceHandler::handle_announcement()` in `tracker-core`. It replaces loopback IPs with the tracker's public IP. If you have two tracker instances on different network interfaces with different public IPs, they need different `external_ip` values. The current global setting cannot express that.
+
+Making `external_ip` per-instance requires passing it as a parameter to `handle_announcement()` instead of having the handler read it from `self.config` — this is architecturally correct: the handler shouldn't know about the server's network topology.
+
+### Why `ipv6_v6only` moves into `Network`
+
+`ipv6_v6only` controls how the OS socket handles IPv4-mapped IPv6 addresses. It is a **networking concern**, not a tracker-protocol concern. Grouping it with `external_ip` and `on_reverse_proxy` inside a per-instance `Network` block is more coherent than having it as a flat field in `HttpTracker`/`UdpTracker`.
+
+## Final Architecture
+
+```rust
+// Per-instance network config — placed inside HttpTracker and UdpTracker
+pub struct Network {
+    pub external_ip: Option<ExternalIp>,
+    pub on_reverse_proxy: bool,
+    pub ipv6_v6only: bool,
+}
+
+// Server-layer config for each HTTP tracker
+pub struct HttpTracker {
+    pub bind_address: SocketAddr,
+    pub tsl_config: Option<TslConfig>,
+    pub tracker_usage_statistics: bool,
+    pub net: Network,                    // ← replaces individual fields
+    // ipv6_v6only REMOVED — now inside net
+}
+
+// Server-layer config for each UDP tracker
+pub struct UdpTracker {
+    pub bind_address: SocketAddr,
+    pub cookie_lifetime: Duration,
+    pub tracker_usage_statistics: bool,
+    pub max_connection_id_errors_per_ip: u32,
+    pub net: Network,                    // ← replaces individual fields
+    // ipv6_v6only REMOVED — now inside net
+}
+
+// Core — no longer has a net field
+pub struct Core {
+    pub announce_policy: AnnouncePolicy,
+    pub database: Database,
+    pub inactive_peer_cleanup_interval: u64,
+    pub listed: bool,
+    // net: Network REMOVED
+    pub private: bool,
+    pub private_mode: Option<PrivateMode>,
+    pub tracker_policy: TrackerPolicy,
+    pub tracker_usage_statistics: bool,
+}
+```
+
+### Design Note: `bind_address` stays flat (not inside `net`)
+
+We considered moving `bind_address` into `Network` since it is a networking concern. We decided to keep it flat for two reasons:
+
+1. **Primary key role**: `bind_address` is the HashMap key for tracker instance containers in `AppContainer` (`HashMap<SocketAddr, Arc<HttpTrackerCoreContainer>>`). Nesting it inside `net` would make lookup more cumbersome without benefit.
+2. **TLS asymmetry**: `tsl_config` (TLS certificate paths) cannot go into `Network`. Keeping `bind_address` and `tsl_config` at the same level while `on_reverse_proxy`, `external_ip`, and `ipv6_v6only` group into `net` creates a cleaner boundary between _socket binding_ (flat) and _socket behaviour / network identity_ (grouped).
+
+### Compatibility with Existing ADRs
+
+| ADR                                               | Impact                                                                                                                                                                                                  | Status                                                                                             |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `20260617093046` (reject wildcard `external_ip`)  | `ExternalIp` newtype unchanged. `external_ip` moves location (from `core.net` to `http_trackers[].net`). The `Network` struct with its `ExternalIp` field stays in `network.rs` as a shared definition. | ✅ Compatible. ADR says "no schema change" — needs updating since this issue changes the location. |
+| `20260620000000` (add `ipv6_v6only` option)       | Field moves from flat `HttpTracker.ipv6_v6only` / `UdpTracker.ipv6_v6only` to `HttpTracker.net.ipv6_v6only` / `UdpTracker.net.ipv6_v6only`. Default (`false`) and behaviour unchanged.                  | ✅ Compatible. ADR needs updating to reflect new field path.                                       |
+| `20260527175600` (keep protocol/domain decoupled) | Not directly related — this issue touches configuration types and service-layer code, not protocol types.                                                                                               | ✅ No impact.                                                                                      |
+
+### User-Facing Migration Note
+
+This is a **breaking configuration change**. Users upgrading to the new tracker version (4.0.0) must update their `tracker.toml`:
+
+**Before:**
+
+```toml
+[core.net]
+external_ip = "203.0.113.5"
+on_reverse_proxy = true
+
+[[http_trackers]]
+bind_address = "0.0.0.0:7070"
+ipv6_v6only = false
+```
+
+**After:**
+
+```toml
+[[http_trackers]]
+bind_address = "0.0.0.0:7070"
+
+[http_trackers.net]
+external_ip = "203.0.113.5"
+on_reverse_proxy = true
+ipv6_v6only = false
+```
+
+The old `[core.net]` section is no longer valid. Each tracker instance must have its own `net` block. The `external_ip` and `on_reverse_proxy` values must be moved into each `[[http_trackers]].net` (and/or `[[udp_trackers]].net`) block. Leaving them out means `false` / `None` defaults apply.
+
+### Future Extensions (not implemented in this issue)
+
+The per-instance `Network` block is a natural home for additional per-tracker networking fields in future issues. Relevant candidates from related work:
+
+#### From the [Torrust Tracker Deployer](https://github.com/torrust/torrust-tracker-deployer)
+
+The deployer's environment configs (e.g. [02-full-stack-lxd.json](https://github.com/torrust/torrust-tracker-deployer/blob/main/docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json)) already include per-tracker metadata that the tracker configuration does not yet support:
+
+```json
+{
+  "http_trackers": [
+    {
+      "bind_address": "0.0.0.0:7070",
+      "domain": "tracker1.example.com",
+      "use_tls_proxy": true
+    },
+    {
+      "bind_address": "0.0.0.0:7071",
+      "domain": "tracker2.example.com",
+      "use_tls_proxy": true
+    }
+  ]
+}
+```
+
+These fields (`domain`, `use_tls_proxy`) describe how each tracker instance is exposed to the public internet — a networking concern that fits naturally into per-instance config.
+
+> **Note on TLS vs reverse proxy**: There are two independent TLS configurations:
+>
+> - `tsl_config` on `HttpTracker` — the tracker terminates TLS **directly** (clients connect via HTTPS directly to the tracker). No proxy involved.
+> - `use_tls_proxy` in the deployer — TLS is terminated at a **reverse proxy** (Caddy, nginx) before forwarding plain HTTP to the tracker.
+>
+> Both are orthogonal to `on_reverse_proxy` (trusting `X-Forwarded-For` headers). You can have:
+>
+> - Direct HTTPS tracker (`tsl_config` set) with or without trusting proxy headers
+> - Tracker behind a TLS proxy (`use_tls_proxy`) with `on_reverse_proxy = true` (common case)
+> - Tracker behind a plain HTTP proxy (no TLS) with `on_reverse_proxy = true`
+> - Tracker directly exposed via plain HTTP without any proxy
+>
+> This issue only addresses `on_reverse_proxy`; TLS configuration remains a separate concern.
+
+#### From Issue #1417 — Public Service URL
+
+Issue [#1417](https://github.com/torrust/torrust-tracker/issues/1417) proposes adding a `public_url` field to each tracker instance:
+
+```toml
+[[http_trackers]]
+public_url = "https://tracker.torrust-demo.com/announce"
+bind_address = "0.0.0.0:7070"
+```
+
+This would allow the tracker to emit the correct public URL in metrics, logs, and API responses, regardless of whether it runs behind a reverse proxy. This is also a per-instance networking concern.
+
+**Decision for #1417**: Store the full URL as a single string (`public_url = "https://tracker1.example.com/announce"`). Consumers can parse out the protocol (→ TLS status), domain, and path segment as needed — no need to decompose the config field. In fact `public_url` subsumes the deployer's `domain` + `use_tls_proxy` approach entirely: the protocol tells us if TLS is used, and the domain is extracted from the URL. The tracker config should use the simplest user-facing form.
+
+#### How these would compose
+
+A future expanded `Network` block could look like:
+
+```json
+{
+  "http_trackers": [
+    {
+      "bind_address": "0.0.0.0:7070",
+      "net": {
+        "external_ip": "203.0.113.5",
+        "on_reverse_proxy": true,
+        "ipv6_v6only": false,
+        "public_url": "https://tracker1.example.com/announce"
+      }
+    }
+  ]
+}
+```
+
+(`public_url` subsumes `domain` and `use_tls_proxy` — the URL's protocol tells us if TLS is used, and the domain is extracted from the URL. The deployer's separate fields are a deployer-internal concern.)
+
+Or these could remain as flat fields on `HttpTracker`/`UdpTracker` depending on how they are consumed. The important thing is that the config structure supports per-instance values — which this issue establishes.
+
+### Full future config types (this issue + proposed extensions)
+
+Below is how the full types would look after this issue's changes plus the proposed future fields (from deployer and #1417). Fields marked `†` are implemented in this issue; fields marked `*` are proposals for future issues.
+
+```rust
+/// Per-instance network topology config.
+/// Grouped because these fields together define how the tracker instance
+/// connects to the network — the external identity, proxy awareness, and
+/// socket behaviour.
+pub struct Network {                              // † this issue
+    pub external_ip: Option<ExternalIp>,          // † from core.net
+    pub on_reverse_proxy: bool,                   // † from core.net
+    pub ipv6_v6only: bool,                        // † from flat field
+}
+
+/// Server-layer config for each HTTP tracker.
+pub struct HttpTracker {
+    // Socket binding — how the OS binds the listener
+    pub bind_address: SocketAddr,
+    pub tsl_config: Option<TslConfig>,            // direct TLS (tracker terminates)
+
+    // Instance metadata
+    pub tracker_usage_statistics: bool,
+
+    // Network topology (grouped)
+    pub net: Network,                              // † new
+
+    // Future extensions (proposed, not in this issue):
+    // pub public_url: Option<String>,             // * #1417 — full URL for metrics/logs. Subsumes domain + TLS detection via URL parsing.
+}
+
+/// Server-layer config for each UDP tracker.
+pub struct UdpTracker {
+    pub bind_address: SocketAddr,
+    pub cookie_lifetime: Duration,
+    pub tracker_usage_statistics: bool,
+    pub max_connection_id_errors_per_ip: u32,
+
+    // Network topology (grouped)
+    pub net: Network,                              // † new
+
+    // Future extensions (proposed, not in this issue):
+    // pub public_url: Option<String>,             // * #1417
+}
+
+/// Core — no longer has any networking config.
+pub struct Core {
+    pub announce_policy: AnnouncePolicy,
+    pub database: Database,
+    pub inactive_peer_cleanup_interval: u64,
+    pub listed: bool,
+    // net: Network REMOVED                         †
+    pub private: bool,
+    pub private_mode: Option<PrivateMode>,
+    pub tracker_policy: TrackerPolicy,
+    pub tracker_usage_statistics: bool,
+}
+```
+
+**Rationale for grouping `external_ip` + `on_reverse_proxy` + `ipv6_v6only`**:
+
+These three fields define how the tracker instance is seen on the network and how it behaves at the socket/protocol level:
+
+- `external_ip`: the public IP identity
+- `on_reverse_proxy`: whether the instance trusts proxy headers
+- `ipv6_v6only`: whether the socket accepts dual-stack or IPv6-only
+
+Future fields like `public_url` is about **public exposure** (how users reach the tracker) rather than **network topology** (how the tracker connects). It could stay flat or join `Network` depending on how it is consumed. The boundary is deliberately flexible — `Network` is not a fixed category but a pragmatic grouping of related concerns.
+
+The `AnnounceHandler` in `tracker-core` stops reading from `self.config.net.external_ip` and instead accepts it as a parameter:
+
+```rust
+pub async fn handle_announcement(
+    &self,
+    info_hash: &InfoHash,
+    peer: &mut peer::Peer,
+    remote_client_ip: &IpAddr,
+    peers_wanted: &PeersWanted,
+    tracker_external_ip: Option<IpAddr>,  // NEW: passed in from caller
+) -> Result<AnnounceData, AnnounceError> {
+    ...
+    peer.change_ip(&assign_ip_address_to_peer(remote_client_ip, tracker_external_ip));
+    ...
+}
+```
+
+## Scope
+
+### In Scope (all phases)
+
+- Add `Network` (with `external_ip`, `on_reverse_proxy`, `ipv6_v6only`) as per-instance field in both `HttpTracker` and `UdpTracker`
+- Remove `Network` from `Core` (remove `core.net` entirely)
+- Modify `AnnounceHandler::handle_announcement()` to accept `external_ip` per-call instead of reading from global config
+- Update all callers of `handle_announcement()` (HTTP services, UDP services, tests) to pass per-instance `external_ip`
+- Update all consumers of `ipv6_v6only` to read from `HttpTracker.net` / `UdpTracker.net` instead of flat struct fields
+- Remove deprecated flat `ipv6_v6only` fields from `HttpTracker` and `UdpTracker`
+- Update test helpers, default config TOML files, integration tests, docs, and doc comments
+- Write ADR for the architecture decision
+
+### Out of Scope
+
+- TOML config migration tooling
+
+## Approach B — Per-instance services (chosen)
+
+For the `on_reverse_proxy` threading, we use **Approach B** (as analysed earlier): each `HttpTrackerCoreContainer` creates per-instance `AnnounceService` and `ScrapeService` storing their own `ReverseProxyMode`. This avoids extending Axum state tuples and keeps handler signatures stable. The full analysis is preserved below in the appendix.
+
+## Implementation Strategy: Baby Steps + Parallel Changes + Draft PR
+
+**Key principles**:
+
+1. **Baby steps**: Each commit is a small, verifiable change
+2. **Parallel changes**: Introduce new code paths alongside old ones before deleting the old ones
+3. **Draft PR**: Open early and keep updated after each commit, running CI checks continuously
+
+### Phase 0 — ADR
+
+Write the Architectural Decision Record documenting:
+
+- Why `Network` moves from global `core.net` to per-instance configs
+- Why `external_ip` becomes a parameter of `handle_announcement()`
+- Why `ipv6_v6only` joins `Network`
+
+### Phase 1 — Add `net: Network` to `HttpTracker` and `UdpTracker` (parallel add)
+
+Add the new `net: Network` field to both tracker config structs. Keep the old fields (`core.net`, flat `ipv6_v6only`) for now. `Network` gains `ipv6_v6only`.
+
+Default for `Network`:
+
+```rust
+Network {
+    external_ip: None,
+    on_reverse_proxy: false,
+    ipv6_v6only: false,
+}
+```
+
+**Verification**: Config deserialization still works with both old and new formats. All existing tests pass unchanged.
+
+### Phase 2 — Modify `AnnounceHandler::handle_announcement()` to accept `external_ip`
+
+Add `tracker_external_ip: Option<IpAddr>` parameter to `handle_announcement()`. The callers temporarily pass `self.config.net.external_ip.map(Into::into)` (still reading from the old global for now).
+
+**Verification**: All `handle_announcement()` call sites compile. No behaviour change.
+
+### Phase 3 — Switch consumers to the new per-instance configs
+
+This is the largest phase, split into sub-tasks (each committed and CI-verified independently):
+
+#### 3a. `on_reverse_proxy`
+
+- `test-helpers`: Set per-tracker `on_reverse_proxy` in `HttpTracker` instead of `core.net`
+- `http-core/services/announce.rs` + `scrape.rs`: Read from per-instance `ReverseProxyMode` (Approach B)
+- `HttpTrackerCoreServices` + `HttpTrackerCoreContainer`: Create per-instance services
+- `src/container.rs`: Flow per-instance mode through `AppContainer`
+- Unit/integration tests: Update all references to per-tracker
+
+#### 3b. `ipv6_v6only`
+
+- `HttpTracker` consumers (`server.rs`, `environment.rs`, `bootstrap/jobs/http_tracker.rs`, contract tests): Read from `http_tracker_config.net.ipv6_v6only`
+- `UdpTracker` consumers (`launcher.rs`, contract tests): Read from `udp_tracker_config.net.ipv6_v6only`
+
+#### 3c. `external_ip`
+
+- `udp-server` tests: Pass per-tracker `external_ip` to `handle_announcement()` (now available from `udp_tracker_config.net.external_ip`)
+- `http-core` tests: Pass per-tracker `external_ip` to `handle_announcement()` (now available from `http_tracker_config.net.external_ip`)
+- `axum-http-server` contract tests: Same
+
+### Phase 4 — Remove deprecated fields
+
+- Delete `core.net` from `Core` struct. Keep `network.rs` with both `Network` and `ExternalIp` — both `HttpTracker` and `UdpTracker` import `Network` from there (single definition, no duplication).
+- Delete flat `ipv6_v6only` fields from `HttpTracker` and `UdpTracker`
+- Delete `get_ext_ip()` from `Configuration` (no longer needed — each instance has its own `external_ip`)
+- Update default TOML files to use the new format
+- Update all doc comments and crate-level docs
+- Update `docs/containers.md`
+
+### Phase 5 — Final verification
+
+- `linter all`
+- Full test suite
+- Manual verification of mixed proxy/non-proxy scenarios
+- Close the draft PR and open the final PR
+
+## Implementation Plan
+
+**Chosen approach**: **Approach B** (per-instance services with `reverse_proxy_mode` field) for `on_reverse_proxy` threading.
+
+| ID  | Phase | Status | Task                                                                      | Notes                                                                                                 |
+| --- | ----- | ------ | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| T0  | 0     | TODO   | Write ADR                                                                 | Record: move `Network` to per-instance, parameterize `external_ip`, join `ipv6_v6only` into `Network` |
+| T1  | 1     | TODO   | Add `net: Network` (with `ipv6_v6only`) to `HttpTracker` and `UdpTracker` | Parallel add — old fields kept. Default `ipv6_v6only = false`                                         |
+| T2  | 2     | TODO   | Add `tracker_external_ip` param to `handle_announcement()`                | Callers pass old global value temporarily                                                             |
+| T3a | 3a    | TODO   | Switch `on_reverse_proxy` consumers to per-instance                       | Approach B: per-instance services with `ReverseProxyMode`                                             |
+| T3b | 3b    | TODO   | Switch `ipv6_v6only` consumers to `net.ipv6_v6only`                       | HTTP + UDP server launchers, tests                                                                    |
+| T3c | 3c    | TODO   | Switch `external_ip` consumers                                            | All callers of `handle_announcement()` pass per-instance value                                        |
+| T4  | 4     | TODO   | Remove deprecated fields                                                  | `core.net`, flat `ipv6_v6only`, `get_ext_ip()`                                                        |
+| T5  | 4     | TODO   | Update default config TOML files                                          | 6 files in `share/default/config/`                                                                    |
+| T6  | 4     | TODO   | Update docs and doc comments                                              | `mod.rs`, `lib.rs`, `containers.md`, `tracker-core/lib.rs`, `extractors/client_ip_sources.rs`         |
+| T7  | 5     | TODO   | Run `linter all` and full test suite                                      |                                                                                                       |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [ ] Spec drafted in `docs/issues/open/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Phase 0: ADR created
+- [ ] Phase 1: `net: Network` added to `HttpTracker` and `UdpTracker` (parallel with old fields)
+- [ ] Phase 2: `handle_announcement()` accepts `tracker_external_ip` param
+- [ ] Phase 3a: `on_reverse_proxy` consumers switched to per-instance
+- [ ] Phase 3b: `ipv6_v6only` consumers switched to `net.ipv6_v6only`
+- [ ] Phase 3c: `external_ip` consumers switched to per-instance
+- [ ] Phase 4: Deprecated fields removed (`core.net`, flat `ipv6_v6only`)
+- [ ] Phase 5: Final verification completed (`linter all`, full test suite)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/closed/`
+
+### Progress Log
+
+Append one line per meaningful update.
+
+- 2026-06-23 00:00 UTC - Copilot - Spec drafted from issue #1640
+- 2026-06-23 14:00 UTC - Copilot - Added design decision analysis (Approach A vs B) after maintainer review
+- 2026-06-23 14:30 UTC - Copilot - Updated spec: remove global `[core.net].on_reverse_proxy`, move to per-tracker `HttpTracker.on_reverse_proxy: bool`. Added ADR task T1.
+- 2026-06-23 16:00 UTC - Copilot - Rewrote spec with full architectural vision: per-instance `Network` for all three fields, phased implementation with baby steps + draft PR.
+- 2026-06-23 17:45 UTC - Copilot - Added design note on `bind_address` staying flat, future extensions section (`domain`, `use_tls_proxy`, `public_url`) referencing deployer and issue #1417.
+- 2026-06-23 18:30 UTC - Copilot - Completed deep review against ADRs 20260617093046, 20260620000000, 20260527175600 and issues #1417, #1671. Added compatibility table and migration note.
+
+## Acceptance Criteria
+
+- [ ] AC1: `on_reverse_proxy` is removed from `[core.net]` and placed per-instance in `HttpTracker.net.on_reverse_proxy` (and `UdpTracker.net.on_reverse_proxy` for future UDP proxy use)
+- [ ] AC2: `external_ip` is removed from `[core.net]` and placed per-instance in `HttpTracker.net.external_ip` and `UdpTracker.net.external_ip`
+- [ ] AC3: `ipv6_v6only` is moved from flat `HttpTracker.ipv6_v6only` and `UdpTracker.ipv6_v6only` into `HttpTracker.net` / `UdpTracker.net`
+- [ ] AC4: `Core.net` (the `Network` struct) is removed from `Core`
+- [ ] AC5: `AnnounceHandler::handle_announcement()` accepts `tracker_external_ip` per-call instead of reading from global config
+- [ ] AC6: Two HTTP trackers with different `on_reverse_proxy` settings behave independently: - Tracker A (`on_reverse_proxy = true`) reads `X-Forwarded-For` headers - Tracker B (`on_reverse_proxy = false` or unset) reads connection info IP
+- [ ] AC7: Example `http_only_public_tracker.rs` builds with the new `HttpTracker::net::on_reverse_proxy` field
+- [ ] AC8: All default config files and docs use the new format
+- [ ] `linter all` exits with code `0`
+- [ ] Relevant tests pass
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior

--- a/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
+++ b/docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
@@ -13,11 +13,11 @@ semantic-links:
     - create-issue
   related-artifacts:
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
-    - github issues/1417 (public service URL)
-    - github issues/1671 (IPv4/IPv6 client metrics)
-    - github torrust/torrust-tracker-deployer
-    - github torrust/torrust-tracker-deployer pull/273
-    - github torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
+    - issue #1417
+    - issue #1671
+    - issue torrust/torrust-tracker-deployer
+    - issue torrust/torrust-tracker-deployer pull/273
+    - issue torrust/torrust-tracker-deployer docs/ai-training/dataset/environment-configs/02-full-stack-lxd.json
     - packages/configuration/src/v2_0_0/http_tracker.rs
     - packages/configuration/src/v2_0_0/udp_tracker.rs
     - packages/configuration/src/v2_0_0/network.rs
@@ -46,7 +46,7 @@ semantic-links:
     - src/lib.rs
     - share/default/config/
     - docs/containers.md
-    - docs/issues/1417
+    - issue #1417
 ---
 
 <!-- skill-link: create-issue -->
@@ -547,7 +547,7 @@ Append one line per meaningful update.
 - [ ] AC4: `Core.net` (the `Network` struct) is removed from `Core`
 - [ ] AC5: `AnnounceHandler::handle_announcement()` accepts `tracker_external_ip` per-call instead of reading from global config
 - [ ] AC6: Two HTTP trackers with different `on_reverse_proxy` settings behave independently: - Tracker A (`on_reverse_proxy = true`) reads `X-Forwarded-For` headers - Tracker B (`on_reverse_proxy = false` or unset) reads connection info IP
-- [ ] AC7: Example `http_only_public_tracker.rs` builds with the new `HttpTracker::net::on_reverse_proxy` field
+- [ ] AC7: Example `http_only_public_tracker.rs` builds with the new `HttpTracker.net.on_reverse_proxy` field
 - [ ] AC8: All default config files and docs use the new format
 - [ ] `linter all` exits with code `0`
 - [ ] Relevant tests pass

--- a/project-words.txt
+++ b/project-words.txt
@@ -11,6 +11,7 @@ alekitto
 alives
 alloca
 analyse
+analysed
 appuser
 argjson
 artefacts


### PR DESCRIPTION
## Summary

This PR adds issue spec files for two related enhancements:

### Issue #1640 — Per-instance Network config

Full spec at `docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md`

Moves `on_reverse_proxy`, `external_ip`, and `ipv6_v6only` from the global `[core.net]` singleton into per-instance `Network` blocks inside `HttpTracker` and `UdpTracker`. Also makes `AnnounceHandler::handle_announcement()` accept `external_ip` as a per-call parameter.

Key decisions documented in the spec:
- **No global fallback** — `[core.net]` is removed entirely
- **Approach B** — per-instance `AnnounceService`/`ScrapeService` with `ReverseProxyMode` field
- **`bind_address` stays flat** — not inside `Network` (it's a HashMap key)
- **`public_url`** — a single URL string, not decomposed (decision for issue #1417)
- Compatibility analysis with existing ADRs and migration note
- Phased implementation plan (baby steps + parallel changes + draft PR)

### Issue #1417 — Public Service URL (draft)

Draft spec at `docs/issues/drafts/1417-add-public-service-url-to-configuration.md`

Proposes adding `public_url: Option<String>` to all tracker and API configs for use in metrics, logging, and API discovery.

## Status

- [ ] Spec file for #1640 reviewed and approved
- [ ] Draft spec for #1417 reviewed and approved
- [ ] Both specs accepted → implementation can begin