### PR TITLE
docs(issues): add automation guardrails EPIC #2003

### DIFF
--- a/docs/issues/open/2003-overhaul-guardrails-and-automation/EPIC.md
+++ b/docs/issues/open/2003-overhaul-guardrails-and-automation/EPIC.md
@@ -1,0 +1,443 @@
+---
+doc-type: epic
+issue-type: task
+status: planned
+github-issue: 2003
+spec-path: docs/issues/open/2003-overhaul-guardrails-and-automation/EPIC.md
+epic-owner: josecelano
+last-updated-utc: 2026-07-20 00:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/
+    - .github/agents/
+    - .github/workflows/
+    - .github/workflows/testing.yaml
+    - .githooks/
+    - contrib/dev-tools/git/hooks/
+    - contrib/dev-tools/git/install-git-hooks.sh
+    - contrib/dev-tools/analysis/workspace-coupling/
+    - deny.toml
+    - project-words.txt
+    - AGENTS.md
+    - docs/templates/EPIC.md
+    - docs/issues/open/1843-migrate-git-hooks-scripts-from-bash-to-rust.md
+    - docs/issues/open/1774-automate-cleanup-completed-issues-skill-script.md
+    - docs/issues/open/1768-refactor-update-dependencies-skill-automation.md
+    - docs/issues/open/2003-overhaul-guardrails-and-automation/initial-inventory.md
+    - docs/issues/open/2003-overhaul-guardrails-and-automation/previous-single-runner-proposal.md
+---
+
+<!-- skill-link: create-issue -->
+
+# EPIC #2003 - Overhaul: Automation Tools and AI Agent Guardrails
+
+## Goal
+
+Research, design, implement, and progressively adopt repository automation and AI-agent
+guardrails that make repetitive tasks deterministic where practical and give humans and agents
+deterministic, timely feedback about whether work satisfies repository rules.
+
+The EPIC starts with discovery, research, and comparison of alternatives. It does not select a
+tool shape, implementation language, crate layout, or single execution model in advance. After
+maintainers record the design decision, the EPIC continues through implementation, progressive
+migration, and removal of superseded paths.
+
+## Previous Design Discussion
+
+An earlier discussion explored consolidating repository guardrails into one extensible Rust
+runner. That proposal introduced independently implemented guardrails, policy-based execution,
+dependency resolution, shared repository context, standardized results, and identical local and
+CI entry points.
+
+The discussion is preserved in
+[`previous-single-runner-proposal.md`](previous-single-runner-proposal.md) as design input. It is
+not the selected architecture. Its assumptions and trade-offs must be evaluated alongside
+distributed and incremental alternatives during this EPIC.
+
+## Why This Is Needed
+
+Repository checks and procedures have grown across several independently maintained surfaces:
+
+- `pre-commit.sh` and `pre-push.sh` contain duplicated step-runner, logging, argument-parsing,
+  and output-format logic around different check lists.
+- `.github/workflows/testing.yaml` is an existing composite guardrail. It repeats some local
+  checks and also enforces broader guarantees through formatting, linters, documentation tests,
+  workspace tests across targets and features, Cargo layer-boundary bans, container image
+  builds, tracker E2E tests, and qBittorrent E2E tests against SQLite, MySQL, and PostgreSQL.
+- Skills and agent instructions describe repeatable workflows and objective rules, but rules
+  expressed only as instructions still depend on an agent interpreting and following them.
+- Some architecture rules are already deterministic through `cargo deny check bans`, while
+  other possible repository-policy checks remain manual or have not been evaluated.
+- Existing automation proposals choose different script locations, interfaces, and
+  implementation approaches without a shared repository-wide decision framework.
+
+This distribution is not inherently wrong. The problem is that the repository lacks a current
+inventory showing ownership, overlap, execution cost, feedback behavior, and which rules should
+remain guidance versus become deterministic applications or tests. Without that evidence, a
+large consolidation could replace working checks with a more complex system without proving a
+benefit.
+
+## Design Principles
+
+The research and options analysis must apply these principles:
+
+1. **Maximize determinism**: when a workflow step or rule has objective inputs and pass/fail
+   semantics, prefer an executable application, test, or linter over instructions asking an
+   agent to reproduce the procedure. Keep skills and agent instructions for orchestration,
+   judgment, and context that cannot be encoded reliably.
+2. **Minimize inference-token and execution waste**: reduce instructions that only restate
+   deterministic behavior, and avoid repeating expensive checks when an equivalent successful
+   result can be reused safely. Any cache must key results by the exact relevant inputs,
+   configuration, tool versions, and check version. Pre-commit checks may need staged-tree
+   identity, while pre-push and CI checks may use commit or tree identity; branch name or commit
+   identity alone is not always sufficient.
+3. **Design for AI agents and humans**: automation must be non-interactive, composable,
+   idempotent where practical, and explicit about side effects. Commands must provide stable
+   exit codes, actionable diagnostics, and streaming machine-readable events using JSON Lines
+   (JSONL/NDJSON) in accordance with the repository CLI output contract. Human-readable
+   presentation may be layered over the same event model.
+4. **Preserve local and CI parity**: checks should have one authoritative implementation that
+   can be invoked consistently by developers, agents, hooks, and CI, even when those entry
+   points select different check profiles.
+5. **Fail safely and explain recovery**: cached results, skipped checks, partial failures, and
+   destructive operations must be visible and auditable. Automation must state why a result was
+   reused or invalidated and what action is required after failure.
+
+## Tooling Taxonomy
+
+Automation actions and guardrail checks are related but are not equivalent. The EPIC must model
+their different safety and result contracts while assessing which infrastructure they can share.
+
+| Type       | Purpose                                                                                             | Side effects                                                       | Typical result                              |
+| ---------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------- |
+| **Action** | Perform repository work, such as updating dependencies or moving issue specs                        | Expected; dry-run/apply and idempotency safeguards may be required | Changed, unchanged, skipped, failed         |
+| **Check**  | Evaluate whether repository work satisfies an objective rule                                        | Read-only by default                                               | Passed, warning, skipped, failed            |
+| **Policy** | Select and order actions/checks for a context such as pre-commit, pre-push, CI, nightly, or release | Inherits the selected operations' effects                          | Aggregate execution result and event stream |
+
+Actions and checks may share configuration loading, repository discovery, Git/Cargo metadata,
+dependency planning, caching infrastructure, JSONL/NDJSON events, diagnostics, and progress
+reporting. They must not share a contract that hides whether an operation mutates state.
+
+Workflows and hooks can themselves be **composite guardrails** when they orchestrate multiple
+checks into one merge or lifecycle gate. In particular, `.github/workflows/testing.yaml` is a
+current composite CI guardrail even though its implementation also performs setup and container
+build actions needed by its checks.
+
+## Scope
+
+### In Scope
+
+- Catalog current automation and guardrails across local hooks, CI workflows, skills, custom
+  agents, repository instructions, linters, dependency checks, and reusable analysis tools.
+- Validate and maintain the initial baseline in
+  [`initial-inventory.md`](initial-inventory.md), including explicit unknowns rather than
+  treating the first pass as complete evidence.
+- Trace each check or workflow by purpose, owner/source of truth, invocation sites, inputs,
+  outputs, runtime tier, environment requirements, duplication, and failure feedback.
+- Distinguish repetitive task automation from verification guardrails; both are relevant, but
+  they require different side-effect, result, retry, and cache contracts even if they share an
+  execution framework.
+- Treat hooks and CI workflows as composite guardrails where they aggregate checks, and inventory
+  their setup/action steps separately from the guarantees they enforce.
+- Identify objective skill and instruction rules that could be enforced mechanically, while
+  retaining human judgment where a deterministic rule would be brittle or incomplete.
+- Assess the likely context and inference-token effect of replacing selected instructions with
+  executable checks, using a documented measurement or estimation method rather than assuming
+  savings.
+- Inventory repeated checks and design safe result reuse based on exact input identity so hooks
+  and agents do not rerun unchanged work unnecessarily.
+- Research multiple implementation and execution models. Options must include retaining
+  distributed tools with clearer contracts as well as one or more consolidation approaches.
+- Compare options using explicit criteria: correctness, feedback latency, local/CI parity,
+  testability, maintainability, portability, incremental adoption, failure modes, developer and
+  agent usability, runtime cost, and migration risk.
+- Evaluate check placement across pre-commit, pre-push, CI, and any future repository-policy or
+  architecture-check category without assuming that every check belongs in one runner.
+- Explore future architecture-check candidates, including dictionary ordering and dependency
+  policy. Document existing coverage from Cargo and `deny.toml`, remaining gaps, false-positive
+  risk, and whether a new category is justified; do not select a framework prematurely.
+- Add a required deterministic check that verifies `project-words.txt` uses one documented
+  ordering rule and contains no duplicate entries. Decide its package and execution tier through
+  the EPIC design rather than coupling it to the tracker library.
+- Re-evaluate #1843, #1774, and #1768 against the resulting evidence and recommend whether each
+  should proceed unchanged, be re-scoped, be split, or be superseded.
+- Present the evidence and options for maintainer review before selecting a full design.
+- Define implementation subissues from the approved design, including ownership, dependency
+  order, migration boundaries, compatibility periods, and independent verification.
+- Implement the approved action, check, policy, output, and result-reuse capabilities through
+  those subissues, including the dictionary-integrity check.
+- Migrate local, agent, and CI consumers progressively; remove superseded implementations and
+  instructions only after parity and rollback evidence is recorded.
+
+### Out of Scope
+
+- Implementing, migrating, or consolidating automation tools or checks before the design decision
+  and implementation subissues are approved.
+- Prescribing a `workspace-tools` crate, a single Rust binary, Bash scripts, a task runner, or
+  any other tool shape before alternatives are compared and reviewed.
+- Prototyping architecture tests before the research identifies a question that requires a
+  bounded proof of concept and maintainers approve that follow-up.
+- Changing the CI/CD provider, release process, or the external `torrust-linting` project.
+- Treating every agent instruction as suitable for deterministic enforcement.
+- Shutdown and runtime task-ownership work. Issue #1586 belongs with shutdown EPIC #1488 and is
+  unrelated to repository automation or agent guardrails.
+
+## Known Existing Issues
+
+These issues are paused dependencies of the EPIC. Their current implementation choices are
+proposals to re-evaluate, not constraints on the EPIC design. Implementation must not resume
+until the architecture decision records whether each issue proceeds, is re-scoped or split, or
+is superseded.
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| Order | Issue                                                 | Local Spec                                                                | Status  | Relationship                                                                                                            |
+| ----- | ----------------------------------------------------- | ------------------------------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 1     | #1843 - Migrate git hooks scripts from Bash to Rust   | `docs/issues/open/1843-migrate-git-hooks-scripts-from-bash-to-rust.md`    | BLOCKED | Pause implementation; runner shape, contracts, check ownership, and migration depend on the design decision             |
+| 2     | #1774 - Automate cleanup of completed issue specs     | `docs/issues/open/1774-automate-cleanup-completed-issues-skill-script.md` | BLOCKED | Pause implementation; action placement, dry-run/apply, GitHub access, and output contract depend on the design decision |
+| 3     | #1768 - Refactor update-dependencies skill automation | `docs/issues/open/1768-refactor-update-dependencies-skill-automation.md`  | BLOCKED | Pause implementation; action decomposition, shared infrastructure, and validation policy depend on the design decision  |
+
+## Proposed Research and Design Subissues
+
+These are proposed planning subissues. Titles and boundaries may be adjusted during maintainer
+review; no GitHub issues should be created from this draft without approval.
+
+| Order | Proposed Issue                                           | Intent                                                                                                         | Expected Output                                                                                                                                                     | Verification                                                                                                                                           | Dependencies                                    |
+| ----- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
+| 1     | Inventory repository automation and guardrails           | Validate and complete the initial current-system evidence baseline                                             | Reviewed revision of `initial-inventory.md` and invocation/overlap map covering local, CI, skill, agent, and architecture-policy surfaces                           | Sample entries traced end to end; catalog cross-checked against repository entry points and reviewed for omissions                                     | Initial inventory in this EPIC                  |
+| 2     | Assess deterministic automation and guardrail candidates | Separate objective rules that are candidates for automation from judgment-based guidance and estimate benefits | Candidate matrix with determinism, current failure mode, proposed enforcement point, expected benefit, token-impact method, cost, and false-positive risk           | Representative skill and instruction rules reviewed by maintainers; rejected candidates retain rationale                                               | Subissue 1                                      |
+| 3     | Enforce project dictionary integrity                     | Add the known required guardrail without coupling it to the tracker library                                    | Deterministic test or check proving `project-words.txt` is sorted by a documented rule and has no duplicates; selected execution tier and actionable failure output | Positive test plus mutations for out-of-order and duplicate entries; invocation verified through the selected local and CI profiles                    | Subissue 2 for placement and interface decision |
+| 4     | Research safe check-result reuse                         | Avoid rerunning equivalent successful pre-commit, pre-push, and agent checks                                   | Cache-key model, invalidation rules, audit record, threat/failure analysis, and measured savings for representative workflows                                       | Mutations to staged content, commit/tree, configuration, tool version, and check version invalidate stale results; exact matches reuse results visibly | Subissues 1 and 2                               |
+| 5     | Define agent-friendly automation contracts               | Standardize non-interactive execution and machine-readable feedback                                            | Contract for JSONL/NDJSON events, stable exit codes, diagnostics, progress/heartbeat, side-effect reporting, and idempotent retries                                 | Fixture or contract tests cover success, failure, progress, cache hit/miss, and malformed invocation                                                   | Subissues 1 and 2                               |
+| 6     | Research and compare architecture options                | Evaluate viable organization, execution, feedback, and migration models without preselecting a tool            | Options paper with diagrams, decision criteria, trade-offs, migration paths, and bounded proof-of-concept recommendations where evidence is insufficient            | Every criterion and design principle applied consistently to each viable option; claims linked to inventory evidence or experiments                    | Subissues 1, 2, 4, and 5                        |
+| 7     | Record maintainer decision and implementation roadmap    | Convert the reviewed options into an explicit decision or documented request for more evidence                 | Decision record, disposition of #1843/#1774/#1768, ordered implementation scope, migration plan, and implementation-ready specs                                     | Maintainer review recorded; roadmap items trace to selected option and include independent verification criteria                                       | Subissues 3 and 6                               |
+| 8     | Implement approved automation foundation                 | Build only the shared contracts and infrastructure justified by the decision                                   | Tested implementation of the approved operation model, event and exit-code contracts, configuration, and any selected planning or result-reuse infrastructure       | Contract, unit, integration, failure, and invalidation tests pass; implementation maps to the decision record without speculative framework features   | Subissues 4, 5, and 7                           |
+| 9     | Implement and migrate approved operations                | Deliver the approved actions and checks, then move consumers without losing current guarantees                 | Dictionary-integrity guardrail plus approved #1843/#1774/#1768 scopes; local, agent, and CI migration; superseded-path removal                                      | Old/new parity or intentional-difference evidence, rollback exercise, consumer migration audit, and selected local/CI policies pass                    | Subissue 8                                      |
+| 10    | Validate rollout and close the EPIC                      | Prove the resulting system is usable, maintainable, and no longer depends on superseded paths                  | Runtime and token-impact results, final ownership map, operating documentation, residual-risk record, and closure dispositions                                      | Representative human and agent workflows pass; required CI guarantees remain enforced; stale references and temporary compatibility paths are removed  | Subissue 9                                      |
+
+## Delivery Strategy
+
+Use an evidence-first, progressive delivery strategy because the problem crosses repository
+workflows, developer tooling, and agent behavior, while the desired architecture is
+intentionally unsettled. Discovery and candidate analysis can gather evidence independently,
+but architecture selection and implementation must wait until both are complete.
+
+Research artifacts should be committed as durable documentation under the EPIC or an approved
+canonical docs location. Implementation subissues begin only after maintainers review the
+alternatives and record a decision. The decision may keep the current distributed model,
+approve only targeted improvements, select consolidation, or request a bounded experiment
+before committing to the remaining implementation.
+
+For each completed subissue in this EPIC, the default completion policy is:
+
+1. Run applicable automatic checks (`linter markdown`, `linter cspell`, and any tests for
+   research utilities or prototypes explicitly approved later).
+2. Run the defined manual review scenarios and record evidence.
+3. Re-review the subissue and EPIC acceptance criteria against the produced evidence.
+
+### Phase 1: Discovery
+
+- Outcome: a validated inventory and overlap map of the current automation and guardrail system.
+- Exit criteria: maintainers can trace what runs, where it runs, what it enforces, and where
+  duplication, redundant execution, feedback gaps, or manual-only rules exist. The initial
+  inventory is reviewed, corrected, and accepted as the baseline for later comparisons.
+
+### Phase 2: Candidate and Options Analysis
+
+- Outcome: a ranked candidate matrix and comparison of multiple viable architectures.
+- Exit criteria: alternatives use common evaluation criteria, identify unresolved evidence,
+  and avoid assuming a single binary, crate, language, or check category.
+
+### Phase 3: Maintainer Decision and Implementation Planning
+
+- Outcome: maintainers select an option, choose targeted changes, request further research, or
+  explicitly retain the current structure.
+- Exit criteria: the decision and rationale are recorded; existing issues have dispositions;
+  only approved implementation work has implementation-ready specs and ordering.
+
+### Phase 4: Foundation Implementation
+
+- Outcome: the minimal shared contracts and infrastructure selected by the decision are
+  implemented and tested without migrating all consumers at once.
+- Exit criteria: operation contracts, machine-readable events, failure behavior, and any
+  approved cache or planning behavior pass focused tests; rollback remains possible.
+
+### Phase 5: Operation Implementation and Progressive Migration
+
+- Outcome: approved actions and checks are delivered, including dictionary integrity, and local,
+  agent, and CI consumers move to the selected interfaces in reviewable increments.
+- Exit criteria: each migration preserves or intentionally revises documented guarantees;
+  superseded paths are removed only after parity, failure, and rollback evidence is accepted.
+
+### Phase 6: Rollout Validation and Closure
+
+- Outcome: the delivered system has final ownership, usage, performance, and maintenance
+  evidence, with paused issues closed, re-scoped, or completed according to the decision.
+- Exit criteria: representative human and agent workflows pass; required CI guarantees remain;
+  stale references and temporary compatibility paths are removed; residual risks are recorded.
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Epic spec drafted in `docs/issues/drafts/`
+- [x] Epic spec reviewed and approved by user/maintainer
+- [x] GitHub epic issue created and issue number added to this spec
+- [ ] Research/design subissues approved, created, and linked in this spec
+- [ ] Initial inventory reviewed and accepted as the Phase 1 baseline
+- [ ] Phase 1 discovery evidence reviewed
+- [ ] Phase 2 candidate and options analysis reviewed
+- [ ] Phase 3 maintainer decision recorded
+- [ ] Phase 4 foundation implementation completed and verified
+- [ ] Phase 5 operation implementation and progressive migration completed
+- [ ] Phase 6 rollout validation completed
+- [ ] Existing issue dispositions recorded for #1843, #1774, and #1768
+- [ ] Subissue statuses kept up to date in the relevant tables
+- [ ] For each completed subissue: automatic checks completed and recorded
+- [ ] For each completed subissue: manual verification completed and recorded
+- [ ] For each completed subissue: acceptance criteria reviewed post-completion
+- [ ] Epic acceptance criteria reviewed and checked off
+- [ ] Epic issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-07-20 00:00 UTC - Copilot - Initial epic draft
+- 2026-07-20 00:00 UTC - Planner - Refined draft to make discovery and options analysis the
+  immediate scope; removed unrelated and unsupported references; separated existing issues from
+  proposed research and design work - draft updated
+- 2026-07-20 00:00 UTC - Copilot - Converted the draft to a folder-type EPIC and recorded an
+  earlier single-runner design discussion as a non-binding supporting artifact
+- 2026-07-20 00:00 UTC - Copilot - Distinguished mutating automation actions from read-only
+  guardrail checks and documented the testing workflow as an existing composite CI guardrail
+- 2026-07-20 00:00 UTC - Copilot - Added the initial repository inventory, paused existing
+  implementation issues pending the design decision, and extended the EPIC through implementation,
+  progressive migration, rollout validation, and closure
+- 2026-07-20 00:00 UTC - josecelano - Approved the draft EPIC and its supporting artifacts
+- 2026-07-20 00:00 UTC - GitHub Operator - Created EPIC #2003 and moved the approved local
+  specification to `docs/issues/open/2003-overhaul-guardrails-and-automation/`
+
+## Acceptance Criteria
+
+- [ ] AC1: A reviewed catalog identifies current automation and guardrails, their invocation
+      sites, ownership, inputs/outputs, runtime tier, environment needs, and feedback behavior.
+- [ ] AC2: An overlap and gap analysis shows which checks are duplicated, unique, manual-only,
+      or already deterministic, including the guarantees enforced by `.github/workflows/testing.yaml`
+      and existing `deny.toml` dependency enforcement.
+- [ ] AC3: A candidate matrix distinguishes repetitive task automation from verification
+      guardrails, records side effects explicitly, and separates mechanically enforceable rules
+      from judgment-based guidance.
+- [ ] AC4: Token/context impact claims use a documented measurement or estimation method and
+      state limitations; the EPIC does not assume that deterministic checks are free.
+- [ ] AC5: Multiple viable architecture options are compared against the same explicit criteria,
+      including at least one incremental/distributed option and one consolidation option.
+- [ ] AC6: Architecture-check research documents current enforcement, candidate gaps, and risks
+      without requiring a framework, crate, binary, or prototype as an EPIC outcome.
+- [ ] AC7: #1843, #1774, and #1768 each receive a documented disposition based on the analysis;
+      #1586 is excluded as unrelated shutdown work.
+- [ ] AC8: Maintainer review is recorded before a full design is selected or implementation
+      subissues begin; unresolved evidence results in explicit research actions.
+- [ ] AC9: Approved implementation subissues have ordered, independently verifiable specs;
+      unapproved implementation ideas remain options rather than commitments.
+- [ ] AC10: Each completed research/design subissue records automatic checks, manual review
+      evidence, and a post-completion acceptance-criteria review.
+- [ ] AC11: A required deterministic check verifies that `project-words.txt` follows its
+      documented ordering rule and contains no duplicates, with mutation evidence for both
+      failure modes.
+- [ ] AC12: The selected automation contract is non-interactive and defines streaming
+      JSONL/NDJSON events, stable exit codes, actionable diagnostics, progress reporting, and
+      explicit side-effect and cache-result reporting.
+- [ ] AC13: Reusable check results are keyed and invalidated by all relevant inputs,
+      configuration, tool versions, and check version; cache hits are visible and cannot silently
+      reuse stale results after representative mutations.
+- [ ] AC14: The selected design defines distinct contracts for mutating actions, read-only
+      checks, and orchestration policies while identifying the infrastructure they may safely
+      share.
+- [ ] AC15: The approved foundation and operations are implemented through independently
+      verifiable subissues, including focused contract, failure, and invalidation tests.
+- [ ] AC16: Local hooks, agent workflows, and CI consumers migrate progressively with documented
+      parity or intentional differences, rollback evidence, and no premature removal of the old path.
+- [ ] AC17: Rollout evidence records runtime and context/token effects, final ownership, residual
+      risks, and removal of stale references and temporary compatibility paths.
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                          |
+| ----- | ---------------------- | ----------------------------------------------------------------- |
+| AC1   | TODO                   | Inventory artifact and maintainer review                          |
+| AC2   | TODO                   | Overlap/gap map                                                   |
+| AC3   | TODO                   | Candidate matrix                                                  |
+| AC4   | TODO                   | Token/context measurement method and results                      |
+| AC5   | TODO                   | Options paper and comparison matrix                               |
+| AC6   | TODO                   | Architecture-check feasibility section                            |
+| AC7   | TODO                   | Existing-issue disposition record                                 |
+| AC8   | TODO                   | Maintainer review record or decision log                          |
+| AC9   | TODO                   | Approved follow-up specs and dependency order                     |
+| AC10  | TODO                   | Subissue verification records                                     |
+| AC11  | TODO                   | Dictionary-integrity check and mutation-test evidence             |
+| AC12  | TODO                   | Automation interface contract and contract-test evidence          |
+| AC13  | TODO                   | Cache-key design, invalidation tests, and measured reuse evidence |
+| AC14  | TODO                   | Action/check/policy contracts and side-effect review              |
+| AC15  | TODO                   | Implementation subissue tests and verification records            |
+| AC16  | TODO                   | Consumer migration, parity, and rollback evidence                 |
+| AC17  | TODO                   | Rollout measurements, ownership map, and stale-path audit         |
+
+## Verification Plan
+
+### Automatic Checks
+
+- `linter markdown`
+- `linter cspell`
+- Validate referenced repository paths while producing and reviewing each research artifact.
+- Run focused tests only for a bounded research utility or proof of concept approved later.
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                             | Steps                                                                                                                         | Expected Result                                                                                                                | Status | Evidence |
+| --- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------ | -------- |
+| M1  | Inventory traceability sample        | Select representative local hook, CI, skill, and architecture-policy entries; trace each from source to invocation and output | Catalog entries match repository behavior, distinguish setup/actions from checks, and identify source of truth and duplication | TODO   |          |
+| M2  | Objective-rule classification review | Review representative accepted and rejected automation candidates with maintainers                                            | Mechanical rules have testable pass/fail semantics; judgment-based rules remain guidance with rationale                        | TODO   |          |
+| M3  | Options comparison review            | Walk maintainers through each option using the same decision criteria and evidence links                                      | Trade-offs and unknowns are visible; no option receives unearned preference from the document structure                        | TODO   |          |
+| M4  | Existing-issue disposition review    | Compare #1843, #1774, and #1768 with the reviewed decision                                                                    | Each issue is retained, re-scoped, split, or superseded with rationale; no unrelated issue is included                         | TODO   |          |
+| M5  | Dictionary guardrail mutation        | Introduce one out-of-order entry and one duplicate in isolated fixtures or temporary copies                                   | The check rejects each mutation with the offending entries and recovery guidance, then passes the unchanged dictionary         | TODO   |          |
+| M6  | Check-result reuse invalidation      | Repeat an unchanged check, then mutate each cache-key input in turn                                                           | Exact inputs produce a visible cache hit; every relevant mutation forces execution and cannot reuse a stale pass               | TODO   |          |
+| M7  | Agent interface exercise             | Invoke representative success, failure, long-running, and cache-hit paths without a TTY                                       | The process never prompts, streams valid JSONL/NDJSON events, exits predictably, and gives actionable failure data             | TODO   |          |
+
+## Risks and Assumptions
+
+- Risk: inventory work becomes an unbounded catalog. Mitigation: record only artifacts that
+  execute tasks, enforce rules, or materially instruct agent execution, and define completion by
+  traced entry points rather than raw file count.
+- Risk: consolidation is treated as inherently simpler. Mitigation: require a distributed,
+  incremental baseline option and compare total ownership and migration cost.
+- Risk: deterministic checks encode incomplete policy and create false confidence. Mitigation:
+  document rule semantics, false-positive/false-negative risks, and keep judgment-based review.
+- Risk: token savings are overstated or moved into tool execution cost. Mitigation: report the
+  measurement boundary, assumptions, and both context and execution costs.
+- Risk: result caching hides failures after relevant inputs change. Mitigation: use
+  content-addressed keys over declared inputs and versions, expose cache decisions, and test
+  invalidation with representative mutations.
+- Risk: machine-readable output is technically valid but difficult for humans or agents to act
+  on. Mitigation: define semantic event contracts and actionable fields, not only JSON syntax,
+  and validate representative consumers.
+- Risk: existing issue scopes conflict with the selected design. Mitigation: do not implement
+  them through this EPIC until their dispositions are reviewed and recorded.
+- Assumption: maintainers prefer evidence and reversible incremental adoption over a mandatory
+  repository-wide migration. Maintainer review may replace this assumption with an explicit
+  constraint.
+
+## References
+
+- Existing candidate issues: #1843, #1774, #1768
+- Unrelated shutdown issue excluded from this EPIC: #1586
+- Current local checks: `contrib/dev-tools/git/hooks/pre-commit.sh`,
+  `contrib/dev-tools/git/hooks/pre-push.sh`
+- Current CI checks: `.github/workflows/testing.yaml`
+- Current dependency-policy enforcement: `deny.toml`, `docs/packages.md`
+- Existing workspace analysis tool: `contrib/dev-tools/analysis/workspace-coupling/`
+- Initial inventory: `docs/issues/open/2003-overhaul-guardrails-and-automation/initial-inventory.md`
+- Previous candidate architecture:
+  `docs/issues/open/2003-overhaul-guardrails-and-automation/previous-single-runner-proposal.md`

--- a/docs/issues/open/2003-overhaul-guardrails-and-automation/initial-inventory.md
+++ b/docs/issues/open/2003-overhaul-guardrails-and-automation/initial-inventory.md
@@ -1,0 +1,195 @@
+# Initial Repository Automation and Guardrail Inventory
+
+## Status and Purpose
+
+This is the EPIC's initial evidence baseline, created before the dedicated inventory subissue.
+It records observed repository entry points and known drift so the subissue starts from a
+reviewable artifact rather than an empty catalog. It is intentionally incomplete: runtime
+measurements, owners, exact trigger coverage, output samples, and end-to-end traces still require
+validation.
+
+This document describes the current system. It does not select the future architecture, assign
+operations to a unified runner, or approve implementation from the paused issues.
+
+## Classification
+
+| Classification         | Meaning                                                                              |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| Action                 | Intentionally changes repository, Git, external service, or published artifact state |
+| Check                  | Evaluates an objective condition and should be read-only except for caches and logs  |
+| Policy                 | Selects and orders operations for an execution context                               |
+| Composite guardrail    | Lifecycle or merge gate composed from multiple checks and required setup/actions     |
+| Guidance/orchestration | Human or agent instructions that select tools, add judgment, or define handoffs      |
+| Setup/infrastructure   | Prepares an environment or artifact needed by another action or check                |
+
+## Runtime Tiers
+
+These tiers are qualitative until Phase 1 records measurements on representative warm and cold
+environments.
+
+| Tier | Current interpretation                                                    |
+| ---- | ------------------------------------------------------------------------- |
+| T0   | Seconds; metadata, file, or focused documentation checks                  |
+| T1   | Roughly one minute; local lint, dependency, and documentation-test gates  |
+| T2   | Several minutes; full builds, tests, compatibility matrices, or coverage  |
+| T3   | Tens of minutes; container builds, E2E suites, publication, or benchmarks |
+
+## Local Git Entry Points
+
+| Artifact / command                           | Class                        | Invocation and current behavior                                                                                                       | Output / side effects                                                                                              | Tier | Source of truth / notes                                                                    |
+| -------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------ |
+| `.githooks/pre-commit`                       | Policy / composite guardrail | Installed Git hook; selects text for TTY stdout and JSON otherwise, then delegates to the pre-commit script                           | Inherits script logs and exit code; dispatcher itself is read-only                                                 | T1   | Dispatcher policy is here; operation list is in the script                                 |
+| `contrib/dev-tools/git/hooks/pre-commit.sh`  | Policy / composite guardrail | Runs `cargo machete --with-metadata`, `cargo deny check bans`, `linter all`, and workspace doc tests; fail-fast                       | Text or one JSON document; creates per-step logs in `TORRUST_GIT_HOOKS_LOG_DIR`; JSON is buffered until completion | T1   | Authoritative current local step list; duplicated runner/reporting framework with pre-push |
+| `.githooks/pre-push`                         | Policy / composite guardrail | Installed Git hook; selects text for TTY stdout and JSON otherwise, then delegates to the pre-push script                             | Inherits script logs and exit code                                                                                 | T2   | Dispatcher policy is here; operation list is in the script                                 |
+| `contrib/dev-tools/git/hooks/pre-push.sh`    | Policy / composite guardrail | Runs nightly format/check/doc and full stable workspace tests; intentionally excludes pre-commit and E2E checks                       | Text or one JSON document; creates per-step logs; fail-fast                                                        | T2   | Authoritative current local step list; assumes pre-commit ran for every pushed commit      |
+| `contrib/dev-tools/git/install-git-hooks.sh` | Action                       | Manually or during Copilot setup; copies every `.githooks/*` file into the active Git hooks directory and sets executable permissions | Mutates `.git/hooks`; plain text; no dry-run                                                                       | T0   | Installation behavior lives in script; copied hooks can become stale until reinstalled     |
+| `contrib/dev-tools/git/check-git-hooks.sh`   | Check                        | Agent skills use it before manual validation to avoid running an installed hook suite twice                                           | Reports installation state; expected read-only                                                                     | T0   | Needs output and exit-code contract validation during Phase 1                              |
+
+## Primitive Checks and Analysis Tools
+
+| Artifact / command                                  | Class         | Guarantee or purpose                                                                               | Invocation points                                                    | Output / side effects                                                | Tier  | Source of truth / gaps                                                                                                 |
+| --------------------------------------------------- | ------------- | -------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------------------------------- |
+| `linter all` and focused `linter <name>`            | Check adapter | Delegates to Clippy, rustfmt, markdownlint, cspell, yamllint, Taplo, and ShellCheck                | Pre-commit, Testing CI, Docs Lint CI, skills, agents, and direct use | Tool-dependent text; tools may create caches or install dependencies | T0-T2 | External `torrust-linting` binary plus repository tool configs; no repository-owned shared event contract              |
+| `cargo machete --with-metadata`                     | Check         | Finds unused Cargo dependencies                                                                    | Pre-commit; described in several skills and agent policies           | Cargo tool output; metadata/cache effects only                       | T1    | Not observed in Testing CI; local gate currently owns it                                                               |
+| `cargo deny check bans` with `deny.toml`            | Check         | Enforces configured dependency/layer bans                                                          | Pre-commit and Testing CI `layer-bans` job                           | Cargo tool output; read-only except caches                           | T0-T1 | Deterministic architecture policy; local and CI invocations duplicate the same primitive                               |
+| Cargo format, check, test, doc, build, and coverage | Check family  | Compiler, formatting, test, documentation, successful build, and coverage guarantees               | Hooks, CI workflows, skills, agents, and direct package validation   | Cargo/tool text and build artifacts under `target/`                  | T1-T3 | Flags and toolchains differ by policy; exact equivalence must not be assumed                                           |
+| E2E runner binaries                                 | Check family  | Tracker behavior and qBittorrent interoperability, including SQLite, MySQL, and PostgreSQL paths   | Testing and Container workflows                                      | JSON-compatible repository CLI output plus containers and logs       | T3    | Require built image, container engine, ports, and database services; overlap is conditionally suppressed in Testing CI |
+| `contrib/dev-tools/analysis/workspace-coupling/`    | Analysis tool | Scans workspace package dependencies and imported paths to produce coupling evidence               | Manual architecture analysis; generated reports under issue folders  | Produces reports; reads Cargo/source metadata                        | T1    | A reusable Rust tool, but not currently a mandatory guardrail; known text-scan limitations are documented in reports   |
+| `project-words.txt` ordering and uniqueness         | Manual rule   | Dictionary entries are expected to be alphabetized; duplicate behavior is not mechanically guarded | Human/agent instructions and review                                  | No current deterministic result                                      | T0    | Required future check is a separate EPIC subissue; ordering semantics must be documented before implementation         |
+
+## GitHub Workflow Inventory
+
+Each workflow is a policy or composite entry point. Setup steps are not themselves evidence that
+the guarded property passed.
+
+| Workflow                    | Class                        | Trigger / guarantee summary                                                                                                             | Side effects and outputs                                                           | Tier  | Overlap / initial observations                                                                                                  |
+| --------------------------- | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `testing.yaml`              | Composite guardrail          | Non-doc pushes/PRs; stable/nightly linters and tests, nightly formatting, doc tests, layer bans, conditional container and database E2E | Builds artifacts/images, starts containers, emits GitHub logs/statuses             | T2-T3 | Repeats local lint/doc/bans and full-test primitives; condition avoids selected overlap with `container.yaml`                   |
+| `docs-lint.yaml`            | Composite guardrail          | Every push/PR; focused Markdown and spelling checks; provides the required signal for docs-only changes                                 | Installs linter and emits statuses                                                 | T0-T1 | Deliberately overlaps `linter all`; path-policy comments must remain synchronized across workflows                              |
+| `container.yaml`            | Composite guardrail / action | Relevant pushes/PRs test a built image and qBittorrent database matrix; protected-branch paths also publish development/release images  | Builds, loads, logs into registry, and may publish container images                | T3    | E2E overlap with Testing is managed by event conditions; combines mutating publication actions with checks                      |
+| `coverage.yaml`             | Check / reporting policy     | Branch coverage run using nightly LLVM tooling                                                                                          | Generates and uploads coverage artifacts/reports                                   | T2-T3 | Related logic also exists in PR coverage generation and upload workflows                                                        |
+| `generate_coverage_pr.yaml` | Check / reporting policy     | Pull-request coverage generation                                                                                                        | Produces coverage and metadata artifacts                                           | T2-T3 | Paired with `upload_coverage_pr.yaml`; split trust/permission boundary needs tracing                                            |
+| `upload_coverage_pr.yaml`   | Action                       | Consumes completed PR coverage workflow output                                                                                          | Writes coverage report content and PR/issue-facing state with elevated permissions | T0-T1 | Mutating second half of PR coverage flow; must remain distinct from the coverage check                                          |
+| `db-compatibility.yaml`     | Composite guardrail          | Persistence-relevant changes; tracker-core tests against MySQL 8.0/8.4 and PostgreSQL 14-17                                             | Starts test containers/services and emits statuses                                 | T2    | Broader than the E2E database-driver matrix in version coverage; narrower in package/path scope                                 |
+| `db-benchmarking.yaml`      | Benchmark policy             | Persistence-relevant changes run small SQLite, MySQL, and PostgreSQL benchmark scenarios                                                | Starts services and produces benchmark output                                      | T2-T3 | Performance signal semantics and whether regressions block are not yet cataloged                                                |
+| `os-compatibility.yaml`     | Composite guardrail          | Non-doc pushes/PRs build stable and nightly on Linux, macOS, and Windows                                                                | Build artifacts/caches and GitHub statuses                                         | T2    | Unique cross-OS guarantee; overlaps Linux builds elsewhere                                                                      |
+| `security-scan.yaml`        | Reporting guardrail          | Container changes, protected branches, daily schedule, and manual runs scan an image with Trivy                                         | Pulls/builds image; uploads SARIF; Trivy steps explicitly use exit code 0          | T2-T3 | Visibility and GitHub Security reporting, not a direct vulnerability-failing job; enforcement ownership is external to the step |
+| `deployment.yaml`           | Composite release policy     | Tracker release branches run full workspace tests before publication                                                                    | Publishes tracker release artifacts/state                                          | T2-T3 | Repeats full tests as a release prerequisite                                                                                    |
+| `deployment-packages.yaml`  | Composite release policy     | Package release paths identify, test, and publish a selected crate                                                                      | Publishes package artifacts and external registry state                            | T2    | Package-scoped test guarantee; parsing and publication are mutating actions                                                     |
+| `copilot-setup-steps.yml`   | Setup / smoke-check policy   | Changes to setup/hook files and manual dispatch build workspace, install tools/hooks, and smoke-check all linters                       | Installs tools and mutates checkout `.git/hooks`; emits status                     | T2    | Validates Copilot environment setup, not product behavior; references only a subset of files whose changes can affect hooks     |
+| `labels.yaml`               | Action                       | Manual or label-config changes export and synchronize GitHub labels                                                                     | Mutates repository files or GitHub labels, depending on job                        | T0    | External-service automation; outside code guardrails but relevant to the shared action contract                                 |
+
+## Skills, Agents, and Repository Guidance
+
+| Surface                                                  | Class                  | Current role                                                                                                  | Deterministic dependency / observed gap                                                                                                       |
+| -------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AGENTS.md`                                              | Policy guidance        | Defines mandatory quality gates, Git workflow, engineering policy, and skill entry points                     | Must be interpreted by agents; currently summarizes local gates and should link rather than duplicate changing procedures                     |
+| `run-pre-commit-checks` and `run-pre-push-checks` skills | Orchestration guidance | Explain installation, duplicate-run avoidance, commands, tiers, output modes, and troubleshooting             | Depend on hook scripts and `check-git-hooks.sh`; pre-commit skill omits the script's current `cargo deny` step and uses older machete wording |
+| `run-linters` and `install-linter` skills                | Orchestration / setup  | Explain focused and aggregate linter use and external tool installation                                       | Depend on external linter behavior; duplicate tool/config lists also summarized in `AGENTS.md`                                                |
+| `setup-dev-environment` skill                            | Setup policy           | Builds workspace, creates storage, installs tools/hooks, runs smoke tests, and verifies tests                 | Mutates machine/working tree state; manual multi-command procedure overlaps Copilot setup workflow                                            |
+| `update-dependencies` skill                              | Action guidance        | Prescribes branch-first dependency updates, classification, validation, and commit preparation                | Mostly manual; #1768 proposes scripts but is paused pending shared design                                                                     |
+| `cleanup-completed-issues` skill                         | Action guidance        | Prescribes issue-state validation and moving completed specs                                                  | Manual GitHub/repository mutation; #1774 proposes a non-interactive script but is paused pending shared design                                |
+| Planning, testing, review, and maintenance skills        | Guidance/policies      | Encode document creation, tests, reviews, security triage, dependency changes, and other repeatable workflows | Mix objective commands with judgment; candidate analysis must avoid converting subjective review into brittle checks                          |
+| Implementer agent                                        | Agent policy           | Requires focused tests, complexity audit after steps, task review, then commit delegation                     | Coordinates Complexity Auditor, Task Reviewer, and Committer; repeats hook command/output details                                             |
+| Committer agent                                          | Agent policy           | Checks hook installation, runs or relies on pre-commit, reviews staged scope, and creates signed commits      | Relies on script/skill correctness; duplicate-run avoidance is procedural                                                                     |
+| Complexity Auditor and Task Reviewer agents              | Review policies        | Evaluate changed-function complexity and acceptance-criteria completion                                       | Judgment-heavy outputs; not equivalent to deterministic repository checks                                                                     |
+| Other specialized agents                                 | Role policies          | Clippy repair, PR review, research, planning, and GitHub operations                                           | Select tools and make judgments; inventory subissue must trace only rules that materially execute or gate work                                |
+
+## Current Invocation and Ownership Map
+
+```text
+git commit -> installed .githooks/pre-commit -> pre-commit.sh
+  -> machete + deny bans + linter all + doc tests
+
+git push -> installed .githooks/pre-push -> pre-push.sh
+  -> nightly fmt/check/doc + stable full tests
+
+push / pull request -> GitHub workflow trigger policies
+  -> docs-only signal OR broader testing/compatibility/container policies
+  -> primitive Cargo/linter checks and repository E2E runners
+
+skills / agents -> choose direct commands, hooks, workflows, and manual review
+  -> repeated procedure text can drift from executable operation lists
+```
+
+Current source-of-truth boundaries are fragmented but identifiable:
+
+- Executable operation semantics live in Cargo tests/binaries, external linters, hook scripts,
+  workflow commands, and tool configuration.
+- Context-specific selection lives in hook step arrays, workflow jobs/triggers, skills, agents,
+  and `AGENTS.md`.
+- Human and agent recovery procedures live primarily in skills and agent definitions.
+- GitHub branch protection and required-check configuration are outside this repository and have
+  not yet been inventoried.
+
+## Initial Overlap and Drift Findings
+
+1. Pre-commit and pre-push duplicate a substantial Bash framework for arguments, execution,
+   timing, logging, JSON escaping, and summaries while selecting different operations.
+2. Local and CI policies invoke several identical primitives, but toolchain, flags, changed-file
+   scope, and environment differ; they are overlapping guarantees, not automatically reusable
+   results.
+3. `linter all` provides one command but not one repository-owned result/event contract; its
+   delegated tools keep separate configuration and ignore rules.
+4. The pre-commit script currently runs four operations, including `cargo deny check bans`, while
+   the pre-commit skill and some agent-facing summaries still describe the older three-step gate.
+5. Hook JSON mode emits one document after execution, so non-interactive consumers receive no
+   structured progress during long steps. Concise mode writes detailed logs outside the event
+   payload.
+6. The installed hooks are copies, creating a stale-installation risk after `.githooks/` changes.
+7. The docs-only path policy is copied across several workflows and depends on comments and path
+   filters remaining synchronized.
+8. Container E2E duplication is controlled through event conditions in Testing and Container;
+   this is an existing example of policy-level redundant-execution avoidance.
+9. Security scanning reports findings through SARIF but deliberately does not fail on Trivy's
+   vulnerability exit status; “security scan passed” must not be interpreted as “no high or
+   critical vulnerabilities.”
+10. Skills and agents contain both judgment and objective procedures. Deterministic candidates
+    must be extracted selectively, leaving review and decision responsibilities explicit.
+
+## Known Gaps for the Inventory Subissue
+
+- Record measured warm/cold runtime and feedback latency for representative local and CI paths.
+- Capture exact stdout, stderr, exit-code, log, artifact, and JSON schemas for each executable
+  entry point.
+- Trace every workflow trigger, path filter, required status, permission boundary, and external
+  service dependency, including branch-protection settings not stored in the repository.
+- Confirm owners and maintenance boundaries for each operation, policy, configuration, and
+  external binary.
+- Enumerate all skill-local scripts and `contrib/dev-tools/` tools that mutate or validate state;
+  the initial pass emphasizes the surfaces already implicated by the EPIC.
+- Separate cache writes needed for execution from repository mutations and identify undeclared
+  network, container, credential, and tool-installation requirements.
+- Build a machine-readable operation-to-policy matrix after identifiers and equivalence semantics
+  are designed; this Markdown inventory is not that future configuration.
+- Validate documentation drift findings against current maintainers' intended policy before
+  treating either executable code or prose as normatively correct.
+- Determine which current checks are merge-required in GitHub settings and which only produce
+  informational statuses.
+
+## Validation Plan for Phase 1
+
+1. Select at least one local hook, one primitive check, one CI composite guardrail, one mutating
+   action, one skill, and one agent policy and trace each from trigger through result.
+2. Cross-check repository files by entry-point class rather than assuming this first-pass list is
+   exhaustive.
+3. Run representative commands only where doing so is safe and useful; record environment,
+   runtime, output channels, exit codes, artifacts, logs, and side effects.
+4. Review overlap claims using exact command, configuration, toolchain, inputs, and environment;
+   label near-matches rather than claiming equivalence without evidence.
+5. Obtain maintainer review of ownership, intentional duplication, external settings, and known
+   omissions, then update this document as the accepted Phase 1 baseline.
+
+## References
+
+- [`EPIC.md`](EPIC.md)
+- [`previous-single-runner-proposal.md`](previous-single-runner-proposal.md)
+- `AGENTS.md`
+- `.github/workflows/`
+- `.github/skills/`
+- `.github/agents/`
+- `.githooks/`
+- `contrib/dev-tools/git/`
+- `contrib/dev-tools/analysis/workspace-coupling/`
+- `deny.toml`
+- `project-words.txt`

--- a/docs/issues/open/2003-overhaul-guardrails-and-automation/previous-single-runner-proposal.md
+++ b/docs/issues/open/2003-overhaul-guardrails-and-automation/previous-single-runner-proposal.md
@@ -1,0 +1,286 @@
+# Previous Discussion: Unified Rust Repository Automation Runner
+
+## Status
+
+This document records an earlier exploratory discussion about a potential implementation for
+repository automation and guardrails. It is historical design input for the EPIC, not an
+approved architecture or implementation plan.
+
+The proposal intentionally makes strong choices so they can be evaluated. The EPIC must compare
+it with distributed and incremental alternatives, validate its assumptions against the current
+repository, and obtain maintainer approval before adopting any part of it.
+
+## Motivation Discussed
+
+The project relies on multiple automation scripts, GitHub Actions steps, and independently
+implemented validation logic. The discussion assumed that continued growth would make this
+system increasingly difficult to maintain, extend, and reuse.
+
+The proposed response was to consolidate repository actions and guardrail checks into one
+extensible Rust automation framework. Instead of maintaining execution logic across shell
+scripts and CI workflow steps, the framework would expose a consistent model usable locally and
+in CI.
+
+## Proposed Goals
+
+- Replace scattered automation execution logic with a unified Rust CLI.
+- Make actions and checks reusable locally and in CI where their environment permits it.
+- Allow new actions and checks to be added without modifying the execution engine.
+- Support different validation policies for different execution contexts.
+- Share common project metadata across validations.
+- Produce consistent output for humans and machines.
+
+These were proposal goals, not conclusions supported by the EPIC inventory or options analysis.
+
+## Proposed Architecture
+
+```text
+      +-----------------------+
+      | Repository Tool Runner|
+      |      (Rust CLI)       |
+      +-----------------------+
+          |
+        Load Policy
+          |
+        Execution Planner
+          |
+       +--------------+--------------+
+       |                             |
+    Actions                        Checks
+  update dependencies            formatting / Clippy
+   archive issue specs             tests / E2E / bans
+```
+
+Each operation would be implemented as an independent **action** or **check**. The runner would
+be responsible only for:
+
+- loading configuration;
+- resolving dependencies;
+- scheduling execution;
+- aggregating results; and
+- reporting progress and outcomes.
+
+## Operation Model
+
+The earlier discussion used “guardrail” for every operation. This refinement separates three
+concepts:
+
+| Type       | Role                                                       | Side effects                   | Example                                            |
+| ---------- | ---------------------------------------------------------- | ------------------------------ | -------------------------------------------------- |
+| **Action** | Performs repository work                                   | Expected and declared          | Update dependencies, archive completed issue specs |
+| **Check**  | Verifies an objective condition                            | Read-only by default           | Formatting, tests, layer-boundary bans             |
+| **Policy** | Selects and orders actions/checks for an execution context | Depends on selected operations | Pre-commit, pre-push, CI, nightly, release         |
+
+They may share execution context, scheduling, output, and cache infrastructure, but actions need
+dry-run/apply, idempotency, and side-effect safeguards that do not belong to read-only checks.
+
+Candidate checks discussed included:
+
+- Rust formatting;
+- Clippy;
+- unit tests;
+- integration tests;
+- end-to-end tests;
+- benchmarks;
+- documentation checks;
+- license validation;
+- dependency auditing;
+- container image validation;
+- API compatibility;
+- Torrust-specific project conventions.
+
+Candidate actions include:
+
+- update dependencies;
+- archive or clean completed issue specifications;
+- prepare branches or commit metadata; and
+- install repository Git hooks.
+
+The intended extension model was that adding an action or check would require implementing a new
+Rust component without changing the core runner.
+
+## Existing Composite Testing Guardrail
+
+`.github/workflows/testing.yaml` is already a composite CI guardrail. Its current guarantees
+include:
+
+- Rust formatting on the nightly matrix entry;
+- all configured linters on stable and nightly;
+- workspace documentation tests;
+- workspace tests, benches, and examples across all targets and features;
+- Cargo dependency layer-boundary bans through `cargo deny check bans`;
+- successful construction of the tracker container image;
+- tracker E2E validation against the container image; and
+- qBittorrent E2E validation with SQLite, MySQL, and PostgreSQL.
+
+This existing database-backed E2E coverage replaces the earlier speculative “SQL migration
+validation” extension. The inventory must describe the guarantee the tests actually provide and
+must not claim migration-schema coverage beyond the observed tests.
+
+The workflow includes setup and image-build actions, but its overall role is a merge/CI
+guardrail. A future design may reuse its individual checks without assuming the workflow itself
+should disappear.
+
+## Policy Model
+
+Policies would define **what runs**, not **how operations run**. Example policies included:
+
+- `quick`;
+- `ci`;
+- `release`;
+- `nightly`; and
+- `benchmark`.
+
+An illustrative mapping was:
+
+| Policy    | Example operations                       |
+| --------- | ---------------------------------------- |
+| `quick`   | formatting, Clippy                       |
+| `ci`      | formatting, Clippy, tests, documentation |
+| `release` | all applicable validations               |
+
+This model aimed to keep local feedback fast while scheduling expensive validations less
+frequently.
+
+## Dependency Resolution
+
+The proposal assumed that some actions and checks naturally depend on others. Examples included:
+
+- benchmarks require successful tests;
+- end-to-end tests require container images; and
+- release validation requires successful documentation generation.
+
+The runner would resolve and schedule these dependencies automatically.
+
+## Shared Execution Context
+
+Every action and check would receive a shared execution context containing relevant project metadata,
+for example:
+
+- workspace path;
+- Cargo metadata;
+- Git information;
+- environment variables;
+- changed files; and
+- CI metadata.
+
+The intended benefit was avoiding duplicated repository-discovery logic across guardrails.
+
+## Standardized Results
+
+Every check would return a common result model. Proposed states were:
+
+- passed;
+- failed;
+- warning; and
+- skipped.
+
+Actions would need a related but distinct result model that makes mutation explicit, such as:
+
+- changed;
+- unchanged;
+- skipped; and
+- failed.
+
+Results could include:
+
+- execution time;
+- summary; and
+- detailed diagnostics.
+
+The common result model was intended to support consistent terminal presentation,
+machine-readable event streams, reports, and CI integration. Any future design should align this
+idea with the EPIC's JSONL/NDJSON, progress, exit-code, and diagnostics principles.
+
+## Illustrative CLI
+
+```bash
+guard run --policy quick
+guard run --policy ci
+guard run --policy release
+guard run fmt
+guard run clippy tests
+guard run --all
+```
+
+The command and binary names were placeholders.
+
+## Proposed CI Integration
+
+The discussion proposed replacing repeated workflow steps such as:
+
+```yaml
+- run: cargo fmt
+- run: cargo clippy
+- run: cargo nextest
+- run: ./scripts/check_docs.sh
+```
+
+with one policy invocation:
+
+```yaml
+- run: cargo guard --policy ci
+```
+
+The intended outcome was for the same automation implementation to run locally and in CI.
+
+## Potential Extensions
+
+The proposed framework was expected to support future checks such as:
+
+- API compatibility analysis;
+- performance regression detection;
+- project-specific architecture rules;
+- documentation completeness checks;
+- security and supply-chain analysis; and
+- custom linting for the Torrust ecosystem.
+
+## Claimed Benefits to Validate
+
+The discussion identified these potential benefits:
+
+- one source of truth for repository operation contracts and policies;
+- strongly typed implementation in Rust;
+- easier extension with new actions and checks;
+- consistent local and CI behavior;
+- faster feedback through configurable policies;
+- less duplicated shell and workflow logic; and
+- a foundation for future quality tooling.
+
+These are hypotheses. The EPIC should validate them against implementation cost, coupling,
+failure isolation, portability, startup and compilation overhead, ownership boundaries, and the
+cost of centralizing unrelated checks.
+
+## Questions for the EPIC
+
+- Does one runner reduce total complexity, or merely move distributed complexity into a central
+  framework?
+- Which checks should be native Rust components, and which should remain external commands
+  orchestrated through stable adapters?
+- Can actions and checks be added without modifying the execution engine in practice, and is a
+  plugin mechanism needed or justified?
+- Which infrastructure can actions and checks safely share without hiding mutation or weakening
+  read-only guarantees?
+- How should local, pre-commit, pre-push, CI, nightly, release, and benchmark policies relate?
+- How should the dependency graph represent generated artifacts, services, databases, and
+  containers in addition to pass/fail prerequisites?
+- How are cache keys, result reuse, cancellation, concurrency, timeouts, and retries represented?
+- How does the runner stream JSONL/NDJSON progress while preserving actionable human output?
+- What remains in GitHub Actions because it is infrastructure orchestration, and which workflows
+  remain valuable composite guardrails even if their checks use shared tooling?
+- Does compiling or installing the runner create a bootstrapping problem for lightweight checks?
+- How can migration happen incrementally without maintaining two conflicting sources of truth?
+- What evidence would justify selecting this proposal over improving the current distributed
+  system?
+
+## Relationship to the EPIC
+
+The EPIC inventory should map this proposal to current hooks, workflows, skills, agents, and
+analysis tools. The options analysis should then compare this model with at least:
+
+1. an improved distributed model with shared contracts;
+2. incremental consolidation of only duplicated execution infrastructure; and
+3. a unified runner similar to this proposal.
+
+No implementation issue should treat this document as an approved decision unless the EPIC
+records that decision after maintainer review.


### PR DESCRIPTION
## Summary

This PR adds the approved EPIC specification for repository automation and AI-agent guardrails.

## Scope

This PR:
- Adds the approved EPIC specification for repository automation and AI-agent guardrails
- Adds the initial current-state inventory
- Preserves the previous unified Rust runner proposal as non-binding design input
- Performs no automation implementation
- Pauses/re-evaluates #1843, #1774, and #1768 through the EPIC design process

## Validation

Full pre-commit workflow passed:
- `cargo machete --with-metadata`
- `cargo deny check bans`
- `linter all`
- `cargo test --doc --workspace`

Branch push succeeded.

Related to #2003