### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/prompts/update-dependencies.prompt.md
+++ b/.github/prompts/update-dependencies.prompt.md
@@ -1,0 +1,14 @@
+---
+name: "Update Dependencies"
+description: "Update Torrust Tracker Cargo dependencies using the repository's required workflow"
+argument-hint: "Optional package name, version constraint, or update scope"
+agent: "agent"
+---
+
+Update the Cargo dependencies in this workspace, strictly following the canonical [dependency update skill](../skills/dev/maintenance/update-dependencies/SKILL.md) and all applicable repository instructions.
+
+Scope: ${input:dependency scope:Update all eligible dependencies}
+
+Treat this as an end-to-end maintenance task. Inspect the current worktree and dependency graph, classify the update as trivial or breaking before changing files, make only the necessary changes, run the required focused validation and repository quality checks, and report the exact updates, validation results, and any deferred breaking migrations.
+
+After successful validation, create the appropriate branch, make a GPG-signed commit, push it to the configured fork remote, and open a pull request targeting `torrust/torrust-tracker:develop`. Request sandbox or user approval whenever an operation requires it. Do not bypass required approval or GPG-signing protections.

--- a/.github/prompts/update-dependencies.prompt.md
+++ b/.github/prompts/update-dependencies.prompt.md
@@ -9,6 +9,6 @@ Update the Cargo dependencies in this workspace, strictly following the canonica
 
 Scope: ${input:dependency scope:Update all eligible dependencies}
 
-Treat this as an end-to-end maintenance task. Inspect the current worktree and dependency graph, classify the update as trivial or breaking before changing files, make only the necessary changes, run the required focused validation and repository quality checks, and report the exact updates, validation results, and any deferred breaking migrations.
+Treat this as an end-to-end maintenance task. Inspect the current worktree and dependency graph, classify the update as trivial or breaking, then create the appropriate branch before changing any dependencies. Make only the necessary changes, run the required focused validation and repository quality checks, and report the exact updates, validation results, and any deferred breaking migrations.
 
-After successful validation, create the appropriate branch, make a GPG-signed commit, push it to the configured fork remote, and open a pull request targeting `torrust/torrust-tracker:develop`. Request sandbox or user approval whenever an operation requires it. Do not bypass required approval or GPG-signing protections.
+After successful validation, make a GPG-signed commit, push it to the configured fork remote, and open a pull request targeting `torrust/torrust-tracker:develop`. Request sandbox or user approval whenever an operation requires it. Do not bypass required approval or GPG-signing protections.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1261,9 +1261,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -1637,9 +1637,9 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2009,9 +2009,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3278,18 +3278,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6105,9 +6105,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6116,9 +6116,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

- add the workspace dependency-update prompt in an isolated first commit
- update eight compatible locked dependencies

Updated packages:

- `cc` 1.4.3 -> 1.4.4
- `either` 1.17.0 -> 1.18.0
- `h2` 0.4.16 -> 0.4.18
- `icu_provider` 2.3.0 -> 2.3.1
- `ref-cast` and `ref-cast-impl` 1.0.26 -> 1.0.27
- `zerovec` 0.11.7 -> 0.11.8
- `zerovec-derive` 0.11.5 -> 0.11.6

## Validation

- `./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`
- pre-push hook: nightly format, workspace check, documentation build, and full stable test suite
