### PR TITLE
docs(issues): refine event metrics delivery plan

### DIFF
--- a/docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
+++ b/docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
@@ -1,0 +1,193 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: draft
+priority: p2
+github-issue: null
+spec-path: docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
+branch: "{issue-number}-optimize-event-publication-without-consumers"
+related-pr: null
+last-updated-utc: 2026-08-18
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - packages/events/src/bus.rs
+    - packages/http-core/src/container.rs
+    - packages/udp-core/src/container.rs
+    - packages/udp-server/src/container.rs
+    - src/container.rs
+    - docs/events-architecture.md
+    - docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
+    - docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Draft - Investigate Event Publication Performance and Consumer Demand
+
+## Goal
+
+Measure the practical cost of always publishing tracker events, inventory every
+consumer required for each event family, and decide from evidence whether a
+consumer-demand optimization is justified.
+
+## Background
+
+`EventBus` currently exposes an absent sender through `SenderStatus::Disabled`.
+Producers that receive no sender skip event construction and publication. This
+is preferable to a no-op sender because it makes the absent-consumer state
+explicit and avoids a broadcast attempt.
+
+Issue #2039 normalizes correctness: metrics-disabled listeners must still
+produce policy-neutral facts for the shared stream. Those facts can be consumed
+by metrics listeners and, for UDP-server cookie errors, by the banning listener.
+Therefore #2039 must keep event publication enabled even when a listener's own
+metrics policy is disabled.
+
+Disabling per-instance metrics is not sufficient to disable publication. For an
+event family to have no required consumer, all of its aggregate metrics
+consumers, non-metrics consumers, and required counters must be inactive. For
+UDP-server events this includes the banning listener and the cookie-error facts
+and counters that it requires, even when ban enforcement is configured as
+disabled. The exact service inventory and performance effect are not yet known.
+
+This is an investigation draft, not an approved implementation issue. It is
+independent of Issue #2039 correctness and is scheduled for reconsideration
+after the final Issue #2035 verification. Do not create a GitHub issue or begin
+implementation until benchmark evidence and the required consumer inventory
+support the work.
+
+## Scope
+
+### In Scope
+
+- Inventory the HTTP-core, UDP-core, and UDP-server event producers,
+  aggregate-metrics consumers, banning consumers, and auxiliary counters.
+- Benchmark representative tracker workloads with event publication enabled and
+  with controlled instrumentation that quantifies publication work.
+- Establish whether event construction and broadcast are a material bottleneck.
+- Define candidate configurations that could safely have no required consumers,
+  including the conditions for disabling aggregate metrics, banning, and
+  banning-related counters.
+- Evaluate an immutable bootstrap-time consumer-demand plan only if the
+  benchmark demonstrates a material benefit.
+- Preserve absent-sender injection rather than introducing a no-op sender if a
+  later implementation is approved.
+
+### Out of Scope
+
+- Changing the semantic contents of HTTP, UDP-core, or UDP-server events.
+- Per-listener metrics filtering and canonical identity propagation, owned by
+  #2039.
+- Changing connection-ID validation or shared ban-service semantics.
+- Implementing consumer-demand optimization before benchmark evidence and
+  explicit maintainer approval.
+- Runtime subscription counting, dynamic listener registration, configuration
+  reload, or an event bus per listener.
+- Using compiler dead-code elimination to solve runtime configuration costs.
+
+## Design Direction
+
+First collect evidence. Benchmark a realistic HTTP and UDP workload while
+recording event construction, clone, and broadcast behavior through controlled
+instrumentation. Do not assume that publication overhead is material without
+measurement.
+
+If the evidence justifies a future implementation, determine publication demand
+once during bootstrap from immutable configured services and consumers. Do not
+infer it from Tokio receiver counts: listeners start asynchronously, and live
+receiver counts would make event publication dependent on startup timing.
+
+The plan must distinguish event family and consumer type:
+
+| Event family | Publication demand                                                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP core    | All aggregate metrics and every other registered HTTP-core consumer must be inactive.                                                       |
+| UDP core     | All aggregate metrics and every other registered UDP-core consumer must be inactive.                                                        |
+| UDP server   | All aggregate metrics, banning, cookie-error counters required by banning, and every other registered UDP-server consumer must be inactive. |
+
+The draft must explicitly resolve whether disabled connection-ID validation
+still requires cookie-error facts and counters. Current documentation says it
+does, so it is not itself a sufficient condition to disable UDP-server
+publication.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                             | Notes / Expected Output                                                                                                        |
+| --- | ------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | TODO   | Inventory consumers and counters | Map every producer, metrics consumer, banning consumer, counter, and bootstrap location for the three shared event families.   |
+| T2  | TODO   | Define measurable workloads      | Select realistic HTTP and UDP workloads plus controlled instrumentation for event publication work.                            |
+| T3  | TODO   | Capture baseline performance     | Record throughput, latency, CPU, and event-publication measurements with #2039 behavior enabled.                               |
+| T4  | TODO   | Analyze optimization feasibility | Identify configurations that could safely have no required consumer and the configuration/service changes they require.        |
+| T5  | TODO   | Decide whether to implement      | Obtain maintainer approval from the evidence; either promote this draft to an implementation issue or close it as not planned. |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Investigation draft created in `docs/issues/drafts/`
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Benchmark evidence reviewed by user/maintainer
+- [ ] Decision recorded to create an implementation issue or close this draft as not planned
+- [ ] #2035 final verification completed; implementation scheduling prerequisite
+
+### Progress Log
+
+- 2026-08-18 UTC - agent and user - Converted from an implementation proposal to an investigation draft. #2039 must always publish policy-neutral facts for correctness; measure the cost and map every consumer/counter before deciding whether a total-publication-disable optimization is worthwhile.
+
+## Acceptance Criteria
+
+- [ ] AC1: A documented inventory identifies every producer, consumer, and required counter for each event family.
+- [ ] AC2: Benchmark evidence quantifies the cost of event publication under representative HTTP and UDP workloads.
+- [ ] AC3: The investigation identifies the exact configuration and service conditions required to have no consumer for each event family.
+- [ ] AC4: The analysis shows whether disabled connection-ID validation still needs UDP cookie-error facts and counters.
+- [ ] AC5: A maintainer-approved decision records whether an optimization implementation issue is justified.
+- [ ] AC6: Documentation records the evidence and decision.
+
+## Verification Plan
+
+### Automatic Checks
+
+- Focused inspection and tests that validate the consumer/counter inventory.
+- Benchmark or controlled instrumentation covering event construction and
+  publication behavior.
+- `linter all` for the investigation documentation.
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                              | Command/Steps                                                                                                                         | Expected Result                                                                                 | Status | Evidence                     |
+| --- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------ | ---------------------------- |
+| M1  | HTTP publication baseline             | Run a representative local HTTP announce workload with #2039 behavior enabled and controlled event instrumentation.                   | Evidence records throughput, latency, CPU, and event-publication work.                          | TODO   | Investigation evidence file. |
+| M2  | UDP publication baseline              | Run a representative local UDP announce and invalid-cookie workload with #2039 behavior enabled and controlled event instrumentation. | Evidence records throughput, latency, CPU, cookie-error processing, and event-publication work. | TODO   | Investigation evidence file. |
+| M3  | Consumer and counter inventory review | Trace each event family from producer through metrics, banning, and required counters.                                                | Evidence identifies the complete conditions for a potential no-consumer configuration.          | TODO   | Investigation evidence file. |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence |
+| ----- | ---------------------- | -------- |
+| AC1   | TODO                   |          |
+| AC2   | TODO                   |          |
+| AC3   | TODO                   |          |
+| AC4   | TODO                   |          |
+| AC5   | TODO                   |          |
+| AC6   | TODO                   |          |
+
+## Risks and Trade-offs
+
+- Assuming that disabled per-instance metrics disable every consumer would recreate #2039's banning defect. Mitigation: inventory metrics, banning, and counters before proposing a demand plan.
+- An optimization may add configuration complexity without a measurable benefit. Mitigation: benchmark before proposing implementation.
+- Runtime receiver counts can transiently report zero during asynchronous startup. Mitigation: exclude live subscription counting from any future design unless independently justified.
+- Optimization work could delay correctness. Mitigation: keep this as a draft and do not make it a #2039 prerequisite.
+
+## References
+
+- Related issues: Issue #2035 and Issue #2039
+- Related PRs: PR #2044 and PR #2048
+- Events architecture: `docs/events-architecture.md`
+- Event bus: `packages/events/src/bus.rs`

--- a/docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
+++ b/docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
@@ -25,7 +25,7 @@ semantic-links:
 
 <!-- skill-link: create-issue -->
 
-# Draft - Investigate Event Publication Performance and Consumer Demand
+# Issue #[To be assigned] - Investigate Event Publication Performance and Consumer Demand
 
 ## Goal
 

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 2035
 spec-path: docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
 branch: 2035-fix-duplicate-port-zero-tracker-instance-bootstrap
 related-pr: null
-last-updated-utc: 2026-08-17
+last-updated-utc: 2026-08-18
 semantic-links:
   skill-links:
     - write-unit-test
@@ -98,17 +98,17 @@ only for this issue's metrics-related final verification and closure.
 
 ## Implementation Plan
 
-| ID  | Status  | Task                                                                                                   | Notes / Expected Output                                                                                                                                          |
-| --- | ------- | ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | DONE    | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                                                          |
-| T2  | DONE    | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                                                       |
-| T3  | DONE    | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                                                    |
-| T4  | DONE    | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                                               |
-| T5  | DONE    | Add HTTP statistics integration coverage                                                               | In `tests/aggregate_stats_fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).                             |
-| T6  | DONE    | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.                                         |
-| T7  | TODO    | Run and record local tracker probes                                                                    | Run fixed-port HTTP and duplicate-port-zero bootstrap scenarios locally; append configuration, commands, outputs, and comparisons to [evidence.md](evidence.md). |
-| T8  | BLOCKED | Land registry metadata migration                                                                       | #2041 must expose started-service canonical identity before final verification.                                                                                  |
-| T9  | BLOCKED | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | Required only for deferred UDP and repeated-port-zero aggregate-statistics tests, final verification, and issue closure.                                         |
+| ID  | Status  | Task                                                                                                   | Notes / Expected Output                                                                                                                                                        |
+| --- | ------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE    | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                                                                        |
+| T2  | DONE    | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                                                                     |
+| T3  | DONE    | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                                                                  |
+| T4  | DONE    | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                                                             |
+| T5  | DONE    | Add HTTP statistics integration coverage                                                               | In `tests/aggregate_stats_fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).                                           |
+| T6  | DONE    | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.                                                       |
+| T7  | TODO    | Run and record final local tracker probes                                                              | After #2039, run fixed-port HTTP/UDP and duplicate-port-zero policy scenarios locally; append configuration, commands, outputs, and comparisons to [evidence.md](evidence.md). |
+| T8  | DONE    | Land registry metadata migration                                                                       | #2041 completed in PR #2048 and exposes canonical started-service identity.                                                                                                    |
+| T9  | BLOCKED | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | #2039 was reopened after a documentation-only commit closed it prematurely. It must complete the deferred policy tests before final verification and issue closure.            |
 
 ## Progress Tracking
 
@@ -118,7 +118,7 @@ only for this issue's metrics-related final verification and closure.
 - [x] GitHub issue created: #2035
 - [x] Prerequisite #2036 completed
 - [x] Bootstrap identity preservation completed
-- [ ] Registry metadata migration completed
+- [x] Registry metadata migration completed (PR #2048)
 - [ ] Event-metrics normalization completed
 - [ ] Final automatic and manual verification completed
 - [x] Acceptance criteria reviewed after implementation
@@ -136,6 +136,10 @@ only for this issue's metrics-related final verification and closure.
 - 2026-07-29 18:14 UTC - user - Distinguished bootstrap configuration collision from UDP server aggregate
   metrics filtering. Fixed-port HTTP statistics coverage belongs to this phase; UDP aggregate
   statistics and repeated-port-zero aggregate statistics remain deferred to #2039.
+- 2026-08-18 - agent and user - Verified that the bootstrap implementation merged in PR #2044 and
+  registry metadata migration merged in PR #2048. #2039 had been prematurely auto-closed by the
+  documentation-only commit `e1dc2350`; it was reopened. #2035 implementation must remain paused
+  until #2039 completes listener-side metrics filtering and its regressions.
 
 ## Acceptance Criteria
 
@@ -162,18 +166,20 @@ only for this issue's metrics-related final verification and closure.
 
 ### Manual Evidence Protocol
 
-Before and after the bootstrap implementation, run the relevant scenarios
-against a locally launched tracker and append exact configuration, commands,
-final listener addresses, REST statistics, and observed result to
-[evidence.md](evidence.md). Do not replace existing baseline evidence.
+The original bootstrap implementation is merged. Do not run its final local
+probes until #2039 has completed its risk-based metrics-policy checkpoints.
+Then run the final scenarios below against a locally launched tracker and append
+exact configuration, commands, final listener addresses, REST statistics, and
+observed result to [evidence.md](evidence.md). Do not replace existing baseline
+evidence.
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                                                            | Expected Result                                                          | Status | Evidence                   |
-| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------ | -------------------------- |
-| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different settings. | Each listener retains the settings from its own configuration block.     | TODO   | [evidence.md](evidence.md) |
-| M2  | Repeat M1 for UDP trackers.                                                         | Each UDP listener retains the settings from its own configuration block. | TODO   |                            |
-| M3  | Run fixed-port enabled/enabled HTTP listeners locally.                              | The aggregate HTTP announce count is `2`.                                | DONE   |                            |
+| ID  | Scenario                                                                            | Expected Result                                                     | Status           | Evidence                   |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------- | -------------------------- |
+| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different policies. | Each listener retains its own configuration and metrics policy.     | BLOCKED by #2039 | [evidence.md](evidence.md) |
+| M2  | Repeat M1 for UDP trackers.                                                         | Each UDP listener retains its own configuration and metrics policy. | BLOCKED by #2039 |                            |
+| M3  | Run fixed-port enabled/enabled HTTP listeners locally.                              | The aggregate HTTP announce count is `2`.                           | DONE             |                            |
 
 ## References
 

--- a/docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
+++ b/docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
@@ -108,8 +108,8 @@ the canonical identity rather than create a competing identity.
   `tests/aggregate_stats_fixed_ports.rs`: UDP enabled/disabled listeners on
   distinct fixed ports, then HTTP and UDP listeners with repeated port-zero
   bindings after bootstrap identity is available.
-- Record progressive manual baseline and post-change evidence for every
-  code-changing task.
+- Record manual baseline and post-change evidence at the risk-based
+  verification checkpoints.
 
 ### Out of Scope
 

--- a/docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
+++ b/docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 2039
 spec-path: docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md
 branch: "2039-normalize-per-instance-event-metrics-policy"
 related-pr: null
-last-updated-utc: 2026-08-17
+last-updated-utc: 2026-08-18
 semantic-links:
   skill-links:
     - create-issue
@@ -19,6 +19,7 @@ semantic-links:
     - docs/adrs/20260727180000_shared_services_across_tracker_instances.md
     - docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
     - docs/issues/closed/2036-add-runtime-service-registry-metadata/ISSUE.md
+    - docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md
     - evidence.md
     - tests/aggregate_stats_fixed_ports.rs
     - packages/events/src/bus.rs
@@ -126,28 +127,50 @@ that identity to find the listener's immutable metrics policy and ignores a
 disabled listener before repository mutation. The UDP banning listener receives
 the same security events regardless of that policy.
 
+To fix this issue, producers must always publish policy-neutral facts for every
+relevant listener, independent of individual listener metrics policy. Metrics
+policy is applied only by metrics listeners, while the UDP banning listener
+continues to receive relevant security facts. This correctness delivery does not
+attempt to disable publication when no consumer is active. The follow-up draft
+specification at
+[`docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md`](../../drafts/optimize-event-publication-without-consumers/ISSUE.md)
+will first measure the performance effect of publication and define whether a
+safe consumer-demand optimization is worthwhile. It does not block this issue's
+correctness delivery.
+
 ## Implementation Plan
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status  | Task                             | Notes / Expected Output                                                                                                                                                                                                      |
-| --- | ------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO    | Inventory event gates            | Map every `SenderStatus`, optional sender, listener, and UDP ban consumer.                                                                                                                                                   |
-| T2  | BLOCKED | Consume #2036 canonical identity | Propagate stable runtime configuration-instance identity; do not use configured addresses.                                                                                                                                   |
-| T3  | TODO    | Always emit HTTP core facts      | Remove metrics-driven producer suppression while preserving event semantics.                                                                                                                                                 |
-| T4  | TODO    | Always emit UDP core facts       | Remove metrics-driven producer suppression while preserving event semantics.                                                                                                                                                 |
-| T5  | TODO    | Always emit UDP server facts     | Decouple the shared UDP server producer from the global metrics gate.                                                                                                                                                        |
-| T6  | TODO    | Filter metrics in listeners      | Apply immutable identity-to-policy filtering before aggregate repository updates.                                                                                                                                            |
-| T7  | TODO    | Preserve banning independence    | Verify cookie-error events reach the shared ban service for every listener policy.                                                                                                                                           |
-| T8  | TODO    | Update REST metrics integration  | Preserve aggregate API counters and UDP operational metrics from filtered repositories.                                                                                                                                      |
-| T9  | TODO    | Add focused tests                | Cover producer independence, listener filtering, and ban-listener behavior.                                                                                                                                                  |
-| T10 | TODO    | Add application tests            | In `tests/aggregate_stats_fixed_ports.rs` and `tests/aggregate_stats_port_zero.rs`, enable deferred UDP fixed-port coverage and add enabled/disabled HTTP/UDP repeated-port-zero coverage; each expects aggregate count `1`. |
-| T11 | TODO    | Validate and document            | Run focused tests, `linter all`, and the manual protocol; update evidence and architecture docs.                                                                                                                             |
+| ID  | Status | Task                             | Notes / Expected Output                                                                                                                                                                                                      |
+| --- | ------ | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Inventory event gates            | Map every `SenderStatus`, optional sender, listener, and UDP ban consumer.                                                                                                                                                   |
+| T2  | TODO   | Consume #2036 canonical identity | Propagate stable runtime configuration-instance identity; do not use configured addresses. #2036 and #2041 are complete prerequisites.                                                                                       |
+| T3  | TODO   | Always emit HTTP core facts      | Remove metrics-driven producer suppression while preserving event semantics.                                                                                                                                                 |
+| T4  | TODO   | Always emit UDP core facts       | Remove metrics-driven producer suppression while preserving event semantics.                                                                                                                                                 |
+| T5  | TODO   | Always emit UDP server facts     | Decouple the shared UDP server producer from the global metrics gate.                                                                                                                                                        |
+| T6  | TODO   | Filter metrics in listeners      | Apply immutable identity-to-policy filtering before aggregate repository updates.                                                                                                                                            |
+| T7  | TODO   | Preserve banning independence    | Verify cookie-error events reach the shared ban service for every listener policy.                                                                                                                                           |
+| T8  | TODO   | Update REST metrics integration  | Preserve aggregate API counters and UDP operational metrics from filtered repositories.                                                                                                                                      |
+| T9  | TODO   | Add focused tests                | Cover producer independence, listener filtering, and ban-listener behavior.                                                                                                                                                  |
+| T10 | TODO   | Add application tests            | In `tests/aggregate_stats_fixed_ports.rs` and `tests/aggregate_stats_port_zero.rs`, enable deferred UDP fixed-port coverage and add enabled/disabled HTTP/UDP repeated-port-zero coverage; each expects aggregate count `1`. |
+| T11 | TODO   | Validate and document            | Run focused tests, `linter all`, and the manual protocol; update evidence and architecture docs.                                                                                                                             |
 
-## Progressive Manual Verification Protocol
+## Risk-Based Manual Verification Protocol
 
-Every code-changing task, T2 through T10, must complete this protocol before
-the next task begins:
+Manual evidence is required after the highest-risk behavior changes rather than
+after every individual implementation task. This avoids duplicating expensive
+local tracker probes for tightly coupled internal refactorings while retaining
+an externally observable control after each change that could affect production
+behavior. The high-risk checkpoints are:
+
+| Checkpoint | Tasks  | Risk controlled                                                                                                                                           | Required manual probes                                         |
+| ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| C1         | T2-T6  | Events may lose canonical listener identity, metrics filtering may misclassify a listener, or shared aggregate repositories may receive the wrong events. | M1, M2, M4, and M5                                             |
+| C2         | T7     | Always-emitted UDP security facts may no longer reach the shared banning listener.                                                                        | M3                                                             |
+| C3         | T8-T10 | REST-visible aggregate metrics or application bootstrap/discovery may regress despite focused tests.                                                      | Repeat M1, M2, M4, and M5 against the final application build. |
+
+For each checkpoint:
 
 1. Select the smallest externally observable probe for the task.
 2. Run it against the pre-change implementation and record configuration,
@@ -158,9 +181,9 @@ the next task begins:
 5. Compare the two records. Explain every intentional difference and add a
    regression before advancing; stop to diagnose every unexpected difference.
 
-Each applicable probe must verify both policies: a metrics-disabled listener
-does not update aggregate metrics, and its UDP cookie errors still reach the
-shared banning listener.
+M1, M2, M4, and M5 must verify that a metrics-disabled listener does not update
+aggregate metrics. M3 must verify that invalid UDP cookies through a
+metrics-disabled listener still reach shared ban enforcement.
 
 ## Progress Tracking
 
@@ -175,7 +198,7 @@ shared banning listener.
 - [ ] Manual verification scenarios executed and recorded (status + evidence)
 - [ ] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
 ### Progress Log
@@ -186,6 +209,10 @@ shared banning listener.
 - 2026-07-29 18:14 UTC - user - Separated the fixed-port UDP aggregate-metrics defect from #2035's
   duplicate-port-zero bootstrap collision. The former is a #2039 regression; the latter must be
   combined with #2035 before repeated-port-zero aggregate-statistics tests are enabled.
+- 2026-08-18 - user - Confirmed that #2039 must be implemented before #2035 can complete its
+  final verification. Replaced per-task manual evidence with risk-based checkpoints: after the
+  combined identity/event/filtering change, after UDP banning independence, and after final
+  REST/application integration.
 
 ## Acceptance Criteria
 
@@ -195,7 +222,7 @@ shared banning listener.
 - [ ] AC4: Metrics-enabled listeners update the existing shared aggregate repositories.
 - [ ] AC5: Metrics filtering uses #2036 canonical identity and works for repeated `0.0.0.0:0` blocks.
 - [ ] AC6: The REST API retains aggregate HTTP/UDP and UDP operational metrics.
-- [ ] AC7: Every code-changing task has baseline and post-change evidence.
+- [ ] AC7: Every risk-based verification checkpoint has baseline and post-change evidence.
 - [ ] AC8: Relevant tests and `linter all` pass.
 
 ## Verification Plan

--- a/docs/pr-reviews/pr-2061-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2061-copilot-suggestions.md
@@ -1,0 +1,38 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2061 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2061
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Processing Log
+
+- 2026-08-18: Started processing suggestions.
+- 2026-08-18: Completed processing suggestions; all Copilot threads were replied to and resolved.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                                       | URL                                                                         | Suggestion Summary                                               | Decision | Reply URL                                                                   | Status | Thread State |
+| --- | --------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6aHkDA | docs/issues/open/2039-normalize-per-instance-event-metrics-policy/ISSUE.md | https://github.com/torrust/torrust-tracker/pull/2061#discussion_r3804358501 | Align the in-scope evidence bullet with risk-based verification. | action   | https://github.com/torrust/torrust-tracker/pull/2061#discussion_r3804903645 | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6aHkDd | docs/issues/drafts/optimize-event-publication-without-consumers/ISSUE.md   | https://github.com/torrust/torrust-tracker/pull/2061#discussion_r3804358545 | Use the conventional unassigned draft issue heading.             | action   | https://github.com/torrust/torrust-tracker/pull/2061#discussion_r3804908132 | DONE   | RESOLVED     |
+
+## Notes
+
+- Each suggestion is tracked as a minimal documentation correction.
+- Both suggestions were fixed in `f0ac4ebd`; `linter all` and the full pre-commit gate passed.


### PR DESCRIPTION
## Summary

Refines the #2039 delivery plan before implementation.

- Records risk-based manual verification checkpoints for the identity, metrics filtering, banning, and final application-integration changes.
- Clarifies that #2039 producers publish policy-neutral facts independently of per-listener `tracker_usage_statistics`; metrics filtering belongs in consumers and UDP banning remains independent.
- Updates #2035's remaining dependency and final-verification status after PR #2044 and PR #2048.
- Adds a benchmark-led draft that investigates the cost and feasibility of disabling event publication only when every required consumer and counter is inactive.

## Validation

- `linter all`
- Pre-commit checks
- Pre-push checks: nightly format/check/doc and stable all-target tests

Related to #2039 and #2035.