### PR TITLE
refactor(udp-core, udp-server, udp-protocol, tracker-client): consolidate duplicate UDP types (#1966)

### DIFF
--- a/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+++ b/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
@@ -6,7 +6,7 @@ priority: p2
 github-issue: 1966
 spec-path: docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
 branch: "1966-1669-si-35-consolidate-duplicate-udp-types"
-related-pr: null
+related-pr: 1991
 last-updated-utc: 2026-07-16 12:00
 semantic-links:
   skill-links:

--- a/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+++ b/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
@@ -1,16 +1,17 @@
 ---
 doc-type: issue
 issue-type: task
-status: planned
+status: in-review
 priority: p2
 github-issue: 1966
 spec-path: docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
 branch: "1966-1669-si-35-consolidate-duplicate-udp-types"
 related-pr: null
-last-updated-utc: 2026-06-30 12:00
+last-updated-utc: 2026-07-16 12:00
 semantic-links:
   skill-links:
     - create-issue
+    - write-markdown-docs
   related-artifacts:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
     - docs/issues/open/1669-overhaul-packages/DECISIONS.md
@@ -126,45 +127,46 @@ future contributors understand the architectural reasoning and do not accidental
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                             | Notes / Expected Output                                                                                                                                                                                                                                            |
-| --- | ------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T1  | TODO   | Consolidate `ConnectionContext` into `udp-core`  | Make `udp-server` import from `udp-core` instead of defining its own copy                                                                                                                                                                                          |
-| T2  | TODO   | Move `MAX_PACKET_SIZE` to `udp-protocol`         | Add `pub const MAX_PACKET_SIZE: usize = 1496;` to `udp-protocol`; update imports                                                                                                                                                                                   |
-| T3  | TODO   | Remove dead `PROTOCOL_ID` from `tracker-client`  | Delete the unused constant                                                                                                                                                                                                                                         |
-| T4  | TODO   | Add `adr:` comments for intentional duplications | Annotate `udp-protocol/src/common.rs`, `http-protocol/src/v1/requests/announce.rs`, `http-protocol/src/v1/responses/announce.rs`, `http-protocol/src/v1/responses/scrape.rs`, and `primitives/src/announce.rs` with `// adr: docs/adrs/20260527175600...` comments |
-| T5  | TODO   | Run full verification                            | `linter all`, `cargo test --workspace`, pre-commit, pre-push                                                                                                                                                                                                       |
+| ID  | Status | Task                                             | Notes / Expected Output                                                                                                                             |
+| --- | ------ | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Consolidate `ConnectionContext` into `udp-core`  | Made fields private in `udp-core`, removed duplicate from `udp-server`, updated all imports to `torrust_tracker_udp_core::event::ConnectionContext` |
+| T2  | DONE   | Move `MAX_PACKET_SIZE` to `udp-protocol`         | Added to `udp-protocol/src/common.rs`, removed from `udp-server/src/lib.rs` and `tracker-client/src/udp/mod.rs`, updated all imports                |
+| T3  | DONE   | Remove dead `PROTOCOL_ID` from `tracker-client`  | Deleted the unused constant                                                                                                                         |
+| T4  | DONE   | Add `adr:` comments for intentional duplications | Annotated all 5 locations with `// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`                                       |
+| T5  | DONE   | Run full verification                            | `cargo test --workspace --all-targets` all pass, `cargo machete` clean, no duplicate definitions remain                                             |
 
 ## Progress Tracking
 
 ### Workflow Checkpoints
 
 - [x] Spec drafted in `docs/issues/drafts/`
-- [ ] Spec reviewed and approved by user/maintainer
+- [x] Spec reviewed and approved by user/maintainer
 - [ ] GitHub issue created and issue number added to this spec
 - [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
 
+- 2026-07-16 12:00 UTC - Copilot - Implementation completed. All T1-T5 done. All ACs verified. 24 files modified.
 - 2026-06-30 12:00 UTC - Copilot - Spec draft created
 
 ## Acceptance Criteria
 
-- [ ] AC1: `ConnectionContext` is defined in exactly one location (imported by the other)
-- [ ] AC2: `MAX_PACKET_SIZE` is defined in `udp-protocol` and imported by both `udp-server` and `tracker-client`
-- [ ] AC3: `PROTOCOL_ID` no longer exists in `tracker-client`
-- [ ] AC4: Each location listed in the "Intentional duplications" section has an `adr:` comment referencing the ADR
-- [ ] AC5: All existing tests pass (`cargo test --workspace`)
-- [ ] AC6: `linter all` exits with code `0`
-- [ ] AC7: Pre-commit and pre-push checks pass
+- [x] AC1: `ConnectionContext` is defined in exactly one location (imported by the other)
+- [x] AC2: `MAX_PACKET_SIZE` is defined in `udp-protocol` and imported by both `udp-server` and `tracker-client`
+- [x] AC3: `PROTOCOL_ID` no longer exists in `tracker-client`
+- [x] AC4: Each location listed in the "Intentional duplications" section has an `adr:` comment referencing the ADR
+- [x] AC5: All existing tests pass (`cargo test --workspace`)
+- [x] AC6: `linter all` exits with code `0`
+- [x] AC7: Pre-commit and pre-push checks pass
 - [ ] Manual verification scenarios are executed and documented (status + evidence)
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
 
 ## Verification Plan
 
@@ -180,24 +182,24 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                                       | Command/Steps                                                                           | Expected Result                           | Status | Evidence                     |
-| --- | ---------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------- | ------ | ---------------------------- |
-| M1  | UDP tracker announces work with tracker-client | Run `tracker_client udp announce` against a local tracker; verify request/response flow | Same behavior as before the consolidation | TODO   | {log/output/screenshot/path} |
-| M2  | UDP scrape works with tracker-client           | Run `tracker_client udp scrape` against a local tracker                                 | Same behavior as before                   | TODO   | {log/output/screenshot/path} |
-| M3  | udp-server tests pass                          | `cargo test -p torrust-tracker-udp-server`                                              | All tests pass                            | TODO   | {log/output/screenshot/path} |
-| M4  | No duplicate definitions remain                | `grep` for `ConnectionContext` and `MAX_PACKET_SIZE` across workspace                   | Only one definition each                  | TODO   | {log/output/screenshot/path} |
+| ID  | Scenario                                       | Command/Steps                                                                           | Expected Result                           | Status | Evidence                  |
+| --- | ---------------------------------------------- | --------------------------------------------------------------------------------------- | ----------------------------------------- | ------ | ------------------------- |
+| M1  | UDP tracker announces work with tracker-client | Run `tracker_client udp announce` against a local tracker; verify request/response flow | Same behavior as before the consolidation | TODO   | Pending — manual E2E test |
+| M2  | UDP scrape works with tracker-client           | Run `tracker_client udp scrape` against a local tracker                                 | Same behavior as before                   | TODO   | Pending — manual E2E test |
+| M3  | udp-server tests pass                          | `cargo test -p torrust-tracker-udp-server`                                              | All tests pass                            | DONE   | 122 unit + 7 integration  |
+| M4  | No duplicate definitions remain                | `grep` for `ConnectionContext` and `MAX_PACKET_SIZE` across workspace                   | Only one definition each                  | DONE   | Verified via grep output  |
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence           |
-| ----- | ---------------------- | ------------------ |
-| AC1   | TODO                   | {test/log/PR link} |
-| AC2   | TODO                   | {test/log/PR link} |
-| AC3   | TODO                   | {test/log/PR link} |
-| AC4   | TODO                   | {test/log/PR link} |
-| AC5   | TODO                   | {test/log/PR link} |
-| AC6   | TODO                   | {test/log/PR link} |
-| AC7   | TODO                   | {test/log/PR link} |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                        |
+| ----- | ---------------------- | ------------------------------------------------------------------------------- |
+| AC1   | DONE                   | grep output: single `pub struct ConnectionContext` in `udp-core/src/event.rs`   |
+| AC2   | DONE                   | grep output: single `pub const MAX_PACKET_SIZE` in `udp-protocol/src/common.rs` |
+| AC3   | DONE                   | grep output: zero references to `PROTOCOL_ID` in `tracker-client`               |
+| AC4   | DONE                   | `adr:` comments added to all 5 locations                                        |
+| AC5   | DONE                   | `cargo test --workspace --all-targets` — all pass                               |
+| AC6   | DONE                   | `linter all` — exit code 0                                                      |
+| AC7   | DONE                   | Pre-commit and pre-push checks pass                                             |
 
 ## Risks and Trade-offs
 

--- a/docs/pr-reviews/pr-1991-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-1991-copilot-suggestions.md
@@ -1,0 +1,46 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #1991 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/1991
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - resolve the PR thread
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-07-16: Started processing suggestions.
+- 2026-07-16: Completed processing suggestions.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                  | URL                                                                                    | Suggestion Summary                                                                              | Decision | Status | Thread State |
+| --- | --------------------- | ------------------------------------- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6Rb5YB | `packages/udp-protocol/src/common.rs` | [comment](https://github.com/torrust/torrust-tracker/pull/1991#discussion_r3595317028) | `InfoHash` comment references deprecated `bittorrent-primitives` instead of `torrust_info_hash` | action   | DONE   | resolved     |
+
+## Notes
+
+- The suggestion is valid: the comment in `common.rs` on `InfoHash` references `bittorrent-primitives::InfoHash` which is a deprecated crate path. Updated to `torrust_info_hash::InfoHash`.
+- No other suggestions were found in the review.

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -35,6 +35,7 @@ const PEER_ADDR: &str = "peer_addr";
 // `NumberOfBytes` concept and domain byte counters, but it is kept local so
 // HTTP wire semantics can evolve independently without forcing cross-protocol
 // or domain-wide refactors.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub struct NumberOfBytes(pub i64);
 

--- a/packages/http-protocol/src/v1/responses/announce/data.rs
+++ b/packages/http-protocol/src/v1/responses/announce/data.rs
@@ -10,6 +10,7 @@ use torrust_peer_id::PeerId;
 // Protocol-local announce response DTOs intentionally duplicate some domain
 // field shapes. This keeps protocol crates decoupled from tracker domain types
 // and centralizes conversions in boundary adapters.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 #[derive(Clone, Debug, PartialEq, Constructor, Default)]
 pub struct AnnounceData {
     pub peers: Vec<Peer>,

--- a/packages/http-protocol/src/v1/responses/scrape/data.rs
+++ b/packages/http-protocol/src/v1/responses/scrape/data.rs
@@ -9,6 +9,7 @@ use torrust_info_hash::InfoHash;
 
 // Intentional boundary duplication: this represents scrape response payload
 // semantics for the HTTP protocol crate, not tracker-domain semantics.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct SwarmMetadata {
     pub complete: u32,
@@ -18,6 +19,7 @@ pub struct SwarmMetadata {
 
 // Intentional boundary duplication: this represents scrape response payload
 // semantics for the HTTP protocol crate, not tracker-domain semantics.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct ScrapeData {
     pub files: BTreeMap<InfoHash, SwarmMetadata>,

--- a/packages/primitives/src/announce.rs
+++ b/packages/primitives/src/announce.rs
@@ -87,6 +87,11 @@ pub struct AnnounceData {
     pub policy: AnnouncePolicy,
 }
 
+/// Intentional boundary duplication: this domain type mirrors
+/// protocol-level `AnnounceEvent` definitions in `udp-protocol` and
+/// `http-protocol`, but is kept here so domain logic does not depend on
+/// protocol wire formats.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum AnnounceEvent {
     Started,

--- a/packages/tracker-client/src/udp/client.rs
+++ b/packages/tracker-client/src/udp/client.rs
@@ -7,11 +7,10 @@ use std::time::Duration;
 use tokio::net::UdpSocket;
 use tokio::time;
 use torrust_net_primitives::service_binding::ServiceBinding;
-use torrust_tracker_udp_protocol::{ConnectRequest, Request, Response, TransactionId};
+use torrust_tracker_udp_protocol::{ConnectRequest, MAX_PACKET_SIZE, Request, Response, TransactionId};
 use zerocopy::byteorder::network_endian::I32;
 
 use super::Error;
-use crate::udp::MAX_PACKET_SIZE;
 
 pub const UDP_CLIENT_LOG_TARGET: &str = "UDP CLIENT";
 

--- a/packages/tracker-client/src/udp/mod.rs
+++ b/packages/tracker-client/src/udp/mod.rs
@@ -7,12 +7,6 @@ use torrust_tracker_udp_protocol::Request;
 
 pub mod client;
 
-/// The maximum number of bytes in a UDP packet.
-pub const MAX_PACKET_SIZE: usize = 1496;
-/// A magic 64-bit integer constant defined in the protocol that is used to
-/// identify the protocol.
-pub const PROTOCOL_ID: i64 = 0x0417_2710_1980;
-
 #[derive(Debug, Clone, Error)]
 pub enum Error {
     #[error("Timeout while waiting for socket to bind: {addr:?}")]

--- a/packages/udp-core/src/event.rs
+++ b/packages/udp-core/src/event.rs
@@ -24,8 +24,8 @@ pub enum Event {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ConnectionContext {
-    pub client_socket_addr: SocketAddr,
-    pub server_service_binding: ServiceBinding,
+    client_socket_addr: SocketAddr,
+    server_service_binding: ServiceBinding,
 }
 
 impl ConnectionContext {

--- a/packages/udp-protocol/src/common.rs
+++ b/packages/udp-protocol/src/common.rs
@@ -21,7 +21,7 @@ pub const MAX_PACKET_SIZE: usize = 1496;
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, IntoBytes, FromBytes, Immutable)]
 #[repr(transparent)]
 // Intentionally kept in `common`: this protocol-level wire type mirrors
-// `bittorrent-primitives::InfoHash` but is kept protocol-local so that wire
+// `torrust_info_hash::InfoHash` but is kept protocol-local so that wire
 // representations can evolve independently of domain types.
 // adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 pub struct InfoHash(pub [u8; 20]);

--- a/packages/udp-protocol/src/common.rs
+++ b/packages/udp-protocol/src/common.rs
@@ -15,10 +15,15 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub trait Ip: Clone + Copy + Debug + PartialEq + Eq + std::hash::Hash + IntoBytes + Immutable {}
 
+/// The maximum number of bytes in a UDP packet.
+pub const MAX_PACKET_SIZE: usize = 1496;
+
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, IntoBytes, FromBytes, Immutable)]
 #[repr(transparent)]
 // Intentionally kept in `common`: this protocol-level wire type mirrors
-// `bittorrent-primitives::InfoHash` and may be unified across packages later.
+// `bittorrent-primitives::InfoHash` but is kept protocol-local so that wire
+// representations can evolve independently of domain types.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 pub struct InfoHash(pub [u8; 20]);
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Debug, IntoBytes, FromBytes, Immutable)]
@@ -47,6 +52,7 @@ impl TransactionId {
 // `packages/primitives/src/number_of_bytes.rs` and HTTP protocol byte counters,
 // but remains UDP-local so protocol wire representations can evolve
 // independently per protocol.
+// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 pub struct NumberOfBytes(pub I64);
 
 impl NumberOfBytes {

--- a/packages/udp-server/src/event.rs
+++ b/packages/udp-server/src/event.rs
@@ -1,11 +1,9 @@
 use std::fmt;
-use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
-use torrust_metrics::label::{LabelSet, LabelValue};
-use torrust_metrics::label_name;
-use torrust_net_primitives::service_binding::{IpFamily, IpType, ServiceBinding};
+use torrust_metrics::label::LabelValue;
 use torrust_tracker_core::error::{AnnounceError, ScrapeError};
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::services::announce::UdpAnnounceError;
 use torrust_tracker_udp_core::services::scrape::UdpScrapeError;
 use torrust_tracker_udp_protocol::AnnounceRequest;
@@ -79,80 +77,6 @@ pub enum UdpResponseKind {
     Error {
         opt_req_kind: Option<UdpRequestKind>,
     },
-}
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ConnectionContext {
-    client_socket_addr: SocketAddr,
-    server_service_binding: ServiceBinding,
-}
-
-impl ConnectionContext {
-    #[must_use]
-    pub fn new(client_socket_addr: SocketAddr, server_service_binding: ServiceBinding) -> Self {
-        Self {
-            client_socket_addr,
-            server_service_binding,
-        }
-    }
-
-    #[must_use]
-    pub fn client_socket_addr(&self) -> SocketAddr {
-        self.client_socket_addr
-    }
-
-    #[must_use]
-    pub fn server_socket_addr(&self) -> SocketAddr {
-        self.server_service_binding.bind_address()
-    }
-
-    #[must_use]
-    pub fn client_address_ip_family(&self) -> IpFamily {
-        self.client_socket_addr.ip().into()
-    }
-
-    #[must_use]
-    pub fn client_address_ip_type(&self) -> IpType {
-        match self.client_socket_addr.ip() {
-            IpAddr::V6(v6) if v6.to_ipv4_mapped().is_some() => IpType::V4MappedV6,
-            _ => IpType::Plain,
-        }
-    }
-}
-
-impl From<ConnectionContext> for LabelSet {
-    fn from(connection_context: ConnectionContext) -> Self {
-        LabelSet::from([
-            (
-                label_name!("server_binding_protocol"),
-                LabelValue::new(&connection_context.server_service_binding.protocol().to_string()),
-            ),
-            (
-                label_name!("server_binding_ip"),
-                LabelValue::new(&connection_context.server_service_binding.bind_address().ip().to_string()),
-            ),
-            (
-                label_name!("server_binding_address_ip_type"),
-                LabelValue::new(&connection_context.server_service_binding.bind_address_ip_type().to_string()),
-            ),
-            (
-                label_name!("server_binding_address_ip_family"),
-                LabelValue::new(&connection_context.server_service_binding.bind_address_ip_family().to_string()),
-            ),
-            (
-                label_name!("server_binding_port"),
-                LabelValue::new(&connection_context.server_service_binding.bind_address().port().to_string()),
-            ),
-            (
-                label_name!("client_address_ip_family"),
-                LabelValue::new(&connection_context.client_address_ip_family().to_string()),
-            ),
-            (
-                label_name!("client_address_ip_type"),
-                LabelValue::new(&connection_context.client_address_ip_type().to_string()),
-            ),
-        ])
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/packages/udp-server/src/handlers/announce.rs
+++ b/packages/udp-server/src/handlers/announce.rs
@@ -7,6 +7,7 @@ use torrust_info_hash::InfoHash;
 use torrust_net_primitives::service_binding::ServiceBinding;
 use torrust_tracker_configuration::Core;
 use torrust_tracker_primitives::AnnounceData;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::services::announce::AnnounceService;
 use torrust_tracker_udp_protocol::{
     AnnounceInterval, AnnounceRequest, AnnounceResponse, AnnounceResponseFixedData, Ipv4AddrBytes, Ipv6AddrBytes, NumberOfPeers,
@@ -15,7 +16,7 @@ use torrust_tracker_udp_protocol::{
 use tracing::{Level, instrument};
 use zerocopy::byteorder::network_endian::I32;
 
-use crate::event::{ConnectionContext, Event, UdpRequestKind};
+use crate::event::{Event, UdpRequestKind};
 use crate::handlers::HandlerError;
 
 /// It handles the `Announce` request.
@@ -217,12 +218,13 @@ pub(crate) mod tests {
             use torrust_tracker_events::bus::SenderStatus;
             use torrust_tracker_primitives::peer::fixture::PeerBuilder;
             use torrust_tracker_udp_core::connection_cookie::{gen_remote_fingerprint, make};
+            use torrust_tracker_udp_core::event::ConnectionContext;
             use torrust_tracker_udp_protocol::{
                 AnnounceInterval, AnnounceResponse, AnnounceResponseFixedData, InfoHash as AquaticInfoHash, Ipv4AddrBytes,
                 Ipv6AddrBytes, NumberOfPeers, Response, ResponsePeer,
             };
 
-            use crate::event::{ConnectionContext, Event, UdpRequestKind};
+            use crate::event::{Event, UdpRequestKind};
             use crate::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
             use crate::handlers::handle_announce;
             use crate::handlers::tests::{
@@ -566,6 +568,7 @@ pub(crate) mod tests {
             use torrust_tracker_events::bus::SenderStatus;
             use torrust_tracker_primitives::peer::fixture::PeerBuilder;
             use torrust_tracker_udp_core::connection_cookie::{gen_remote_fingerprint, make};
+            use torrust_tracker_udp_core::event::ConnectionContext;
             use torrust_tracker_udp_core::event::bus::EventBus;
             use torrust_tracker_udp_core::event::sender::Broadcaster;
             use torrust_tracker_udp_core::services::announce::AnnounceService;
@@ -574,7 +577,7 @@ pub(crate) mod tests {
                 Ipv6AddrBytes, NumberOfPeers, Response, ResponsePeer,
             };
 
-            use crate::event::{ConnectionContext, Event, UdpRequestKind};
+            use crate::event::{Event, UdpRequestKind};
             use crate::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
             use crate::handlers::handle_announce;
             use crate::handlers::tests::{
@@ -866,11 +869,12 @@ pub(crate) mod tests {
                 use torrust_tracker_core::whitelist::authorization::WhitelistAuthorization;
                 use torrust_tracker_core::whitelist::repository::in_memory::InMemoryWhitelist;
                 use torrust_tracker_udp_core::connection_cookie::{gen_remote_fingerprint, make};
+                use torrust_tracker_udp_core::event::ConnectionContext;
                 use torrust_tracker_udp_core::services::announce::AnnounceService;
                 use torrust_tracker_udp_core::{self, event as core_event};
                 use torrust_tracker_udp_protocol::InfoHash as AquaticInfoHash;
 
-                use crate::event::{ConnectionContext, Event, UdpRequestKind};
+                use crate::event::{Event, UdpRequestKind};
                 use crate::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
                 use crate::handlers::handle_announce;
                 use crate::handlers::tests::{

--- a/packages/udp-server/src/handlers/connect.rs
+++ b/packages/udp-server/src/handlers/connect.rs
@@ -3,11 +3,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use torrust_net_primitives::service_binding::ServiceBinding;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::services::connect::ConnectService;
 use torrust_tracker_udp_protocol::{ConnectRequest, ConnectResponse, ConnectionId, Response};
 use tracing::{Level, instrument};
 
-use crate::event::{ConnectionContext, Event, UdpRequestKind};
+use crate::event::{Event, UdpRequestKind};
 
 /// It handles the `Connect` request.
 #[instrument(fields(transaction_id), skip(connect_service, opt_udp_server_stats_event_sender), ret(level = Level::TRACE))]
@@ -61,12 +62,13 @@ mod tests {
         use torrust_tracker_events::bus::SenderStatus;
         use torrust_tracker_udp_core::connection_cookie::make;
         use torrust_tracker_udp_core::event as core_event;
+        use torrust_tracker_udp_core::event::ConnectionContext;
         use torrust_tracker_udp_core::event::bus::EventBus;
         use torrust_tracker_udp_core::event::sender::Broadcaster;
         use torrust_tracker_udp_core::services::connect::ConnectService;
         use torrust_tracker_udp_protocol::{ConnectRequest, ConnectResponse, Response, TransactionId};
 
-        use crate::event::{ConnectionContext, Event, UdpRequestKind};
+        use crate::event::{Event, UdpRequestKind};
         use crate::handlers::handle_connect;
         use crate::handlers::tests::{
             MockUdpCoreStatsEventSender, MockUdpServerStatsEventSender, sample_ipv4_remote_addr,

--- a/packages/udp-server/src/handlers/error.rs
+++ b/packages/udp-server/src/handlers/error.rs
@@ -4,6 +4,7 @@ use std::ops::Range;
 
 use torrust_net_primitives::service_binding::ServiceBinding;
 use torrust_tracker_udp_core::UDP_TRACKER_LOG_TARGET;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::services::announce::UdpAnnounceError;
 use torrust_tracker_udp_core::services::scrape::UdpScrapeError;
 use torrust_tracker_udp_protocol::{ErrorResponse, Response, TransactionId};
@@ -12,7 +13,7 @@ use uuid::Uuid;
 use zerocopy::byteorder::network_endian::I32;
 
 use crate::error::Error;
-use crate::event::{ConnectionContext, Event, UdpRequestKind};
+use crate::event::{Event, UdpRequestKind};
 
 #[allow(clippy::too_many_arguments)]
 #[instrument(fields(transaction_id), skip(opt_udp_server_stats_event_sender), ret(level = Level::TRACE))]

--- a/packages/udp-server/src/handlers/scrape.rs
+++ b/packages/udp-server/src/handlers/scrape.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use torrust_net_primitives::service_binding::ServiceBinding;
 use torrust_tracker_primitives::ScrapeData;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::services::scrape::ScrapeService;
 use torrust_tracker_udp_core::{self};
 use torrust_tracker_udp_protocol::{
@@ -13,7 +14,7 @@ use torrust_tracker_udp_protocol::{
 use tracing::{Level, instrument};
 use zerocopy::byteorder::network_endian::I32;
 
-use crate::event::{ConnectionContext, Event, UdpRequestKind};
+use crate::event::{Event, UdpRequestKind};
 use crate::handlers::HandlerError;
 
 /// It handles the `Scrape` request.
@@ -369,9 +370,10 @@ mod tests {
 
             use mockall::predicate::eq;
             use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+            use torrust_tracker_udp_core::event::ConnectionContext;
 
             use super::sample_scrape_request;
-            use crate::event::{ConnectionContext, Event, UdpRequestKind};
+            use crate::event::{Event, UdpRequestKind};
             use crate::handlers::handle_scrape;
             use crate::handlers::tests::{
                 MockUdpServerStatsEventSender, initialize_core_tracker_services_for_default_tracker_configuration,
@@ -419,9 +421,10 @@ mod tests {
 
             use mockall::predicate::eq;
             use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+            use torrust_tracker_udp_core::event::ConnectionContext;
 
             use super::sample_scrape_request;
-            use crate::event::{ConnectionContext, Event, UdpRequestKind};
+            use crate::event::{Event, UdpRequestKind};
             use crate::handlers::handle_scrape;
             use crate::handlers::tests::{
                 MockUdpServerStatsEventSender, initialize_core_tracker_services_for_default_tracker_configuration,

--- a/packages/udp-server/src/lib.rs
+++ b/packages/udp-server/src/lib.rs
@@ -647,9 +647,6 @@ use std::net::SocketAddr;
 
 use torrust_clock::clock;
 
-/// The maximum number of bytes in a UDP packet.
-pub const MAX_PACKET_SIZE: usize = 1496;
-
 /// This code needs to be copied into each crate.
 /// Working version, for production.
 #[cfg(not(test))]

--- a/packages/udp-server/src/server/launcher.rs
+++ b/packages/udp-server/src/server/launcher.rs
@@ -13,12 +13,13 @@ use torrust_server_lib::registar::ServiceHealthCheckJob;
 use torrust_server_lib::signals::{Halted, Started, shutdown_signal_with_message};
 use torrust_tracker_client::udp::client::check;
 use torrust_tracker_udp_core::container::UdpTrackerCoreContainer;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::{self, UDP_TRACKER_LOG_TARGET};
 use tracing::instrument;
 
 use super::request_buffer::ActiveRequests;
 use crate::container::UdpTrackerServerContainer;
-use crate::event::{ConnectionContext, Event};
+use crate::event::Event;
 use crate::server::bound_socket::BoundSocket;
 use crate::server::processor::Processor;
 use crate::server::receiver::Receiver;

--- a/packages/udp-server/src/server/mod.rs
+++ b/packages/udp-server/src/server/mod.rs
@@ -4,8 +4,6 @@ use std::fmt::Debug;
 use derive_more::derive::Display;
 use thiserror::Error;
 
-use super::RawRequest;
-
 pub mod bound_socket;
 pub mod launcher;
 pub mod processor;

--- a/packages/udp-server/src/server/processor.rs
+++ b/packages/udp-server/src/server/processor.rs
@@ -6,13 +6,14 @@ use std::time::Duration;
 use tokio::time::Instant;
 use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
 use torrust_tracker_udp_core::container::UdpTrackerCoreContainer;
+use torrust_tracker_udp_core::event::ConnectionContext;
 use torrust_tracker_udp_core::{self};
 use torrust_tracker_udp_protocol::Response;
 use tracing::{Level, instrument};
 
 use super::bound_socket::BoundSocket;
 use crate::container::UdpTrackerServerContainer;
-use crate::event::{self, ConnectionContext, Event, UdpRequestKind};
+use crate::event::{self, Event, UdpRequestKind};
 use crate::handlers::CookieTimeValues;
 use crate::{RawRequest, handlers};
 

--- a/packages/udp-server/src/server/receiver.rs
+++ b/packages/udp-server/src/server/receiver.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::Stream;
+use torrust_tracker_udp_protocol::MAX_PACKET_SIZE;
 
-use super::RawRequest;
 use super::bound_socket::BoundSocket;
-use crate::MAX_PACKET_SIZE;
+use crate::RawRequest;
 
 pub struct Receiver {
     pub socket: Arc<BoundSocket>,

--- a/packages/udp-server/src/statistics/event/handler/error.rs
+++ b/packages/udp-server/src/statistics/event/handler/error.rs
@@ -2,8 +2,9 @@ use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::LabelSet;
 use torrust_metrics::{label_name, metric_name};
 use torrust_peer_id::PeerClient;
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::{ConnectionContext, ErrorKind, UdpRequestKind};
+use crate::event::{ErrorKind, UdpRequestKind};
 use crate::statistics::repository::Repository;
 use crate::statistics::{UDP_TRACKER_SERVER_CONNECTION_ID_ERRORS_TOTAL, UDP_TRACKER_SERVER_ERRORS_TOTAL};
 
@@ -106,9 +107,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::statistics::event::handler::error::ErrorKind;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;

--- a/packages/udp-server/src/statistics/event/handler/request_aborted.rs
+++ b/packages/udp-server/src/statistics/event/handler/request_aborted.rs
@@ -1,8 +1,8 @@
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::LabelSet;
 use torrust_metrics::metric_name;
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::ConnectionContext;
 use crate::statistics::UDP_TRACKER_SERVER_REQUESTS_ABORTED_TOTAL;
 use crate::statistics::repository::Repository;
 
@@ -26,9 +26,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
 

--- a/packages/udp-server/src/statistics/event/handler/request_accepted.rs
+++ b/packages/udp-server/src/statistics/event/handler/request_accepted.rs
@@ -1,8 +1,9 @@
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::{LabelSet, LabelValue};
 use torrust_metrics::{label_name, metric_name};
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::{ConnectionContext, UdpRequestKind};
+use crate::event::UdpRequestKind;
 use crate::statistics::UDP_TRACKER_SERVER_REQUESTS_ACCEPTED_TOTAL;
 use crate::statistics::repository::Repository;
 
@@ -31,9 +32,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;

--- a/packages/udp-server/src/statistics/event/handler/request_banned.rs
+++ b/packages/udp-server/src/statistics/event/handler/request_banned.rs
@@ -1,8 +1,8 @@
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::LabelSet;
 use torrust_metrics::metric_name;
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::ConnectionContext;
 use crate::statistics::UDP_TRACKER_SERVER_REQUESTS_BANNED_TOTAL;
 use crate::statistics::repository::Repository;
 
@@ -26,9 +26,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
 

--- a/packages/udp-server/src/statistics/event/handler/request_received.rs
+++ b/packages/udp-server/src/statistics/event/handler/request_received.rs
@@ -1,8 +1,8 @@
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::LabelSet;
 use torrust_metrics::metric_name;
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::ConnectionContext;
 use crate::statistics::UDP_TRACKER_SERVER_REQUESTS_RECEIVED_TOTAL;
 use crate::statistics::repository::Repository;
 
@@ -26,9 +26,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
 

--- a/packages/udp-server/src/statistics/event/handler/response_sent.rs
+++ b/packages/udp-server/src/statistics/event/handler/response_sent.rs
@@ -1,8 +1,9 @@
 use torrust_clock::DurationSinceUnixEpoch;
 use torrust_metrics::label::{LabelSet, LabelValue};
 use torrust_metrics::{label_name, metric_name};
+use torrust_tracker_udp_core::event::ConnectionContext;
 
-use crate::event::{ConnectionContext, UdpRequestKind, UdpResponseKind};
+use crate::event::{UdpRequestKind, UdpResponseKind};
 use crate::statistics::UDP_TRACKER_SERVER_RESPONSES_SENT_TOTAL;
 use crate::statistics::repository::Repository;
 
@@ -70,9 +71,10 @@ mod tests {
 
     use torrust_clock::clock::Time;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_udp_core::event::ConnectionContext;
 
     use crate::CurrentClock;
-    use crate::event::{ConnectionContext, Event};
+    use crate::event::Event;
     use crate::handlers::announce::tests::announce_request::AnnounceRequestBuilder;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;

--- a/packages/udp-server/tests/server/contract.rs
+++ b/packages/udp-server/tests/server/contract.rs
@@ -9,8 +9,7 @@ use std::time::Duration;
 
 use torrust_tracker_client::udp::client::UdpTrackerClient;
 use torrust_tracker_test_helpers::{configuration, logging};
-use torrust_tracker_udp_protocol::{ConnectRequest, ConnectionId, Response, TransactionId};
-use torrust_tracker_udp_server::MAX_PACKET_SIZE;
+use torrust_tracker_udp_protocol::{ConnectRequest, ConnectionId, MAX_PACKET_SIZE, Response, TransactionId};
 
 use crate::server::asserts::get_error_response_message;
 


### PR DESCRIPTION
## Summary

Consolidates duplicate UDP type definitions across the workspace per the issue spec.

### Changes

- **ConnectionContext**: Consolidated into `udp-core` (private fields with accessors). Removed duplicate from `udp-server` — all consumers now import from `torrust_tracker_udp_core::event::ConnectionContext`.
- **MAX_PACKET_SIZE**: Moved to `udp-protocol/src/common.rs`, imported by both `udp-server` and `tracker-client`.
- **PROTOCOL_ID**: Removed dead constant from `tracker-client` (unused, confirmed via grep).
- **adr: comments**: Added `// adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md` to all 5 intentional duplication locations.
- **Linter fixes**: Fixed `clippy::doc_markdown` in `primitives/src/announce.rs`, removed unused `super::RawRequest` import in `udp-server/src/server/mod.rs`.

### Verification

- `linter all` — exit code 0
- `cargo test --workspace --all-targets` — all pass
- `cargo machete` — no new unused dependencies
- Pre-commit and pre-push hooks — all pass
- No duplicate `ConnectionContext` or `MAX_PACKET_SIZE` definitions remain

Closes #1966
