### PR TITLE
docs(issues): add issue specs for #1964, #1965 (SI-34), and #1966 (SI-35)

### DIFF
--- a/.github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+++ b/.github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
@@ -174,7 +174,7 @@ Both are integrated into this workflow automatically.
 
 ## Example
 
-See `docs/pr-reviews/pr-1733-copilot-suggestions.md` for a complete worked example
+See `docs/pr-reviews/EXAMPLE-COMPLETED.md` for a complete worked example
 with all 26 Copilot suggestions processed, decided, and resolved.
 
 ## Completion Checklist

--- a/docs/issues/open/1964-rename-number-of-downloads-btree-map-type-alias.md
+++ b/docs/issues/open/1964-rename-number-of-downloads-btree-map-type-alias.md
@@ -1,0 +1,159 @@
+---
+doc-type: issue
+issue-type: task
+status: planned
+priority: p2
+github-issue: 1964
+spec-path: docs/issues/open/1964-rename-number-of-downloads-btree-map-type-alias.md
+branch: "1964-rename-number-of-downloads-btree-map"
+related-pr: null
+last-updated-utc: 2026-06-30 12:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - packages/primitives/src/lib.rs
+    - packages/tracker-core/src/databases/traits/torrent_metrics.rs
+    - packages/tracker-core/src/databases/driver/sqlite/torrent_metrics_store.rs
+    - packages/tracker-core/src/databases/driver/mysql/torrent_metrics_store.rs
+    - packages/tracker-core/src/databases/driver/postgres/torrent_metrics_store.rs
+    - packages/tracker-core/src/statistics/persisted/downloads.rs
+    - packages/tracker-core/src/torrent/repository/in_memory.rs
+    - packages/tracker-core/src/torrent/manager.rs
+    - packages/swarm-coordination-registry/src/swarm/registry.rs
+    - packages/torrent-repository-benchmarking/src/repository/mod.rs
+    - packages/torrent-repository-benchmarking/src/repository/
+    - packages/torrent-repository-benchmarking/tests/
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1964 - Rename `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash`
+
+## Goal
+
+Rename the type alias `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash` so the name
+expresses the _intent_ of the type ("downloads per info-hash") rather than its internal
+implementation (`BTreeMap`).
+
+## Background
+
+The type alias is defined in `packages/primitives/src/lib.rs`:
+
+```rust
+pub type NumberOfDownloads = u32;
+pub type NumberOfDownloadsBTreeMap = BTreeMap<InfoHash, NumberOfDownloads>;
+```
+
+It represents the number of completed downloads per info-hash and serves as the persistence
+boundary for torrent download counts — used by all three database drivers (SQLite, MySQL,
+PostgreSQL) when loading torrent metrics from the database.
+
+The current name `NumberOfDownloadsBTreeMap` leaks the implementation detail (`BTreeMap`). If the
+underlying collection were ever changed (e.g., to a `HashMap`), the name would become misleading
+and need a follow-up rename.
+
+The sibling type `NumberOfDownloads` is named after _what_ it represents, not _how_ it's stored
+(`u32`). The pair should follow the same convention.
+
+A workspace-wide search found 19 source files and 4 documentation files referencing this alias,
+making this a low-risk but moderately broad rename.
+
+## Scope
+
+### In Scope
+
+- Rename `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash` in `packages/primitives/src/lib.rs`
+- Update all references across the workspace (~19 source files + 4 doc files)
+- Verify `linter all` and the full test suite pass
+
+### Out of Scope
+
+- Changing the underlying collection type (`BTreeMap` → something else)
+- Renaming other type aliases in the codebase
+- Changing the `NumberOfDownloads` alias (already well-named)
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                  | Notes / Expected Output                                                                                  |
+| --- | ------ | ------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Rename definition in primitives crate | Change `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash` in `packages/primitives/src/lib.rs` |
+| T2  | TODO   | Update core domain references         | Update imports/usages in `tracker-core`, `swarm-coordination-registry`, etc.                             |
+| T3  | TODO   | Update benchmarking references        | Update imports/usages in `torrent-repository-benchmarking` crate and tests                               |
+| T4  | TODO   | Update documentation                  | Update the 4 doc files referencing the old name                                                          |
+| T5  | TODO   | Run full verification                 | `linter all`, `cargo test --workspace`, pre-commit checks                                                |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Spec drafted in `docs/issues/drafts/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] GitHub issue created and issue number added to this spec
+- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-06-30 12:00 UTC - Copilot - Spec draft created
+
+## Acceptance Criteria
+
+- [ ] AC1: `NumberOfDownloadsBTreeMap` no longer appears anywhere in the codebase
+- [ ] AC2: `NumberOfDownloadsPerInfoHash` is the sole name for the type alias
+- [ ] AC3: All tests pass (`cargo test --workspace`)
+- [ ] AC4: `linter all` exits with code `0`
+- [ ] AC5: Pre-commit checks pass
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter all`
+- `cargo test --workspace`
+- Pre-commit checks (`./contrib/dev-tools/git/hooks/pre-commit.sh`)
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                    | Command/Steps                                                           | Expected Result                            | Status | Evidence                     |
+| --- | --------------------------- | ----------------------------------------------------------------------- | ------------------------------------------ | ------ | ---------------------------- |
+| M1  | Build succeeds after rename | `cargo build --workspace`                                               | Zero errors, no warnings related to rename | TODO   | {log/output/screenshot/path} |
+| M2  | grep confirms no old name   | `grep -r "NumberOfDownloadsBTreeMap" --include="*.rs" --include="*.md"` | No matches found                           | TODO   | {log/output/screenshot/path} |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence           |
+| ----- | ---------------------- | ------------------ |
+| AC1   | TODO                   | {test/log/PR link} |
+| AC2   | TODO                   | {test/log/PR link} |
+| AC3   | TODO                   | {test/log/PR link} |
+| AC4   | TODO                   | {test/log/PR link} |
+| AC5   | TODO                   | {test/log/PR link} |
+
+## Risks and Trade-offs
+
+- **Risk**: Mass rename could miss a reference if a file uses a differently-formatted reference
+  (e.g., macro-generated code). **Mitigation**: grep for the old name after the rename to confirm
+  zero matches.
+- **Risk**: External consumers of `torrust-tracker-primitives` (crates.io) could break if they
+  depend on the old name. **Mitigation**: Check if any published reverse-dependencies use this
+  type. The crate has minimal external consumers and the type is internal-facing.
+
+## References
+
+- Definition: `packages/primitives/src/lib.rs` (line 71)
+- Usage sites: 19 source files across `tracker-core`, `swarm-coordination-registry`,
+  `torrent-repository-benchmarking`, and their tests
+- Docs: 4 documentation files in `docs/issues/` referencing the type

--- a/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
+++ b/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
@@ -1,0 +1,197 @@
+---
+doc-type: issue
+issue-type: task
+status: planned
+priority: p1
+github-issue: 1965
+spec-path: docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
+issue-folder: docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/
+branch: "1965-1669-si-34-consolidate-duplicate-http-types"
+related-pr: null
+last-updated-utc: 2026-06-30 12:00
+semantic-links:
+  skill-links:
+    - create-issue
+    - run-tracker-locally
+  related-artifacts:
+    - docs/issues/open/1669-overhaul-packages/EPIC.md
+    - docs/issues/open/1669-overhaul-packages/DECISIONS.md
+    - packages/http-protocol/src/v1/requests/
+    - packages/http-protocol/src/v1/responses/
+    - packages/axum-http-server/tests/server/requests/
+    - packages/axum-http-server/tests/server/responses/
+    - packages/tracker-client/src/http/client/requests/
+    - packages/tracker-client/src/http/client/responses/
+    - .github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1965 - EPIC 1669 SI-34: Consolidate Duplicate HTTP Types into `http-protocol`
+
+> **Parent EPIC**: [#1669 — Overhaul: Packages](https://github.com/torrust/torrust-tracker/issues/1669)
+> **EPIC Reference**: `docs/issues/open/1669-overhaul-packages/EPIC.md`
+>
+> **Issue type**: Folder issue — manual verification evidence and command logs will be documented
+> in a separate `manual-verification.md` file alongside this spec inside the issue folder at
+> `docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/`.
+
+## Goal
+
+Eliminate duplicate HTTP request/response type definitions across the workspace by consolidating
+them into `packages/http-protocol`, and add the `http-protocol` dependency to `tracker-client` so
+both consumers import from a single source of truth.
+
+## Background
+
+Three crate locations define overlapping HTTP request and response types:
+
+1. **`packages/http-protocol/src/v1/{requests,responses}/`** — server-side protocol parsing (production library)
+2. **`packages/axum-http-server/tests/server/{requests,responses}/`** — test helpers (test-only code)
+3. **`packages/tracker-client/src/http/client/{requests,responses}/`** — tracker client library (production library)
+
+Locations (2) and (3) define their own copies of types that semantically belong in (1):
+
+- `axum-http-server` **has** `http-protocol` as a dependency, but its tests define their own types instead of using it
+- `tracker-client` does **not** depend on `http-protocol` at all
+
+The duplication creates maintenance burden: any change to these types must be replicated in two
+or three places. Several types (especially `Error`, `Compact`, `CompactPeer`, `CompactPeerList`,
+scrape `Query`/`QueryBuilder`/`QueryParams`, `ByteArray20`, `InfoHash`, `percent_encode_byte_array`)
+are byte-for-byte identical between locations (2) and (3).
+
+The `http-protocol` crate is the canonical home for HTTP tracker protocol types. Client-side
+parsing/serialization types are a natural extension of this crate, not a separate concern.
+
+## Scope
+
+### In Scope
+
+- Add client-side request construction and response deserialization types to `packages/http-protocol`
+  (e.g., query builders, response structs with `serde_bencode` derives)
+- Replace duplicate types in `packages/axum-http-server/tests/server/` with imports from `http-protocol`
+- Replace duplicate types in `packages/tracker-client/src/http/client/` with imports from `http-protocol`
+- Add `http-protocol` as a dependency of `tracker-client`
+- Create a `use-tracker-client` skill in `.github/skills/usage/` capturing the manual verification learnings
+- Verify all tests pass and no functionality regresses
+
+### Out of Scope
+
+- Merging `packages/http-protocol` with other protocol crates
+- Changing the public API of `http-protocol` beyond what's needed for consolidation
+- Removing or refactoring the server-side types in `http-protocol`
+- Changing how `axum-http-server` production code uses `http-protocol`
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                                | Notes / Expected Output                                                                         |
+| --- | ------ | --------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Survey duplicate types and decide merge strategy    | Catalog exact types to move; identify which location has the "best" version                     |
+| T2  | TODO   | Add client-side types to `http-protocol`            | Move query builders, response deserialization structs, and shared helpers                       |
+| T3  | TODO   | Add `http-protocol` dependency to `tracker-client`  | Update `Cargo.toml`, verify dependency tree                                                     |
+| T4  | TODO   | Replace duplicate types in `tracker-client`         | Delete local copies, update imports to `http-protocol`                                          |
+| T5  | TODO   | Replace duplicate types in `axum-http-server` tests | Delete local copies, update imports to `http-protocol`                                          |
+| T6  | TODO   | Run full verification                               | `linter all`, `cargo test --workspace`, pre-commit, pre-push                                    |
+| T7  | TODO   | Create `use-tracker-client` skill                   | New skill in `.github/skills/usage/use-tracker-client/` with learnings from manual verification |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Spec drafted in `docs/issues/drafts/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] GitHub issue created and issue number added to this spec
+- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-06-30 12:00 UTC - Copilot - Spec draft created
+
+## Acceptance Criteria
+
+- [ ] AC1: No HTTP request/response types are duplicated between `http-protocol`, `axum-http-server` tests, and `tracker-client`
+- [ ] AC2: `tracker-client` depends on `http-protocol` and imports types from it instead of defining its own
+- [ ] AC3: `axum-http-server` tests import types from `http-protocol` instead of defining their own
+- [ ] AC4: All existing tests pass (`cargo test --workspace`)
+- [ ] AC5: `linter all` exits with code `0`
+- [ ] AC6: Pre-commit and pre-push checks pass
+- [ ] AC7: No `deps.rs` or layer-violation regressions
+- [ ] AC8: `use-tracker-client` skill is created in `.github/skills/usage/` with proper YAML frontmatter and instructions
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter all`
+- `cargo test --workspace`
+- Pre-commit checks (`./contrib/dev-tools/git/hooks/pre-commit.sh`)
+- Pre-push checks (`./contrib/dev-tools/git/hooks/pre-push.sh`)
+- `cargo machete` (no unused dependencies introduced)
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+All manual verification evidence — including full command output, troubleshooting notes, and
+step-by-step logs — will be recorded in a separate `manual-verification.md` file inside the
+issue folder. The Evidence column below links to the relevant section of that file.
+
+**Skills used during manual verification**:
+
+- **Run tracker locally**: [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) — start the tracker with default development configuration
+- **Tracker client**: No dedicated skill exists yet. A `use-tracker-client` skill will be created
+  in `.github/skills/usage/` as the final step of this issue, capturing the learnings from the
+  manual verification process.
+
+| ID  | Scenario                                        | Command/Steps                                                                            | Expected Result                                     | Status | Evidence                             |
+| --- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------- | ------ | ------------------------------------ |
+| M1  | HTTP tracker announces work with tracker-client | Run `tracker_client http announce` against a local tracker; verify request/response flow | Same behavior as before the consolidation           | TODO   | `manual-verification.md#m1-announce` |
+| M2  | HTTP scrape works with tracker-client           | Run `tracker_client http scrape` against a local tracker                                 | Same behavior as before                             | TODO   | `manual-verification.md#m2-scrape`   |
+| M3  | axum-http-server integration tests pass         | `cargo test -p torrust-tracker-axum-http-server --test integration`                      | All tests pass                                      | TODO   | `manual-verification.md#m3-tests`    |
+| M4  | No duplicate type definitions remain            | `grep` for key struct names (e.g., `struct Query`, `struct CompactPeer`) in old paths    | Only imports, no local definitions for merged types | TODO   | `manual-verification.md#m4-grep`     |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence           |
+| ----- | ---------------------- | ------------------ |
+| AC1   | TODO                   | {test/log/PR link} |
+| AC2   | TODO                   | {test/log/PR link} |
+| AC3   | TODO                   | {test/log/PR link} |
+| AC4   | TODO                   | {test/log/PR link} |
+| AC5   | TODO                   | {test/log/PR link} |
+| AC6   | TODO                   | {test/log/PR link} |
+| AC7   | TODO                   | {test/log/PR link} |
+| AC8   | TODO                   | {test/log/PR link} |
+
+## Risks and Trade-offs
+
+- **Risk**: Client-side types differ subtly between `tracker-client` and `axum-http-server` tests
+  (e.g., `Event` default variant, `numwant` field presence). **Mitigation**: The implementer must
+  survey both versions and ensure the consolidated type in `http-protocol` accommodates both use
+  cases. Where differences are intentional, use configuration (e.g., builder methods, `Option`
+  fields) rather than separate types.
+- **Risk**: Adding `http-protocol` as a dependency of `tracker-client` increases compile time for
+  the client. **Mitigation**: `http-protocol` is already a lightweight crate with few transitive
+  dependencies; the impact should be negligible.
+- **Risk**: The consolidation might change the public API of `http-protocol`, potentially breaking
+  external consumers. **Mitigation**: Review all existing `pub` exports and ensure backward
+  compatibility, or bump the version appropriately with clear changelog entries.
+
+## References
+
+- Parent EPIC: [#1669](https://github.com/torrust/torrust-tracker/issues/1669)
+- EPIC spec: `docs/issues/open/1669-overhaul-packages/EPIC.md`
+- Decisions log: `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
+- Duplicate analysis: exploration performed 2026-06-30 by Copilot
+- Related ADR: `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`

--- a/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
+++ b/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
@@ -149,9 +149,9 @@ issue folder. The Evidence column below links to the relevant section of that fi
 
 **Skills used during manual verification**:
 
-- **Run tracker locally**: [`.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) — start the tracker with default development configuration
+- **Run tracker locally**: [`../../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`](../../../../.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md) — start the tracker with default development configuration
 - **Tracker client**: No dedicated skill exists yet. A `use-tracker-client` skill will be created
-  in `.github/skills/usage/` as the final step of this issue, capturing the learnings from the
+  in `../../../../.github/skills/usage/` as the final step of this issue, capturing the learnings from the
   manual verification process.
 
 | ID  | Scenario                                        | Command/Steps                                                                            | Expected Result                                     | Status | Evidence                             |

--- a/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md
+++ b/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md
@@ -1,0 +1,113 @@
+# Manual Verification — Issue #1965 (EPIC 1669 SI-34)
+
+> This file records manual verification evidence for the issue.
+> It is populated during implementation.
+>
+> Skills used:
+>
+> - Run tracker locally: `.github/skills/dev/environment-setup/run-tracker-locally/SKILL.md`
+> - Tracker client: skill to be created as part of this issue (T7)
+
+---
+
+## M1: HTTP tracker announces work with tracker-client
+
+| Field            | Value  |
+| ---------------- | ------ |
+| **Status**       | `TODO` |
+| **Date**         |        |
+| **Performed by** |        |
+
+### Steps
+
+```text
+(To be filled during verification)
+```
+
+### Output
+
+```text
+(To be filled during verification)
+```
+
+### Result
+
+(To be filled: PASS / FAIL with notes)
+
+---
+
+## M2: HTTP scrape works with tracker-client
+
+| Field            | Value  |
+| ---------------- | ------ |
+| **Status**       | `TODO` |
+| **Date**         |        |
+| **Performed by** |        |
+
+### Steps
+
+```text
+(To be filled during verification)
+```
+
+### Output
+
+```text
+(To be filled during verification)
+```
+
+### Result
+
+(To be filled: PASS / FAIL with notes)
+
+---
+
+## M3: axum-http-server integration tests pass
+
+| Field            | Value  |
+| ---------------- | ------ |
+| **Status**       | `TODO` |
+| **Date**         |        |
+| **Performed by** |        |
+
+### Steps
+
+```text
+(To be filled during verification)
+```
+
+### Output
+
+```text
+(To be filled during verification)
+```
+
+### Result
+
+(To be filled: PASS / FAIL with notes)
+
+---
+
+## M4: No duplicate type definitions remain
+
+| Field            | Value  |
+| ---------------- | ------ |
+| **Status**       | `TODO` |
+| **Date**         |        |
+| **Performed by** |        |
+
+### Steps
+
+```text
+(To be filled during verification)
+```
+
+### Output
+
+```text
+(To be filled during verification)
+```
+
+### Result
+
+(To be filled: PASS / FAIL with notes)

--- a/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md
+++ b/docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md
@@ -1,3 +1,13 @@
+---
+doc-type: issue
+issue-type: task
+status: planned
+priority: p1
+github-issue: 1965
+spec-path: docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md
+last-updated-utc: 2026-06-30 12:00
+---
+
 # Manual Verification — Issue #1965 (EPIC 1669 SI-34)
 
 > This file records manual verification evidence for the issue.

--- a/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+++ b/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
@@ -1,0 +1,219 @@
+---
+doc-type: issue
+issue-type: task
+status: planned
+priority: p2
+github-issue: 1966
+spec-path: docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+branch: "1966-1669-si-35-consolidate-duplicate-udp-types"
+related-pr: null
+last-updated-utc: 2026-06-30 12:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1669-overhaul-packages/EPIC.md
+    - docs/issues/open/1669-overhaul-packages/DECISIONS.md
+    - packages/udp-protocol/src/
+    - packages/udp-core/src/event.rs
+    - packages/udp-server/src/event.rs
+    - packages/udp-server/src/lib.rs
+    - packages/tracker-client/src/udp/mod.rs
+    - docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
+    - packages/primitives/src/announce.rs
+    - packages/http-protocol/src/v1/requests/announce.rs
+    - packages/http-protocol/src/v1/responses/announce.rs
+    - packages/http-protocol/src/v1/responses/scrape.rs
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1966 - EPIC 1669 SI-35: Consolidate Duplicate UDP Types
+
+> **Parent EPIC**: [#1669 — Overhaul: Packages](https://github.com/torrust/torrust-tracker/issues/1669)
+> **EPIC Reference**: `docs/issues/open/1669-overhaul-packages/EPIC.md`
+
+## Goal
+
+Eliminate duplicate type definitions and constants in the UDP tracker packages by consolidating
+them into their canonical locations.
+
+## Background
+
+A workspace-wide audit of UDP-related packages found that the UDP layer is significantly cleaner
+than the HTTP layer — the core protocol types (`ConnectRequest`, `ConnectResponse`,
+`AnnounceRequest`, `AnnounceResponse`, `ScrapeRequest`, `ScrapeResponse`, `Request`, `Response`,
+`ErrorResponse`, `ResponsePeer`, `TorrentScrapeStatistics`) are defined exclusively in
+`packages/udp-protocol/src/` and imported everywhere else. This is the correct architecture.
+
+However, three duplications were found:
+
+### 🔴 `ConnectionContext` — full copy-paste
+
+The struct and its entire `impl` block are duplicated between:
+
+|                                            | `packages/udp-core/src/event.rs` (line 26)                                                                        | `packages/udp-server/src/event.rs` (line 85)                                                                      |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Fields**                                 | `pub client_socket_addr: SocketAddr`, `pub server_service_binding: ServiceBinding`                                | `client_socket_addr: SocketAddr` (private), `server_service_binding: ServiceBinding` (private)                    |
+| **Methods**                                | `new()`, `client_socket_addr()`, `server_socket_addr()`, `client_address_ip_family()`, `client_address_ip_type()` | `new()`, `client_socket_addr()`, `server_socket_addr()`, `client_address_ip_family()`, `client_address_ip_type()` |
+| **Derive**                                 | `Debug, PartialEq, Eq, Clone`                                                                                     | `Debug, PartialEq, Eq, Clone`                                                                                     |
+| **`From<ConnectionContext> for LabelSet`** | Yes                                                                                                               | Yes                                                                                                               |
+
+The only difference is field visibility (`pub` in core, private in server). The impl blocks are
+identical. One should be the canonical definition and the other should import it.
+
+### 🟡 `MAX_PACKET_SIZE` — same constant, two locations
+
+| Package                                            | File                                       | Value  |
+| -------------------------------------------------- | ------------------------------------------ | ------ |
+| `packages/udp-server/src/lib.rs` (line 651)        | `pub const MAX_PACKET_SIZE: usize = 1496;` | `1496` |
+| `packages/tracker-client/src/udp/mod.rs` (line 11) | `pub const MAX_PACKET_SIZE: usize = 1496;` | `1496` |
+
+The `tracker-client` already depends on `udp-protocol`. This constant could live in
+`udp-protocol` and be shared by both consumers.
+
+### 🟡 `PROTOCOL_ID` — dead code copy
+
+| Package                                            | Symbol                | Value               | Visibility   |
+| -------------------------------------------------- | --------------------- | ------------------- | ------------ |
+| `packages/udp-protocol/src/connect.rs` (line 15)   | `PROTOCOL_IDENTIFIER` | `4_497_486_125_440` | `pub(crate)` |
+| `packages/tracker-client/src/udp/mod.rs` (line 14) | `PROTOCOL_ID`         | `0x0417_2710_1980`  | `pub`        |
+
+Same magic constant with different names. `PROTOCOL_ID` in `tracker-client` is **unused** — a
+grep shows no references to it anywhere. It should be removed.
+
+### 🟢 Intentional duplications (not in scope)
+
+The following are kept separate per
+[ADR 20260527175600](docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md)
+and are **not** addressed by this issue:
+
+- `AnnounceEvent` — `udp-protocol` vs `primitives` (wire type vs domain type)
+- `InfoHash` — `udp-protocol` vs `torrust_info_hash` (wire type vs domain type)
+- `NumberOfBytes` — `udp-protocol` vs `primitives` vs `http-protocol` (wire type vs domain type)
+
+These types currently have comments like `// Intentionally kept in...` or `// Intentional boundary duplication` but
+do not explicitly reference the ADR. As part of this issue, each location will gain a `// adr:` comment so
+future contributors understand the architectural reasoning and do not accidentally re-couple the types.
+
+**Code locations to annotate**:
+
+- `packages/udp-protocol/src/common.rs` — `InfoHash` (line 20) and `NumberOfBytes` (line 46)
+- `packages/http-protocol/src/v1/requests/announce.rs` — `NumberOfBytes` (line 28)
+- `packages/http-protocol/src/v1/responses/announce.rs` — `Announce` DTO (line 11)
+- `packages/http-protocol/src/v1/responses/scrape.rs` — scrape response DTOs (lines 10, 20)
+- `packages/primitives/src/announce.rs` — `AnnounceEvent` (line 91)
+
+## Scope
+
+### In Scope
+
+- Consolidate `ConnectionContext` into a single canonical definition (likely in `udp-core`)
+- Move `MAX_PACKET_SIZE` to `udp-protocol` and import it in both `udp-server` and `tracker-client`
+- Remove the unused `PROTOCOL_ID` constant from `tracker-client`
+- Add `adr:` comments to the code locations listed under "Intentional duplications" referencing
+  ADR `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`, so future
+  contributors understand why the duplication exists and do not accidentally re-couple the types
+- Verify all tests pass and no functionality regresses
+
+### Out of Scope
+
+- Merging protocol-level types (`AnnounceEvent`, `InfoHash`, `NumberOfBytes`) — governed by ADR
+- Changing the public API of `udp-protocol` beyond what's needed for consolidation
+- Refactoring the UDP server architecture
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                             | Notes / Expected Output                                                                                                                                                                                                                                            |
+| --- | ------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | TODO   | Consolidate `ConnectionContext` into `udp-core`  | Make `udp-server` import from `udp-core` instead of defining its own copy                                                                                                                                                                                          |
+| T2  | TODO   | Move `MAX_PACKET_SIZE` to `udp-protocol`         | Add `pub const MAX_PACKET_SIZE: usize = 1496;` to `udp-protocol`; update imports                                                                                                                                                                                   |
+| T3  | TODO   | Remove dead `PROTOCOL_ID` from `tracker-client`  | Delete the unused constant                                                                                                                                                                                                                                         |
+| T4  | TODO   | Add `adr:` comments for intentional duplications | Annotate `udp-protocol/src/common.rs`, `http-protocol/src/v1/requests/announce.rs`, `http-protocol/src/v1/responses/announce.rs`, `http-protocol/src/v1/responses/scrape.rs`, and `primitives/src/announce.rs` with `// adr: docs/adrs/20260527175600...` comments |
+| T5  | TODO   | Run full verification                            | `linter all`, `cargo test --workspace`, pre-commit, pre-push                                                                                                                                                                                                       |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Spec drafted in `docs/issues/drafts/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] GitHub issue created and issue number added to this spec
+- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-06-30 12:00 UTC - Copilot - Spec draft created
+
+## Acceptance Criteria
+
+- [ ] AC1: `ConnectionContext` is defined in exactly one location (imported by the other)
+- [ ] AC2: `MAX_PACKET_SIZE` is defined in `udp-protocol` and imported by both `udp-server` and `tracker-client`
+- [ ] AC3: `PROTOCOL_ID` no longer exists in `tracker-client`
+- [ ] AC4: Each location listed in the "Intentional duplications" section has an `adr:` comment referencing the ADR
+- [ ] AC5: All existing tests pass (`cargo test --workspace`)
+- [ ] AC5: `linter all` exits with code `0`
+- [ ] AC6: Pre-commit and pre-push checks pass
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter all`
+- `cargo test --workspace`
+- Pre-commit checks (`./contrib/dev-tools/git/hooks/pre-commit.sh`)
+- Pre-push checks (`./contrib/dev-tools/git/hooks/pre-push.sh`)
+- `cargo machete` (no unused dependencies introduced)
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                                       | Command/Steps                                                                           | Expected Result                           | Status | Evidence                     |
+| --- | ---------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------- | ------ | ---------------------------- |
+| M1  | UDP tracker announces work with tracker-client | Run `tracker_client udp announce` against a local tracker; verify request/response flow | Same behavior as before the consolidation | TODO   | {log/output/screenshot/path} |
+| M2  | UDP scrape works with tracker-client           | Run `tracker_client udp scrape` against a local tracker                                 | Same behavior as before                   | TODO   | {log/output/screenshot/path} |
+| M3  | udp-server tests pass                          | `cargo test -p torrust-tracker-udp-server`                                              | All tests pass                            | TODO   | {log/output/screenshot/path} |
+| M4  | No duplicate definitions remain                | `grep` for `ConnectionContext` and `MAX_PACKET_SIZE` across workspace                   | Only one definition each                  | TODO   | {log/output/screenshot/path} |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence           |
+| ----- | ---------------------- | ------------------ |
+| AC1   | TODO                   | {test/log/PR link} |
+| AC2   | TODO                   | {test/log/PR link} |
+| AC3   | TODO                   | {test/log/PR link} |
+| AC4   | TODO                   | {test/log/PR link} |
+| AC5   | TODO                   | {test/log/PR link} |
+| AC6   | TODO                   | {test/log/PR link} |
+| AC7   | TODO                   | {test/log/PR link} |
+
+## Risks and Trade-offs
+
+- **Risk**: `ConnectionContext` has different field visibility (`pub` in core, private in server).
+  **Mitigation**: The consolidated definition should use `pub` fields (or provide accessor methods)
+  so both consumers can use it without friction.
+- **Risk**: Moving `MAX_PACKET_SIZE` to `udp-protocol` changes its visibility scope.
+  **Mitigation**: Make it `pub` in `udp-protocol`; both consumers already depend on it.
+- **Risk**: Removing `PROTOCOL_ID` could break something if it's used via macro or build script.
+  **Mitigation**: The grep confirmed zero references; removal is safe.
+
+## References
+
+- Parent EPIC: [#1669](https://github.com/torrust/torrust-tracker/issues/1669)
+- EPIC spec: `docs/issues/open/1669-overhaul-packages/EPIC.md`
+- Decisions log: `docs/issues/open/1669-overhaul-packages/DECISIONS.md`
+- Duplicate analysis: exploration performed 2026-06-30 by Copilot
+- Related ADR: `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`
+- Related HTTP consolidation issue: `docs/issues/drafts/1669-si-34-consolidate-duplicate-http-types-into-http-protocol.md`

--- a/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+++ b/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
@@ -161,8 +161,8 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [ ] AC3: `PROTOCOL_ID` no longer exists in `tracker-client`
 - [ ] AC4: Each location listed in the "Intentional duplications" section has an `adr:` comment referencing the ADR
 - [ ] AC5: All existing tests pass (`cargo test --workspace`)
-- [ ] AC5: `linter all` exits with code `0`
-- [ ] AC6: Pre-commit and pre-push checks pass
+- [ ] AC6: `linter all` exits with code `0`
+- [ ] AC7: Pre-commit and pre-push checks pass
 - [ ] Manual verification scenarios are executed and documented (status + evidence)
 - [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
 

--- a/docs/pr-reviews/EXAMPLE-COMPLETED.md
+++ b/docs/pr-reviews/EXAMPLE-COMPLETED.md
@@ -6,9 +6,9 @@ semantic-links:
     - docs/pr-reviews/README.md
 ---
 
-# PR #1733 Copilot Suggestions Tracking
+# PR #<PR_NUMBER> Copilot Suggestions Tracking (EXAMPLE - COMPLETED)
 
-Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/1733
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/<PR_NUMBER>
 
 Status legend:
 
@@ -18,9 +18,9 @@ Status legend:
 
 ## Processing Log
 
-- 2026-05-06: Started processing suggestions (downloaded 26 threads from PR #1733)
-- 2026-05-06: Applied code/doc fixes and committed changes
-- 2026-05-06: Resolved all 26 threads in PR #1733
+- <YYYY-MM-DD>: Started processing suggestions (downloaded 26 threads from PR #<PR_NUMBER>)
+- <YYYY-MM-DD>: Applied code/doc fixes and committed changes
+- <YYYY-MM-DD>: Resolved all 26 threads in PR #<PR_NUMBER>
 
 All suggestions (action and no-action) have been processed and marked resolved.
 

--- a/docs/pr-reviews/README.md
+++ b/docs/pr-reviews/README.md
@@ -15,7 +15,7 @@ This directory contains tools and templates for managing GitHub Copilot code rev
 ## Files
 
 - [docs/templates/COPILOT-SUGGESTIONS-TEMPLATE.md](../templates/COPILOT-SUGGESTIONS-TEMPLATE.md) — Reusable template for tracking and processing Copilot suggestions on any PR. Copy and customize for each new PR.
-- **pr-1733-copilot-suggestions.md** — Example of a completed suggestion review for PR #1733, showing how to document decisions, process suggestions, and track resolutions.
+- **EXAMPLE-COMPLETED.md** — Example of a completed suggestion review, showing how to document decisions, process suggestions, and track resolutions. Use uppercase `EXAMPLE` files as reference; copy the template from `docs/templates/COPILOT-SUGGESTIONS-TEMPLATE.md` for new PRs.
 
 ## Workflow
 
@@ -33,4 +33,4 @@ This directory contains tools and templates for managing GitHub Copilot code rev
 
 ## Example
 
-See `pr-1733-copilot-suggestions.md` for a complete example where all 26 Copilot suggestions were reviewed, processed, and resolved.
+See `EXAMPLE-COMPLETED.md` for a complete example where all 26 Copilot suggestions were reviewed, processed, and resolved.

--- a/docs/pr-reviews/pr-1967-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-1967-copilot-suggestions.md
@@ -1,0 +1,44 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #1967 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/1967
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - resolve the PR thread
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-06-30: Started processing suggestions.
+- 2026-06-30: Completed processing suggestions.
+
+## Suggestions
+
+| #   | Thread ID               | Path                                                                                       | URL                                                                                    | Suggestion Summary                                                                                | Decision                       | Status | Thread State |
+| --- | ----------------------- | ------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------ | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6NNrmf` | `docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md`               | [Comment](https://github.com/torrust/torrust-tracker/pull/1967#discussion_r3497403152) | Relative link `../../.github/skills/...` is broken — needs 4 `..` segments from the nested folder | action — fix the relative link | DONE   | RESOLVED     |
+| 2   | `PRRT_kwDOGp2yqc6NNrnB` | `docs/issues/open/1965-1669-si-34-consolidate-duplicate-http-types/manual-verification.md` | [Comment](https://github.com/torrust/torrust-tracker/pull/1967#discussion_r3497403199) | Missing YAML frontmatter for docs metadata consistency                                            | action — add YAML frontmatter  | DONE   | RESOLVED     |
+| 3   | `PRRT_kwDOGp2yqc6NNrnc` | `docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md`                      | [Comment](https://github.com/torrust/torrust-tracker/pull/1967#discussion_r3497403232) | AC numbering duplicates AC5 and skips AC7 — renumber to align with table                          | action — fix AC numbering      | DONE   | RESOLVED     |


### PR DESCRIPTION
Related to #1964, #1965, #1966

Spec-only PR. Adds three new issue specification documents:

- **#1964**: Rename `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash`
- **#1965 (EPIC 1669 SI-34)**: Consolidate duplicate HTTP types into `http-protocol`
- **#1966 (EPIC 1669 SI-35)**: Consolidate duplicate UDP types

No code changes. These are spec documents that define the scope, implementation plan,
and acceptance criteria for each issue before any implementation work begins.
