### PR TITLE
docs(skills): document workflow action updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,3 +1,5 @@
+# skill-link: update-github-workflow-actions
+# GitHub Actions updates require matching Torrust organization allowed-actions policy entries.
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/skills/dev/maintenance/update-dependencies/SKILL.md
+++ b/.github/skills/dev/maintenance/update-dependencies/SKILL.md
@@ -4,6 +4,12 @@ description: Guide for updating project dependencies in the torrust-tracker proj
 metadata:
   author: torrust
   version: "1.0"
+semantic-links:
+  skill-links:
+    - update-github-workflow-actions
+  related-artifacts:
+    - .github/dependabot.yaml
+    - .github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
 ---
 
 # Updating Dependencies
@@ -12,6 +18,8 @@ This skill guides you through updating project dependencies for the Torrust Trac
 
 Use `.github/skills/dev/maintenance/add-rust-dependency/SKILL.md` when introducing a new crate.
 This skill is for updating already-declared dependencies.
+Use `.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md` for GitHub Actions
+workflow dependency updates and organization action-allowlist synchronization.
 
 Delivery policy:
 

--- a/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
+++ b/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: update-github-workflow-actions
+description: Update GitHub Actions workflow dependencies safely in Torrust Tracker, including synchronizing the Torrust organization allowlist. Use when updating workflow action versions, Dependabot GitHub Actions updates, or allowed-actions settings.
+metadata:
+  author: torrust
+  version: "1.0"
+semantic-links:
+  skill-links:
+    - update-dependencies
+  related-artifacts:
+    - .github/dependabot.yaml
+    - .github/skills/dev/maintenance/update-dependencies/SKILL.md
+    - docs/skills/semantic-skill-link-convention.md
+---
+
+# Updating GitHub Workflow Actions
+
+Use this skill to update `uses:` action references in `.github/workflows/`.
+For Cargo dependency updates, use
+`.github/skills/dev/maintenance/update-dependencies/SKILL.md` instead.
+
+## Delivery Policy
+
+- Never push directly to `develop` or `main`.
+- Open a pull request to `torrust/torrust-tracker:develop` from a branch in the configured fork remote.
+- Keep actions on explicit versions. Do not replace an exact action version with a moving major tag solely to work around an allowlist failure.
+
+## Update Workflow
+
+1. Start from an up-to-date `develop` branch and create a dedicated branch.
+2. Identify every matching action reference and review the action's release notes for compatibility or security implications.
+3. Update all intended `.github/workflows/*.yaml` references consistently. Dependabot manages GitHub Actions updates through `.github/dependabot.yaml`; preserve its explicit version format.
+4. Before opening the pull request, update the Torrust organization allowed-actions policy at [Organization Actions settings](https://github.com/organizations/torrust/settings/actions).
+   - Add an allowlist pattern that permits the versioned reference, such as `owner/action@v2.*`.
+   - Prefer a scoped, stable pattern over a moving `owner/action@v2` tag when Dependabot updates exact versions.
+   - Confirm that the configured pattern matches the full `uses:` reference, including its version.
+5. Add one semantic `skill-link: update-github-workflow-actions` comment near the workflow's top-level metadata and review the related skills when updating the workflow policy.
+6. Run `linter yaml`, `git diff --check`, and the relevant repository checks before committing.
+7. Commit with a signed Conventional Commit, push the branch to the fork remote, and open a PR targeting `develop`.
+8. Confirm affected workflow runs are queued and pass. If a run is blocked by the allowlist, correct the organization policy and rerun the failed jobs; do not weaken the workflow pin.
+
+## Allowlist Failure Diagnosis
+
+An error such as "The action `owner/action@vX.Y.Z` is not allowed" means the organization policy does not match the action reference exactly enough. Check the configured allowed patterns at the organization settings URL above against the workflow's `uses:` value.
+
+For example, an allowlist entry `taiki-e/install-action@v2` does not permit `taiki-e/install-action@v2.85.5`. Configure `taiki-e/install-action@v2.*` to allow Dependabot-managed versioned v2 updates.
+
+## Skill Links
+
+- `.github/dependabot.yaml` controls automated GitHub Actions update proposals.
+- `.github/skills/dev/maintenance/update-dependencies/SKILL.md` is the corresponding workflow for Cargo dependencies.
+- `docs/skills/semantic-skill-link-convention.md` defines the required semantic-link syntax.

--- a/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
+++ b/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
@@ -9,6 +9,7 @@ semantic-links:
     - update-dependencies
   related-artifacts:
     - .github/dependabot.yaml
+    - .github/workflows/
     - .github/skills/dev/maintenance/update-dependencies/SKILL.md
     - docs/skills/semantic-skill-link-convention.md
 ---

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,5 +1,6 @@
 name: Coverage
 
+# skill-link: update-github-workflow-actions
 # adr: docs/adrs/20260612000000_adopt_sccache_for_ci_bare_builds.md
 # sccache added for cross-run compilation caching on bare CI builds.
 

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -1,5 +1,6 @@
 name: Generate Coverage Report (PR)
 
+# skill-link: update-github-workflow-actions
 # Path policy: skip this workflow when every changed file is documentation.
 # See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,5 +1,6 @@
 name: Testing
 
+# skill-link: update-github-workflow-actions
 # adr: docs/adrs/20260612000000_adopt_sccache_for_ci_bare_builds.md
 # This workflow includes sccache for bare CI builds outside Docker containers, replacing Swatinem/rust-cache.
 # See ADR for evidence and rationale.

--- a/docs/pr-reviews/pr-2090-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2090-copilot-suggestions.md
@@ -1,0 +1,52 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2090 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for <https://github.com/torrust/torrust-tracker/pull/2090>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-08-24: Started processing suggestions.
+- 2026-08-24: Completed processing suggestions; all unresolved Copilot threads are resolved.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                                     | URL                                                                           | Suggestion Summary                                                          | Decision | Reply URL                                                                     | Status | Thread State |
+| --- | --------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6bxKlD | `.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md` | <https://github.com/torrust/torrust-tracker/pull/2090#discussion_r3845347550> | Link the GitHub Actions workflows directory as a related semantic artifact. | action   | <https://github.com/torrust/torrust-tracker/pull/2090#discussion_r3845399465> | DONE   | RESOLVED     |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.


### PR DESCRIPTION
## Summary

- add a repeatable skill for updating version-pinned GitHub Actions workflow dependencies
- document synchronizing exact action references with the Torrust organization allowed-actions policy
- link the workflow skill with the Cargo dependency workflow, Dependabot configuration, and affected workflows

## Validation

- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`
- `linter markdown`
- `linter yaml`

## CI verification

This PR intentionally exercises the Coverage and Testing workflows after the organization allowlist was updated to permit `taiki-e/install-action@v2.85.5`.