### PR TITLE
test(integration): add application lifecycle fixture

### DIFF
--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
@@ -24,6 +24,8 @@ semantic-links:
     - src/bootstrap/jobs/manager.rs
     - packages/test-helpers/
     - docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
+    - https://github.com/torrust/torrust-tracker/issues/1488
+    - https://github.com/torrust/torrust-tracker/pull/1993
 ---
 
 # Issue #1419 - Allow multiple integration tests at the main app level
@@ -206,8 +208,8 @@ completed work and remaining tasks are recorded after the decision pivot.
 
 - [ ] Specification drafted and approved by user/maintainer
 - [ ] GitHub issue #1419 already exists (created by maintainer)
-- [ ] Implementation completed
-- [ ] Automatic verification completed (current main-level integration-test targets)
+- [x] Implementation completed (partial improvement; cooperative server shutdown remains deferred)
+- [x] Automatic verification completed (current main-level integration-test targets)
 - [ ] Acceptance criteria reviewed after implementation
 - [ ] Issue closed and specification moved to `docs/issues/closed/`
 
@@ -229,6 +231,17 @@ completed work and remaining tasks are recorded after the decision pivot.
 - 2026-08-24 - agent - Added `completion-plan.md` as the decision record for the non-trivial
   teardown work. It documents the lifecycle problem, rejected alternatives, selected test-local
   fixture direction, and mandatory manual verification evidence.
+- 2026-08-24 - agent - Implemented an initial `TrackerApplicationFixture` and migrated the current
+  suites. Focused tests exposed a lifecycle gap: `JobManager::cancel()` reaches event-listener jobs,
+  but tracker server jobs wait on separate halt channels and run until their per-job wait timeout.
+  Production shutdown coordination is deferred to #1488; #1419 will retain the fixture and use the
+  best shutdown sequence currently exposed by production.
+- 2026-08-24 - agent - Completed the partial-delivery manual verification: all six current
+  main-level targets passed in one invocation; `metrics-port-zero` passed with `--nocapture` and
+  with `--test-threads=1`; and the full pre-commit quality gate passed. Each suite took 60–81
+  seconds because current server jobs can consume `wait_for_all`'s per-job timeout. Successful
+  process exit is not evidence of cooperative server shutdown; that proof remains deferred to
+  #1488.
 
 ## Acceptance Criteria
 
@@ -245,11 +258,16 @@ completed work and remaining tasks are recorded after the decision pivot.
 - [x] AC6: Global stats coverage includes multiple metrics, not only `tcp4_announces_handled`.
 - [x] AC7: Test utilities for temp workspace creation (config + storage) and port extraction are
       available and documented.
-- [ ] AC8: Every current main-level suite deterministically cancels and waits for its application
-      jobs before its temporary workspace is released.
-- [ ] AC9: All current main-level integration-test targets pass cleanly with normal parallel
-      scheduling, and a representative target passes in serial mode.
-- [ ] AC10: `linter all` passes.
+- [x] AC8: Every current main-level suite uses `TrackerApplicationFixture` to invoke the best
+      currently exposed production shutdown sequence—`JobManager::cancel()` followed by
+      `wait_for_all(...)`—before its temporary workspace is released.
+- [ ] AC8a: After shutdown-overhaul #1488 is implemented, review the integration fixture against
+      the new production lifecycle and prove server jobs finish cooperatively without consuming the
+      current per-job timeout.
+- [x] AC9: All current main-level integration-test targets pass with normal parallel scheduling,
+      and a representative target passes in serial mode. Current production server jobs can still
+      consume the per-job shutdown timeout; cooperative completion is deferred to AC8a.
+- [x] AC10: `linter all` passes.
 
 ## Verification Plan
 
@@ -261,13 +279,31 @@ completed work and remaining tasks are recorded after the decision pivot.
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                   | Expected Result                                                                           | Status | Evidence                                                 |
-| --- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | ------ | -------------------------------------------------------- |
-| M1  | Run all current targets in one invocation  | All targets pass; no port, configuration, storage, or shutdown interference               | TODO   | Record command, UTC date, exit status, and observation   |
-| M2  | Run `metrics-port-zero` with `--nocapture` | Explicit teardown completes; services have distinct, non-zero final bindings              | TODO   | Record command, UTC date, exit status, and observation   |
-| M3  | Verify focused teardown coverage           | Awaited shutdown completes before workspace cleanup; no process-exit or sleep-based proof | TODO   | Record test name, UTC date, exit status, and observation |
-| M4  | Run `metrics-port-zero` in serial mode     | Suite has no implicit dependency on parallel scheduling                                   | TODO   | Record command, UTC date, exit status, and observation   |
-| M5  | Run `linter all` after implementation      | Full quality gate passes                                                                  | TODO   | Record command, UTC date, exit status, and observation   |
+| ID  | Scenario                                   | Expected Result                                                                           | Status | Evidence                                                                                                                                                                  |
+| --- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | Run all current targets in one invocation  | All targets pass; no port, configuration, storage, or shutdown interference               | DONE   | 2026-08-24; exit 0; all six targets passed. Each took 60–81 seconds because server jobs can consume the current per-job wait timeout.                                     |
+| M2  | Run `metrics-port-zero` with `--nocapture` | Explicit teardown completes; services have distinct, non-zero final bindings              | DONE   | 2026-08-24; exit 0; 1 test passed in 80.07 seconds. The scenario validates distinct non-zero final bindings; duration reflects the current server-job timeout limitation. |
+| M3  | Verify focused teardown coverage           | Awaited shutdown completes before workspace cleanup; no process-exit or sleep-based proof | DONE   | 2026-08-24; exit 0; `it_should_apply_metrics_policy_to_port_zero_tracker_instances` calls fixture shutdown then asserts the workspace has been released.                  |
+| M4  | Run `metrics-port-zero` in serial mode     | Suite has no implicit dependency on parallel scheduling                                   | DONE   | 2026-08-24; exit 0; 1 test passed with `--test-threads=1` in 80.07 seconds.                                                                                               |
+| M5  | Run `linter all` after implementation      | Full quality gate passes                                                                  | DONE   | 2026-08-24; exit 0; pre-commit gate passed `linter all` plus cargo machete, cargo deny, Containerfile lint, and documentation tests.                                      |
+
+### Verification Evidence
+
+All commands below completed with exit status `0` on 2026-08-24:
+
+```sh
+cargo test --test metrics-fixed-ports --test metrics-port-zero --test metrics-udp-error-enabled-port-zero --test metrics-udp-error-disabled-port-zero --test banning-udp-metrics-disabled-port-zero --test scaffold
+cargo test --test metrics-port-zero -- --nocapture
+cargo test --test metrics-port-zero -- --test-threads=1
+TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json
+linter all
+```
+
+The multi-target invocation passed all six suites. `metrics-port-zero` passed in both focused runs.
+The focused lifecycle assertion confirms that fixture shutdown returns before the temporary workspace
+is released. The test executables took 60–81 seconds because current HTTP, UDP, REST API, and health
+check server jobs can consume `JobManager::wait_for_all`'s per-job timeout. This is a known current
+production limitation, not proof of cooperative server completion; #1488 owns that follow-up.
 
 ## Risks and Trade-offs
 
@@ -355,10 +391,14 @@ and side-effect-free runtime-registry discovery used by these suites. It creates
 containing a configuration file and tracker storage directory, while port-zero services publish
 their final bindings under canonical service roles and `ConfigurationInstanceId` values.
 
-The remaining lifecycle gap is deterministic teardown. Current tests retain the returned
-`JobManager` as `_jobs` and depend on scope/process exit. Before closing this issue, the shared
-fixture or each suite must explicitly call `JobManager::cancel()` and `wait_for_all(...)` before
-its temporary workspace is released.
+`TrackerApplicationFixture` now owns the workspace and `JobManager`, and explicitly calls
+`cancel()` then `wait_for_all(...)` before releasing its workspace. Focused execution showed that
+the current production shutdown path does not yet propagate cancellation to server-specific halt
+channels, so server jobs can reach `wait_for_all`'s per-job timeout. That production concern is
+owned by [shutdown-overhaul #1488](https://github.com/torrust/torrust-tracker/issues/1488), whose
+draft planning PR [#1993](https://github.com/torrust/torrust-tracker/pull/1993) selects token
+watching in each server job starter rather than a separate coordinator. #1419 deliberately does
+not implement a competing shutdown mechanism.
 
 The former pause for #2035 and #2036 is no longer active: repeated `0.0.0.0:0` HTTP and UDP
 configuration blocks retain distinct instance identities, and the runtime registry metadata needed
@@ -373,26 +413,29 @@ issue. The problem statement, alternatives, selected fixture direction, and mand
 protocol are documented in [completion-plan.md](completion-plan.md). That companion document must
 be reviewed before implementation begins.
 
-| ID  | Status | Step                                          | Implementation and completion evidence                                                                                                                                                                                                                 |
-| --- | ------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| R1  | TODO   | Review lifecycle problem and fixture decision | Review [completion-plan.md](completion-plan.md): `_jobs` drop-only cleanup neither cancels nor awaits jobs. Confirm the selected test-local fixture approach and reject production `Drop` or child-process alternatives for this issue.                |
-| R2  | TODO   | Implement deterministic teardown              | Replace `_jobs` drop-only cleanup in every current main-level suite. The selected fixture must call `JobManager::cancel()` followed by `wait_for_all(...)` before `EphemeralTrackerWorkspace` is dropped.                                              |
-| R3  | TODO   | Prove teardown behavior                       | Add focused coverage that exercises the shared lifecycle path and proves awaited shutdown without process exit or sleep-based assertions.                                                                                                              |
-| R4  | TODO   | Align test documentation                      | Update `tests/scaffold.rs` references to the removed `stats` target and revise `tests/AGENTS.md` to describe tracing as one of several process-global lifecycle constraints, not the sole blocker.                                                     |
-| R5  | TODO   | Run mandatory manual integration verification | Execute the required manual runs defined in [completion-plan.md](completion-plan.md): normal parallel targets, `--nocapture`, and a representative serial run. Record the exact command, UTC date, exit status, and observation in this specification. |
-| R6  | TODO   | Run the full quality gate                     | Run `linter all`; record the UTC date, exit status, and result in this specification.                                                                                                                                                                  |
-| R7  | TODO   | Perform closure review                        | Confirm all acceptance criteria, move the issue specification to `docs/issues/closed/`, and close GitHub issue #1419.                                                                                                                                  |
+| ID  | Status | Step                                          | Implementation and completion evidence                                                                                                                                                                                    |
+| --- | ------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| R1  | DONE   | Review lifecycle problem and fixture decision | The test-local fixture direction was selected. It centralizes the best shutdown sequence that current production exposes.                                                                                                 |
+| R2  | DONE   | Implement partial deterministic teardown      | `TrackerApplicationFixture` owns the application workspace and invokes `cancel()` then `wait_for_all(...)` before workspace release; all current suites use it.                                                           |
+| R3  | DONE   | Prove current fixture ordering                | Focused coverage proves awaited fixture shutdown precedes workspace cleanup without process-exit or sleep-based assertions.                                                                                               |
+| R4  | DONE   | Align test documentation                      | Update `tests/scaffold.rs` references to the removed `stats` target and revise `tests/AGENTS.md` to document the fixture and process-global lifecycle constraints.                                                        |
+| R5  | DONE   | Run mandatory manual integration verification | On 2026-08-24, exit 0: all six targets passed together; `metrics-port-zero` passed with `--nocapture` and in serial mode. Each suite took 60–81 seconds because server jobs can consume the current per-job wait timeout. |
+| R6  | DONE   | Run the full quality gate                     | On 2026-08-24, exit 0: the pre-commit gate passed, including `linter all`.                                                                                                                                                |
+| R7  | TODO   | Open partial-improvement PR                   | Submit the fixture, suite migration, focused ordering coverage, and documentation. State that cooperative server shutdown remains owned by #1488.                                                                         |
+| R8  | TODO   | Revisit after shutdown overhaul #1488         | After #1488's production shutdown work merges, review this fixture against its finalized API, update it if needed, and complete AC8a. Keep #1419 open until that review is recorded.                                      |
+| R9  | TODO   | Perform final closure review                  | After the #1488 follow-up, confirm all acceptance criteria, move the issue specification to `docs/issues/closed/`, and close GitHub issue #1419.                                                                          |
 
 #### Implementation Sequence
 
-1. Inspect `JobManager::cancel()` and `JobManager::wait_for_all(...)` and choose the smallest
-   shared fixture API that can enforce the required lifetime order. Review the alternatives and
-   decision criteria in [completion-plan.md](completion-plan.md) first.
-2. Implement the fixture and migrate every current suite, including `scaffold`; do not leave
-   `_jobs` bindings that silently rely on process exit.
-3. Add and run focused teardown coverage before changing unrelated test behavior.
-4. Update `tests/scaffold.rs` and `tests/AGENTS.md` to match the implemented model.
-5. Complete every mandatory manual run in [completion-plan.md](completion-plan.md), including the
+1. Complete and record the partial-delivery manual verification of the fixture, noting that the
+   current production server jobs may consume their wait timeout.
+2. Run the full quality gate and submit the partial-improvement PR. Do not add server shutdown
+   coordination in #1419.
+3. After #1488 merges, review its finalized shutdown API and update the fixture to call the same
+   application lifecycle boundary.
+4. Add and run post-overhaul focused coverage that proves cooperative server completion before
+   workspace cleanup, without fixed sleeps.
+5. Repeat every mandatory manual run in [completion-plan.md](completion-plan.md), including the
    normal parallel, `--nocapture`, and representative serial commands, then run `linter all`.
 6. Update the verification evidence and acceptance criteria. Only then prepare the issue for
    closure.
@@ -403,6 +446,9 @@ be reviewed before implementation begins.
   unless a second, non-main-level consumer establishes a real shared need.
 - A new integration-test binary is not required merely to prove teardown. Prefer focused coverage
   in the existing test structure.
+- Do not implement a server-halt coordinator, pass cancellation tokens through server packages, or
+  otherwise change production shutdown in this issue. Those responsibilities are explicitly owned
+  by shutdown-overhaul #1488 and its implementation subissues.
 - Do not claim temporary directories are cleaned after a forced process interruption; normal
   `TempDir` cleanup is sufficient once jobs stop before the workspace is dropped.
 - Do not close the issue until the normal parallel invocation and `linter all` have both passed.

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 1419
 spec-path: docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
 branch: 1419-allow-multiple-integration-tests
 related-pr: null
-last-updated-utc: 2026-08-17
+last-updated-utc: 2026-08-24
 semantic-links:
   skill-links:
     - write-unit-test
@@ -15,25 +15,32 @@ semantic-links:
     - docs/adrs/20260728115400_define_registar_as_runtime_service_registry.md
     - docs/issues/open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md
     - docs/issues/closed/2036-add-runtime-service-registry-metadata/ISSUE.md
-    - tests/stats.rs
-    - tests/servers/
+    - tests/AGENTS.md
+    - tests/common/
+    - tests/metrics/
+    - tests/banning/
+    - tests/scaffold.rs
     - src/app.rs
+    - src/bootstrap/jobs/manager.rs
     - packages/test-helpers/
+    - docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
 ---
 
 # Issue #1419 - Allow multiple integration tests at the main app level
 
 ## Goal
 
-Enable running multiple independent integration tests at the main application level (`tests/stats.rs`)
-in parallel without port conflicts, configuration collisions, or logging initialization errors.
+Enable independent main-application integration-test executables to run in parallel without port,
+configuration, storage, or process-global-state collisions. Each executable owns one tracker
+application instance and runs its scenarios sequentially.
 
 ## Background
 
-Currently, there is one integration test for global metrics at the main app level
-(`tests/servers/api/contract/stats/mod.rs`). This test verifies behavior that can only be tested at
-the main app level, specifically that multiple tracker instances (HTTP and UDP) running on different
-socket addresses contribute to global metrics aggregation.
+The current test structure contains dedicated Cargo integration-test targets for port-zero metrics,
+fixed-port metrics, UDP error-policy behavior, UDP banning behavior, and a scaffolding example.
+They verify application-level behavior such as multiple HTTP/UDP listener coordination and global
+metrics aggregation. The former `tests/stats.rs` and `tests/servers/api/contract/stats/mod.rs`
+locations no longer exist.
 
 Most tests are correctly located inside the `packages/` directory, testing individual components in
 isolation. Integration tests at the main app level should be reserved for testing application-level
@@ -177,20 +184,21 @@ which creates isolated workspaces with separate config and storage directories f
 
 ## Implementation Plan
 
-**Strategy**: First prove the scaffolding is broken by adding a second test case that would conflict,
-then fix the scaffolding infrastructure, then expand coverage.
+**Status**: The following table is the historical implementation plan. Its original single-
+`stats`-executable premise was superseded by the per-executable execution model below. The actual
+completed work and remaining tasks are recorded after the decision pivot.
 
-| ID  | Status | Task                                                        | Notes                                                                                                                                                                |
-| --- | ------ | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | DONE   | Create `tests/AGENTS.md` with guidelines and TODO list      | Document what belongs in main-level integration tests vs package tests; include prioritized TODO list of future valuable integration tests                           |
-| T2  | TODO   | Add second assertion to existing stats test                 | Check another global stat field (e.g., `tcp4_scrapes_handled` or `tcp6_announces_handled`) to prove need for parallel test capability                                |
-| T3  | TODO   | Create test utilities module                                | `tests/helpers.rs` with utilities for temp workspace creation (config + storage dirs) and port extraction                                                            |
-| T4  | TODO   | Add utility to create isolated temp workspace               | Returns `TempDir` with subdirectories for config and storage; writes TOML config; sets `TORRUST_TRACKER_CONFIG_TOML_PATH` env var                                    |
-| T5  | TODO   | Add utility to extract bound addresses from `AppContainer`  | Query `Registar` or job handles to get actual bound `SocketAddr` for HTTP API, trackers, etc.                                                                        |
-| T6  | TODO   | Update existing stats test to use port 0 and temp workspace | Replace `env::set_var` with isolated temp workspace, use port 0, extract actual ports for requests; fixes scaffolding to support parallelism                         |
-| T7  | TODO   | Expand global stats test coverage                           | Add tests for more global stat metrics now that scaffolding supports it (scrape counters, different IP families, etc.)                                               |
-| T8  | TODO   | Add shared-event-bus policy integration test                | After #2036 and event-metrics normalization, verify enabled and disabled HTTP/UDP listeners share aggregate buses while only enabled traffic changes public metrics. |
-| T9  | TODO   | Run automatic verification                                  | `cargo test --test stats` must pass with all tests running concurrently                                                                                              |
+| ID  | Status | Task                                                          | Notes                                                                                                   |
+| --- | ------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Create `tests/AGENTS.md` with guidelines and TODO list        | `tests/AGENTS.md` documents scope, execution model, and test layout.                                    |
+| T2  | DONE   | Create independent integration-test executables               | `Cargo.toml` explicitly registers the current nested test targets.                                      |
+| T3  | DONE   | Create test utilities module                                  | Reusable utilities live in `tests/common/`, not the obsolete `tests/helpers.rs` proposal.               |
+| T4  | DONE   | Add utility to create isolated temp workspace                 | `EphemeralTrackerWorkspace` creates a `TempDir`, config file, and storage directory.                    |
+| T5  | DONE   | Add utility to extract bound addresses from `AppContainer`    | Runtime registry helpers use service role and `ConfigurationInstanceId`.                                |
+| T6  | DONE   | Migrate appropriate suites to port 0 and temporary workspaces | Port-zero metrics, UDP-error, and banning suites use isolated workspaces.                               |
+| T7  | DONE   | Expand global stats test coverage                             | Current suites cover HTTP/UDP announces plus request, connection, response, error, and banning metrics. |
+| T8  | DONE   | Resolve prerequisites for port-zero identity discovery        | #2035 bootstrap behavior and #2036 registry metadata are present and consumed by helpers.               |
+| T9  | TODO   | Run automatic verification                                    | Use the current multi-target command in the revised verification plan.                                  |
 
 ## Progress Tracking
 
@@ -199,7 +207,7 @@ then fix the scaffolding infrastructure, then expand coverage.
 - [ ] Specification drafted and approved by user/maintainer
 - [ ] GitHub issue #1419 already exists (created by maintainer)
 - [ ] Implementation completed
-- [ ] Automatic verification completed (`cargo test --test stats`)
+- [ ] Automatic verification completed (current main-level integration-test targets)
 - [ ] Acceptance criteria reviewed after implementation
 - [ ] Issue closed and specification moved to `docs/issues/closed/`
 
@@ -215,42 +223,51 @@ then fix the scaffolding infrastructure, then expand coverage.
 - 2026-07-27 17:35 UTC - agent - Recorded the decision to use one tracker application per Cargo
   integration-test executable, with sequential scenarios per suite and a non-Docker process runner
   deferred unless in-process lifecycle control proves insufficient
+- 2026-08-24 - agent - Reconciled the specification with the current `tests/` implementation and
+  replaced the remaining-work list with an ordered completion plan: deterministic teardown,
+  teardown coverage, documentation alignment, focused verification, quality gate, and closure review.
+- 2026-08-24 - agent - Added `completion-plan.md` as the decision record for the non-trivial
+  teardown work. It documents the lifecycle problem, rejected alternatives, selected test-local
+  fixture direction, and mandatory manual verification evidence.
 
 ## Acceptance Criteria
 
 - [x] AC1: `tests/AGENTS.md` exists and documents guidelines for what belongs at main-level vs
       package-level, with a TODO list of future valuable integration tests.
-- [ ] AC2: Multiple integration tests can run concurrently with `cargo test --test stats`
-      without port conflicts.
-- [ ] AC3: Each test uses an isolated temporary workspace with separate config and storage
+- [x] AC2: Independent main-level integration-test executables are registered and can run
+      concurrently as separate Cargo processes without shared environment state.
+- [x] AC3: Current port-zero suites use an isolated temporary workspace with separate config and storage
       directories (no shared environment variables or storage paths).
-- [ ] AC4: Tests using port 0 can extract the actual bound ports from `AppContainer` to construct
+- [x] AC4: Tests using port 0 can extract the actual bound ports from `AppContainer` to construct
       request URLs.
-- [ ] AC5: The existing stats integration test is updated to use an isolated temp workspace and
-      port 0.
-- [ ] AC6: Global stats test coverage includes multiple metrics (not just `tcp4_announces_handled`).
-- [ ] AC7: Test utilities for temp workspace creation (config + storage) and port extraction are
+- [x] AC5: Port-zero suites use an isolated temp workspace and port 0 where the scenario does not
+      require fixed ports.
+- [x] AC6: Global stats coverage includes multiple metrics, not only `tcp4_announces_handled`.
+- [x] AC7: Test utilities for temp workspace creation (config + storage) and port extraction are
       available and documented.
-- [ ] AC8: `cargo test --test stats` passes cleanly with expanded test coverage.
-- [ ] AC9: `linter all` passes.
+- [ ] AC8: Every current main-level suite deterministically cancels and waits for its application
+      jobs before its temporary workspace is released.
+- [ ] AC9: All current main-level integration-test targets pass cleanly with normal parallel
+      scheduling, and a representative target passes in serial mode.
+- [ ] AC10: `linter all` passes.
 
 ## Verification Plan
 
 ### Automatic Checks
 
-- `cargo test --test stats` — Must pass with all integration tests running concurrently
-- `cargo test --test stats -- --test-threads=1` — Verify tests also work in serial mode
+- `cargo test --test metrics-fixed-ports --test metrics-port-zero --test metrics-udp-error-enabled-port-zero --test metrics-udp-error-disabled-port-zero --test banning-udp-metrics-disabled-port-zero --test scaffold` — Must pass with normal parallel scheduling after deterministic teardown is implemented
+- `cargo test --test metrics-port-zero -- --test-threads=1` — Verify a representative suite also works in serial mode after deterministic teardown is implemented
 - `linter all` — Standard quality gate
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                                                | Expected Result                                                                   | Status | Evidence |
-| --- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------ | -------- |
-| M1  | Run `cargo test --test stats` with default parallelism                  | All tests pass; no port conflicts or configuration collisions                     | TODO   |          |
-| M2  | Run `cargo test --test stats -- --nocapture` to see logs                | Each test shows unique bound ports; no env var configuration warnings             | TODO   |          |
-| M3  | Add a third integration test temporarily and run the suite              | All three tests run concurrently without interference                             | TODO   |          |
-| M4  | Verify temp workspaces are cleaned up after tests complete              | No leftover temporary directories in `/tmp` or system temp directory              | TODO   |          |
-| M5  | Run tests in serial mode: `cargo test --test stats -- --test-threads=1` | Tests pass in serial mode (no implicit dependency on parallelism for correctness) | TODO   |          |
+| ID  | Scenario                                   | Expected Result                                                                           | Status | Evidence                                                 |
+| --- | ------------------------------------------ | ----------------------------------------------------------------------------------------- | ------ | -------------------------------------------------------- |
+| M1  | Run all current targets in one invocation  | All targets pass; no port, configuration, storage, or shutdown interference               | TODO   | Record command, UTC date, exit status, and observation   |
+| M2  | Run `metrics-port-zero` with `--nocapture` | Explicit teardown completes; services have distinct, non-zero final bindings              | TODO   | Record command, UTC date, exit status, and observation   |
+| M3  | Verify focused teardown coverage           | Awaited shutdown completes before workspace cleanup; no process-exit or sleep-based proof | TODO   | Record test name, UTC date, exit status, and observation |
+| M4  | Run `metrics-port-zero` in serial mode     | Suite has no implicit dependency on parallel scheduling                                   | TODO   | Record command, UTC date, exit status, and observation   |
+| M5  | Run `linter all` after implementation      | Full quality gate passes                                                                  | TODO   | Record command, UTC date, exit status, and observation   |
 
 ## Risks and Trade-offs
 
@@ -323,6 +340,73 @@ its own database and storage paths, and port `0` for listeners.
 injection through the environment is safe between separate test executables. It must not be
 modified concurrently by separate scenarios in one executable.
 
+### Current Implementation Status
+
+The revised execution model is implemented by the explicit targets in `Cargo.toml`:
+
+- `metrics-port-zero` tests duplicate port-zero listener identity and metrics policy.
+- `metrics-fixed-ports` tests fixed-port multi-listener routing and aggregate metrics.
+- `metrics-udp-error-enabled-port-zero`, `metrics-udp-error-disabled-port-zero`, and
+  `banning-udp-metrics-disabled-port-zero` test the related UDP policy variants.
+- `scaffold` documents the pattern for a new isolated suite.
+
+`tests/common/workspace.rs` provides the shared `EphemeralTrackerWorkspace`, startup readiness,
+and side-effect-free runtime-registry discovery used by these suites. It creates a unique `TempDir`
+containing a configuration file and tracker storage directory, while port-zero services publish
+their final bindings under canonical service roles and `ConfigurationInstanceId` values.
+
+The remaining lifecycle gap is deterministic teardown. Current tests retain the returned
+`JobManager` as `_jobs` and depend on scope/process exit. Before closing this issue, the shared
+fixture or each suite must explicitly call `JobManager::cancel()` and `wait_for_all(...)` before
+its temporary workspace is released.
+
+The former pause for #2035 and #2036 is no longer active: repeated `0.0.0.0:0` HTTP and UDP
+configuration blocks retain distinct instance identities, and the runtime registry metadata needed
+for stable endpoint discovery is available. The implementation is now ready for teardown work and
+verification.
+
+### Completion Plan
+
+The remaining work is deliberately limited to lifecycle correctness, documentation alignment, and
+verification. Do not add new application-level behavior or a child-process runner as part of this
+issue. The problem statement, alternatives, selected fixture direction, and mandatory manual test
+protocol are documented in [completion-plan.md](completion-plan.md). That companion document must
+be reviewed before implementation begins.
+
+| ID  | Status | Step                                          | Implementation and completion evidence                                                                                                                                                                                                                 |
+| --- | ------ | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| R1  | TODO   | Review lifecycle problem and fixture decision | Review [completion-plan.md](completion-plan.md): `_jobs` drop-only cleanup neither cancels nor awaits jobs. Confirm the selected test-local fixture approach and reject production `Drop` or child-process alternatives for this issue.                |
+| R2  | TODO   | Implement deterministic teardown              | Replace `_jobs` drop-only cleanup in every current main-level suite. The selected fixture must call `JobManager::cancel()` followed by `wait_for_all(...)` before `EphemeralTrackerWorkspace` is dropped.                                              |
+| R3  | TODO   | Prove teardown behavior                       | Add focused coverage that exercises the shared lifecycle path and proves awaited shutdown without process exit or sleep-based assertions.                                                                                                              |
+| R4  | TODO   | Align test documentation                      | Update `tests/scaffold.rs` references to the removed `stats` target and revise `tests/AGENTS.md` to describe tracing as one of several process-global lifecycle constraints, not the sole blocker.                                                     |
+| R5  | TODO   | Run mandatory manual integration verification | Execute the required manual runs defined in [completion-plan.md](completion-plan.md): normal parallel targets, `--nocapture`, and a representative serial run. Record the exact command, UTC date, exit status, and observation in this specification. |
+| R6  | TODO   | Run the full quality gate                     | Run `linter all`; record the UTC date, exit status, and result in this specification.                                                                                                                                                                  |
+| R7  | TODO   | Perform closure review                        | Confirm all acceptance criteria, move the issue specification to `docs/issues/closed/`, and close GitHub issue #1419.                                                                                                                                  |
+
+#### Implementation Sequence
+
+1. Inspect `JobManager::cancel()` and `JobManager::wait_for_all(...)` and choose the smallest
+   shared fixture API that can enforce the required lifetime order. Review the alternatives and
+   decision criteria in [completion-plan.md](completion-plan.md) first.
+2. Implement the fixture and migrate every current suite, including `scaffold`; do not leave
+   `_jobs` bindings that silently rely on process exit.
+3. Add and run focused teardown coverage before changing unrelated test behavior.
+4. Update `tests/scaffold.rs` and `tests/AGENTS.md` to match the implemented model.
+5. Complete every mandatory manual run in [completion-plan.md](completion-plan.md), including the
+   normal parallel, `--nocapture`, and representative serial commands, then run `linter all`.
+6. Update the verification evidence and acceptance criteria. Only then prepare the issue for
+   closure.
+
+#### Completion Boundaries
+
+- The shared fixture may remain inside `tests/common/`; do not move it to `packages/test-helpers/`
+  unless a second, non-main-level consumer establishes a real shared need.
+- A new integration-test binary is not required merely to prove teardown. Prefer focused coverage
+  in the existing test structure.
+- Do not claim temporary directories are cleaned after a forced process interruption; normal
+  `TempDir` cleanup is sufficient once jobs stop before the workspace is dropped.
+- Do not close the issue until the normal parallel invocation and `linter all` have both passed.
+
 ### Relationship to E2E Tests
 
 This is not a replacement for container E2E tests. Main-application integration suites provide
@@ -365,23 +449,22 @@ parallel full-application instances inside a single executable.
 
 ## Implementation Pause and Prerequisites
 
-The current integration suite correctly verifies aggregate statistics across two started HTTP
-listeners. Its endpoint discovery is intentionally temporary: `tests/common/mod.rs` identifies
-HTTP trackers and the REST API through distinct bind-IP conventions. If discovery is incorrect,
-the test fails rather than producing a false aggregate-stats success, but the convention is not a
-valid application contract and must not be extended to more integration suites.
+The current integration suites verify aggregate statistics across multiple started HTTP and UDP
+listeners. Endpoint discovery is no longer temporary: `tests/common/workspace.rs` queries the
+runtime registry by canonical service role and exact `ConfigurationInstanceId`, rather than bind-IP
+conventions or registry ordering.
 
-During implementation, two prerequisite defects were discovered. Work on this issue stops after
-the current, working scaffold is documented and merged. The prerequisites will be implemented and
-merged independently; #1419 remains open and resumes on that clean base.
+During implementation, two prerequisite defects were discovered. Both prerequisites are now
+implemented, so this issue resumes with deterministic teardown, documentation cleanup, and
+verification.
 
 1. Bug #2035: [fix duplicate port-zero tracker instance bootstrap](../../open/2035-fix-duplicate-port-zero-tracker-instance-bootstrap/ISSUE.md)
-   — `AppContainer` stores HTTP and UDP per-instance containers in `HashMap<SocketAddr, _>`.
-   Repeated `0.0.0.0:0` configuration blocks overwrite each other before startup, so distinct
-   per-instance configuration can be silently lost.
+   — `AppContainer` now retains HTTP and UDP per-instance containers with their
+   `ConfigurationInstanceId`, preventing repeated `0.0.0.0:0` configuration blocks from
+   overwriting each other before startup.
 2. Feature #2036: [add runtime service registry metadata](../../closed/2036-add-runtime-service-registry-metadata/ISSUE.md)
-   — `Registar` cannot expose stable service role or configuration-instance identity without
-   health-check side effects. This requires a coordinated `torrust-server-lib` change and release.
+   — `Registar` metadata now exposes stable service role and configuration-instance identity for
+   side-effect-free test endpoint discovery.
 
 The runtime registry boundary remains recorded in
 [ADR 20260728115400](../../../adrs/20260728115400_define_registar_as_runtime_service_registry.md).

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
@@ -1,0 +1,186 @@
+# Completion Plan — Issue #1419
+
+> **Issue specification:** [ISSUE.md](ISSUE.md)
+>
+> **Status:** Proposed; requires maintainer review before implementation
+> **Scope:** Deterministic teardown, related test coverage, documentation alignment, and manual plus automated verification
+
+## Purpose
+
+This document supplies the problem statement, alternatives, decision criteria, and verification
+requirements for the remaining non-trivial work in issue #1419. `ISSUE.md` remains the source of
+truth for scope, acceptance criteria, and progress. This companion document explains why the
+remaining lifecycle work is necessary and how it must be evaluated before implementation.
+
+## Problem: Application Jobs Outlive Test-Suite Ownership
+
+Each current main-level integration-test suite creates an `EphemeralTrackerWorkspace`, starts the
+application through `start_tracker_with_config`, and receives an `AppContainer` plus a
+`JobManager`. The suite binds the manager as `_jobs` and lets it drop when the test function ends.
+
+Dropping `JobManager` does not request cancellation or wait for its `JoinHandle`s. `JobManager`
+only performs a graceful shutdown when its owner explicitly:
+
+1. calls `JobManager::cancel()` to signal the shared cancellation token; and
+2. consumes the manager with `JobManager::wait_for_all(grace_period)` to await each job.
+
+The existing tests therefore rely on test-process termination to end servers and background jobs.
+That violates the selected one-application-per-executable lifecycle: the tracker should stop before
+its `TempDir` workspace is released. It also hides shutdown failures, makes resource ownership
+unclear, and prevents a focused test from proving graceful teardown without process exit.
+
+This is not a port-zero or runtime-registry defect. Port-zero bindings, isolated temporary
+workspaces, and runtime endpoint discovery are already implemented. The remaining defect is that
+the test fixture does not own shutdown as part of its normal lifecycle.
+
+## Required Outcome
+
+Every current main-level suite must have one clear owner for its application lifecycle. After the
+last scenario completes, that owner must cancel the application jobs, await them with a bounded
+grace period, and only then permit the `EphemeralTrackerWorkspace` to be dropped.
+
+The resulting test structure must make the required lifetime order evident:
+
+```text
+create workspace → start application → run sequential scenarios → cancel jobs → await jobs → drop workspace
+```
+
+The solution must not depend on process exit, a fixed sleep, parsing logs, or a new application
+configuration.
+
+## Alternatives Considered
+
+### Alternative A — Keep `_jobs` and rely on test-process exit
+
+**Description:** Retain the current bindings and permit process termination to clean up tasks and
+listeners.
+
+**Rejected because:** It does not execute `JobManager`'s intended cancellation and waiting API,
+cannot prove normal teardown, and allows the workspace to be dropped while tasks may still use
+runtime state. It also makes lifecycle failures invisible unless they manifest as a later test or
+process-level failure.
+
+### Alternative B — Add explicit teardown code in every suite
+
+**Description:** At the end of each suite, manually call `jobs.cancel()` followed by
+`jobs.wait_for_all(...)`.
+
+**Advantages:** Minimal new abstraction and direct use of the existing shutdown API.
+
+**Rejected as the default approach because:** Six suites would repeat lifecycle-sensitive ordering.
+A future suite could forget one operation, select a different grace period, or drop the workspace
+first. Repeated teardown also makes failure-safe cleanup difficult when a scenario returns or
+panics before the final lines of the test body execute.
+
+### Alternative C — Introduce a test-local suite lifecycle fixture
+
+**Description:** Add a small fixture under `tests/common/` that owns both the
+`EphemeralTrackerWorkspace` and `JobManager`, exposes the `AppContainer` needed by scenarios, and
+provides one explicit asynchronous shutdown operation. The fixture enforces that the workspace
+outlives the awaited jobs.
+
+**Selected, subject to implementation review.** It centralizes the required ownership order in the
+same test-local module that already owns workspace creation, startup readiness, and endpoint
+discovery. It avoids exporting main-application-specific lifecycle behavior through
+`packages/test-helpers` before there is a second consumer.
+
+An asynchronous operation cannot be performed from a normal Rust `Drop` implementation. The
+fixture must therefore make shutdown explicit in each suite, or use a test-runner structure that
+can always await shutdown before returning. The implementation must document its behavior when a
+scenario fails or panics; it must not claim that synchronous `Drop` guarantees async graceful
+teardown.
+
+### Alternative D — Make `JobManager` abort jobs on drop
+
+**Description:** Change production `JobManager` drop semantics so dropping it aborts all tasks.
+
+**Rejected because:** This changes a general production lifecycle contract to solve a test-fixture
+ownership problem. Aborting is not equivalent to cooperative cancellation plus bounded graceful
+waiting, and it would affect every production caller.
+
+### Alternative E — Run the tracker as a child process
+
+**Description:** Replace the in-process suite with a process runner that terminates the tracker
+process after testing.
+
+**Rejected for this issue:** The current in-process architecture already supplies the required
+application composition coverage. A child-process runner adds readiness, diagnostic capture,
+signal, and cleanup concerns without being needed to solve the existing `JobManager` ownership
+gap. It remains deferred for future tests of executable startup, signals, logging, or exit behavior.
+
+## Chosen Direction
+
+Implement **Alternative C**, a smallest-possible lifecycle fixture in `tests/common/`, subject to
+review of the exact API. It must:
+
+- retain the `EphemeralTrackerWorkspace` for at least as long as tracker jobs are awaited;
+- expose the `Arc<AppContainer>` needed by existing scenario functions without duplicating runtime
+  discovery logic;
+- use the existing `JobManager::cancel()` and `JobManager::wait_for_all(...)` APIs;
+- define one shared, documented grace period appropriate for the current suites;
+- require explicit awaited shutdown before a successful suite returns; and
+- keep ownership test-local rather than modifying production lifecycle semantics.
+
+The exact fixture name and API are intentionally not prescribed here. The implementation should
+prefer a minimal, intention-revealing interface over a general-purpose test framework.
+
+## Test-Coverage Design
+
+The implementation must add focused coverage for the lifecycle helper itself, in addition to
+migrating all current suites.
+
+The focused test should establish observable ordering rather than merely call the helper:
+
+1. Start a tracker using an isolated workspace through the shared fixture.
+2. Complete a small existing scenario or readiness assertion.
+3. Invoke the fixture's explicit asynchronous shutdown.
+4. Assert the shutdown operation completed before releasing the fixture/workspace.
+
+The test must not use a sleep as proof of completion and must not rely on test-process exit. If the
+existing `JobManager` API does not expose sufficient observability to prove more than successful
+awaited completion, document that limitation and use the successful bounded wait as the lifecycle
+contract. Do not introduce production-only test hooks solely for this issue without a separately
+reviewed justification.
+
+All suites using `start_tracker_with_config` must migrate in the same change, including
+`tests/scaffold.rs`. No `_jobs` binding may remain as an implicit teardown mechanism.
+
+## Documentation Changes
+
+Update the following alongside the code:
+
+- `tests/scaffold.rs`: replace references to the removed `stats` target with actual current targets
+  and show the explicit lifecycle shutdown pattern.
+- `tests/AGENTS.md`: describe tracing as one of several process-global lifecycle constraints;
+  retain the one-application-per-executable rule and add the fixture's required shutdown sequence.
+- `ISSUE.md`: mark implementation tasks only after code and verification evidence exist. Record
+  commands, dates, results, and any deviation from this decision document.
+
+## Manual Verification Is Mandatory
+
+Automated tests are necessary but insufficient for this lifecycle change. The implementation changes
+how real listeners and background jobs are stopped, so manual execution of the affected integration
+targets is mandatory after implementation. Record the command, UTC date, exit status, and concise
+observed result in `ISSUE.md`.
+
+### Required Manual Runs
+
+| ID  | Command / action                                            | Expected observation                                                                                       |
+| --- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| MV1 | Run all current main-level targets in one Cargo invocation. | All targets exit successfully without port, configuration, storage, or shutdown interference.              |
+| MV2 | Run `metrics-port-zero` with `-- --nocapture`.              | The suite completes after explicit teardown; its port-zero services have distinct non-zero final bindings. |
+| MV3 | Run `metrics-port-zero` with `-- --test-threads=1`.         | The suite succeeds in serial mode and does not depend on normal parallel scheduling.                       |
+| MV4 | Run `linter all`.                                           | The repository quality gate succeeds after the code and documentation changes.                             |
+
+Use the commands listed in `ISSUE.md` as the authoritative command text. If a command must change,
+update both documents in the same change and explain why.
+
+## Implementation Checklist
+
+- [ ] Review this decision record and confirm the selected fixture direction.
+- [ ] Implement the smallest test-local lifecycle fixture.
+- [ ] Migrate every current suite and remove `_jobs` drop-only cleanup.
+- [ ] Add focused lifecycle coverage.
+- [ ] Update `tests/scaffold.rs` and `tests/AGENTS.md`.
+- [ ] Execute and record MV1–MV4.
+- [ ] Update `ISSUE.md` progress, acceptance criteria, and closure decision.

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/completion-plan.md
@@ -2,8 +2,9 @@
 
 > **Issue specification:** [ISSUE.md](ISSUE.md)
 >
-> **Status:** Proposed; requires maintainer review before implementation
-> **Scope:** Deterministic teardown, related test coverage, documentation alignment, and manual plus automated verification
+> **Status:** Partial improvement ready for review; cooperative server shutdown deferred to #1488
+> **Scope:** Current-production lifecycle fixture, related test coverage, documentation alignment,
+> and manual plus automated verification
 
 ## Purpose
 
@@ -33,20 +34,58 @@ This is not a port-zero or runtime-registry defect. Port-zero bindings, isolated
 workspaces, and runtime endpoint discovery are already implemented. The remaining defect is that
 the test fixture does not own shutdown as part of its normal lifecycle.
 
-## Required Outcome
+## Discovery: Current Production Cancellation Does Not Stop Servers
+
+The initial implementation introduced `TrackerApplicationFixture` in `tests/common/` and migrated
+the current main-level suites to its explicit `shutdown().await` path. The fixture correctly calls
+`JobManager::cancel()` followed by `wait_for_all(...)` before releasing its workspace.
+
+Focused suite runs exposed a missing production shutdown connection. `JobManager::cancel()` signals
+the shared `CancellationToken` used by event-listener and maintenance jobs. HTTP tracker, REST API,
+UDP tracker, and health-check server jobs instead wait on their own service-specific oneshot halt
+channels. They therefore do not finish when the manager cancellation token is signaled, and each
+can consume `wait_for_all`'s per-job grace timeout.
+
+The fixture establishes correct test ownership and must be retained, but it cannot itself resolve
+this production lifecycle gap.
+
+## Deferral to Shutdown Overhaul #1488
+
+The production shutdown refactor belongs to
+[shutdown-overhaul #1488](https://github.com/torrust/torrust-tracker/issues/1488), not #1419.
+Its draft planning PR [#1993](https://github.com/torrust/torrust-tracker/pull/1993) records the
+selected direction: each server job starter watches `JobManager`'s `CancellationToken`, then sends
+`Halted::Normal` to its own existing halt channel and awaits the server task. This is intentionally
+different from introducing a new application-owned server-halt coordinator.
+
+Issue #1419 must not implement a competing production shutdown mechanism while #1488 is still open. It
+will deliver a partial integration-test improvement that consistently invokes the best lifecycle
+currently exposed by production:
+
+```text
+fixture shutdown → JobManager::cancel() → JobManager::wait_for_all(...) → workspace drop
+```
+
+This sequence makes test ownership explicit and ensures the workspace is retained until the current
+production wait path returns. It does **not** prove that each server exits cooperatively; current
+server jobs may still consume their configured per-job wait timeout. That limitation must be
+recorded in #1419's partial-improvement PR and revisited after #1488 merges.
+
+## Partial-Delivery Required Outcome
 
 Every current main-level suite must have one clear owner for its application lifecycle. After the
-last scenario completes, that owner must cancel the application jobs, await them with a bounded
-grace period, and only then permit the `EphemeralTrackerWorkspace` to be dropped.
+last scenario completes, that owner must invoke the current production shutdown sequence and only
+then permit the `EphemeralTrackerWorkspace` to be dropped.
 
-The resulting test structure must make the required lifetime order evident:
+The resulting test and application lifecycle must make the required order evident:
 
 ```text
 create workspace → start application → run sequential scenarios → cancel jobs → await jobs → drop workspace
 ```
 
-The solution must not depend on process exit, a fixed sleep, parsing logs, or a new application
-configuration.
+The partial delivery must not depend on process exit, a fixed sleep, parsing logs, or a new
+application configuration. Cooperative server termination without timeout is explicitly deferred
+to #1488.
 
 ## Alternatives Considered
 
@@ -88,9 +127,32 @@ An asynchronous operation cannot be performed from a normal Rust `Drop` implemen
 fixture must therefore make shutdown explicit in each suite, or use a test-runner structure that
 can always await shutdown before returning. The implementation must document its behavior when a
 scenario fails or panics; it must not claim that synchronous `Drop` guarantees async graceful
-teardown.
+teardown. This alternative has been implemented, but requires the server-coordination alternative
+below to complete graceful shutdown.
 
-### Alternative D — Make `JobManager` abort jobs on drop
+### Alternative D — Coordinate `JobManager` cancellation with existing server halt channels
+
+**Description:** Keep the existing per-service oneshot halt channels and introduce the smallest
+application-owned coordinator that observes the application shutdown request and sends each
+service's normal halt signal. `JobManager::wait_for_all(...)` then awaits the existing server job
+handles after their services have been asked to stop.
+
+**Deferred to #1488.** The server packages already own graceful stop behavior behind their halt
+channels. However, #1488/#1993 selected a different production implementation: server job starters
+watch the shared cancellation token and invoke their own halt channel. #1419 must not create a
+competing coordinator while that overhaul remains open.
+
+### Alternative E — Change every server job to consume `CancellationToken`
+
+**Description:** Pass `JobManager`'s token into HTTP, REST API, UDP, and health-check server
+launchers, then alter each server to select between the token and its halt channel.
+
+**Rejected for this issue:** This propagates application-specific cancellation through multiple
+server package APIs that already have a dedicated graceful-halt contract. It expands the API
+surface and duplicates shutdown inputs where a single application-level coordinator can reuse the
+existing channels.
+
+### Alternative F — Make `JobManager` abort jobs on drop
 
 **Description:** Change production `JobManager` drop semantics so dropping it aborts all tasks.
 
@@ -98,7 +160,7 @@ teardown.
 ownership problem. Aborting is not equivalent to cooperative cancellation plus bounded graceful
 waiting, and it would affect every production caller.
 
-### Alternative E — Run the tracker as a child process
+### Alternative G — Run the tracker as a child process
 
 **Description:** Replace the in-process suite with a process runner that terminates the tracker
 process after testing.
@@ -108,21 +170,22 @@ application composition coverage. A child-process runner adds readiness, diagnos
 signal, and cleanup concerns without being needed to solve the existing `JobManager` ownership
 gap. It remains deferred for future tests of executable startup, signals, logging, or exit behavior.
 
-## Chosen Direction
+## Chosen Direction for Partial Delivery
 
-Implement **Alternative C**, a smallest-possible lifecycle fixture in `tests/common/`, subject to
-review of the exact API. It must:
+Retain **Alternative C**, the test-local `TrackerApplicationFixture`, and defer **Alternative D**
+to #1488. The partial delivery must:
 
 - retain the `EphemeralTrackerWorkspace` for at least as long as tracker jobs are awaited;
 - expose the `Arc<AppContainer>` needed by existing scenario functions without duplicating runtime
   discovery logic;
-- use the existing `JobManager::cancel()` and `JobManager::wait_for_all(...)` APIs;
+- call the current production shutdown sequence: `JobManager::cancel()` then
+  `JobManager::wait_for_all(...)`;
 - define one shared, documented grace period appropriate for the current suites;
 - require explicit awaited shutdown before a successful suite returns; and
 - keep ownership test-local rather than modifying production lifecycle semantics.
 
-The exact fixture name and API are intentionally not prescribed here. The implementation should
-prefer a minimal, intention-revealing interface over a general-purpose test framework.
+When #1488 merges, review its finalized lifecycle boundary and modify the fixture to use that API.
+Do not duplicate the production server-halt implementation in `tests/common/`.
 
 ## Test-Coverage Design
 
@@ -134,13 +197,12 @@ The focused test should establish observable ordering rather than merely call th
 1. Start a tracker using an isolated workspace through the shared fixture.
 2. Complete a small existing scenario or readiness assertion.
 3. Invoke the fixture's explicit asynchronous shutdown.
-4. Assert the shutdown operation completed before releasing the fixture/workspace.
+4. Assert the awaited current-production shutdown returns before releasing the fixture/workspace.
 
-The test must not use a sleep as proof of completion and must not rely on test-process exit. If the
-existing `JobManager` API does not expose sufficient observability to prove more than successful
-awaited completion, document that limitation and use the successful bounded wait as the lifecycle
-contract. Do not introduce production-only test hooks solely for this issue without a separately
-reviewed justification.
+The test must not use a sleep as proof of ordering and must not rely on test-process exit. For this
+partial delivery, it must **not** claim that server jobs finish cooperatively: current production
+does not provide that guarantee. Post-#1488 coverage must distinguish completed jobs from a
+`wait_for_all` timeout without adding production-only test hooks unless separately justified.
 
 All suites using `start_tracker_with_config` must migrate in the same change, including
 `tests/scaffold.rs`. No `_jobs` binding may remain as an implicit teardown mechanism.
@@ -158,29 +220,34 @@ Update the following alongside the code:
 
 ## Manual Verification Is Mandatory
 
-Automated tests are necessary but insufficient for this lifecycle change. The implementation changes
-how real listeners and background jobs are stopped, so manual execution of the affected integration
-targets is mandatory after implementation. Record the command, UTC date, exit status, and concise
-observed result in `ISSUE.md`.
+Automated tests are necessary but insufficient for this lifecycle change. Manual execution of the
+affected integration targets is mandatory after implementation. Record the command, UTC date, exit
+status, and concise observed result in `ISSUE.md`, including that the current production shutdown
+path may consume server-job timeouts. Do not represent successful process exit as proof of
+cooperative server shutdown.
 
 ### Required Manual Runs
 
-| ID  | Command / action                                            | Expected observation                                                                                       |
-| --- | ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| MV1 | Run all current main-level targets in one Cargo invocation. | All targets exit successfully without port, configuration, storage, or shutdown interference.              |
-| MV2 | Run `metrics-port-zero` with `-- --nocapture`.              | The suite completes after explicit teardown; its port-zero services have distinct non-zero final bindings. |
-| MV3 | Run `metrics-port-zero` with `-- --test-threads=1`.         | The suite succeeds in serial mode and does not depend on normal parallel scheduling.                       |
-| MV4 | Run `linter all`.                                           | The repository quality gate succeeds after the code and documentation changes.                             |
+| ID  | Command / action                                            | Expected observation                                                                                                                                                       |
+| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MV1 | Run all current main-level targets in one Cargo invocation. | All targets exit successfully without port, configuration, storage, or shutdown interference.                                                                              |
+| MV2 | Run `metrics-port-zero` with `-- --nocapture`.              | The suite completes after explicit current-production teardown; its port-zero services have distinct non-zero final bindings. Record any observed job-timeout diagnostics. |
+| MV3 | Run `metrics-port-zero` with `-- --test-threads=1`.         | The suite succeeds in serial mode and does not depend on normal parallel scheduling.                                                                                       |
+| MV4 | Run `linter all`.                                           | The repository quality gate succeeds after the code and documentation changes.                                                                                             |
 
 Use the commands listed in `ISSUE.md` as the authoritative command text. If a command must change,
 update both documents in the same change and explain why.
 
 ## Implementation Checklist
 
-- [ ] Review this decision record and confirm the selected fixture direction.
-- [ ] Implement the smallest test-local lifecycle fixture.
-- [ ] Migrate every current suite and remove `_jobs` drop-only cleanup.
-- [ ] Add focused lifecycle coverage.
-- [ ] Update `tests/scaffold.rs` and `tests/AGENTS.md`.
-- [ ] Execute and record MV1–MV4.
-- [ ] Update `ISSUE.md` progress, acceptance criteria, and closure decision.
+- [x] Implement the test-local `TrackerApplicationFixture` and migrate the current suites away
+      from `_jobs` drop-only cleanup.
+- [x] Run and record partial-delivery verification, explicitly documenting the current server-job
+      timeout limitation.
+- [x] Update `tests/scaffold.rs` and `tests/AGENTS.md`.
+- [x] Execute and record MV1–MV4.
+- [ ] Open a partial-improvement PR and keep #1419 open.
+- [ ] After #1488 merges, revise the fixture and add coverage that distinguishes cooperative
+      completion from a job timeout.
+- [ ] Update `ISSUE.md` progress, acceptance criteria, and closure decision after the #1488
+      follow-up.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -91,21 +91,21 @@ binaries that use the same ports.
 ### Why one binary per configuration?
 
 The 1:1 mapping between integration-test binaries and tracker configurations
-exists because the current application startup has several global side effects
-that prevent running multiple isolated tracker instances in the same process:
+exists because the current application startup has several process-global
+lifecycle constraints that prevent running multiple isolated tracker instances
+in the same process:
 
-1. **`tracing` global initialization** (main blocker): The `tracing` crate
-   initializes a global subscriber. Once set, it cannot be reset for a second
-   tracker instance in the same process. This means two tracker applications
-   sharing a process would share logging state and configuration.
-2. **Environment-variable config injection**: The tracker reads its
+1. **`tracing` global initialization**: The `tracing` crate initializes a
+   global subscriber. Once set, it cannot be reset for a second tracker
+   instance in the same process. This means tracker applications sharing a
+   process would share logging state and configuration.
+2. **Environment-variable configuration injection**: The tracker reads its
    configuration from the `TORRUST_TRACKER_CONFIG_TOML_PATH` environment
    variable. Multiple tracker instances in the same process would race on
    this variable.
-3. **Static secrets and clock state**: Values like seed secrets and the
+3. **Static secrets and clock state**: Values such as seed secrets and the
    deterministic test clock are process-global. While these could be refactored
-   into injected dependencies, the tracing global subscriber remains the
-   fundamental blocker.
+   into injected dependencies, they remain lifecycle constraints today.
 
 Until these global side effects are eliminated (tracked in
 [#1430](https://github.com/torrust/torrust-tracker/issues/1430)), each
@@ -126,7 +126,12 @@ All integration tests at this level must:
    for making requests
 4. **Be independent**: Each top-level test binary must be able to run in isolation or concurrently
    with others (it is the binary, not the function, that is the unit of isolation)
-5. **Clean up resources**: Use RAII patterns (temp dirs, handles) for automatic cleanup
+5. **Shut down explicitly**: Start suites with `TrackerApplicationFixture::start`, then call
+   `fixture.shutdown().await` after the final scenario. This cancels and waits for all
+   application jobs before dropping its workspace. `Drop` cannot provide awaited async teardown.
+   If a scenario panics before that call, ordinary Rust drop semantics still release the workspace,
+   but cannot guarantee asynchronous graceful shutdown; keep scenarios small and ensure successful
+   paths always perform the explicit shutdown.
 
 ## Current Test Structure
 
@@ -136,7 +141,7 @@ tests/
 ├── common/
 │   ├── configuration.rs              # Shared integration-test configurations
 │   ├── mod.rs                        # Re-exports from submodules
-│   ├── workspace.rs                  # Tracker workspace setup and URL discovery
+│   ├── workspace.rs                  # Workspace, lifecycle fixture, and URL discovery
 │   └── statistics.rs                 # Aggregate statistics query helpers
 ├── banning/
 │   └── udp_metrics_disabled_port_zero.rs # Disabled-listener ban statistics
@@ -155,8 +160,9 @@ tests/
    configuration than the existing suite, create a new explicit Cargo test target
    (e.g., `tests/metrics/fixed_ports.rs`). If they share the same configuration, add
    scenarios to the existing suite's runner function.
-3. **Reuse shared utilities**: Import `mod common;` and use the helpers in `tests/common/mod.rs`
-   for workspace setup, tracker startup, and port discovery.
+3. **Reuse shared utilities**: Import `mod common;`, use `TrackerApplicationFixture::start` for
+   workspace setup and tracker startup, then call `fixture.shutdown().await` after the final
+   scenario. Use the remaining helpers for port discovery.
 4. **Use port `0` by default**: Bind services to port `0` unless the scenario specifically
    requires distinct fixed addresses.
 5. **Extract bound ports**: Query the registar or `AppContainer` to discover actual socket addresses.

--- a/tests/banning/udp_metrics_disabled_port_zero.rs
+++ b/tests/banning/udp_metrics_disabled_port_zero.rs
@@ -17,9 +17,9 @@ async fn it_should_increase_banned_ip_metric_for_metrics_disabled_port_zero_udp_
     // Arrange
     let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
     let app_container = fixture.app_container();
-    let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
+    let api_url = common::http_api_url(app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
-        &app_container,
+        app_container,
         common::PortZeroMetricsPolicyConfiguration::METRICS_DISABLED_UDP_TRACKER_ID,
     )
     .await;

--- a/tests/banning/udp_metrics_disabled_port_zero.rs
+++ b/tests/banning/udp_metrics_disabled_port_zero.rs
@@ -15,8 +15,8 @@ pub(crate) type CurrentClock = clock::Stopped;
 #[tokio::test]
 async fn it_should_increase_banned_ip_metric_for_metrics_disabled_port_zero_udp_listener() {
     // Arrange
-    let workspace = common::EphemeralTrackerWorkspace::new(common::PortZeroMetricsPolicyConfiguration::TOML);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
+    let app_container = fixture.app_container();
     let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
         &app_container,
@@ -34,4 +34,6 @@ async fn it_should_increase_banned_ip_metric_for_metrics_disabled_port_zero_udp_
         statistics_after.udp_banned_ips_total,
         statistics_before.udp_banned_ips_total + 1
     );
+
+    fixture.shutdown().await;
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -33,6 +33,6 @@ pub use torrust_tracker_test_helpers::{
 };
 #[allow(unused_imports)]
 pub use workspace::{
-    EphemeralTrackerWorkspace, http_api_url, http_tracker_urls, service_binding_for_identity, start_tracker_with_config,
-    udp_socket_addr, udp_socket_addr_for_identity, udp_tracker_urls,
+    EphemeralTrackerWorkspace, TrackerApplicationFixture, http_api_url, http_tracker_urls, service_binding_for_identity,
+    start_tracker_with_config, udp_socket_addr, udp_socket_addr_for_identity, udp_tracker_urls,
 };

--- a/tests/common/workspace.rs
+++ b/tests/common/workspace.rs
@@ -60,7 +60,7 @@ impl EphemeralTrackerWorkspace {
 /// temporary workspace. Rust `Drop` cannot perform this asynchronous teardown.
 pub struct TrackerApplicationFixture {
     app_container: Arc<AppContainer>,
-    jobs: JobManager,
+    jobs: Option<JobManager>,
     workspace: EphemeralTrackerWorkspace,
 }
 
@@ -72,15 +72,15 @@ impl TrackerApplicationFixture {
 
         Self {
             app_container,
-            jobs,
+            jobs: Some(jobs),
             workspace,
         }
     }
 
     /// Returns the application container used by suite scenarios.
     #[must_use]
-    pub fn app_container(&self) -> Arc<AppContainer> {
-        Arc::clone(&self.app_container)
+    pub const fn app_container(&self) -> &Arc<AppContainer> {
+        &self.app_container
     }
 
     /// Returns the temporary workspace path for lifecycle assertions.
@@ -92,17 +92,18 @@ impl TrackerApplicationFixture {
     }
 
     /// Gracefully stops tracker jobs before releasing the workspace.
-    pub async fn shutdown(self) {
-        let Self {
-            app_container,
-            jobs,
-            workspace,
-        } = self;
-
+    pub async fn shutdown(mut self) {
+        let jobs = self.jobs.take().expect("tracker jobs must be available before shutdown");
         jobs.cancel();
         jobs.wait_for_all(TRACKER_SHUTDOWN_GRACE_PERIOD).await;
-        drop(app_container);
-        drop(workspace);
+    }
+}
+
+impl Drop for TrackerApplicationFixture {
+    fn drop(&mut self) {
+        if let Some(jobs) = &self.jobs {
+            jobs.cancel();
+        }
     }
 }
 

--- a/tests/common/workspace.rs
+++ b/tests/common/workspace.rs
@@ -12,13 +12,16 @@ use torrust_tracker_lib::container::AppContainer;
 use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
 use url::Url;
 
+/// Maximum time to await each tracker job after requesting cancellation.
+const TRACKER_SHUTDOWN_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// A temporary workspace for an integration test.
 ///
 /// Creates an isolated directory with config file and storage directory.
 /// The `{STORAGE_PATH}` placeholder in the config TOML is replaced with
 /// the absolute path to the temp storage directory.
 pub struct EphemeralTrackerWorkspace {
-    _temp_dir: TempDir,
+    temp_dir: TempDir,
     config_path: PathBuf,
 }
 
@@ -33,15 +36,73 @@ impl EphemeralTrackerWorkspace {
         let resolved = config_toml.replace("{STORAGE_PATH}", &storage_path.to_string_lossy());
         std::fs::write(&config_path, resolved).expect("failed to write config file");
 
-        Self {
-            _temp_dir: temp_dir,
-            config_path,
-        }
+        Self { temp_dir, config_path }
     }
 
     #[must_use]
     pub fn config_path(&self) -> &Path {
         &self.config_path
+    }
+
+    #[must_use]
+    // Each integration target compiles this shared module independently; only
+    // the lifecycle coverage target queries the workspace path.
+    #[allow(dead_code)]
+    pub fn path(&self) -> &Path {
+        self.temp_dir.path()
+    }
+}
+
+/// Owns a tracker application and its isolated test workspace.
+///
+/// Call [`Self::shutdown`] explicitly after the suite scenarios finish. It
+/// cancels and awaits the tracker jobs before releasing the application and
+/// temporary workspace. Rust `Drop` cannot perform this asynchronous teardown.
+pub struct TrackerApplicationFixture {
+    app_container: Arc<AppContainer>,
+    jobs: JobManager,
+    workspace: EphemeralTrackerWorkspace,
+}
+
+impl TrackerApplicationFixture {
+    /// Starts one tracker application in an isolated workspace.
+    pub async fn start(config_toml: &str) -> Self {
+        let workspace = EphemeralTrackerWorkspace::new(config_toml);
+        let (app_container, jobs) = start_tracker_with_config(&workspace).await;
+
+        Self {
+            app_container,
+            jobs,
+            workspace,
+        }
+    }
+
+    /// Returns the application container used by suite scenarios.
+    #[must_use]
+    pub fn app_container(&self) -> Arc<AppContainer> {
+        Arc::clone(&self.app_container)
+    }
+
+    /// Returns the temporary workspace path for lifecycle assertions.
+    #[must_use]
+    // See the per-target compilation note on `EphemeralTrackerWorkspace::path`.
+    #[allow(dead_code)]
+    pub fn workspace_path(&self) -> PathBuf {
+        self.workspace.path().to_path_buf()
+    }
+
+    /// Gracefully stops tracker jobs before releasing the workspace.
+    pub async fn shutdown(self) {
+        let Self {
+            app_container,
+            jobs,
+            workspace,
+        } = self;
+
+        jobs.cancel();
+        jobs.wait_for_all(TRACKER_SHUTDOWN_GRACE_PERIOD).await;
+        drop(app_container);
+        drop(workspace);
     }
 }
 

--- a/tests/metrics/fixed_ports.rs
+++ b/tests/metrics/fixed_ports.rs
@@ -71,12 +71,15 @@ const FIXED_PORT_CONFIG: &str = r#"
 #[tokio::test]
 async fn it_should_apply_metrics_policy_to_fixed_port_tracker_instances() {
     // Arrange
-    let workspace = common::EphemeralTrackerWorkspace::new(FIXED_PORT_CONFIG);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(FIXED_PORT_CONFIG).await;
+    let app_container = fixture.app_container();
 
     // Act
     it_should_aggregate_http_announces_only_from_metrics_enabled_listener(&app_container).await;
     it_should_aggregate_udp_events_only_from_metrics_enabled_listener(&app_container).await;
+
+    // Assert
+    fixture.shutdown().await;
 }
 
 /// Both HTTP listeners are on distinct fixed ports, but only the

--- a/tests/metrics/fixed_ports.rs
+++ b/tests/metrics/fixed_ports.rs
@@ -75,8 +75,8 @@ async fn it_should_apply_metrics_policy_to_fixed_port_tracker_instances() {
     let app_container = fixture.app_container();
 
     // Act
-    it_should_aggregate_http_announces_only_from_metrics_enabled_listener(&app_container).await;
-    it_should_aggregate_udp_events_only_from_metrics_enabled_listener(&app_container).await;
+    it_should_aggregate_http_announces_only_from_metrics_enabled_listener(app_container).await;
+    it_should_aggregate_udp_events_only_from_metrics_enabled_listener(app_container).await;
 
     // Assert
     fixture.shutdown().await;

--- a/tests/metrics/port_zero.rs
+++ b/tests/metrics/port_zero.rs
@@ -27,8 +27,9 @@ pub(crate) type CurrentClock = clock::Stopped;
 #[tokio::test]
 async fn it_should_apply_metrics_policy_to_port_zero_tracker_instances() {
     // Arrange
-    let workspace = common::EphemeralTrackerWorkspace::new(common::PortZeroMetricsPolicyConfiguration::TOML);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
+    let workspace_path = fixture.workspace_path();
+    let app_container = fixture.app_container();
 
     // Assert
     it_should_preserve_distinct_configurations_for_duplicate_port_zero_instances(&app_container);
@@ -37,6 +38,15 @@ async fn it_should_apply_metrics_policy_to_port_zero_tracker_instances() {
     // Act and Assert
     it_should_aggregate_http_announces_only_from_metrics_enabled_port_zero_listener(&app_container).await;
     it_should_aggregate_udp_announces_only_from_metrics_enabled_port_zero_listener(&app_container).await;
+
+    // Act
+    fixture.shutdown().await;
+
+    // Assert
+    assert!(
+        !workspace_path.exists(),
+        "the workspace must be released only after awaited tracker shutdown"
+    );
 }
 
 /// Repeated configuration blocks must retain their canonical identity after

--- a/tests/metrics/port_zero.rs
+++ b/tests/metrics/port_zero.rs
@@ -32,12 +32,12 @@ async fn it_should_apply_metrics_policy_to_port_zero_tracker_instances() {
     let app_container = fixture.app_container();
 
     // Assert
-    it_should_preserve_distinct_configurations_for_duplicate_port_zero_instances(&app_container);
-    it_should_preserve_runtime_identity_for_duplicate_port_zero_instances(&app_container).await;
+    it_should_preserve_distinct_configurations_for_duplicate_port_zero_instances(app_container);
+    it_should_preserve_runtime_identity_for_duplicate_port_zero_instances(app_container).await;
 
     // Act and Assert
-    it_should_aggregate_http_announces_only_from_metrics_enabled_port_zero_listener(&app_container).await;
-    it_should_aggregate_udp_announces_only_from_metrics_enabled_port_zero_listener(&app_container).await;
+    it_should_aggregate_http_announces_only_from_metrics_enabled_port_zero_listener(app_container).await;
+    it_should_aggregate_udp_announces_only_from_metrics_enabled_port_zero_listener(app_container).await;
 
     // Act
     fixture.shutdown().await;

--- a/tests/metrics/udp_error_disabled_port_zero.rs
+++ b/tests/metrics/udp_error_disabled_port_zero.rs
@@ -17,9 +17,9 @@ async fn it_should_not_record_cookie_error_from_metrics_disabled_port_zero_udp_l
     // Arrange
     let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
     let app_container = fixture.app_container();
-    let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
+    let api_url = common::http_api_url(app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
-        &app_container,
+        app_container,
         common::PortZeroMetricsPolicyConfiguration::METRICS_DISABLED_UDP_TRACKER_ID,
     )
     .await;

--- a/tests/metrics/udp_error_disabled_port_zero.rs
+++ b/tests/metrics/udp_error_disabled_port_zero.rs
@@ -15,8 +15,8 @@ pub(crate) type CurrentClock = clock::Stopped;
 #[tokio::test]
 async fn it_should_not_record_cookie_error_from_metrics_disabled_port_zero_udp_listener() {
     // Arrange
-    let workspace = common::EphemeralTrackerWorkspace::new(common::PortZeroMetricsPolicyConfiguration::TOML);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
+    let app_container = fixture.app_container();
     let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
         &app_container,
@@ -31,4 +31,6 @@ async fn it_should_not_record_cookie_error_from_metrics_disabled_port_zero_udp_l
     // Assert
     let statistics_after = common::get_tracker_statistics(&api_url, "MyAccessToken").await;
     assert_eq!(statistics_after.udp4_errors_handled, statistics_before.udp4_errors_handled);
+
+    fixture.shutdown().await;
 }

--- a/tests/metrics/udp_error_enabled_port_zero.rs
+++ b/tests/metrics/udp_error_enabled_port_zero.rs
@@ -17,9 +17,9 @@ async fn it_should_record_cookie_error_from_metrics_enabled_port_zero_udp_listen
     // Arrange
     let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
     let app_container = fixture.app_container();
-    let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
+    let api_url = common::http_api_url(app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
-        &app_container,
+        app_container,
         common::PortZeroMetricsPolicyConfiguration::METRICS_ENABLED_UDP_TRACKER_ID,
     )
     .await;

--- a/tests/metrics/udp_error_enabled_port_zero.rs
+++ b/tests/metrics/udp_error_enabled_port_zero.rs
@@ -15,8 +15,8 @@ pub(crate) type CurrentClock = clock::Stopped;
 #[tokio::test]
 async fn it_should_record_cookie_error_from_metrics_enabled_port_zero_udp_listener() {
     // Arrange
-    let workspace = common::EphemeralTrackerWorkspace::new(common::PortZeroMetricsPolicyConfiguration::TOML);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(common::PortZeroMetricsPolicyConfiguration::TOML).await;
+    let app_container = fixture.app_container();
     let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
     let udp_tracker_address = common::udp_socket_addr_for_identity(
         &app_container,
@@ -34,4 +34,6 @@ async fn it_should_record_cookie_error_from_metrics_enabled_port_zero_udp_listen
         statistics_after.udp4_errors_handled,
         statistics_before.udp4_errors_handled + 1
     );
+
+    fixture.shutdown().await;
 }

--- a/tests/scaffold.rs
+++ b/tests/scaffold.rs
@@ -107,10 +107,10 @@ async fn the_stats_api_endpoint_should_aggregate_announces_across_multiple_track
     let app_container = fixture.app_container();
 
     // ── 3. Discover bound addresses ──────────────────────────────────
-    let tracker_urls = common::http_tracker_urls(&app_container).await;
+    let tracker_urls = common::http_tracker_urls(app_container).await;
     assert_eq!(tracker_urls.len(), 2, "expected two HTTP trackers");
 
-    let api_url = common::http_api_url(&app_container).await.expect("expected an HTTP API URL");
+    let api_url = common::http_api_url(app_container).await.expect("expected an HTTP API URL");
 
     // ── 4. Scenario: announce to both trackers ───────────────────────
     let client = reqwest::Client::new();

--- a/tests/scaffold.rs
+++ b/tests/scaffold.rs
@@ -18,8 +18,8 @@
 //!
 //! A different initial configuration belongs in another binary.
 //! For example, `tests/bootstrap.rs` would exercise the startup/shutdown
-//! lifecycle, while `tests/stats.rs` exercises the global statistics API
-//! under one configuration.
+//! lifecycle, while `tests/metrics/port_zero.rs` exercises the global
+//! statistics API under one configuration.
 //!
 //! ## Shared Helpers
 //!
@@ -32,6 +32,8 @@
 //! - Isolated temporary workspace per suite (`EphemeralTrackerWorkspace`).
 //! - Registration-acknowledgement readiness for every configured service.
 //! - Sequential scenarios that account for accumulated state.
+//! - Explicit awaited shutdown through `TrackerApplicationFixture` before the
+//!   temporary workspace is released.
 //!
 //! ## Endpoint Discovery
 //!
@@ -45,10 +47,10 @@
 //! cargo test --test scaffold
 //! ```
 //!
-//! Both `stats` and `scaffold` binaries can run in parallel:
+//! The `metrics-port-zero` and `scaffold` binaries can run in parallel:
 //!
 //! ```text
-//! cargo test --test stats --test scaffold
+//! cargo test --test metrics-port-zero --test scaffold
 //! ```
 mod common;
 
@@ -56,8 +58,6 @@ use serde::Deserialize;
 use torrust_tracker_rest_api_client::connection_info::{ConnectionInfo, Origin};
 use torrust_tracker_rest_api_client::v1::client::ApiHttpClient as TrackerApiClient;
 use url::Url;
-
-use crate::common::EphemeralTrackerWorkspace;
 
 /// Demo: the stats API should aggregate announces across multiple trackers.
 ///
@@ -103,8 +103,8 @@ async fn the_stats_api_endpoint_should_aggregate_announces_across_multiple_track
     "#;
 
     // ── 2. Start tracker on isolated workspace ───────────────────────
-    let workspace = EphemeralTrackerWorkspace::new(config_toml);
-    let (app_container, _jobs) = common::start_tracker_with_config(&workspace).await;
+    let fixture = common::TrackerApplicationFixture::start(config_toml).await;
+    let app_container = fixture.app_container();
 
     // ── 3. Discover bound addresses ──────────────────────────────────
     let tracker_urls = common::http_tracker_urls(&app_container).await;
@@ -130,8 +130,8 @@ async fn the_stats_api_endpoint_should_aggregate_announces_across_multiple_track
     let stats = get_stats(&api_url, "MyAccessToken").await;
     assert_eq!(stats.tcp4_announces_handled, 2, "two announces should be aggregated");
 
-    // The tracker application and its temporary workspace are cleaned up
-    // when `workspace` and `_jobs` are dropped at the end of this scope.
+    // ── 6. Shut down before releasing the temporary workspace ────────
+    fixture.shutdown().await;
 }
 
 /// Statistics subset relevant to this demo.


### PR DESCRIPTION
## Summary

Add `TrackerApplicationFixture` for main-application integration suites. The fixture owns the isolated workspace, application container, and `JobManager`, then invokes the best shutdown sequence exposed by current production before releasing the workspace.

- Migrate the current metrics, UDP-policy, banning, and scaffold suites from implicit `_jobs` drop cleanup.
- Add focused lifecycle ordering coverage: the workspace is released only after awaited fixture shutdown.
- Reconcile #1419 documentation and record the verification evidence.

## Verification

- `cargo test --test metrics-fixed-ports --test metrics-port-zero --test metrics-udp-error-enabled-port-zero --test metrics-udp-error-disabled-port-zero --test banning-udp-metrics-disabled-port-zero --test scaffold`
- `cargo test --test metrics-port-zero -- --nocapture`
- `cargo test --test metrics-port-zero -- --test-threads=1`
- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`

## Scope and Follow-up

Partially addresses #1419; it intentionally remains open.

Current server jobs can consume `JobManager::wait_for_all`'s per-job timeout because they do not yet react to the shared cancellation token. This change makes test lifecycle ownership explicit but does not claim cooperative server completion. Production shutdown coordination is deferred to #1488 and draft PR #1993; this PR does not introduce a competing shutdown mechanism.