### PR TITLE
Fix deprecated Cargo Rust lint names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,15 +110,15 @@ members = [
 ]
 
 [workspace.lints.rust]
-deprecated-safe = { level = "deny", priority = -1 }
-future-incompatible = { level = "deny", priority = -1 }
-let-underscore = { level = "deny", priority = -1 }
-nonstandard-style = { level = "deny", priority = -1 }
-rust-2018-compatibility = { level = "deny", priority = -1 }
-rust-2018-idioms = { level = "deny", priority = -1 }
-rust-2021-compatibility = { level = "deny", priority = -1 }
-rust-2024-compatibility = { level = "deny", priority = -1 }
-unsafe-code = { level = "warn", priority = -1 }
+deprecated_safe = { level = "deny", priority = -2 }
+future_incompatible = { level = "deny", priority = -2 }
+let_underscore = { level = "deny", priority = -2 }
+nonstandard_style = { level = "deny", priority = -2 }
+rust_2018_compatibility = { level = "deny", priority = -2 }
+rust_2018_idioms = { level = "deny", priority = -2 }
+rust_2021_compatibility = { level = "deny", priority = -2 }
+rust_2024_compatibility = { level = "deny", priority = -2 }
+unsafe_code = { level = "warn", priority = 0 }
 unused = { level = "deny", priority = -2 }
 warnings = { level = "deny", priority = -1 }
 


### PR DESCRIPTION
Replace Cargo's deprecated hyphenated Rust lint keys with their canonical underscore forms.

Lint groups use priority `-2` so `warnings` at priority `-1` can deterministically override them without triggering `clippy::lint_groups_priority`. `unsafe_code` uses priority `0` to preserve its intentional `warn` level against `warnings = deny`.

Fixes #2062

Validation:
- Pre-commit quality gate
- Pre-push quality gate