### PR TITLE
chore(deps): update GitHub Actions

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -199,7 +199,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -250,7 +250,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.5.2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache
@@ -47,7 +47,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.85.5
         with:
           tool: grcov,cargo-llvm-cov
 

--- a/.github/workflows/db-benchmarking.yaml
+++ b/.github/workflows/db-benchmarking.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache
@@ -70,7 +70,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache
@@ -100,7 +100,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache

--- a/.github/workflows/db-compatibility.yaml
+++ b/.github/workflows/db-compatibility.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache
@@ -81,7 +81,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.85.5
         with:
           tool: grcov,cargo-llvm-cov
 

--- a/.github/workflows/os-compatibility.yaml
+++ b/.github/workflows/os-compatibility.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -85,7 +85,7 @@ jobs:
           scanners: "vuln"
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v4.37.4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache
@@ -76,7 +76,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-llvm-cov, cargo-nextest
 
@@ -150,7 +150,7 @@ jobs:
 
       - id: sccache
         name: Install sccache (GHA backend)
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@v0.0.11
 
       - id: enable-sccache
         name: Enable sccache


### PR DESCRIPTION
## Summary

Consolidates the pending Dependabot workflow-action updates for:

- `github/codeql-action` to `v4.37.4`
- `taiki-e/install-action` to `v2.85.5`
- `docker/login-action` to `v4.5.2`
- `mozilla-actions/sccache-action` to `v0.0.11`

Closes #2043
Closes #2047
Closes #2052
Closes #2053

## Validation

- `git diff --check`
- Required pre-commit validation