### PR TITLE
Document UDP connection ID validation policy

### DIFF
--- a/docs/issues/closed/1447-change-logging-threshold-connection-id-error.md
+++ b/docs/issues/closed/1447-change-logging-threshold-connection-id-error.md
@@ -15,7 +15,6 @@ semantic-links:
     - packages/udp-server/src/handlers/error.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1447 - Change the logging threshold for connection ID error to `WARNING`
 

--- a/docs/issues/closed/1505-optimize-peer-ip-list-from-swarm/ISSUE.md
+++ b/docs/issues/closed/1505-optimize-peer-ip-list-from-swarm/ISSUE.md
@@ -31,7 +31,6 @@ semantic-links:
     - packages/tracker-client/src/http/client/responses/announce.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1505 — Optimization: return peer IP list from swarm (lowest-level layer) to servers (highest-level layer)
 

--- a/docs/issues/closed/1507-review-localhost-peer-ip.md
+++ b/docs/issues/closed/1507-review-localhost-peer-ip.md
@@ -19,7 +19,6 @@ semantic-links:
     - share/default/config/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1507 - Review IP assigned to localhost peers
 

--- a/docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
+++ b/docs/issues/closed/1671-ipv4-ipv6-client-metrics/ISSUE.md
@@ -22,7 +22,6 @@ semantic-links:
     - packages/configuration/src/v2_0_0/http_tracker.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1671 - IPv4/IPv6 client metrics: support per-client IP family labels and separate socket bindings
 

--- a/docs/issues/closed/1736-docs-http3-proxy.md
+++ b/docs/issues/closed/1736-docs-http3-proxy.md
@@ -15,7 +15,6 @@ semantic-links:
     - docs/templates/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1736 - docs(http): document HTTP/3 support via reverse proxy
 

--- a/docs/issues/closed/1765-native-http3-readiness.md
+++ b/docs/issues/closed/1765-native-http3-readiness.md
@@ -15,7 +15,6 @@ semantic-links:
     - docs/templates/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1765 - feat(http-tracker): evaluate and implement native HTTP/3 support
 

--- a/docs/issues/closed/1769-refactor-pre-commit-checks-performance-and-verbosity.md
+++ b/docs/issues/closed/1769-refactor-pre-commit-checks-performance-and-verbosity.md
@@ -27,7 +27,6 @@ semantic-links:
     - docs/issues/open/1770-refactor-pre-push-checks-performance-and-verbosity.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1769 - Refactor pre-commit checks for lower verbosity and faster feedback
 

--- a/docs/issues/closed/1771-merge-clients-into-unified-tracker-client-cli.md
+++ b/docs/issues/closed/1771-merge-clients-into-unified-tracker-client-cli.md
@@ -20,7 +20,6 @@ semantic-links:
     - console/tracker-client/src/console/clients/unified/mod.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1771 — Merge all tracker client tools into a single unified `tracker_client` CLI
 

--- a/docs/issues/closed/1778-migrate-to-rust-edition-2024.md
+++ b/docs/issues/closed/1778-migrate-to-rust-edition-2024.md
@@ -16,7 +16,6 @@ semantic-links:
     - .github/skills/dev/planning/create-issue/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1778 - Migrate workspace from Rust edition 2021 to edition 2024
 

--- a/docs/issues/closed/1780-refactor-pre-push-checks-performance-and-verbosity.md
+++ b/docs/issues/closed/1780-refactor-pre-push-checks-performance-and-verbosity.md
@@ -19,7 +19,6 @@ semantic-links:
     - .github/skills/dev/git-workflow/run-pre-push-checks/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1780 - Refactor pre-push checks for output-mode parity and clearer failure feedback
 

--- a/docs/issues/closed/1786-tighten-lint-config.md
+++ b/docs/issues/closed/1786-tighten-lint-config.md
@@ -16,7 +16,6 @@ semantic-links:
     - .cargo/config.toml
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1786 - Migrate lint configuration to `[workspace.lints]` in Cargo.toml
 

--- a/docs/issues/closed/1787-evaluate-msrv-bump.md
+++ b/docs/issues/closed/1787-evaluate-msrv-bump.md
@@ -17,7 +17,6 @@ semantic-links:
     - .github/skills/dev/maintenance/setup-dev-environment/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1787 - Evaluate and update workspace MSRV above 1.85
 

--- a/docs/issues/closed/1790-move-duration-since-unix-epoch-to-torrust-tracker-clock.md
+++ b/docs/issues/closed/1790-move-duration-since-unix-epoch-to-torrust-tracker-clock.md
@@ -16,7 +16,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1790 - Move `DurationSinceUnixEpoch` from `torrust-tracker-primitives` to `torrust-tracker-clock`
 

--- a/docs/issues/closed/1793-1669-03-define-per-package-default-timeout-constants.md
+++ b/docs/issues/closed/1793-1669-03-define-per-package-default-timeout-constants.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1793 - Define per-package default timeout constants and remove `DEFAULT_TIMEOUT` from `torrust-tracker-configuration`
 

--- a/docs/issues/closed/1795-1669-04-move-announce-policy-to-torrust-tracker-primitives.md
+++ b/docs/issues/closed/1795-1669-04-move-announce-policy-to-torrust-tracker-primitives.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1795 - Move `AnnouncePolicy` from `torrust-tracker-configuration` to `torrust-tracker-primitives`
 

--- a/docs/issues/closed/1797-1669-05-create-torrust-net-primitives-and-move-service-binding.md
+++ b/docs/issues/closed/1797-1669-05-create-torrust-net-primitives-and-move-service-binding.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1797 - Create `torrust-net-primitives` and move `ServiceBinding` from `torrust-tracker-primitives`
 

--- a/docs/issues/closed/1798-global-cli-output-contract-adr.md
+++ b/docs/issues/closed/1798-global-cli-output-contract-adr.md
@@ -17,7 +17,6 @@ semantic-links:
     - console/tracker-client/docs/contracts/tracker-cli-io-contract.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1798 - Define a Global CLI Output Contract for the Tracker (ADR)
 

--- a/docs/issues/closed/1803-improve-docs-folder-navigation.md
+++ b/docs/issues/closed/1803-improve-docs-folder-navigation.md
@@ -20,8 +20,6 @@ semantic-links:
     - .markdownlint.json
 ---
 
-<!-- skill-link: create-issue -->
-<!-- skill-link: write-markdown-docs -->
 
 # Issue #1803 - Improve `docs/` folder navigation
 

--- a/docs/issues/closed/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
+++ b/docs/issues/closed/1804-use-cargo-machete-with-metadata-and-remove-unused-dev-deps.md
@@ -19,7 +19,6 @@ semantic-links:
     - packages/swarm-coordination-registry/Cargo.toml
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1804 - Use `cargo machete --with-metadata` and remove unused dev dependencies
 

--- a/docs/issues/closed/1805-fix-workspace-coupling-report-for-brace-and-reexport-imports.md
+++ b/docs/issues/closed/1805-fix-workspace-coupling-report-for-brace-and-reexport-imports.md
@@ -17,7 +17,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1805 - Overhaul workspace-coupling report tool: replace regex scanner with `syn` and adopt CLI output contract
 

--- a/docs/issues/closed/1813-1669-06-resolve-bittorrent-tracker-core-rest-api-layer-violation.md
+++ b/docs/issues/closed/1813-1669-06-resolve-bittorrent-tracker-core-rest-api-layer-violation.md
@@ -17,7 +17,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1813 - Resolve `bittorrent-tracker-core` ↔ `torrust-tracker-rest-api-client` layer violation
 

--- a/docs/issues/closed/1816-1669-07-align-torrust-prefix-rename-tracker-specific-packages.md
+++ b/docs/issues/closed/1816-1669-07-align-torrust-prefix-rename-tracker-specific-packages.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1816 - Align `torrust-` prefix: rename tracker-specific packages to `torrust-tracker-`
 

--- a/docs/issues/closed/1819-1669-08-rename-torrust-tracker-metrics-to-torrust-metrics.md
+++ b/docs/issues/closed/1819-1669-08-rename-torrust-tracker-metrics-to-torrust-metrics.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1819 - Rename `torrust-tracker-metrics` to `torrust-metrics`
 

--- a/docs/issues/closed/1821-1669-09-rename-torrust-tracker-clock-to-torrust-clock.md
+++ b/docs/issues/closed/1821-1669-09-rename-torrust-tracker-clock-to-torrust-clock.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1821 - Rename `torrust-tracker-clock` to `torrust-clock`
 

--- a/docs/issues/closed/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
+++ b/docs/issues/closed/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1823 - Rename `torrust-tracker-located-error` to `torrust-located-error`
 

--- a/docs/issues/closed/1829-1669-11-rename-crates-and-folders-to-match-desired-tracker-workspace.md
+++ b/docs/issues/closed/1829-1669-11-rename-crates-and-folders-to-match-desired-tracker-workspace.md
@@ -19,7 +19,6 @@ semantic-links:
     - AGENTS.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1829 - Rename crates and folders to match EPIC desired tracker workspace state
 

--- a/docs/issues/closed/1830-1669-12-decouple-http-protocol-from-tracker-core.md
+++ b/docs/issues/closed/1830-1669-12-decouple-http-protocol-from-tracker-core.md
@@ -21,7 +21,6 @@ semantic-links:
     - packages/axum-http-tracker-server/src/v1/handlers/scrape.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1830 - Decouple `http-protocol` from `tracker-core`
 

--- a/docs/issues/closed/1834-1669-13-decouple-http-protocol-from-udp-protocol.md
+++ b/docs/issues/closed/1834-1669-13-decouple-http-protocol-from-udp-protocol.md
@@ -18,7 +18,6 @@ semantic-links:
     - packages/primitives/src/announce.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1834 - Decouple `http-protocol` from `udp-protocol`
 

--- a/docs/issues/closed/1835-1669-14-decouple-http-protocol-from-tracker-primitives.md
+++ b/docs/issues/closed/1835-1669-14-decouple-http-protocol-from-tracker-primitives.md
@@ -27,7 +27,6 @@ semantic-links:
     - packages/axum-http-server/src/v1/handlers/scrape.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1835 - Decouple `http-protocol` from `torrust-tracker-primitives`
 

--- a/docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/ISSUE.md
+++ b/docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/ISSUE.md
@@ -21,7 +21,6 @@ semantic-links:
     - .github/skills/dev/planning/create-issue/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1841 - Baseline workflow profiling and bottleneck analysis
 

--- a/docs/issues/closed/1851-1840-workflow-performance-dockerignore-audit/ISSUE.md
+++ b/docs/issues/closed/1851-1840-workflow-performance-dockerignore-audit/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1851 - Audit .dockerignore to minimize Docker build context
 

--- a/docs/issues/closed/1852-1840-workflow-performance-recipe-stage-manifest-only-copy/ISSUE.md
+++ b/docs/issues/closed/1852-1840-workflow-performance-recipe-stage-manifest-only-copy/ISSUE.md
@@ -21,7 +21,6 @@ semantic-links:
     - docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1852 - Restrict recipe stage to manifest-only COPY to prevent spurious cook cache invalidation
 

--- a/docs/issues/closed/1853-1840-workflow-performance-containerfile-target-scope/ISSUE.md
+++ b/docs/issues/closed/1853-1840-workflow-performance-containerfile-target-scope/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1726-1840-workflow-performance-sccache/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1853 - Narrow Containerfile build targets to tracker image needs
 

--- a/docs/issues/closed/1854-1840-workflow-performance-container-test-gating/ISSUE.md
+++ b/docs/issues/closed/1854-1840-workflow-performance-container-test-gating/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/adrs/20260603000000_keep_unit_tests_inside_container_build.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1854 - Evaluate test execution policy in container image build
 

--- a/docs/issues/closed/1856-1669-analyse-configuration-package-coupling/ISSUE.md
+++ b/docs/issues/closed/1856-1669-analyse-configuration-package-coupling/ISSUE.md
@@ -22,7 +22,6 @@ semantic-links:
     - docs/adrs/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1856 — Analyse configuration package coupling and evaluate splitting strategies
 

--- a/docs/issues/closed/1859-1669-move-tracker-policy-and-private-mode-to-primitives/ISSUE.md
+++ b/docs/issues/closed/1859-1669-move-tracker-policy-and-private-mode-to-primitives/ISSUE.md
@@ -21,7 +21,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1859 — Move `TrackerPolicy`, `TORRENT_PEERS_LIMIT`, and `PrivateMode` to `torrust-tracker-primitives`
 

--- a/docs/issues/closed/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
+++ b/docs/issues/closed/1860-1669-evaluate-tslconfig-move-to-axum-server/ISSUE.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1860 — Evaluate moving `TslConfig` from `torrust-tracker-configuration` into `torrust-tracker-axum-server`
 

--- a/docs/issues/closed/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md
+++ b/docs/issues/closed/1861-1669-narrow-envcontainer-initialize-config-slices/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1861 — Revisit `EnvContainer::initialize` to accept narrower config slices
 

--- a/docs/issues/closed/1864-1669-review-torrent-peers-limit/ISSUE.md
+++ b/docs/issues/closed/1864-1669-review-torrent-peers-limit/ISSUE.md
@@ -21,7 +21,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/DECISIONS.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1864 — Review and refactor `TORRENT_PEERS_LIMIT`: hardcoded constant vs. config option
 

--- a/docs/issues/closed/1868-1840-workflow-performance-exclude-irrelevant-workspace-members/ISSUE.md
+++ b/docs/issues/closed/1868-1840-workflow-performance-exclude-irrelevant-workspace-members/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1854-1840-workflow-performance-container-test-gating/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1868 - Exclude irrelevant workspace members from container build
 

--- a/docs/issues/closed/1869-1840-workflow-performance-dependency-layer-cache-reuse/ISSUE.md
+++ b/docs/issues/closed/1869-1840-workflow-performance-dependency-layer-cache-reuse/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/drafts/1840-workflow-performance-split-external-dep-cache-layer/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1869 - Improve dependency-layer cache reuse within each workflow
 

--- a/docs/issues/closed/1879-1669-17-extract-torrust-clock-to-standalone-repo.md
+++ b/docs/issues/closed/1879-1669-17-extract-torrust-clock-to-standalone-repo.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/closed/1790-move-duration-since-unix-epoch-to-torrust-tracker-clock.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1879 - Extract `torrust-clock` to a standalone repository
 

--- a/docs/issues/closed/1881-1669-16-migrate-contrib-bencode-to-torrust-bittorrent/ISSUE.md
+++ b/docs/issues/closed/1881-1669-16-migrate-contrib-bencode-to-torrust-bittorrent/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1881 - Migrate `contrib/bencode` to `torrust/torrust-bittorrent` as `torrust-bencode`
 

--- a/docs/issues/closed/1882-1669-18-extract-torrust-metrics-to-standalone-repo.md
+++ b/docs/issues/closed/1882-1669-18-extract-torrust-metrics-to-standalone-repo.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/closed/1819-1669-08-rename-torrust-tracker-metrics-to-torrust-metrics.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1882 - Extract `torrust-metrics` to a standalone repository
 

--- a/docs/issues/closed/1884-1669-19-move-bittorrent-peer-id-to-torrust-bittorrent.md
+++ b/docs/issues/closed/1884-1669-19-move-bittorrent-peer-id-to-torrust-bittorrent.md
@@ -22,7 +22,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1884 - Move `packages/peer-id` to `torrust/torrust-bittorrent` as `torrust-peer-id`
 

--- a/docs/issues/closed/1885-1669-20-extract-torrust-net-primitives-to-standalone-repo.md
+++ b/docs/issues/closed/1885-1669-20-extract-torrust-net-primitives-to-standalone-repo.md
@@ -29,7 +29,6 @@ semantic-links:
     - docs/issues/closed/1797-1669-05-create-torrust-net-primitives-and-move-service-binding.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1885 - Extract `torrust-net-primitives` to a standalone repository
 

--- a/docs/issues/closed/1889-1669-21-migrate-from-bittorrent-primitives-to-torrust-info-hash.md
+++ b/docs/issues/closed/1889-1669-21-migrate-from-bittorrent-primitives-to-torrust-info-hash.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1889 - Migrate from `bittorrent-primitives` to `torrust-info-hash`
 

--- a/docs/issues/closed/1894-1669-22-extract-torrust-located-error-to-standalone-repo.md
+++ b/docs/issues/closed/1894-1669-22-extract-torrust-located-error-to-standalone-repo.md
@@ -25,7 +25,6 @@ semantic-links:
     - docs/issues/closed/1823-1669-10-rename-torrust-tracker-located-error-to-torrust-located-error.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1894 - SI-22: Extract `torrust-located-error` to a standalone repository
 

--- a/docs/issues/closed/1898-document-security-analysis-process.md
+++ b/docs/issues/closed/1898-document-security-analysis-process.md
@@ -23,7 +23,6 @@ semantic-links:
     - https://github.com/torrust/torrust-tracker/issues/1463
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1898 - Document security analysis process and catalog non-affecting Containerfile CVEs
 

--- a/docs/issues/closed/1903-1669-si-23-relocate-axum-rest-api-server-test-environment.md
+++ b/docs/issues/closed/1903-1669-si-23-relocate-axum-rest-api-server-test-environment.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/drafts/1669-decouple-rest-api-core-from-udp-internals.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1903 (SI-23) - Relocate `axum-rest-api-server` Test Environment Infrastructure
 

--- a/docs/issues/closed/1904-1669-si-24-relocate-http-server-test-environment.md
+++ b/docs/issues/closed/1904-1669-si-24-relocate-http-server-test-environment.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report-2026-06-10.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1904 (SI-24) - Relocate `axum-http-server` Test Environment Infrastructure
 

--- a/docs/issues/closed/1906-1669-si-25-relocate-udp-server-test-environment.md
+++ b/docs/issues/closed/1906-1669-si-25-relocate-udp-server-test-environment.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report-2026-06-10.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1906 (SI-25) - Relocate `udp-server` Test Environment Infrastructure
 

--- a/docs/issues/closed/1907-1669-si-26-remove-udp-protocol-peer-id-re-export.md
+++ b/docs/issues/closed/1907-1669-si-26-remove-udp-protocol-peer-id-re-export.md
@@ -17,7 +17,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report-2026-06-10.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1907 (SI-26) - Remove `udp-protocol` Re-export of `PeerId`/`PeerClient`
 

--- a/docs/issues/closed/1908-1669-si-27-move-driver-enum-to-primitives.md
+++ b/docs/issues/closed/1908-1669-si-27-move-driver-enum-to-primitives.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report-2026-06-10.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1908 (SI-27) - Move `Driver` Enum from `configuration` to `primitives`
 

--- a/docs/issues/closed/1909-1669-si-28-extract-server-lib-to-standalone-repo.md
+++ b/docs/issues/closed/1909-1669-si-28-extract-server-lib-to-standalone-repo.md
@@ -28,7 +28,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1909 (SI-28) - Extract `torrust-server-lib` to a standalone repository
 

--- a/docs/issues/closed/1910-1669-si-29-rename-udp-and-http-core-protocol-crates-to-remove-redundant-tracker.md
+++ b/docs/issues/closed/1910-1669-si-29-rename-udp-and-http-core-protocol-crates-to-remove-redundant-tracker.md
@@ -25,7 +25,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/DECISIONS.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1910 (SI-29) - Remove redundant `-tracker-` from HTTP and UDP crate names
 

--- a/docs/issues/closed/1925-1669-si-31-configure-cargo-deny-for-layer-boundary-enforcement.md
+++ b/docs/issues/closed/1925-1669-si-31-configure-cargo-deny-for-layer-boundary-enforcement.md
@@ -24,7 +24,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/workspace-coupling-report-2026-06-10.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1925 - Configure `cargo deny` for workspace layer boundary enforcement
 

--- a/docs/issues/closed/1926-1669-si-32-define-package-versioning-strategy.md
+++ b/docs/issues/closed/1926-1669-si-32-define-package-versioning-strategy.md
@@ -23,7 +23,6 @@ semantic-links:
     - docs/release_process.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1926 — Define and implement package versioning strategy for EPIC #1669
 

--- a/docs/issues/closed/1938-rest-api-contract-first-migration/EPIC.md
+++ b/docs/issues/closed/1938-rest-api-contract-first-migration/EPIC.md
@@ -22,7 +22,6 @@ semantic-links:
     - docs/issues/closed/1938-rest-api-contract-first-migration/
 ---
 
-<!-- skill-link: create-issue -->
 
 # REST API Contract-First Migration (follow-up to SI-33 PoC)
 

--- a/docs/issues/closed/1939-1938-si-1-migrate-health-check-context.md
+++ b/docs/issues/closed/1939-1938-si-1-migrate-health-check-context.md
@@ -20,7 +20,6 @@ semantic-links:
     - packages/rest-api-runtime-adapter/src/
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-1: Migrate `health_check` context to contract-first architecture
 

--- a/docs/issues/closed/1940-1938-si-2-migrate-whitelist-context.md
+++ b/docs/issues/closed/1940-1938-si-2-migrate-whitelist-context.md
@@ -23,7 +23,6 @@ semantic-links:
     - packages/axum-rest-api-server/src/v1/state.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-2: Migrate `whitelist` context to contract-first architecture
 

--- a/docs/issues/closed/1941-1938-si-3-migrate-auth-key-context.md
+++ b/docs/issues/closed/1941-1938-si-3-migrate-auth-key-context.md
@@ -24,7 +24,6 @@ semantic-links:
     - packages/clock/
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-3: Migrate `auth_key` context to contract-first architecture
 

--- a/docs/issues/closed/1942-1938-si-4-migrate-stats-context.md
+++ b/docs/issues/closed/1942-1938-si-4-migrate-stats-context.md
@@ -27,7 +27,6 @@ semantic-links:
     - packages/axum-rest-api-server/src/main.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-4: Migrate `stats` context to contract-first architecture
 

--- a/docs/issues/closed/1943-1938-si-5-deprecate-rest-api-core.md
+++ b/docs/issues/closed/1943-1938-si-5-deprecate-rest-api-core.md
@@ -20,7 +20,6 @@ semantic-links:
     - packages/axum-rest-api-server/Cargo.toml
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-5: Deprecate `rest-api-core` and remove from workspace
 

--- a/docs/issues/closed/1944-1938-si-6-align-rest-api-client.md
+++ b/docs/issues/closed/1944-1938-si-6-align-rest-api-client.md
@@ -18,7 +18,6 @@ semantic-links:
     - packages/rest-api-client/Cargo.toml
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-6: Introduce `ApiClient` — a high-level REST API client over protocol DTOs
 

--- a/docs/issues/closed/1959-1938-si-7-review-tests-align-v1-namespace.md
+++ b/docs/issues/closed/1959-1938-si-7-review-tests-align-v1-namespace.md
@@ -22,7 +22,6 @@ semantic-links:
     - packages/rest-api-client/src/
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-7: Review tests and align v1 namespace across REST API packages
 

--- a/docs/issues/closed/1964-rename-number-of-downloads-btree-map-type-alias.md
+++ b/docs/issues/closed/1964-rename-number-of-downloads-btree-map-type-alias.md
@@ -26,7 +26,6 @@ semantic-links:
     - packages/torrent-repository-benchmarking/tests/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1964 - Rename `NumberOfDownloadsBTreeMap` to `NumberOfDownloadsPerInfoHash`
 

--- a/docs/issues/closed/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
+++ b/docs/issues/closed/1965-1669-si-34-consolidate-duplicate-http-types/ISSUE.md
@@ -27,7 +27,6 @@ semantic-links:
     - .github/skills/dev/environment-setup/run-tracker-locally/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1965 - EPIC 1669 SI-34: Consolidate Duplicate HTTP Types into `http-protocol`
 

--- a/docs/issues/closed/1969-1938-si-8-eliminate-unwraps-from-rest-api-client.md
+++ b/docs/issues/closed/1969-1938-si-8-eliminate-unwraps-from-rest-api-client.md
@@ -16,7 +16,6 @@ semantic-links:
     - packages/rest-api-client/src/v1/client.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # SI-8: Eliminate all unwraps from the REST API client package
 

--- a/docs/issues/drafts/1669-01-establish-baseline-analysis.md
+++ b/docs/issues/drafts/1669-01-establish-baseline-analysis.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Establish baseline: workspace coupling analysis and README audit
 

--- a/docs/issues/drafts/1669-extract-torrust-tracker-client-to-standalone-repo.md
+++ b/docs/issues/drafts/1669-extract-torrust-tracker-client-to-standalone-repo.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1669-overhaul-packages/EPIC.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Extract `torrust-tracker-client` to standalone repository
 

--- a/docs/issues/drafts/1669-update-all-package-readmes.md
+++ b/docs/issues/drafts/1669-update-all-package-readmes.md
@@ -17,7 +17,6 @@ semantic-links:
     - packages/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Standardize package READMEs and Cargo.toml metadata
 

--- a/docs/issues/drafts/1840-workflow-performance-alternative-linker/ISSUE.md
+++ b/docs/issues/drafts/1840-workflow-performance-alternative-linker/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Switch to a faster linker (mold or lld) to reduce link time
 

--- a/docs/issues/drafts/1840-workflow-performance-buildkit-cargo-cache-mounts/ISSUE.md
+++ b/docs/issues/drafts/1840-workflow-performance-buildkit-cargo-cache-mounts/ISSUE.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/open/1726-1840-workflow-performance-sccache/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Pass Cargo registry/git caches into BuildKit to speed up cook stage rebuilds
 

--- a/docs/issues/drafts/1840-workflow-performance-container-workflow-build-deduplication/ISSUE.md
+++ b/docs/issues/drafts/1840-workflow-performance-container-workflow-build-deduplication/ISSUE.md
@@ -19,7 +19,6 @@ semantic-links:
     - docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Evaluate removing duplicate container build from container workflow
 

--- a/docs/issues/drafts/1840-workflow-performance-pgo-optimization.md
+++ b/docs/issues/drafts/1840-workflow-performance-pgo-optimization.md
@@ -17,7 +17,6 @@ semantic-links:
     - .github/workflows/container.yaml
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Apply Profile-Guided Optimization (PGO) to the tracker release binary
 

--- a/docs/issues/drafts/1840-workflow-performance-prebuilt-base-images/ISSUE.md
+++ b/docs/issues/drafts/1840-workflow-performance-prebuilt-base-images/ISSUE.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/issues/closed/1841-1840-workflow-performance-baseline-analysis/benchmark-results-baseline.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Publish stable base stages as pre-built Docker Hub images
 

--- a/docs/issues/drafts/1840-workflow-performance-split-external-dep-cache-layer/ISSUE.md
+++ b/docs/issues/drafts/1840-workflow-performance-split-external-dep-cache-layer/ISSUE.md
@@ -23,7 +23,6 @@ semantic-links:
     - docs/issues/open/1869-1840-workflow-performance-dependency-layer-cache-reuse/ISSUE.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Investigate splitting cook layer to isolate external dependency cache
 

--- a/docs/issues/drafts/cli-output-contract-migration.md
+++ b/docs/issues/drafts/cli-output-contract-migration.md
@@ -18,7 +18,6 @@ semantic-links:
     - packages/configuration/src/lib.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #[To be assigned] - Migrate Existing Binaries to the Global CLI Output Contract
 

--- a/docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
+++ b/docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
@@ -6,8 +6,8 @@ priority: p2
 github-issue: 1136
 spec-path: docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
 branch: "1136-connection-id-validation-policy"
-related-pr: null
-last-updated-utc: 2026-07-20 12:23
+related-pr: 2002
+last-updated-utc: 2026-07-20 12:32
 semantic-links:
   skill-links:
     - create-issue
@@ -220,6 +220,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
   EPIC #1978, and verified its position immediately after #1453
 - 2026-07-20 12:26 UTC - committer - Verified the specification progress and
   two-file commit scope before the spec-only commit
+- 2026-07-20 12:32 UTC - agent - Opened spec-only PR #2002 against `develop`
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
+++ b/docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
@@ -1,0 +1,332 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: planned
+priority: p2
+github-issue: 1136
+spec-path: docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
+branch: "1136-connection-id-validation-policy"
+related-pr: null
+last-updated-utc: 2026-07-20 12:23
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1978-configuration-overhaul-epic.md
+    - docs/issues/open/1453-1978-ip-bans-reset-interval-configurable.md
+    - packages/configuration/src/v3_0_0/udp_tracker.rs
+    - packages/udp-core/src/connection_cookie.rs
+    - packages/udp-core/src/services/announce.rs
+    - packages/udp-core/src/services/scrape.rs
+    - packages/udp-server/src/server/processor.rs
+    - packages/udp-server/tests/server/contract.rs
+---
+
+# Issue #1136 - Add configurable UDP connection ID validation policy
+
+> **EPIC position**: Subissue 7 of 11 in EPIC #1978, immediately after
+> #1453. It is not functionally dependent on #1453, but implementing #1453 first
+> establishes the global ban-cleanup configuration boundary before this issue
+> adds a per-listener validation policy.
+
+## Goal
+
+Allow operators to disable UDP connection ID validation for a specific UDP tracker
+listener when compatibility with non-compliant clients is more important than the
+anti-spoofing and replay protection provided by BEP 15 connection IDs.
+
+Strict validation remains the secure default.
+
+## Background
+
+BEP 15 clients first obtain a connection ID from the tracker and then include it in
+announce and scrape requests. Torrust generates a stateless encrypted cookie from the
+client socket address fingerprint and issue time. Validation accepts only decoded issue
+times inside a narrow range determined by `cookie_lifetime`.
+
+Some clients reuse expired connection IDs. Issue #1136 originally proposed ignoring
+connection ID expiration, while a later discussion suggested a Boolean option that
+would disable validation entirely.
+
+The existing per-listener `cookie_lifetime` setting can already increase the accepted
+time window. It does not provide an explicit way to support clients that reuse IDs
+indefinitely.
+
+### Security constraint
+
+An expiration-only bypass is not a safe middle ground with the current cookie design.
+The cookie uses non-authenticated encryption, and the fingerprint is mixed into the
+cookie through wrapping arithmetic rather than a MAC. The narrow timestamp window is
+therefore part of what makes arbitrary or wrong-fingerprint connection IDs unlikely to
+validate.
+
+A random or wrong-fingerprint connection ID can decode to a normal timestamp classified
+as expired. Accepting every `ValueExpired` result would consequently accept more than
+known, previously valid but expired IDs. It would weaken validation without making that
+trade-off obvious to operators.
+
+For that reason, this specification exposes only two honest policies:
+
+- `strict`: preserve all existing validation.
+- `disabled`: skip connection ID validation for announce and scrape requests.
+
+## Design Decisions
+
+### Decision 1: Use an enum, not a Boolean
+
+Add a public `ConnectionIdValidationPolicy` enum to the v3 UDP tracker configuration:
+
+```rust,ignore
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ConnectionIdValidationPolicy {
+    #[default]
+    Strict,
+    Disabled,
+}
+```
+
+An enum communicates that this is a security policy and leaves room for a future mode
+only if a safe, precisely defined alternative becomes available.
+
+### Decision 2: Configure each UDP listener independently
+
+Add the following field to `v3_0_0::udp_tracker::UdpTracker`:
+
+```rust,ignore
+pub connection_id_validation: ConnectionIdValidationPolicy,
+```
+
+Example configuration:
+
+```toml
+[[udp_trackers]]
+bind_address = "0.0.0.0:6969"
+connection_id_validation = "strict"
+
+[[udp_trackers]]
+bind_address = "127.0.0.1:6970"
+connection_id_validation = "disabled"
+```
+
+Per-listener placement allows an operator to expose a strict public listener while
+isolating a compatibility listener through network controls.
+
+### Decision 3: Preserve strict validation by default
+
+When the field is omitted, behavior is identical to the current implementation:
+
+- Reject non-normal decoded values.
+- Reject expired values.
+- Reject future-dated values.
+- Reject values that fail when checked against the client socket fingerprint and valid
+  time range.
+- Emit the existing connection-cookie error and banning events.
+
+### Decision 4: Define `disabled` precisely
+
+When `connection_id_validation = "disabled"`:
+
+- Announce and scrape handlers do not call the connection cookie validator.
+- The connection ID value is ignored, including malformed, expired, future-dated, and
+  wrong-fingerprint values that can be represented by the protocol type.
+- Requests continue through all non-cookie validation, authorization, and tracker policy
+  checks.
+- The connect action is unchanged and continues issuing connection IDs.
+- No connection-cookie error, connection-ID error metric, or IP-ban counter increment is
+  produced for the bypassed check.
+- The listener logs a warning at startup stating that connection ID validation is
+  disabled and UDP anti-spoofing/replay protection is reduced.
+
+### Decision 5: Apply the change only to schema v3
+
+The new enum and field are added only under `packages/configuration/src/v3_0_0/`.
+Schema v2 and its global re-exports remain unchanged. Migration of application consumers
+and `share/default/config/` to schema v3 remains part of final cleanup issue #1980.
+
+## Scope
+
+### In Scope
+
+- Add `ConnectionIdValidationPolicy` with `strict` and `disabled` variants to schema v3
+- Add a per-listener `connection_id_validation` field to `v3_0_0::UdpTracker`
+- Default the policy to `strict`
+- Propagate the policy from configuration through UDP server startup and request
+  processing
+- Apply the policy consistently to announce and scrape requests
+- Preserve connect request behavior
+- Preserve current cookie-error metrics and banning behavior in strict mode
+- Suppress cookie-error metrics and ban increments when validation is disabled
+- Emit a startup warning for each listener using the disabled policy
+- Add configuration, unit, integration, and mixed-listener tests
+- Document the security implications of the disabled policy
+
+### Out of Scope
+
+- Adding an expiration-only compatibility mode
+- Changing the cookie generation or cryptographic algorithm
+- Changing `cookie_lifetime` semantics or defaults
+- Changing ban thresholds or cleanup scheduling (covered by #1453)
+- Disabling authorization, whitelist, private tracker, or request-shape validation
+- Adding the field to schema v2
+- Switching application consumers or default configuration files to schema v3 (covered
+  by #1980)
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                             | Notes / Expected Output                                                                |
+| --- | ------ | ------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| T1  | TODO   | Add the v3 validation policy                     | Enum and per-listener field in `v3_0_0/udp_tracker.rs`; default is `strict`            |
+| T2  | TODO   | Add configuration serialization tests            | Missing field defaults to strict; both string values round-trip                        |
+| T3  | TODO   | Add shared policy-aware cookie authentication    | One UDP core boundary implements strict validation and the disabled bypass             |
+| T4  | TODO   | Propagate policy through UDP server construction | Policy reaches request processing without global state                                 |
+| T5  | TODO   | Apply the shared policy to announce and scrape   | Both request paths use the same authentication behavior                                |
+| T6  | TODO   | Preserve observability and banning semantics     | Strict emits current events; disabled emits no cookie-error or ban-counter event       |
+| T7  | TODO   | Warn when starting an insecure listener          | Warning identifies the affected UDP service binding                                    |
+| T8  | TODO   | Add mixed-listener contract coverage             | Strict and disabled listeners behave independently in the same process                 |
+| T9  | TODO   | Update v3 schema documentation and test fixtures | Do not modify v2 or active `share/default/config/` files                               |
+| T10 | TODO   | Run automatic and manual verification            | Linters, focused tests, workspace tests, pre-push checks, and recorded manual evidence |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Spec drafted in `docs/issues/drafts/`
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue already exists and issue number matches spec
+- [x] GitHub issue title/body updated to match the approved specification
+- [x] Issue linked as a subissue of EPIC #1978
+- [x] EPIC #1978 local specification updated with the new ordering and dependency edge
+- [x] Spec moved to `docs/issues/open/` after approval
+- [ ] (Recommended) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [x] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-07-20 11:52 UTC - agent - Drafted local specification for maintainer
+  review; proposed secure-default per-listener `strict | disabled` policy
+- 2026-07-20 11:52 UTC - maintainer - Approved the proposed design decisions
+- 2026-07-20 12:12 UTC - agent - Promoted the approved specification and added
+  #1136 to the local EPIC as subissue 7 of 11
+- 2026-07-20 12:23 UTC - agent - Updated GitHub issue #1136, linked it to
+  EPIC #1978, and verified its position immediately after #1453
+- 2026-07-20 12:26 UTC - committer - Verified the specification progress and
+  two-file commit scope before the spec-only commit
+
+## Acceptance Criteria
+
+- [ ] AC1: Schema v3 exposes `ConnectionIdValidationPolicy` with exactly `strict`
+      and `disabled` serialized values
+- [ ] AC2: Every v3 UDP tracker listener has a `connection_id_validation` setting
+- [ ] AC3: Omitting the setting defaults to `strict` and preserves current behavior
+- [ ] AC4: Strict mode rejects non-normal, expired, future-dated, and
+      wrong-fingerprint connection IDs for announce and scrape requests
+- [ ] AC5: Disabled mode bypasses only connection ID validation for announce and scrape
+- [ ] AC6: Connect requests continue issuing connection IDs in both modes
+- [ ] AC7: Disabled mode does not emit connection-cookie error events, increment
+      connection-ID error metrics, or increment IP-ban counters for the bypassed check
+- [ ] AC8: A startup warning identifies each listener configured with disabled validation
+- [ ] AC9: Strict and disabled listeners can run simultaneously without sharing policy
+- [ ] AC10: Schema v2 behavior and public types remain unchanged
+- [ ] AC11: Security implications and recommended network isolation are documented
+- [ ] `linter all` exits with code `0`
+- [ ] Relevant focused and workspace tests pass
+- [ ] Pre-push checks pass
+- [ ] Manual verification scenarios are executed and documented (status + evidence)
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+
+## Verification Plan
+
+Define verification before implementation starts and execute it before closing the issue.
+
+### Automatic Checks
+
+- `linter all`
+- `cargo test -p torrust-tracker-configuration`
+- `cargo test -p torrust-tracker-udp-core`
+- `cargo test -p torrust-tracker-udp-server`
+- `cargo test --workspace --tests --benches --examples --all-targets --all-features`
+- `./contrib/dev-tools/git/hooks/pre-push.sh`
+
+Required focused coverage:
+
+- Configuration default and TOML round-trip for both policy values
+- Announce with valid, expired, future-dated, non-normal, and wrong-fingerprint IDs in
+  strict mode
+- Scrape with the same connection ID classes in strict mode
+- Announce and scrape with arbitrary IDs in disabled mode
+- Cookie-error metrics and ban counters in both modes
+- Two simultaneous listeners using different policies
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                                | Command/Steps                                                                                               | Expected Result                                                                                  | Status | Evidence |
+| --- | --------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------ | -------- |
+| M1  | Strict listener rejects an invalid ID   | Start a local strict UDP listener; send announce and scrape requests using an expired or zero connection ID | Requests receive the existing connection-ID error; error metrics and ban counters increase       | TODO   |          |
+| M2  | Disabled listener accepts an invalid ID | Start a local disabled UDP listener; repeat the same announce and scrape requests                           | Requests pass cookie validation and continue through normal request handling; no ban increment   | TODO   |          |
+| M3  | Mixed policies remain isolated          | Start strict and disabled listeners in one process; send the same invalid requests to both                  | Strict listener rejects them; disabled listener accepts them; neither listener changes the other | TODO   |          |
+| M4  | Insecure mode is visible                | Start a listener with `connection_id_validation = "disabled"` and inspect startup logs                      | A warning identifies the listener and reduced anti-spoofing/replay protection                    | TODO   |          |
+
+Notes:
+
+- Manual verification is mandatory even when automated tests pass.
+- Record commands, relevant logs, and observed metric/ban counter values in the Evidence
+  column or a linked evidence artifact.
+- If a scenario fails, record the failure and diagnosis in the progress log before
+  proceeding.
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   |          |
+| AC2   | TODO                   |          |
+| AC3   | TODO                   |          |
+| AC4   | TODO                   |          |
+| AC5   | TODO                   |          |
+| AC6   | TODO                   |          |
+| AC7   | TODO                   |          |
+| AC8   | TODO                   |          |
+| AC9   | TODO                   |          |
+| AC10  | TODO                   |          |
+| AC11  | TODO                   |          |
+
+## Risks and Trade-offs
+
+- **Reduced spoofing and replay protection**: Disabled mode accepts arbitrary connection
+  IDs for announce and scrape. Mitigation: strict remains the default, startup emits a
+  warning, documentation recommends binding compatibility listeners to trusted networks
+  or protecting them with external network controls.
+- **Misleading partial validation**: An expiration-only bypass could appear safer while
+  accepting arbitrary values decoded as old timestamps. Mitigation: do not expose that
+  mode with the current cookie design.
+- **Policy propagation complexity**: The setting crosses configuration, UDP server, and
+  UDP core boundaries. Mitigation: pass an immutable enum value explicitly and avoid
+  global state.
+- **Behavior drift between announce and scrape**: Separate authentication paths can
+  diverge. Mitigation: share policy evaluation or add mirrored tests for both services.
+- **Operational confusion with `cookie_lifetime`**: Operators may not understand which
+  option to use. Mitigation: document that `cookie_lifetime` widens strict validation,
+  while `disabled` removes it entirely.
+- **Mixed-listener assumptions**: Ban services and metrics must remain scoped correctly.
+  Mitigation: add a contract test with strict and disabled listeners in one process.
+
+## References
+
+- GitHub issue: #1136
+- Configuration overhaul EPIC: #1978
+- Related ban-cleanup subissue: #1453
+- UDP tracker protocol: BEP 15
+- Existing cookie validation: `packages/udp-core/src/connection_cookie.rs`
+- Existing announce validation: `packages/udp-core/src/services/announce.rs`
+- Existing scrape validation: `packages/udp-core/src/services/scrape.rs`

--- a/docs/issues/open/1415-1978-use-service-binding-instead-of-socket-addr.md
+++ b/docs/issues/open/1415-1978-use-service-binding-instead-of-socket-addr.md
@@ -19,7 +19,6 @@ semantic-links:
     - src/bootstrap/jobs/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1415 - Use `ServiceBinding` (protocol + address) instead of bare `SocketAddr` for service identity
 

--- a/docs/issues/open/1417-1978-add-public-service-url-to-configuration.md
+++ b/docs/issues/open/1417-1978-add-public-service-url-to-configuration.md
@@ -21,7 +21,6 @@ semantic-links:
     - packages/configuration/src/v3_0_0/health_check_api.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1417 - Include public service URL in configuration
 

--- a/docs/issues/open/1453-1978-ip-bans-reset-interval-configurable.md
+++ b/docs/issues/open/1453-1978-ip-bans-reset-interval-configurable.md
@@ -18,7 +18,6 @@ semantic-links:
     - src/bootstrap/jobs/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1453 - Allow setting the IP bans reset interval via configuration and remove duplicate execution of cronjob to clean bans
 

--- a/docs/issues/open/1490-1978-decompose-database-config-and-overhaul-secrets.md
+++ b/docs/issues/open/1490-1978-decompose-database-config-and-overhaul-secrets.md
@@ -18,7 +18,6 @@ semantic-links:
     - packages/configuration/src/lib.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1490 - Decompose database config and overhaul secrets with `secrecy` crate
 

--- a/docs/issues/open/1586-use-joinset-in-jobmanager.md
+++ b/docs/issues/open/1586-use-joinset-in-jobmanager.md
@@ -19,7 +19,6 @@ semantic-links:
     - src/AGENTS.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1586 - Consider using `tokio::task::JoinSet` in `JobManager`
 

--- a/docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md
+++ b/docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md
@@ -44,7 +44,6 @@ semantic-links:
     - docs/containers.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1640 - Move `on_reverse_proxy` to per-tracker config (and relocate `Network`)
 

--- a/docs/issues/open/1669-overhaul-packages/EPIC.md
+++ b/docs/issues/open/1669-overhaul-packages/EPIC.md
@@ -25,7 +25,6 @@ semantic-links:
     - docs/media/packages/dependencies-workspace-packages.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # EPIC #1669 - Overhaul: Packages
 

--- a/docs/issues/open/1768-refactor-update-dependencies-skill-automation.md
+++ b/docs/issues/open/1768-refactor-update-dependencies-skill-automation.md
@@ -16,7 +16,6 @@ semantic-links:
     - .github/skills/dev/maintenance/add-rust-dependency/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1768 - Refactor update-dependencies skill automation
 

--- a/docs/issues/open/1774-automate-cleanup-completed-issues-skill-script.md
+++ b/docs/issues/open/1774-automate-cleanup-completed-issues-skill-script.md
@@ -17,7 +17,6 @@ semantic-links:
     - docs/issues/closed/README.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1774 - Automate cleanup of completed issue specs with a non-interactive script
 

--- a/docs/issues/open/1840-improve-pr-workflow-performance-epic/EPIC.md
+++ b/docs/issues/open/1840-improve-pr-workflow-performance-epic/EPIC.md
@@ -16,7 +16,6 @@ semantic-links:
     - .github/skills/dev/planning/create-issue/SKILL.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # EPIC #1840 - Improve PR Workflow Performance
 

--- a/docs/issues/open/1843-migrate-git-hooks-scripts-from-bash-to-rust.md
+++ b/docs/issues/open/1843-migrate-git-hooks-scripts-from-bash-to-rust.md
@@ -24,7 +24,6 @@ semantic-links:
     - .github/agents/committer.agent.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1843 — Migrate git hooks scripts from Bash to Rust
 

--- a/docs/issues/open/1875-review-lto-fat-in-dev-profile.md
+++ b/docs/issues/open/1875-review-lto-fat-in-dev-profile.md
@@ -18,7 +18,6 @@ semantic-links:
     - docs/skills/semantic-skill-link-convention.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1875 - Review and fix `lto = "fat"` in `[profile.dev]`
 

--- a/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
+++ b/docs/issues/open/1966-1669-si-35-consolidate-duplicate-udp-types.md
@@ -27,7 +27,6 @@ semantic-links:
     - packages/http-protocol/src/v1/responses/scrape.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1966 - EPIC 1669 SI-35: Consolidate Duplicate UDP Types
 

--- a/docs/issues/open/1978-configuration-overhaul-epic.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic.md
@@ -18,8 +18,6 @@ semantic-links:
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
 ---
 
-<!-- skill-link: create-issue -->
-
 # EPIC #1978 - Configuration Overhaul (schema v3.0.0)
 
 ## Goal

--- a/docs/issues/open/1978-configuration-overhaul-epic.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic.md
@@ -4,7 +4,7 @@ status: open
 github-issue: 1978
 spec-path: docs/issues/open/1978-configuration-overhaul-epic.md
 epic-owner: josecelano
-last-updated-utc: 2026-07-13 21:00
+last-updated-utc: 2026-07-20 12:23
 semantic-links:
   skill-links:
     - create-issue
@@ -13,6 +13,8 @@ semantic-links:
     - packages/configuration/src/lib.rs
     - docs/issues/open/1417-1978-add-public-service-url-to-configuration.md
     - docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md
+      - docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
+      - docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
 ---
 
@@ -49,6 +51,12 @@ The current configuration schema (`v2.0.0`) has accumulated several limitations:
 6. **No logging style configuration** — `TraceStyle` is hardcoded to `Default`, not
    configurable (#889). Additionally, the `threshold` field name is misleading — it
    should be renamed to `trace_filter` to match `tracing` crate terminology.
+7. **No UDP connection ID validation policy** — every UDP listener validates connection
+   IDs strictly, preventing isolated compatibility listeners for non-compliant clients
+   that reuse expired or arbitrary IDs (#1136).
+8. **No opt-in support for the HTTP announce `ip` parameter** — the parameter is parsed
+   but ignored, so controlled deployments cannot choose to trust a client-provided peer
+   address (#1987).
 
 Several of these changes are **breaking** (schema reorganisation, field renames,
 removal of global `[core.net]`), making this the right time to bump the schema
@@ -61,7 +69,7 @@ version from `2.0.0` to `3.0.0`.
 - Bump configuration schema version from `2.0.0` to `3.0.0`
 - Copy `v2_0_0` module to `v3_0_0` as the starting point for breaking changes
 - Copy crate-root `logging.rs` into both versioned modules (making each self-contained)
-- All six configuration enhancements listed below
+- All eight configuration enhancements listed below
 - Final cleanup: remove global re-exports, migrate all consumers to explicit v3 imports
 - Migration path / backward compatibility considerations where feasible
 
@@ -75,17 +83,19 @@ version from `2.0.0` to `3.0.0`.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| Order | Issue                                                                                                          | Local Spec                                                                     | Status | Notes                                                                            |
-| ----- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------- |
-| 1     | [#1979](../../issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/open/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`    | TODO   | Foundation: all other subissues depend on this                                   |
-| 2     | [#1981](../../issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/open/1981-1978-fix-tsl-config-tls-config-typo.md`                 | TODO   | Mechanical rename; ~21 files; do early to avoid conflicts with #5                |
-| 3     | [#1640](../../issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`      | TODO   | Heaviest change (~30 files); establishes per-instance `Network` block            |
-| 4     | [#1417](../../issues/1417) — Include public service URL in configuration                                       | `docs/issues/open/1417-1978-add-public-service-url-to-configuration.md`        | TODO   | Depends on #3 for `Network` placement decision; adds flat `public_url` field     |
-| 5     | [#1415](../../issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/open/1415-1978-use-service-binding-instead-of-socket-addr.md`     | TODO   | Independent; no config changes; can be parallel with #6, #7, #8                  |
-| 6     | [#1453](../../issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/open/1453-1978-ip-bans-reset-interval-configurable.md`            | TODO   | Independent; new `[udp_tracker_server]` section; can be parallel with #5, #7, #8 |
-| 7     | [#1490](../../issues/1490) — Decompose database config and overhaul secrets with `secrecy` crate               | `docs/issues/open/1490-1978-decompose-database-config-and-overhaul-secrets.md` | TODO   | After #3 (both touch `Core`); can be parallel with #5, #6, #8                    |
-| 8     | [#889](../../issues/889) — New config option for logging style                                                 | `docs/issues/open/889-1978-new-config-option-for-logging-style.md`             | TODO   | Independent; can be parallel with #5, #6, #7                                     |
-| 9     | [#1980](../../issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`           | TODO   | Must be last; depends on ALL other subissues                                     |
+| Order | Issue                                                                                                          | Local Spec                                                                              | Status | Notes                                                                           |
+| ----- | -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------- |
+| 1     | [#1979](../../issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/open/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`             | TODO   | Foundation: all other subissues depend on this                                  |
+| 2     | [#1981](../../issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/open/1981-1978-fix-tsl-config-tls-config-typo.md`                          | TODO   | Mechanical rename; ~21 files; do early to avoid conflicts with #5               |
+| 3     | [#1640](../../issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`               | TODO   | Heaviest change (~30 files); establishes per-instance `Network` block           |
+| 4     | [#1417](../../issues/1417) — Include public service URL in configuration                                       | `docs/issues/open/1417-1978-add-public-service-url-to-configuration.md`                 | TODO   | Depends on #3 for `Network` placement decision; adds flat `public_url` field    |
+| 5     | [#1415](../../issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/open/1415-1978-use-service-binding-instead-of-socket-addr.md`              | TODO   | Independent; no config changes; can be parallel with #6, #7, #8, #9             |
+| 6     | [#1453](../../issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/open/1453-1978-ip-bans-reset-interval-configurable.md`                     | TODO   | Independent global UDP policy; implement before #7 to establish its boundary    |
+| 7     | [#1136](../../issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md`        | TODO   | Independent per-listener policy; ordered after related global ban cleanup in #6 |
+| 8     | [#1490](../../issues/1490) — Decompose database config and overhaul secrets with `secrecy` crate               | `docs/issues/open/1490-1978-decompose-database-config-and-overhaul-secrets.md`          | TODO   | After #3 (both touch `Core`); can be parallel with #5, #6, #7, #9               |
+| 9     | [#889](../../issues/889) — New config option for logging style                                                 | `docs/issues/open/889-1978-new-config-option-for-logging-style.md`                      | TODO   | Independent; can be parallel with #5, #6, #7, #8                                |
+| 10    | [#1987](../../issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md` | TODO   | After #3 and external prerequisite #1985; per-HTTP-tracker opt-in policy        |
+| 11    | [#1980](../../issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`                    | TODO   | Must be last; depends on ALL other subissues                                    |
 
 ## Delivery Strategy
 
@@ -97,35 +107,39 @@ graph TD
     sub1 --> sub3["3. #1640 Network block"]
     sub1 --> sub5["5. #1415 ServiceBinding"]
     sub1 --> sub6["6. #1453 IP bans"]
-    sub1 --> sub8["8. #889 Logging style"]
+      sub1 --> sub7["7. #1136 Connection ID policy"]
+      sub1 --> sub9["9. #889 Logging style"]
     sub2 --> sub3
     sub3 --> sub4["4. #1417 public_url"]
-    sub3 --> sub7["7. #1490 Secrets/secrecy"]
-    sub4 --> sub9["9. Final cleanup"]
-    sub5 --> sub9
-    sub6 --> sub9
-    sub7 --> sub9
-    sub8 --> sub9
+      sub3 --> sub8["8. #1490 Secrets/secrecy"]
+      sub3 --> sub10["10. #1987 Announce IP policy"]
+      sub4 --> sub11["11. Final cleanup"]
+      sub5 --> sub11
+      sub6 --> sub11
+      sub7 --> sub11
+      sub8 --> sub11
+      sub9 --> sub11
+      sub10 --> sub11
 ```
 
 ### Critical path
 
 ```text
-1 → 2 → 3 → 4 → 9
-1 → 2 → 3 → 7 → 9
+1 → 2 → 3 → 4 → 11
+1 → 2 → 3 → 8 → 11
 ```
 
-Subissues #5, #6, #8 are independent and can run in parallel with the critical path.
+Subissues #5, #6, #7, #9 are independent and can run in parallel with the critical path.
 
 ### Conflict hotspots
 
-| File(s)                             | Touched by             | Mitigation                                                       |
-| ----------------------------------- | ---------------------- | ---------------------------------------------------------------- |
-| `v3_0_0/http_tracker.rs`            | #2, #3, #4             | Implement sequentially: #2 → #3 → #4                             |
-| `v3_0_0/core.rs`                    | #3, #7                 | #3 first (removes `core.net`), then #7 (changes `database` type) |
-| `src/bootstrap/`                    | #3, #5, #6, #7, #8, #9 | Sequential order; #9 resolves all import paths last              |
-| `share/default/config/`             | ALL                    | Each subissue updates its relevant section; #9 does final pass   |
-| `test-helpers/src/configuration.rs` | #2, #3, #7, #9         | Sequential; each appends to test config defaults                 |
+| File(s)                             | Touched by                       | Mitigation                                                 |
+| ----------------------------------- | -------------------------------- | ---------------------------------------------------------- |
+| `v3_0_0/http_tracker.rs`            | #2, #3, #4, #10                  | Implement sequentially: #2 → #3 → #4 → #10                 |
+| `v3_0_0/core.rs`                    | #3, #8                           | #3 first (removes `core.net`), then #8 changes `database`  |
+| `src/bootstrap/`                    | #3, #5, #6, #7, #8, #9, #10, #11 | Sequential order; #11 resolves all import paths last       |
+| `share/default/config/`             | ALL                              | Each subissue updates its section; #11 does the final pass |
+| `test-helpers/src/configuration.rs` | #2, #3, #7, #8, #10, #11         | Sequential; each appends to test config defaults           |
 
 ### Phase 0: Foundation
 
@@ -135,8 +149,9 @@ Subissues #5, #6, #8 are independent and can run in parallel with the critical p
 ### Phase 1: Structural changes (sequential)
 
 - **Subissue #3** (#1640) — Per-instance `Network` block. Heaviest change (~30 files). Establishes the `Network` struct that #4 references.
-- **Subissue #7** (#1490) — Database enum decomposition + `secrecy` crate. After #3 (both touch `Core`). ~35 files.
+- **Subissue #8** (#1490) — Database enum decomposition + `secrecy` crate. After #3 (both touch `Core`). ~35 files.
 - **Subissue #4** (#1417) — `public_url` flat field. After #3 (depends on `Network` placement decision). ~6 files.
+- **Subissue #10** (#1987) — Opt-in use of the HTTP announce `ip` parameter. After #3 and external prerequisite #1985.
 
 ### Phase 2: Independent changes (parallel)
 
@@ -144,11 +159,12 @@ These can run in any order or in parallel branches:
 
 - **Subissue #5** (#1415) — `ServiceBinding` instead of `SocketAddr`. No config changes. ~10 files.
 - **Subissue #6** (#1453) — IP bans reset interval + fix duplicate cleanup. Isolated new config section. ~5 files.
-- **Subissue #8** (#889) — Logging style config. Isolated to `Logging` struct. ~5 files.
+- **Subissue #7** (#1136) — Per-listener UDP connection ID validation policy. Implement after #6 to keep related UDP policy work ordered.
+- **Subissue #9** (#889) — Logging style config. Isolated to `Logging` struct. ~5 files.
 
 ### Phase 3: Integration
 
-- **Subissue #9** — Final cleanup: remove global re-exports, migrate all ~30 consumers to explicit `v3_0_0` imports. Remove crate-root `logging.rs`. Keep `v2_0_0` module deprecated.
+- **Subissue #11** — Final cleanup: remove global re-exports, migrate all ~30 consumers to explicit `v3_0_0` imports. Remove crate-root `logging.rs`. Keep `v2_0_0` module deprecated.
 
 For each subissue implementation in this EPIC, the default completion policy is:
 
@@ -163,7 +179,7 @@ For each subissue implementation in this EPIC, the default completion policy is:
 - [ ] Epic spec drafted in `docs/issues/drafts/`
 - [ ] Epic spec reviewed and approved by user/maintainer
 - [ ] GitHub epic issue created and issue number added to this spec
-- [ ] Subissues created and linked in this spec
+- [x] Subissues created and linked in this spec
 - [ ] Subissue statuses kept up to date in the `Subissues` table
 - [ ] For each implemented subissue: automatic checks completed and recorded
 - [ ] For each implemented subissue: manual verification completed and recorded
@@ -172,7 +188,7 @@ For each subissue implementation in this EPIC, the default completion policy is:
 - [x] Epic spec drafted in `docs/issues/open/1978-configuration-overhaul-epic.md`
 - [x] Epic spec reviewed and approved by user/maintainer
 - [x] GitHub epic issue created: #1978
-- [ ] Subissues created and linked in this spec
+- [x] Subissues created and linked in this spec
 - [ ] Subissue statuses kept up to date in the `Subissues` table
 - [ ] For each implemented subissue: automatic checks completed and recorded
 - [ ] For each implemented subissue: manual verification completed and recorded
@@ -190,10 +206,13 @@ For each subissue implementation in this EPIC, the default completion policy is:
 - 2026-07-14 00:00 UTC - josecelano - Rewrote #1490 spec: decomposed `Database` into enum (`Sqlite3`, `MySQL(ConnectionInfo)`, `PostgreSQL(ConnectionInfo)`); removed backward-compat fallback; added ripple-effect analysis (~25 files). Renamed issue title.
 - 2026-07-15 00:00 UTC - josecelano - Dependency analysis complete. Reordered subissues: #1640 before #1417 (Network block first), #1490 after #1640 (both touch Core). Independent subissues (#1415, #1453, #889) can run in parallel. Added dependency graph and conflict hotspot table.
 - 2026-07-15 00:00 UTC - josecelano - GitHub issues created: EPIC #1978, #1979 (copy baseline), #1980 (final cleanup), #1981 (tsl typo). Specs moved to `docs/issues/open/` with issue number prefix.
+- 2026-07-20 12:12 UTC - agent - Added #1136 as subissue 7 of 11 after #1453; documented the secure-default per-listener UDP connection ID validation policy and reconciled the local EPIC with existing subissue #1987.
+- 2026-07-20 12:23 UTC - agent - Updated the GitHub EPIC body, linked #1136,
+  and verified all 11 native subissues in the documented order.
 
 ## Acceptance Criteria
 
-- [ ] All required subissues are created and linked.
+- [x] All required subissues are created and linked.
 - [ ] Implementation order is explicit and justified.
 - [ ] Dependencies and blockers are documented and current.
 - [ ] Epic status reflects actual state of linked subissues.
@@ -204,14 +223,14 @@ For each subissue implementation in this EPIC, the default completion policy is:
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                  |
-| ----- | ---------------------- | ----------------------------------------- |
-| AC1   | TODO                   | All subissues created and linked          |
-| AC2   | TODO                   | Schema v3.0.0 is active and functional    |
-| AC3   | TODO                   | All six enhancements are implemented      |
-| AC4   | TODO                   | `linter all` passes                       |
-| AC5   | TODO                   | All tests pass (`cargo test --workspace`) |
-| AC6   | TODO                   | Default config files updated to v3.0.0    |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                              |
+| ----- | ---------------------- | --------------------------------------------------------------------- |
+| AC1   | DONE                   | GitHub EPIC #1978 reports 11 linked subissues in the documented order |
+| AC2   | TODO                   | Schema v3.0.0 is active and functional                                |
+| AC3   | TODO                   | All eight enhancements are implemented                                |
+| AC4   | TODO                   | `linter all` passes                                                   |
+| AC5   | TODO                   | All tests pass (`cargo test --workspace`)                             |
+| AC6   | TODO                   | Default config files updated to v3.0.0                                |
 
 ## Risks and Trade-offs
 
@@ -227,7 +246,7 @@ For each subissue implementation in this EPIC, the default completion policy is:
 
 ## References
 
-- Related issues: #1417, #1640, #1490, #1453, #1415, #889
+- Related issues: #1417, #1640, #1490, #1453, #1415, #1136, #889, #1987
 - Related PRs: #1937 (spec for #1640)
 - Related ADRs: `docs/adrs/20260617093046_reject_wildcard_external_ip.md`
 - Related EPICs: #1669 (package overhaul)

--- a/docs/issues/open/1978-configuration-overhaul-epic.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic.md
@@ -13,8 +13,8 @@ semantic-links:
     - packages/configuration/src/lib.rs
     - docs/issues/open/1417-1978-add-public-service-url-to-configuration.md
     - docs/issues/open/1640-1978-per-http-tracker-on-reverse-proxy-setting.md
-      - docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
-      - docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md
+    - docs/issues/open/1136-1978-configurable-udp-connection-id-validation-policy.md
+    - docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
 ---
 

--- a/docs/issues/open/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md
+++ b/docs/issues/open/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md
@@ -17,7 +17,6 @@ semantic-links:
     - share/default/config/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1979 - Copy configuration schema v2_0_0 to v3_0_0 as baseline
 

--- a/docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md
+++ b/docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md
@@ -30,7 +30,6 @@ semantic-links:
     - contrib/dev-tools/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1980 - Final cleanup: remove global re-exports, migrate all consumers to explicit versioned imports
 

--- a/docs/issues/open/1981-1978-fix-tsl-config-tls-config-typo.md
+++ b/docs/issues/open/1981-1978-fix-tsl-config-tls-config-typo.md
@@ -30,7 +30,6 @@ semantic-links:
     - docs/issues/open/1640-per-http-tracker-on-reverse-proxy-setting.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1981 - Fix `tsl_config` → `tls_config` typo
 

--- a/docs/issues/open/1985-rename-peer-addr-to-ip-in-http-announce-request/ISSUE.md
+++ b/docs/issues/open/1985-rename-peer-addr-to-ip-in-http-announce-request/ISSUE.md
@@ -23,7 +23,6 @@ semantic-links:
     - docs/adrs/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1985 - Rename `peer_addr` GET param to `ip` in HTTP announce request (BEP 3)
 

--- a/docs/issues/open/1986-align-http-tracker-compact-default-with-bep-23/ISSUE.md
+++ b/docs/issues/open/1986-align-http-tracker-compact-default-with-bep-23/ISSUE.md
@@ -20,7 +20,6 @@ semantic-links:
     - packages/axum-http-server/tests/server/v1/contract/for_all_config_modes/receiving_an_announce_request.rs
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1986 - Return compact peer list by default when `compact` param is absent (BEP 23)
 

--- a/docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md
+++ b/docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md
@@ -24,7 +24,6 @@ semantic-links:
     - evidence-chihaya-no-dns-support.md
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #1987 - Add per-HTTP-tracker config option to use peer IP from `ip` GET parameter (sub-issue of #1978)
 

--- a/docs/issues/open/889-1978-new-config-option-for-logging-style.md
+++ b/docs/issues/open/889-1978-new-config-option-for-logging-style.md
@@ -18,7 +18,6 @@ semantic-links:
     - src/bootstrap/
 ---
 
-<!-- skill-link: create-issue -->
 
 # Issue #889 - New config option for logging style
 


### PR DESCRIPTION
## Summary

- specify issue #1136 as a per-listener UDP connection ID validation policy with `strict` and `disabled` modes
- keep strict validation as the secure default and reject an unsafe expiration-only mode
- define announce, scrape, connect, metrics, banning, warning, and mixed-listener behavior
- add automatic and mandatory manual verification plans
- add #1136 to configuration overhaul EPIC #1978 after #1453
- reconcile the EPIC with existing subissue #1987, yielding 11 ordered subissues with final cleanup last

## Scope

This is a specification-only PR. It does not implement the configuration or UDP behavior. Implementation starts after this specification is reviewed and merged.

Related to #1136
Related to #1978

## Verification

- `linter all`
- pre-commit hook: `cargo machete`, `cargo deny check bans`, all linters, workspace doc tests
- pre-push hook: nightly format/check/docs and full stable workspace tests
- YAML frontmatter parsing
- `git diff --check`
- GPG signature verification