### PR TITLE
docs: add star history chart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ _We kindly ask you to take time and consider The Torrust Project [Contributor Ag
 
 This project was a joint effort by [Nautilus Cyberneering GmbH][nautilus] and [Dutch Bits]. Also thanks to [Naim A.] and [greatest-ape] for some parts of the code. Further added features and functions thanks to [Power2All].
 
+## Star History
+
+<a href="https://star-history.com/#torrust/torrust-tracker&Date" rel="nofollow noreferrer noopener" target="_blank">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date" />
+  </picture>
+</a>
+
 [container_wf]: ../../actions/workflows/container.yaml
 [container_wf_b]: ../../actions/workflows/container.yaml/badge.svg
 [coverage_wf]: ../../actions/workflows/coverage.yaml

--- a/README.md
+++ b/README.md
@@ -246,11 +246,11 @@ This project was a joint effort by [Nautilus Cyberneering GmbH][nautilus] and [D
 
 ## Star History
 
-<a href="https://star-history.com/#torrust/torrust-tracker&Date" rel="nofollow noreferrer noopener" target="_blank">
+<a href="https://www.star-history.com/?repos=torrust%2Ftorrust-tracker&type=date&logscale=&legend=top-left" rel="nofollow noreferrer noopener" target="_blank">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=torrust/torrust-tracker&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
Add a Star History chart to the README that visualizes the repository's star count over time.

Closes #1951