### PR TITLE
Fix shared UDP connection ID error limit configuration

### DIFF
--- a/docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
@@ -2,7 +2,7 @@
 doc-type: guide
 parent-epic: 1978
 spec-path: docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
-last-updated-utc: 2026-08-21
+last-updated-utc: 2026-08-24
 ---
 
 # Migrating from Configuration v2.0.0 to v3.0.0
@@ -17,18 +17,19 @@ update, and why.
 
 ## Quick reference
 
-| v2 field / section          | v3 equivalent                                                    | Subissue | Status    |
-| --------------------------- | ---------------------------------------------------------------- | -------- | --------- |
-| `[core.net]` (global)       | Per-tracker `[http_trackers.network]` / `[udp_trackers.network]` | #1640    | DONE      |
-| `tsl_config`                | `tls_config`                                                     | #1981    | DONE      |
-| No public URL field         | `public_url` on HTTP trackers, UDP trackers, and HTTP API        | #1417    | DONE      |
-| `on_reverse_proxy` (global) | Per-HTTP-tracker `network.on_reverse_proxy`                      | #1640    | DONE      |
-| No logging style option     | `[logging] trace_style`                                          | #889     | DONE      |
-| `threshold`                 | `trace_filter`                                                   | #889     | DONE      |
-| No connection ID policy     | `[udp_tracker_server] connection_id_validation`                  | #1136    | DONE      |
-| Hardcoded IP bans interval  | `[udp_tracker_server] ip_bans_reset_interval_in_secs`            | #1453    | IN_REVIEW |
-| Flat `[core.database]`      | Database enum with per-driver config                             | #1490    | DONE      |
-| No announce `ip` opt-in     | Per-HTTP-tracker opt-in field (TBD)                              | #1987    | TODO      |
+| v2 field / section           | v3 equivalent                                                    | Subissue | Status    |
+| ---------------------------- | ---------------------------------------------------------------- | -------- | --------- |
+| `[core.net]` (global)        | Per-tracker `[http_trackers.network]` / `[udp_trackers.network]` | #1640    | DONE      |
+| `tsl_config`                 | `tls_config`                                                     | #1981    | DONE      |
+| No public URL field          | `public_url` on HTTP trackers, UDP trackers, and HTTP API        | #1417    | DONE      |
+| `on_reverse_proxy` (global)  | Per-HTTP-tracker `network.on_reverse_proxy`                      | #1640    | DONE      |
+| No logging style option      | `[logging] trace_style`                                          | #889     | DONE      |
+| `threshold`                  | `trace_filter`                                                   | #889     | DONE      |
+| No connection ID policy      | `[udp_tracker_server] connection_id_validation`                  | #1136    | DONE      |
+| Hardcoded IP bans interval   | `[udp_tracker_server] ip_bans_reset_interval_in_secs`            | #1453    | IN_REVIEW |
+| Per-listener UDP error limit | `[udp_tracker_server] max_connection_id_errors_per_ip`           | #2083    | IN_REVIEW |
+| Flat `[core.database]`       | Database enum with per-driver config                             | #1490    | DONE      |
+| No announce `ip` opt-in      | Per-HTTP-tracker opt-in field (TBD)                              | #1987    | TODO      |
 
 ## Step 1: Update the schema version
 
@@ -198,11 +199,39 @@ ip_bans_reset_interval_in_secs = 86400
 > effect at runtime until the final consumer migration (#1980). The value
 > is currently read from the v3 default constant.
 
+## Step 8: Move the UDP connection-ID error limit to the shared server section
+
+**Subissue**: #2083 — Move UDP connection-ID error limit to shared server configuration
+
+In v2, `max_connection_id_errors_per_ip` appears in every `[[udp_trackers]]`
+entry. In v3, it must be declared once in `[udp_tracker_server]`. The tracker
+uses one shared ban service for all UDP listeners, so a per-listener value would
+misrepresent the effective policy and could make it depend on listener order.
+
+```toml
+# v2 — remove this field from every listener
+[[udp_trackers]]
+bind_address = "0.0.0.0:6969"
+max_connection_id_errors_per_ip = 10
+
+[[udp_trackers]]
+bind_address = "0.0.0.0:6970"
+max_connection_id_errors_per_ip = 10
+
+# v3 — declare the shared policy once
+[udp_tracker_server]
+max_connection_id_errors_per_ip = 10
+```
+
+The default remains `10`. V3 rejects the old listener-scoped field rather than
+accepting repeated values. The setting takes effect at runtime when #1980
+activates v3 configuration consumers.
+
 <!-- ────────────────────────────────────────────────────────────────────── -->
 <!-- SECTIONS BELOW ARE TODO — to be filled as each subissue is implemented -->
 <!-- ────────────────────────────────────────────────────────────────────── -->
 
-## Step 8: Update the database configuration
+## Step 9: Update the database configuration
 
 **Subissue**: #1490 — Decompose v3 database configuration
 
@@ -261,7 +290,7 @@ changing TOML syntax. #1490 then represents the isolated v3 database password
 as a secret value, also without changing the TOML syntax shown above. Both must
 be merged before the configuration crate's v3 public API is published.
 
-## Step 9: Configure HTTP announce IP trust policy
+## Step 10: Configure HTTP announce IP trust policy
 
 **Subissue**: #1987 — Use peer IP from the HTTP announce `ip` parameter
 
@@ -296,6 +325,7 @@ Use this checklist to verify your configuration is ready for v3:
 - [ ] Global `[core.net]` replaced with per-tracker `network` blocks
 - [ ] `on_reverse_proxy` moved to per-HTTP-tracker `network` block (if `true`)
 - [ ] `external_ip` moved to per-tracker `network` blocks (if set)
+- [ ] `max_connection_id_errors_per_ip` moved from every `[[udp_trackers]]` entry to `[udp_tracker_server]` (if set)
 - [ ] `threshold` renamed to `trace_filter` in `[logging]`
 - [ ] `trace_style` added to `[logging]` (optional, defaults to `"full"`)
 - [ ] `public_url` added to trackers and API (optional, recommended for reverse proxies)

--- a/docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md
+++ b/docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md
@@ -10,7 +10,7 @@ branch: "2083-move-max-connection-id-errors-per-ip-to-udp-tracker-server"
 related-pr: null
 depends-on: null
 blocks: 1980
-last-updated-utc: 2026-08-24 00:00
+last-updated-utc: 2026-08-24 11:04
 semantic-links:
   skill-links:
     - create-issue
@@ -153,16 +153,16 @@ contract for operators moving from the currently active v2 field placement.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                             | Notes / Expected Output                                                                                                                                                                                  |
-| --- | ------ | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Confirm the pre-#1980 v3 configuration boundary  | Record every affected v3 schema, fixture, example, documentation artifact, and #1980 production-wiring handoff before editing.                                                                           |
-| T2  | TODO   | Move the v3 configuration field                  | `UdpTrackerServer` owns the global default and serde field; `UdpTracker` no longer exposes it.                                                                                                           |
-| T3  | TODO   | Update v3 fixtures, examples, and documentation  | Remove the listener-scoped setting and update the v2-to-v3 migration guide; do not change the active v2 defaults.                                                                                        |
-| T4  | TODO   | Define #1980 production-wiring handoff           | Update #1980 to migrate constructors, read the one v3 `udp_tracker_server` limit in `AppContainer`, and pass it once to `UdpTrackerCoreServices`; no production v2 path changes in this issue.           |
-| T5  | TODO   | Add schema regression tests                      | Cover defaults, explicit global values, and rejection of the removed listener field. Direct-construction and runtime cross-listener enforcement coverage is added when #1980 activates v3 in production. |
-| T6  | TODO   | Update migration and configuration documentation | Describe the v2 per-listener to v3 global move and update defaults and examples.                                                                                                                         |
-| T7  | TODO   | Run automatic and manual verification            | Record commands, results, and evidence in this specification.                                                                                                                                            |
-| T8  | TODO   | Re-review acceptance criteria                    | Compare observed behaviour and evidence against every acceptance criterion before closure.                                                                                                               |
+| ID  | Status | Task                                             | Notes / Expected Output                                                                                                                                                                                                               |
+| --- | ------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Confirm the pre-#1980 v3 configuration boundary  | Record every affected v3 schema, fixture, example, documentation artifact, and #1980 production-wiring handoff before editing.                                                                                                        |
+| T2  | TODO   | Move the v3 configuration field                  | `UdpTrackerServer` owns the global default and serde field; `UdpTracker` no longer exposes it.                                                                                                                                        |
+| T3  | TODO   | Update v3 fixtures, examples, and documentation  | Remove the listener-scoped setting and update the v2-to-v3 migration guide; do not change the active v2 defaults.                                                                                                                     |
+| T4  | DONE   | Define #1980 production-wiring handoff           | #1980 already owns T12–T13: migrate constructors, read the one v3 `udp_tracker_server` limit in `AppContainer`, pass it once to `UdpTrackerCoreServices`, and prove runtime enforcement; no production v2 path changes in this issue. |
+| T5  | TODO   | Add schema regression tests                      | Cover defaults, explicit global values, and rejection of the removed listener field. Direct-construction and runtime cross-listener enforcement coverage is added when #1980 activates v3 in production.                              |
+| T6  | TODO   | Update migration and configuration documentation | Describe the v2 per-listener to v3 global move and update defaults and examples.                                                                                                                                                      |
+| T7  | TODO   | Run automatic and manual verification            | Record commands, results, and evidence in this specification.                                                                                                                                                                         |
+| T8  | TODO   | Re-review acceptance criteria                    | Compare observed behaviour and evidence against every acceptance criterion before closure.                                                                                                                                            |
 
 ## Progress Tracking
 
@@ -191,6 +191,7 @@ Append one line per meaningful update.
 
 - 2026-08-24 00:00 UTC - GitHub Copilot - Drafted a dedicated bug specification from the confirmed finding in #2067; it corrects v3 before #1980 activates v3 in the production runtime.
 - 2026-08-24 11:04 UTC - GitHub Copilot/User - User approved the draft; created GitHub issue #2083 and linked it as a native subissue of EPIC #1978.
+- 2026-08-24 11:04 UTC - GitHub Copilot/User - User confirmed that #1980 must own the production-wiring handoff. Verified that its T12–T13 and AC8–AC9 already explicitly cover the required `AppContainer` migration and order-independent two-listener runtime test.
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md
+++ b/docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md
@@ -10,7 +10,7 @@ branch: "2083-move-max-connection-id-errors-per-ip-to-udp-tracker-server"
 related-pr: null
 depends-on: null
 blocks: 1980
-last-updated-utc: 2026-08-24 11:04
+last-updated-utc: 2026-08-24 15:00
 semantic-links:
   skill-links:
     - create-issue
@@ -155,14 +155,14 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                                             | Notes / Expected Output                                                                                                                                                                                                               |
 | --- | ------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Confirm the pre-#1980 v3 configuration boundary  | Record every affected v3 schema, fixture, example, documentation artifact, and #1980 production-wiring handoff before editing.                                                                                                        |
-| T2  | TODO   | Move the v3 configuration field                  | `UdpTrackerServer` owns the global default and serde field; `UdpTracker` no longer exposes it.                                                                                                                                        |
-| T3  | TODO   | Update v3 fixtures, examples, and documentation  | Remove the listener-scoped setting and update the v2-to-v3 migration guide; do not change the active v2 defaults.                                                                                                                     |
+| T1  | DONE   | Confirm the pre-#1980 v3 configuration boundary  | Inventoried v3 schema, generated defaults, schema tests, migration guide, and #1980 runtime handoff; active v2 files remain untouched.                                                                                                |
+| T2  | DONE   | Move the v3 configuration field                  | `UdpTrackerServer` owns the global default and serde field; `UdpTracker` no longer exposes it.                                                                                                                                        |
+| T3  | DONE   | Update v3 fixtures, examples, and documentation  | Updated generated v3 defaults and the v2-to-v3 migration guide; active v2 defaults remain unchanged.                                                                                                                                  |
 | T4  | DONE   | Define #1980 production-wiring handoff           | #1980 already owns T12–T13: migrate constructors, read the one v3 `udp_tracker_server` limit in `AppContainer`, pass it once to `UdpTrackerCoreServices`, and prove runtime enforcement; no production v2 path changes in this issue. |
-| T5  | TODO   | Add schema regression tests                      | Cover defaults, explicit global values, and rejection of the removed listener field. Direct-construction and runtime cross-listener enforcement coverage is added when #1980 activates v3 in production.                              |
-| T6  | TODO   | Update migration and configuration documentation | Describe the v2 per-listener to v3 global move and update defaults and examples.                                                                                                                                                      |
-| T7  | TODO   | Run automatic and manual verification            | Record commands, results, and evidence in this specification.                                                                                                                                                                         |
-| T8  | TODO   | Re-review acceptance criteria                    | Compare observed behaviour and evidence against every acceptance criterion before closure.                                                                                                                                            |
+| T5  | DONE   | Add schema regression tests                      | Added default, explicit round-trip, two-listener global configuration, and obsolete listener-field rejection coverage. Direct-construction and runtime cross-listener enforcement coverage remains in #1980.                          |
+| T6  | DONE   | Update migration and configuration documentation | Documented the v2 per-listener to v3 global move and updated generated v3 defaults.                                                                                                                                                   |
+| T7  | DONE   | Run automatic and manual verification            | Focused, full workspace, pre-commit, and pre-push checks passed; manual schema scenarios are recorded below.                                                                                                                          |
+| T8  | DONE   | Re-review acceptance criteria                    | Re-reviewed after independent audit; AC1–AC5 are satisfied and AC6 remains correctly deferred to #1980.                                                                                                                               |
 
 ## Progress Tracking
 
@@ -174,13 +174,13 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] GitHub issue #2083 created and issue number added to this spec
 - [x] Linked as a subissue of EPIC #1978 in GitHub and in the EPIC specification
 - [x] Spec moved to `docs/issues/open/` after approval
-- [ ] V3 schema correction completed before #1980
-- [ ] #1980 production wiring handoff recorded and accepted
+- [x] V3 schema correction completed before #1980
+- [x] #1980 production wiring handoff recorded and accepted
 - [ ] (Optional, recommended for this cross-cutting bug) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [ ] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
@@ -192,6 +192,8 @@ Append one line per meaningful update.
 - 2026-08-24 00:00 UTC - GitHub Copilot - Drafted a dedicated bug specification from the confirmed finding in #2067; it corrects v3 before #1980 activates v3 in the production runtime.
 - 2026-08-24 11:04 UTC - GitHub Copilot/User - User approved the draft; created GitHub issue #2083 and linked it as a native subissue of EPIC #1978.
 - 2026-08-24 11:04 UTC - GitHub Copilot/User - User confirmed that #1980 must own the production-wiring handoff. Verified that its T12–T13 and AC8–AC9 already explicitly cover the required `AppContainer` migration and order-independent two-listener runtime test.
+- 2026-08-24 15:00 UTC - GitHub Copilot - Moved the v3 field from `UdpTracker` to `UdpTrackerServer`, updated generated defaults and migration documentation, and added focused schema regression tests. `cargo test -p torrust-tracker-configuration` passed (109 tests).
+- 2026-08-24 15:00 UTC - GitHub Copilot - Independent review confirmed the v3 schema change is correctly scoped. Corrected the premature AC6 completion claim because #1980 production wiring remains pending. Pre-commit, full workspace, and pre-push verification subsequently passed.
 
 ## Acceptance Criteria
 
@@ -239,11 +241,11 @@ documented development-environment setup before recording verification results.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                                     | Command/Steps                                                                                                                                                                                                            | Expected Result                                                                                                                                                    | Status | Evidence                                        |
-| --- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ | ----------------------------------------------- |
-| M1  | Inspect the corrected v3 configuration shape | Deserialize a v3 fixture with two `[[udp_trackers]]` entries and `[udp_tracker_server] max_connection_id_errors_per_ip = 2` in `torrust-tracker-configuration` tests. Run `cargo test -p torrust-tracker-configuration`. | The threshold is accepted only in `[udp_tracker_server]`; both listener entries remain free of the global setting.                                                 | TODO   | Fixture path, test name, command output         |
-| M2  | Reject obsolete listener configuration       | Add `max_connection_id_errors_per_ip = 2` inside a v3 `[[udp_trackers]]` block and deserialize it with `torrust-tracker-configuration` configuration tests.                                                              | Loading is rejected as an unknown `UdpTracker` field; the migration guide supplies the correct `[udp_tracker_server]` placement.                                   | TODO   | Focused configuration test and error output     |
-| M3  | Verify #1980 runtime-test handoff            | Review the #1980 implementation plan and acceptance criteria after updating them for the production container handoff.                                                                                                   | #1980 explicitly owns the constructor migration, cross-listener runtime test, and production `AppContainer` wiring required to activate this corrected v3 setting. | TODO   | Updated #1980 task and acceptance-criterion IDs |
+| ID  | Scenario                                     | Command/Steps                                                                                                                                                                                                            | Expected Result                                                                                                                                                    | Status | Evidence                                                                                                                                       |
+| --- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | Inspect the corrected v3 configuration shape | Deserialize a v3 fixture with two `[[udp_trackers]]` entries and `[udp_tracker_server] max_connection_id_errors_per_ip = 2` in `torrust-tracker-configuration` tests. Run `cargo test -p torrust-tracker-configuration`. | The threshold is accepted only in `[udp_tracker_server]`; both listener entries remain free of the global setting.                                                 | DONE   | `v3_0_0::tests::configuration_should_apply_one_global_connection_id_error_limit_to_multiple_udp_trackers`; 2026-08-24 focused test run passed. |
+| M2  | Reject obsolete listener configuration       | Add `max_connection_id_errors_per_ip = 2` inside a v3 `[[udp_trackers]]` block and deserialize it with `torrust-tracker-configuration` configuration tests.                                                              | Loading is rejected as an unknown `UdpTracker` field; the migration guide supplies the correct `[udp_tracker_server]` placement.                                   | DONE   | `v3_0_0::tests::configuration_should_reject_a_listener_scoped_connection_id_error_limit`; 2026-08-24 focused test run passed.                  |
+| M3  | Verify #1980 runtime-test handoff            | Review the #1980 implementation plan and acceptance criteria after updating them for the production container handoff.                                                                                                   | #1980 explicitly owns the constructor migration, cross-listener runtime test, and production `AppContainer` wiring required to activate this corrected v3 setting. | DONE   | #1980 T12–T13, AC8–AC9, and M4 already record the required ownership.                                                                          |
 
 Notes:
 
@@ -257,14 +259,14 @@ Notes:
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence |
-| ----- | ---------------------- | -------- |
-| AC1   | TODO                   |          |
-| AC2   | TODO                   |          |
-| AC3   | TODO                   |          |
-| AC4   | TODO                   |          |
-| AC5   | TODO                   |          |
-| AC6   | TODO                   |          |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                                                       |
+| ----- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1   | DONE                   | `UdpTrackerServer` declares the documented, serde-defaulted global field with default `10`; focused configuration tests passed.                                |
+| AC2   | DONE                   | Removed the field from v3 `UdpTracker`; aggregate schema test rejects the obsolete listener-scoped key.                                                        |
+| AC3   | DONE                   | A two-listener configuration accepts one server-wide value; no listener field remains to select by order. Runtime enforcement is explicitly deferred to #1980. |
+| AC4   | DONE                   | Updated generated v3 default TOML and schema tests; no v3 listener-scoped value remains.                                                                       |
+| AC5   | DONE                   | Migration guide includes v2/v3 before-and-after TOML, the shared-service rationale, default, and rejection behavior.                                           |
+| AC6   | TODO                   | #1980 T12–T13, AC8–AC9, and M4 explicitly own the remaining production migration and runtime validation; its implementation is pending.                        |
 
 ## Risks and Trade-offs
 

--- a/docs/pr-reviews/pr-2087-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2087-copilot-suggestions.md
@@ -1,0 +1,52 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2087 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2087
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-08-24: Started processing suggestions.
+- 2026-08-24: Completed processing suggestions; all unresolved Copilot threads were replied to and resolved.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                                                  | URL                                                                         | Suggestion Summary                                                  | Decision                                                                                                            | Reply URL                                                                   | Status | Thread State |
+| --- | --------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6bwJih | docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md | https://github.com/torrust/torrust-tracker/pull/2087#discussion_r3844954992 | Remove outdated TODO banner.                                        | no-action: the current migration guide already has an accurate partial-completion status and no quoted TODO banner. | https://github.com/torrust/torrust-tracker/pull/2087#discussion_r3845071295 | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6bwJjE | packages/configuration/src/v3_0_0/udp_tracker_server.rs                               | https://github.com/torrust/torrust-tracker/pull/2087#discussion_r3844955055 | Document that the IP-ban threshold is enforced only in strict mode. | action: clarified the field documentation in commit a74d6459.                                                       | https://github.com/torrust/torrust-tracker/pull/2087#discussion_r3845092032 | DONE   | RESOLVED     |
+
+## Notes
+
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/pr-reviews/pr-2087-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2087-copilot-suggestions.md
@@ -37,6 +37,7 @@ Status legend:
 
 - 2026-08-24: Started processing suggestions.
 - 2026-08-24: Completed processing suggestions; all unresolved Copilot threads were replied to and resolved.
+- 2026-08-24: Refreshed PR #2087 review threads after the latest push; `list-unresolved-threads.sh` returned no unresolved threads.
 
 ## Suggestions
 

--- a/packages/configuration/src/v3_0_0/mod.rs
+++ b/packages/configuration/src/v3_0_0/mod.rs
@@ -240,6 +240,8 @@
 //!
 //! [udp_tracker_server]
 //! ip_bans_reset_interval_in_secs = 86400
+//! max_connection_id_errors_per_ip = 10
+//! connection_id_validation = "strict"
 //!
 //! [http_api]
 //! bind_address = "127.0.0.1:1212"
@@ -568,6 +570,7 @@ mod tests {
 
                                 [udp_tracker_server]
                                 ip_bans_reset_interval_in_secs = 86400
+                                max_connection_id_errors_per_ip = 10
                                 connection_id_validation = "strict"
 
                                 [health_check_api]
@@ -623,6 +626,79 @@ mod tests {
 
             assert_eq!(configuration.udp_tracker_server.ip_bans_reset_interval_in_secs.get(), 7200);
             assert_eq!(configuration.logging.trace_style, TraceStyle::Json);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn configuration_should_apply_one_global_connection_id_error_limit_to_multiple_udp_trackers() {
+        figment::Jail::expect_with(|_jail| {
+            let info = Info {
+                config_toml: r#"
+                    [metadata]
+                    schema_version = "3.0.0"
+
+                    [logging]
+                    trace_filter = "info"
+
+                    [core]
+                    listed = false
+                    private = false
+
+                    [udp_tracker_server]
+                    max_connection_id_errors_per_ip = 2
+
+                    [[udp_trackers]]
+                    bind_address = "127.0.0.1:6969"
+
+                    [[udp_trackers]]
+                    bind_address = "127.0.0.1:6970"
+                "#
+                .to_string()
+                .into(),
+                config_toml_path: String::new(),
+            };
+
+            let configuration = Configuration::load(&info).expect("configuration should load");
+
+            assert_eq!(configuration.udp_tracker_server.max_connection_id_errors_per_ip, 2);
+            assert_eq!(configuration.udp_trackers.expect("UDP trackers should deserialize").len(), 2);
+
+            Ok(())
+        });
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn configuration_should_reject_a_listener_scoped_connection_id_error_limit() {
+        figment::Jail::expect_with(|_jail| {
+            let info = Info {
+                config_toml: r#"
+                    [metadata]
+                    schema_version = "3.0.0"
+
+                    [logging]
+                    trace_filter = "info"
+
+                    [core]
+                    listed = false
+                    private = false
+
+                    [[udp_trackers]]
+                    bind_address = "127.0.0.1:6969"
+                    max_connection_id_errors_per_ip = 2
+                "#
+                .to_string()
+                .into(),
+                config_toml_path: String::new(),
+            };
+
+            assert!(
+                Configuration::load(&info).is_err(),
+                "v3 must reject the removed listener-scoped global error limit"
+            );
 
             Ok(())
         });

--- a/packages/configuration/src/v3_0_0/udp_tracker.rs
+++ b/packages/configuration/src/v3_0_0/udp_tracker.rs
@@ -29,11 +29,6 @@ pub struct UdpTracker {
     #[serde(default = "UdpTracker::default_tracker_usage_statistics")]
     pub tracker_usage_statistics: bool,
 
-    /// The maximum number of connection ID errors per IP before the client is
-    /// banned. Default is `10`.
-    #[serde(default = "UdpTracker::default_max_connection_id_errors_per_ip")]
-    pub max_connection_id_errors_per_ip: u32,
-
     /// The public-facing URL of this UDP tracker instance, e.g.
     /// `"udp://tracker.example.com:6969"`. Used for metrics labels, logging,
     /// and API discovery. Must use the `udp://` scheme. Optional; defaults to `None`.
@@ -50,7 +45,6 @@ impl Default for UdpTracker {
             bind_address: Self::default_bind_address(),
             cookie_lifetime: Self::default_cookie_lifetime(),
             tracker_usage_statistics: Self::default_tracker_usage_statistics(),
-            max_connection_id_errors_per_ip: Self::default_max_connection_id_errors_per_ip(),
             public_url: Self::default_public_url(),
             network: Self::default_network(),
         }
@@ -68,10 +62,6 @@ impl UdpTracker {
 
     fn default_tracker_usage_statistics() -> bool {
         false
-    }
-
-    fn default_max_connection_id_errors_per_ip() -> u32 {
-        10
     }
 
     fn default_public_url() -> Option<UdpUrl> {

--- a/packages/configuration/src/v3_0_0/udp_tracker_server.rs
+++ b/packages/configuration/src/v3_0_0/udp_tracker_server.rs
@@ -47,7 +47,8 @@ pub struct UdpTrackerServer {
     pub ip_bans_reset_interval_in_secs: IpBansResetIntervalInSecs,
 
     /// Maximum invalid connection IDs accepted from one IP before the shared
-    /// ban service bans it. Defaults to `10`.
+    /// ban service bans it when connection ID validation is `strict`. Defaults
+    /// to `10`.
     ///
     /// This is a global setting because every UDP listener uses the same ban
     /// service. Configuring it per listener would make the effective security

--- a/packages/configuration/src/v3_0_0/udp_tracker_server.rs
+++ b/packages/configuration/src/v3_0_0/udp_tracker_server.rs
@@ -46,6 +46,15 @@ pub struct UdpTrackerServer {
     #[serde(default = "default_ip_bans_reset_interval_in_secs")]
     pub ip_bans_reset_interval_in_secs: IpBansResetIntervalInSecs,
 
+    /// Maximum invalid connection IDs accepted from one IP before the shared
+    /// ban service bans it. Defaults to `10`.
+    ///
+    /// This is a global setting because every UDP listener uses the same ban
+    /// service. Configuring it per listener would make the effective security
+    /// policy depend on listener declaration order.
+    #[serde(default = "default_max_connection_id_errors_per_ip")]
+    pub max_connection_id_errors_per_ip: u32,
+
     /// Connection ID validation policy for all UDP tracker listeners.
     ///
     /// This is a global setting because the ban service is shared across all
@@ -71,6 +80,7 @@ impl Default for UdpTrackerServer {
     fn default() -> Self {
         Self {
             ip_bans_reset_interval_in_secs: default_ip_bans_reset_interval_in_secs(),
+            max_connection_id_errors_per_ip: default_max_connection_id_errors_per_ip(),
             connection_id_validation: ConnectionIdValidationPolicy::default(),
         }
     }
@@ -145,6 +155,10 @@ fn default_ip_bans_reset_interval_in_secs() -> IpBansResetIntervalInSecs {
         .expect("the default IP-ban reset interval must satisfy its minimum")
 }
 
+fn default_max_connection_id_errors_per_ip() -> u32 {
+    10
+}
+
 #[cfg(test)]
 mod tests {
     use crate::v3_0_0::udp_tracker_server::{ConnectionIdValidationPolicy, IpBansResetIntervalInSecs, UdpTrackerServer};
@@ -155,6 +169,29 @@ mod tests {
             UdpTrackerServer::default().ip_bans_reset_interval_in_secs.get(),
             UdpTrackerServer::DEFAULT_IP_BANS_RESET_INTERVAL_IN_SECS
         );
+    }
+
+    #[test]
+    fn it_should_default_max_connection_id_errors_per_ip_to_ten() {
+        assert_eq!(UdpTrackerServer::default().max_connection_id_errors_per_ip, 10);
+    }
+
+    #[test]
+    fn it_should_use_the_default_max_connection_id_errors_per_ip_when_omitted() {
+        let config: UdpTrackerServer = toml::from_str("").expect("empty config should deserialize");
+
+        assert_eq!(config.max_connection_id_errors_per_ip, 10);
+    }
+
+    #[test]
+    fn it_should_deserialize_and_serialize_max_connection_id_errors_per_ip() {
+        let original: UdpTrackerServer =
+            toml::from_str("max_connection_id_errors_per_ip = 2").expect("the global error limit should deserialize");
+
+        let serialized = toml::to_string(&original).expect("the global error limit should serialize");
+        let deserialized: UdpTrackerServer = toml::from_str(&serialized).expect("the global error limit should round trip");
+
+        assert_eq!(deserialized.max_connection_id_errors_per_ip, 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Move the v3 `max_connection_id_errors_per_ip` configuration from each UDP listener to the shared `[udp_tracker_server]` section. This reflects the deliberately shared `BanService` boundary and removes listener-order-dependent configuration semantics.

- add the documented server-wide default of `10`
- reject the removed per-listener v3 field and cover default, round-trip, and two-listener schema behaviour
- update generated v3 defaults and the v2-to-v3 migration guide

## Validation

- `cargo test -p torrust-tracker-configuration`
- `linter all`
- `./contrib/dev-tools/git/hooks/pre-commit.sh`
- `cargo test --tests --benches --examples --workspace --all-targets --all-features`
- `./contrib/dev-tools/git/hooks/pre-push.sh`

## Follow-up

Production v3 consumer migration, including wiring the server-wide value through `AppContainer` and a cross-listener runtime test, remains explicitly assigned to #1980.

Related to #2083