### PR TITLE
docs(issues): verify #2035 port-zero bootstrap fix

### DIFF
--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
@@ -158,6 +158,9 @@ only for this issue's metrics-related final verification and closure.
   distinct HTTP and UDP final bindings to canonical identities; announces to disabled and enabled
   listeners yielded aggregate HTTP and UDP counts of `1`, and invalid cookies through the disabled
   UDP listener still triggered a shared ban. Recorded commands and output in [evidence.md](evidence.md).
+- 2026-08-20 - agent - Repeated the final probe with the exact `0.0.0.0:0` HTTP and UDP bindings
+  from the original collision. Each configuration identity received a distinct final wildcard
+  binding, and the aggregate metrics and banning results matched the loopback probe.
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
@@ -181,7 +181,7 @@ only for this issue's metrics-related final verification and closure.
   distinct fixed ports produce aggregate announce counts of `1` for each protocol.
 - `tests/metrics/port_zero.rs`: repeated-port-zero HTTP and UDP listeners retain their distinct
   canonical identities and produce aggregate announce counts of `1` for each protocol.
-- `cargo test --test metrics-port-zero --test metrics-fixed-ports --test banning-udp-metrics-disabled-port-zero --test scaffold -- --test-threads=1`.
+- `cargo test --test metrics-port-zero --test metrics-fixed-ports --test banning-udp-metrics-disabled-port-zero --test metrics-udp-error-enabled-port-zero --test metrics-udp-error-disabled-port-zero --test scaffold -- --test-threads=1`.
 - `linter all`.
 
 ### Manual Evidence Protocol

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 2035
 spec-path: docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
 branch: 2035-fix-duplicate-port-zero-tracker-instance-bootstrap
 related-pr: null
-last-updated-utc: 2026-08-18
+last-updated-utc: 2026-08-20
 semantic-links:
   skill-links:
     - write-unit-test
@@ -83,6 +83,17 @@ metrics policy correct: the UDP server has one application-wide event bus and
 repository, while producer-side metrics suppression can hide facts required by
 the independent banning listener.
 
+### Completion Boundary
+
+The bootstrap phase of this issue is independently verified: duplicate
+port-zero HTTP and UDP configuration blocks retain distinct containers,
+canonical identities, and final listener bindings. It was intentionally not
+sufficient to close this issue. The original user-visible outcome also requires
+end-to-end proof that a metrics-disabled listener does not update shared
+aggregate metrics while a metrics-enabled sibling does, without preventing UDP
+banning from observing cookie-error facts. That policy belongs to #2039, whose
+listener-side filtering makes the final #2035 probes meaningful and safe.
+
 Issue [#2035](https://github.com/torrust/torrust-tracker/issues/2035) is
 delivered in two phases. After #2036 defines canonical runtime
 service/configuration-instance identity, this issue can reimplement bootstrap
@@ -98,17 +109,17 @@ only for this issue's metrics-related final verification and closure.
 
 ## Implementation Plan
 
-| ID  | Status  | Task                                                                                                   | Notes / Expected Output                                                                                                                                                        |
-| --- | ------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T1  | DONE    | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                                                                        |
-| T2  | DONE    | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                                                                     |
-| T3  | DONE    | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                                                                  |
-| T4  | DONE    | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                                                             |
-| T5  | DONE    | Add HTTP statistics integration coverage                                                               | In `tests/metrics/fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).                                                   |
-| T6  | DONE    | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.                                                       |
-| T7  | TODO    | Run and record final local tracker probes                                                              | After #2039, run fixed-port HTTP/UDP and duplicate-port-zero policy scenarios locally; append configuration, commands, outputs, and comparisons to [evidence.md](evidence.md). |
-| T8  | DONE    | Land registry metadata migration                                                                       | #2041 completed in PR #2048 and exposes canonical started-service identity.                                                                                                    |
-| T9  | BLOCKED | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | #2039 was reopened after a documentation-only commit closed it prematurely. It must complete the deferred policy tests before final verification and issue closure.            |
+| ID  | Status | Task                                                                                                   | Notes / Expected Output                                                                                                                                                        |
+| --- | ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE   | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                                                                        |
+| T2  | DONE   | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                                                                     |
+| T3  | DONE   | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                                                                  |
+| T4  | DONE   | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                                                             |
+| T5  | DONE   | Add HTTP statistics integration coverage                                                               | In `tests/metrics/fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).                                                   |
+| T6  | DONE   | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.                                                       |
+| T7  | TODO   | Run and record final local tracker probes                                                              | After #2039, run fixed-port HTTP/UDP and duplicate-port-zero policy scenarios locally; append configuration, commands, outputs, and comparisons to [evidence.md](evidence.md). |
+| T8  | DONE   | Land registry metadata migration                                                                       | #2041 completed in PR #2048 and exposes canonical started-service identity.                                                                                                    |
+| T9  | DONE   | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | #2039 completed listener-side filtering and its deferred policy regressions; final #2035 verification can now proceed.                                                         |
 
 ## Progress Tracking
 
@@ -119,7 +130,7 @@ only for this issue's metrics-related final verification and closure.
 - [x] Prerequisite #2036 completed
 - [x] Bootstrap identity preservation completed
 - [x] Registry metadata migration completed (PR #2048)
-- [ ] Event-metrics normalization completed
+- [x] Event-metrics normalization completed
 - [ ] Final automatic and manual verification completed
 - [x] Acceptance criteria reviewed after implementation
 
@@ -140,6 +151,9 @@ only for this issue's metrics-related final verification and closure.
   registry metadata migration merged in PR #2048. #2039 had been prematurely auto-closed by the
   documentation-only commit `e1dc2350`; it was reopened. #2035 implementation must remain paused
   until #2039 completes listener-side metrics filtering and its regressions.
+- 2026-08-20 - agent and user - Confirmed #2039's implementation and verification are complete.
+  The bootstrap phase had already established configuration-to-container correspondence; final
+  #2035 verification can now prove its end-to-end metrics and banning outcome.
 
 ## Acceptance Criteria
 
@@ -175,11 +189,11 @@ evidence.
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                                                            | Expected Result                                                     | Status           | Evidence                   |
-| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------- | -------------------------- |
-| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different policies. | Each listener retains its own configuration and metrics policy.     | BLOCKED by #2039 | [evidence.md](evidence.md) |
-| M2  | Repeat M1 for UDP trackers.                                                         | Each UDP listener retains its own configuration and metrics policy. | BLOCKED by #2039 |                            |
-| M3  | Run fixed-port enabled/enabled HTTP listeners locally.                              | The aggregate HTTP announce count is `2`.                           | DONE             |                            |
+| ID  | Scenario                                                                            | Expected Result                                                     | Status | Evidence                   |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------ | -------------------------- |
+| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different policies. | Each listener retains its own configuration and metrics policy.     | TODO   | [evidence.md](evidence.md) |
+| M2  | Repeat M1 for UDP trackers.                                                         | Each UDP listener retains its own configuration and metrics policy. | TODO   |                            |
+| M3  | Run fixed-port enabled/enabled HTTP listeners locally.                              | The aggregate HTTP announce count is `2`.                           | DONE   |                            |
 
 ## References
 

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
@@ -109,17 +109,17 @@ only for this issue's metrics-related final verification and closure.
 
 ## Implementation Plan
 
-| ID  | Status | Task                                                                                                   | Notes / Expected Output                                                                                                                                                        |
-| --- | ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T1  | DONE   | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                                                                        |
-| T2  | DONE   | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                                                                     |
-| T3  | DONE   | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                                                                  |
-| T4  | DONE   | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                                                             |
-| T5  | DONE   | Add HTTP statistics integration coverage                                                               | In `tests/metrics/fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).                                                   |
-| T6  | DONE   | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.                                                       |
-| T7  | TODO   | Run and record final local tracker probes                                                              | After #2039, run fixed-port HTTP/UDP and duplicate-port-zero policy scenarios locally; append configuration, commands, outputs, and comparisons to [evidence.md](evidence.md). |
-| T8  | DONE   | Land registry metadata migration                                                                       | #2041 completed in PR #2048 and exposes canonical started-service identity.                                                                                                    |
-| T9  | DONE   | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | #2039 completed listener-side filtering and its deferred policy regressions; final #2035 verification can now proceed.                                                         |
+| ID  | Status | Task                                                                                                   | Notes / Expected Output                                                                                                              |
+| --- | ------ | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE   | Land [#2036](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md) canonical identity      | Bootstrap identity aligns with the canonical runtime identity contract.                                                              |
+| T2  | DONE   | Replace address-keyed container lookup                                                                 | Use an order-preserving representation or canonical identity, not configured `SocketAddr`.                                           |
+| T3  | DONE   | Start matching containers                                                                              | Pass each configuration entry's matching container into HTTP and UDP startup.                                                        |
+| T4  | DONE   | Correlate lifecycle logs                                                                               | Include canonical identity with configured and final binding logs.                                                                   |
+| T5  | DONE   | Add HTTP statistics integration coverage                                                               | In `tests/metrics/fixed_ports.rs`, added fixed-port HTTP test. Aggregate count `1` blocked by #2039 (shared HTTP event bus).         |
+| T6  | DONE   | Add bootstrap regressions                                                                              | Cover duplicate port-zero HTTP/UDP configuration-to-container correspondence without asserting aggregate metrics policy.             |
+| T7  | DONE   | Run and record final local tracker probes                                                              | Ran duplicate-port-zero HTTP/UDP policy and metrics-disabled UDP banning probes; results are recorded in [evidence.md](evidence.md). |
+| T8  | DONE   | Land registry metadata migration                                                                       | #2041 completed in PR #2048 and exposes canonical started-service identity.                                                          |
+| T9  | DONE   | Land [#2039](../2039-normalize-per-instance-event-metrics-policy/ISSUE.md) event-metrics normalization | #2039 completed listener-side filtering and its deferred policy regressions; final #2035 verification can now proceed.               |
 
 ## Progress Tracking
 
@@ -131,7 +131,7 @@ only for this issue's metrics-related final verification and closure.
 - [x] Bootstrap identity preservation completed
 - [x] Registry metadata migration completed (PR #2048)
 - [x] Event-metrics normalization completed
-- [ ] Final automatic and manual verification completed
+- [x] Final automatic and manual verification completed
 - [x] Acceptance criteria reviewed after implementation
 
 ### Progress Log
@@ -154,6 +154,10 @@ only for this issue's metrics-related final verification and closure.
 - 2026-08-20 - agent and user - Confirmed #2039's implementation and verification are complete.
   The bootstrap phase had already established configuration-to-container correspondence; final
   #2035 verification can now prove its end-to-end metrics and banning outcome.
+- 2026-08-20 - agent - Ran the final duplicate-port-zero local probe. Startup logs mapped
+  distinct HTTP and UDP final bindings to canonical identities; announces to disabled and enabled
+  listeners yielded aggregate HTTP and UDP counts of `1`, and invalid cookies through the disabled
+  UDP listener still triggered a shared ban. Recorded commands and output in [evidence.md](evidence.md).
 
 ## Acceptance Criteria
 
@@ -170,12 +174,11 @@ only for this issue's metrics-related final verification and closure.
 ### Automatic Checks
 
 - Focused regression tests for `AppContainer` and startup jobs after prerequisites land.
-- `tests/metrics/fixed_ports.rs`: enabled/enabled HTTP listeners on distinct fixed
-  ports must produce aggregate `tcp4_announces_handled == 2`. Enabled/disabled filtering
-  is deferred to #2039.
-- Defer the equivalent UDP fixed-port and repeated-port-zero HTTP/UDP aggregate-statistics tests
-  to #2039; they assert listener-side metrics filtering rather than bootstrap configuration selection.
-- `cargo test --test metrics-port-zero --test metrics-fixed-ports --test scaffold`.
+- `tests/metrics/fixed_ports.rs`: metrics-disabled and metrics-enabled HTTP and UDP listeners on
+  distinct fixed ports produce aggregate announce counts of `1` for each protocol.
+- `tests/metrics/port_zero.rs`: repeated-port-zero HTTP and UDP listeners retain their distinct
+  canonical identities and produce aggregate announce counts of `1` for each protocol.
+- `cargo test --test metrics-port-zero --test metrics-fixed-ports --test banning-udp-metrics-disabled-port-zero --test scaffold -- --test-threads=1`.
 - `linter all`.
 
 ### Manual Evidence Protocol
@@ -189,11 +192,11 @@ evidence.
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                                                            | Expected Result                                                     | Status | Evidence                   |
-| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------ | -------------------------- |
-| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different policies. | Each listener retains its own configuration and metrics policy.     | TODO   | [evidence.md](evidence.md) |
-| M2  | Repeat M1 for UDP trackers.                                                         | Each UDP listener retains its own configuration and metrics policy. | TODO   |                            |
-| M3  | Run fixed-port enabled/enabled HTTP listeners locally.                              | The aggregate HTTP announce count is `2`.                           | DONE   |                            |
+| ID  | Scenario                                                                            | Expected Result                                                                                                                                   | Status | Evidence                                                                          |
+| --- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------- |
+| M1  | Start two HTTP trackers with identical `0.0.0.0:0` bindings and different policies. | Each listener retains its own configuration; only the enabled listener updates aggregate metrics.                                                 | DONE   | [evidence.md](evidence.md)                                                        |
+| M2  | Repeat M1 for UDP trackers.                                                         | Each listener retains its own configuration; only the enabled listener updates aggregate metrics and the disabled listener still reaches banning. | DONE   | [evidence.md](evidence.md)                                                        |
+| M3  | Run fixed-port disabled/enabled HTTP listeners locally.                             | The aggregate HTTP announce count is `1`.                                                                                                         | DONE   | [#2039 evidence](../2039-normalize-per-instance-event-metrics-policy/evidence.md) |
 
 ## References
 

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence-artifacts/wildcard-port-zero-manual.toml
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence-artifacts/wildcard-port-zero-manual.toml
@@ -1,0 +1,43 @@
+# Final manual verification configuration for repeated wildcard port-zero bindings.
+# Run with:
+# TORRUST_TRACKER_CONFIG_TOML_PATH="$PWD/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence-artifacts/wildcard-port-zero-manual.toml" \
+#   cargo run --bin torrust-tracker
+
+[metadata]
+app = "torrust-tracker"
+purpose = "configuration"
+schema_version = "2.0.0"
+
+[logging]
+threshold = "info"
+
+[core]
+listed = false
+private = false
+
+[[http_trackers]]
+bind_address = "0.0.0.0:0"
+tracker_usage_statistics = false
+
+[[http_trackers]]
+bind_address = "0.0.0.0:0"
+tracker_usage_statistics = true
+
+[[udp_trackers]]
+bind_address = "0.0.0.0:0"
+tracker_usage_statistics = false
+max_connection_id_errors_per_ip = 10
+
+[[udp_trackers]]
+bind_address = "0.0.0.0:0"
+tracker_usage_statistics = true
+max_connection_id_errors_per_ip = 10
+
+[http_api]
+bind_address = "127.0.0.1:17100"
+
+[http_api.access_tokens]
+admin = "MyAccessToken"
+
+[health_check_api]
+bind_address = "127.0.0.1:17101"

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
@@ -197,3 +197,102 @@ assertion `left == right` failed
 The observed `2` shows that both listeners inherited the second configuration block's enabled
 statistics setting. After the bootstrap fix, remove the `#[ignore]` attribute and the same test
 must pass with the expected count of `1`.
+
+## Final Port-Zero Verification
+
+### Environment
+
+- Revision: `4560c0403dfb4c7d9da5e3a9bd8c56fe1bf4f85d`
+- Execution date: `2026-08-20`
+- Configuration:
+  [`../../2039-normalize-per-instance-event-metrics-policy/evidence-artifacts/port-zero-manual.toml`](../../2039-normalize-per-instance-event-metrics-policy/evidence-artifacts/port-zero-manual.toml)
+- REST API: `http://127.0.0.1:17100/api/v1/stats?token=MyAccessToken`
+
+The configuration defines two HTTP and two UDP listeners on `127.0.0.1:0`.
+For both protocols, configuration instance `0` disables usage statistics and
+instance `1` enables them.
+
+### Commands
+
+Started the tracker with:
+
+```sh
+TORRUST_TRACKER_CONFIG_TOML_PATH="$PWD/docs/issues/open/2039-normalize-per-instance-event-metrics-policy/evidence-artifacts/port-zero-manual.toml" \
+  cargo run --bin torrust-tracker
+```
+
+After reading the identity and final bindings from startup logs, queried REST
+statistics before and after one announce to each listener:
+
+```sh
+curl -fsS 'http://127.0.0.1:17100/api/v1/stats?token=MyAccessToken'
+cargo run -q -p torrust-tracker-client --bin tracker_client -- http announce http://127.0.0.1:60889 9c8b2213e30bff212b0c360d26f9a02131642200
+cargo run -q -p torrust-tracker-client --bin tracker_client -- http announce http://127.0.0.1:37067 9c8b2213e30bff212b0c360d26f9a02131642200
+cargo run -q -p torrust-tracker-client --bin tracker_client -- udp announce udp://127.0.0.1:35064 9c8b2213e30bff212b0c360d26f9a02131642200
+cargo run -q -p torrust-tracker-client --bin tracker_client -- udp announce udp://127.0.0.1:58877 9c8b2213e30bff212b0c360d26f9a02131642200
+curl -fsS 'http://127.0.0.1:17100/api/v1/stats?token=MyAccessToken'
+```
+
+Finally, ran the invalid-cookie probe through the metrics-disabled UDP listener:
+
+```sh
+python3 docs/issues/open/2039-normalize-per-instance-event-metrics-policy/evidence-artifacts/invalid_cookie_probe.py 127.0.0.1 35064
+curl -fsS 'http://127.0.0.1:17100/api/v1/stats?token=MyAccessToken'
+```
+
+### Runtime Bindings
+
+Startup logs mapped the canonical configuration instances to final bindings:
+
+| Instance        | Metrics policy | Final binding             |
+| --------------- | -------------- | ------------------------- |
+| `HttpTracker:0` | Disabled       | `http://127.0.0.1:60889/` |
+| `HttpTracker:1` | Enabled        | `http://127.0.0.1:37067/` |
+| `UdpTracker:0`  | Disabled       | `udp://127.0.0.1:35064`   |
+| `UdpTracker:1`  | Enabled        | `udp://127.0.0.1:58877`   |
+
+Each listener accepted its announce request. Before traffic, both aggregate
+announce counters were `0`. After all four announces, REST statistics reported:
+
+```text
+tcp4_announces_handled: 1
+udp4_announces_handled: 1
+udp4_requests: 2
+udp4_connections_handled: 1
+udp4_responses: 2
+udp4_errors_handled: 0
+udp_banned_ips_total: 0
+```
+
+The invalid-cookie probe printed:
+
+```text
+PASS: the twelfth invalid request timed out after shared ban enforcement
+```
+
+After that probe, REST reported `udp_banned_ips_total: 1`. The existing usage
+metric values remained unchanged: `udp4_requests: 2`,
+`udp4_announces_handled: 1`, and `udp4_errors_handled: 0`.
+
+### Result
+
+The duplicate port-zero listeners retained their own configuration and
+canonical identity through startup. Metrics from instance `0` were filtered
+from the shared aggregates while instance `1` contributed normally. Objective
+UDP cookie-error facts from the metrics-disabled listener still reached shared
+banning enforcement.
+
+### Automated Verification
+
+The final focused regression suite passed with one test in each target:
+
+```sh
+cargo test \
+  --test metrics-port-zero \
+  --test metrics-fixed-ports \
+  --test banning-udp-metrics-disabled-port-zero \
+  --test metrics-udp-error-enabled-port-zero \
+  --test metrics-udp-error-disabled-port-zero \
+  --test scaffold \
+  -- --test-threads=1
+```

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
@@ -290,17 +290,17 @@ same probe was repeated with
 [`evidence-artifacts/wildcard-port-zero-manual.toml`](evidence-artifacts/wildcard-port-zero-manual.toml),
 which configures every public listener as `0.0.0.0:0`.
 
-Startup logs mapped each configured identity to a distinct final wildcard
-binding:
+Startup logs mapped each configured identity to a distinct final wildcard bind
+socket address. The probe clients used the corresponding loopback endpoints:
 
-| Instance        | Metrics policy | Final binding           |
-| --------------- | -------------- | ----------------------- |
-| `HttpTracker:0` | Disabled       | `http://0.0.0.0:41223/` |
-| `HttpTracker:1` | Enabled        | `http://0.0.0.0:39525/` |
-| `UdpTracker:0`  | Disabled       | `udp://0.0.0.0:39302`   |
-| `UdpTracker:1`  | Enabled        | `udp://0.0.0.0:44277`   |
+| Instance        | Metrics policy | Bind socket address | Client endpoint           |
+| --------------- | -------------- | ------------------- | ------------------------- |
+| `HttpTracker:0` | Disabled       | `0.0.0.0:41223`     | `http://127.0.0.1:41223/` |
+| `HttpTracker:1` | Enabled        | `0.0.0.0:39525`     | `http://127.0.0.1:39525/` |
+| `UdpTracker:0`  | Disabled       | `0.0.0.0:39302`     | `udp://127.0.0.1:39302`   |
+| `UdpTracker:1`  | Enabled        | `0.0.0.0:44277`     | `udp://127.0.0.1:44277`   |
 
-The clients connected to the corresponding `127.0.0.1` ports. One announce to
+One announce to
 each listener produced `tcp4_announces_handled: 1`,
 `udp4_announces_handled: 1`, `udp4_requests: 2`,
 `udp4_connections_handled: 1`, and `udp4_responses: 2`. The invalid-cookie

--- a/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
+++ b/docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/evidence.md
@@ -282,6 +282,32 @@ from the shared aggregates while instance `1` contributed normally. Objective
 UDP cookie-error facts from the metrics-disabled listener still reached shared
 banning enforcement.
 
+### Wildcard Binding Confirmation
+
+The preceding probe used loopback bindings to simplify local connections. The
+original collision applies specifically to repeated wildcard bindings, so the
+same probe was repeated with
+[`evidence-artifacts/wildcard-port-zero-manual.toml`](evidence-artifacts/wildcard-port-zero-manual.toml),
+which configures every public listener as `0.0.0.0:0`.
+
+Startup logs mapped each configured identity to a distinct final wildcard
+binding:
+
+| Instance        | Metrics policy | Final binding           |
+| --------------- | -------------- | ----------------------- |
+| `HttpTracker:0` | Disabled       | `http://0.0.0.0:41223/` |
+| `HttpTracker:1` | Enabled        | `http://0.0.0.0:39525/` |
+| `UdpTracker:0`  | Disabled       | `udp://0.0.0.0:39302`   |
+| `UdpTracker:1`  | Enabled        | `udp://0.0.0.0:44277`   |
+
+The clients connected to the corresponding `127.0.0.1` ports. One announce to
+each listener produced `tcp4_announces_handled: 1`,
+`udp4_announces_handled: 1`, `udp4_requests: 2`,
+`udp4_connections_handled: 1`, and `udp4_responses: 2`. The invalid-cookie
+probe against `UdpTracker:0` printed the expected twelfth-request ban result;
+afterward `udp_banned_ips_total: 1`, while those usage values remained
+unchanged.
+
 ### Automated Verification
 
 The final focused regression suite passed with one test in each target:


### PR DESCRIPTION
## Summary

- clarify why the independently verified bootstrap fix remained open pending #2039's listener-side metrics filtering and UDP banning independence
- record final local HTTP and UDP duplicate-port-zero verification, including metrics-disabled and metrics-enabled listeners
- add and execute the exact repeated `0.0.0.0:0` reproduction configuration, confirming distinct final bindings, aggregate metrics filtering, and shared UDP banning

## Verification

- `cargo test --test metrics-port-zero --test metrics-fixed-ports --test banning-udp-metrics-disabled-port-zero --test metrics-udp-error-enabled-port-zero --test metrics-udp-error-disabled-port-zero --test scaffold -- --test-threads=1`
- `linter all`
- pre-push hook: nightly format/check/doc plus stable workspace tests

Closes #2035.