### PR TITLE
docs(readme): add sealed_token to Star History widget URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,12 +246,12 @@ This project was a joint effort by [Nautilus Cyberneering GmbH][nautilus] and [D
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=torrust%2Ftorrust-tracker&type=date&logscale=&legend=top-left" rel="nofollow noreferrer noopener" target="_blank">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left" />
-  </picture>
+<a href="https://www.star-history.com/?repos=torrust%2Ftorrust-tracker&type=date&logscale=&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&theme=dark&legend=top-left&sealed_token=EZxXVF9XAD8H2DhnWPfead9gIAICpoo6hryWYUlgQD8O8sumGOar4rnhl38CGJLKVB8MEX5G3u1SRvQG_zb4FB23WQbEeL9TKfHUS88RbQ6lHyQeK-EgIyz_oh2idrLePDHKsH1zyk489E1adJUnbrjdLs57Q9F7XKLqUH_cUSCjvSVnKbg9yRXd8Ktm" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left&sealed_token=EZxXVF9XAD8H2DhnWPfead9gIAICpoo6hryWYUlgQD8O8sumGOar4rnhl38CGJLKVB8MEX5G3u1SRvQG_zb4FB23WQbEeL9TKfHUS88RbQ6lHyQeK-EgIyz_oh2idrLePDHKsH1zyk489E1adJUnbrjdLs57Q9F7XKLqUH_cUSCjvSVnKbg9yRXd8Ktm" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=torrust/torrust-tracker&type=date&legend=top-left&sealed_token=EZxXVF9XAD8H2DhnWPfead9gIAICpoo6hryWYUlgQD8O8sumGOar4rnhl38CGJLKVB8MEX5G3u1SRvQG_zb4FB23WQbEeL9TKfHUS88RbQ6lHyQeK-EgIyz_oh2idrLePDHKsH1zyk489E1adJUnbrjdLs57Q9F7XKLqUH_cUSCjvSVnKbg9yRXd8Ktm" />
+ </picture>
 </a>
 
 [container_wf]: ../../actions/workflows/container.yaml


### PR DESCRIPTION
## Description

Fixes #1996

Adds the `sealed_token` parameter to all three Star History image URLs (dark mode source, light mode source, and fallback `<img>`) in the README to prevent rate-limiting on the Star History API.

## Related Issues

- #1996
- #1951