### PR TITLE
docs(issues): specify optional v3 database configuration

### DIFF
--- a/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
@@ -20,6 +20,7 @@ semantic-links:
     - docs/issues/open/2023-1978-expose-configured-public-urls-in-runtime-observability.md
     - docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md
     - docs/issues/open/1490-1978-decompose-database-configuration.md
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
     - docs/issues/open/2079-adopt-secrecy-for-sensitive-configuration.md
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
 ---
@@ -98,6 +99,7 @@ Status values: `TODO`, `IN_PROGRESS`, `IN_REVIEW`, `BLOCKED`, `DONE`.
 | 6     | [#1453](https://github.com/torrust/torrust-tracker/issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/closed/1453-1978-ip-bans-reset-interval-configurable/ISSUE.md`                | DONE   | V3 setting validated; one cancellation-managed bootstrap cleanup job uses the v3 default constant. Runtime configuration use is deferred to #1980.        |
 | 7     | [#1136](https://github.com/torrust/torrust-tracker/issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/closed/1136-1978-configurable-udp-connection-id-validation-policy.md`         | DONE   | PR #2032 merged; all 12 ACs met; manual verification deferred to #1980.                                                                                   |
 | 8     | [#1490](https://github.com/torrust/torrust-tracker/issues/1490) — Decompose v3 database configuration                                               | `docs/issues/open/1490-1978-decompose-database-configuration.md`                           | TODO   | After #3 and #2079; isolates the v3 password as `Secret<String>`.                                                                                         |
+| 8a    | [#999](https://github.com/torrust/torrust-tracker/issues/999) — Make v3 database configuration optional when persistence is unused                  | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                       | TODO   | Follows #1490. Analysis and solution determine persistence dependencies, REST API behaviour, and whether it blocks #1980/v3 activation.                   |
 | 9     | [#889](https://github.com/torrust/torrust-tracker/issues/889) — New config option for logging style                                                 | `docs/issues/closed/889-1978-new-config-option-for-logging-style.md`                       | DONE   | V3 schema implemented; includes negative test for removed `threshold` key. Manual verification is deferred to #1980.                                      |
 | 10    | [#1987](https://github.com/torrust/torrust-tracker/issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md`    | TODO   | After #3 and external prerequisite #1985; per-HTTP-tracker opt-in policy                                                                                  |
 | 11    | [#2083](https://github.com/torrust/torrust-tracker/issues/2083) — Move UDP connection-ID error limit to shared server configuration                 | `docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md` | TODO   | Corrects the v3 shared UDP `BanService` configuration boundary found in #2067; blocks #1980 production activation.                                        |
@@ -130,6 +132,7 @@ graph TD
       sub1 --> secrecy["#2079 Secrecy"]
       sub3 --> sub8["8. #1490 Database configuration"]
       secrecy --> sub8
+      sub8 --> sub8a["8a. #999 optional database configuration"]
       sub3 --> sub10["10. #1987 Announce IP policy"]
       sub1 --> sub11["11. #2083 shared UDP error limit"]
       sub4 --> sub12["12. Final cleanup"]
@@ -140,6 +143,7 @@ graph TD
       sub9 --> sub12
       sub10 --> sub12
       sub11 --> sub12
+      sub8a -. "pending Phase 2 decision" .-> sub12
       sub4 --> sub13["13. public_url runtime observability"]
       sub12 --> sub13
       sub12 --> sub14["14. Post-v3 flat-service research"]
@@ -151,6 +155,7 @@ graph TD
 1 → 2 → 3 → 4 → 12
 1 → 2 → 3 → 8 → 12
 1 → secrecy → 8 → 12
+1 → 2 → 3 → 8 → 8a → 12 (only if Phase 2 confirms #999 blocks activation)
 1 → 11 → 12
 ```
 
@@ -177,6 +182,7 @@ Subissues #5, #6, #7, #9 are independent and can run in parallel with the critic
 - **Subissue #3** (#1640) — Per-instance `Network` block in schema v3.0.0. Establishes the `Network` struct that #4 references; v3 does not support removed v2 field names.
 - **Release-gated prerequisite #2079** — Adopt `secrecy` for sensitive configuration first. It protects API tokens in v2 and v3 and establishes the `Secret<String>` convention without changing legacy database URLs.
 - **Subissue #8** (#1490) — Database enum decomposition. After #3 and the secrecy follow-up; it uses `Secret<String>` for the new isolated v3 database password.
+- **Subissue #8a** (#999) — Analyze and define v3 optional database configuration after #1490. The analysis-and-solution PR determines every persistence requirement, REST API behaviour, and whether the implementation must precede #1980.
 - **Subissue #4** (#1417) — `public_url` flat field. After #3 (depends on `Network` placement decision). ~6 files.
 - **Subissue #10** (#1987) — Opt-in use of the HTTP announce `ip` parameter. After #3 and external prerequisite #1985.
 
@@ -292,6 +298,7 @@ For each subissue implementation in this EPIC, the default completion policy is:
 - 2026-08-21 16:30 UTC - Copilot/User - Split #1490's schema-decomposition and secret-typing work. #1490 now defines the final v3 database configuration shape; a release-gated `secrecy` prerequisite was drafted.
 - 2026-08-21 16:45 UTC - josecelano - Ordered the smaller secrecy refactor first. It protects API tokens in v2 and v3 without wrapping legacy database URLs; #1490 follows and uses the established `Secret<String>` convention for the isolated v3 database password.
 - 2026-08-21 17:00 UTC - Copilot/User - Maintainer approved and created the secrecy prerequisite as GitHub issue #2079; moved its specification to `docs/issues/open/`.
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Added #999 as a pending v3 configuration subissue after #1490. Its analysis-and-solution phase must decide whether optional database configuration blocks #1980 and v3 activation; v2 remains unchanged.
 
 ## Acceptance Criteria
 
@@ -331,7 +338,7 @@ For each subissue implementation in this EPIC, the default completion policy is:
 
 ## References
 
-- Related issues: #1417, #1640, #1490, #1453, #1415, #1136, #889, #1987
+- Related issues: #1417, #1640, #1490, #999, #1453, #1415, #1136, #889, #1987
 - Related PRs: #1937 (spec for #1640)
 - Related ADRs: `docs/adrs/20260617093046_reject_wildcard_external_ip.md`
 - Related EPICs: #1669 (package overhaul)

--- a/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
@@ -293,4 +293,4 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 - V3 database-shape issue: #1490
 - V3 runtime-consumer migration: #1980
 - SQLite migrations: `packages/tracker-core/migrations/sqlite/`
-- PostgreSQL migrations: `packages/tracker-core/migrations/postgres/`
+- PostgreSQL migrations: `packages/tracker-core/migrations/postgresql/`

--- a/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
@@ -1,0 +1,296 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: planned
+priority: p2
+epic: 1978
+github-issue: 999
+spec-path: docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+branch: "999-avoid-unneeded-database-initialization"
+related-pr: null
+depends-on: 1490
+blocks: null
+last-updated-utc: 2026-08-25 00:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+    - docs/issues/open/1490-1978-decompose-database-configuration.md
+    - docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
+    - packages/configuration/src/v3_0_0/core.rs
+    - packages/configuration/src/v3_0_0/database.rs
+    - packages/configuration/src/validator.rs
+    - packages/tracker-core/
+    - src/container.rs
+    - share/container/entry_script_sh
+    - docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+---
+
+# Issue #999 - Make v3 database configuration optional when persistence is unused
+
+> **EPIC position**: Configuration-overhaul subissue of EPIC #1978. It follows
+> #1490, which defines the driver-specific v3 `Database` representation. Phase
+> 1 and Phase 2 must determine whether this issue blocks #1980 and activation of
+> the v3 configuration schema.
+
+## Goal
+
+Allow a tracker using configuration schema v3.0.0 to omit `[core.database]`
+when no enabled capability requires persistence. In that mode, startup must not
+construct a database driver, create database files, connect to network
+databases, or run migrations.
+
+The tracker must reject an invalid configuration at startup when an enabled
+persistence-backed capability requires a database but `[core.database]` is
+omitted. It must not silently disable that capability or fail later through an
+unexpected database access.
+
+## Background
+
+Issue #999 was opened when every tracker startup created a SQLite database and
+its tables, even for benchmarking configurations that did not use persistence.
+The persistence implementation has since changed substantially: the tracker
+uses migrations, supports SQLite, MySQL, and PostgreSQL, and the configuration
+overhaul has introduced a driver-specific v3 `Database` representation in
+issue #1490. The active runtime still uses v2 configuration until #1980.
+
+The original report remains relevant because startup may still initialize the
+database and execute migrations even when no feature consumes persistence.
+However, its proposed implementation—moving table creation out of a driver
+constructor—is not a design decision for the current architecture. The Phase 1
+inventory must establish the actual construction and migration lifecycle before
+Phase 2 selects a solution.
+
+Known persistence-backed domains include whitelist entries, torrent completion
+metrics, and private-tracker keys. Management REST API paths may expose or
+mutate the same domains. Their configuration switches, direct dependencies, and
+indirect assumptions that a database is always available are not yet fully
+inventoried.
+
+## Scope
+
+### In Scope
+
+- Define the v3-only contract for an optional `[core.database]` section.
+- Investigate and document the current configuration, startup, migration, and
+  persistence-consumer behaviour for every supported database driver, including
+  container entrypoint side effects.
+- Inventory direct and indirect dependencies on `tracker-core` persistence,
+  including whitelist, torrent metrics, private-tracker keys, and management
+  REST API operations.
+- Decide and document startup validation for every enabled capability that
+  requires persistence.
+- Preserve the all-or-nothing schema lifecycle: once any enabled capability
+  requires persistence, initialize the selected database and apply the complete
+  shared migration set. Do not create feature-specific database schemas or
+  feature-specific migration streams.
+- Decide and document the management REST API contract when persistence is
+  unavailable.
+- Define the implementation, regression coverage, migration documentation, and
+  operational verification required by the approved solution.
+- Determine whether the change must precede #1980 and v3 activation; update
+  EPIC #1978's ordering and activation criteria if it does.
+
+### Out of Scope
+
+- Changing v2.0.0 configuration types, defaults, validation, or database
+  lifecycle. V2 operators continue supplying a database configuration, even
+  when an unused SQLite database is created.
+- Replacing or redesigning the v3 driver-specific database representation
+  introduced by #1490.
+- Choosing a persistence abstraction outside `packages/tracker-core` without
+  evidence that the current package boundary cannot support the approved
+  contract.
+- Changing persistence-domain behaviour, schema contents, or migration history
+  except where required to avoid initialization when persistence is unused.
+- Silently disabling a configured persistence-backed capability.
+
+## Architectural Decisions
+
+### Decision 1: Restrict any configuration change to v3
+
+If the approved solution changes the configuration contract, v3 alone makes
+`[core.database]` optional. V2 remains unchanged for compatibility; users can
+continue configuring an otherwise unused SQLite database.
+
+### Decision 2: Separate evidence, solution, and implementation delivery
+
+This issue has three phases. The first follow-up PR completes Phase 1 and Phase
+2 together without changing runtime behaviour. A second follow-up PR implements
+the approved Phase 3 plan. The current PR contains only this planning scaffold.
+
+### Decision 3: Fail validation rather than degrade persistence silently
+
+The final design must make an absent database configuration a startup
+configuration error whenever an enabled capability needs persistence. The exact
+capability inventory and validation location remain Phase 1 and Phase 2 work.
+
+The expected mechanism is a configuration-consistency rule in
+`packages/configuration/src/validator.rs`, invoked during bootstrap before
+`AppContainer` construction. The existing precedent is
+`UselessPrivateModeSection`: `[core.private_mode]` is rejected unless
+`core.private = true`. This issue must use that layer only if the approved
+database requirement is a relationship between configuration options; it must
+not use it for field-local parsing or value invariants.
+
+The implementation must keep feature-to-database requirements explicit at the
+application boundary. It must not distribute optional-database checks through
+repositories or feature implementation code, where a missed call site could
+become a delayed runtime failure. Phase 2 will decide whether the bootstrap
+rule is implemented through the configuration-consistency validator or a
+bootstrap-owned validation step, based on the documented validation-layer
+policy and the final configuration model.
+
+- Related ADRs:
+  `docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md`.
+- ADRs to create: Decide during Phase 2. Create an ADR only if the selected
+  optional-persistence lifecycle changes an enduring architecture boundary.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                           | Notes / Expected Output                                                                                                 |
+| --- | ------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Complete persistence analysis                  | Populate `analysis.md` with evidence for the current lifecycle, all consumers, and driver-specific migration behaviour. |
+| T2  | TODO   | Approve an optional-persistence design         | Populate `solution.md` with the selected v3 contract, validation, API behaviour, compatibility, and ordering decision.  |
+| T3  | TODO   | Implement optional v3 database configuration   | Apply only the Phase 2-approved design; do not change v2.                                                               |
+| T4  | TODO   | Add regression coverage                        | Cover absent and present database configurations, required-feature validation, migrations, and REST API behaviour.      |
+| T5  | TODO   | Update migration and operational documentation | Explain the v2-to-v3 difference and any changed deployment requirements.                                                |
+| T6  | TODO   | Verify and re-review                           | Run required automatic and manual checks; update acceptance evidence.                                                   |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] GitHub issue #999 reviewed, including its original implementation comment
+- [x] Spec-only branch created
+- [x] Folder-based specification scaffold created
+- [x] Spec reviewed and approved by user/maintainer
+- [ ] Spec-only PR merged into `develop`
+- [ ] Phase 1 and Phase 2 analysis-and-solution PR merged
+- [ ] Phase 3 implementation PR merged
+- [ ] Automatic verification completed
+- [ ] Manual verification scenarios executed and recorded
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Issue closed and specification moved to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Created the v3-only,
+  folder-based planning scaffold. Confirmed that v2 remains unchanged and that
+  the analysis-and-solution work precedes implementation.
+- 2026-08-25 00:00 UTC - User - Approved the specification for the spec-only
+  PR.
+
+## Acceptance Criteria
+
+- [ ] AC1: Phase 1 inventories the actual v2/v3 configuration, database-driver
+      construction, and migration lifecycle for SQLite, MySQL, and PostgreSQL.
+- [ ] AC2: Phase 1 inventories all direct and indirect persistence consumers,
+      their enablement configuration, and their management REST API coupling.
+- [ ] AC3: Phase 2 defines an approved v3-only configuration and startup
+      validation contract for omitted `[core.database]`.
+- [ ] AC4: The approved design prevents a database driver, database connection,
+      database-file creation, and migration execution when persistence is not
+      configured or required.
+- [ ] AC5: The approved design rejects startup with a clear error when an
+      enabled persistence-backed capability requires a missing database.
+- [ ] AC6: The approved design defines deterministic REST API behaviour when
+      persistence is unavailable.
+- [ ] AC7: When persistence is required by at least one enabled capability, the
+      implementation initializes the selected driver and applies the complete
+      shared migration set; it does not create feature-specific schemas or run
+      feature-specific migrations.
+- [ ] AC8: Phase 2 determines and records whether this issue blocks #1980 and
+      v3 activation; the EPIC ordering and migration guidance are updated if
+      required.
+- [ ] AC9: The implementation preserves v2 configuration and behaviour.
+- [ ] AC10: The final v3 end-to-end scenario reproduces the original
+      persistence-disabled benchmark use case without a database file,
+      connection, or migration, with evidence recorded in
+      `baseline-e2e-verification.md`.
+- [ ] AC11: The supported container startup path permits a v3 deployment with
+      no persistence, without requiring database-driver configuration or
+      installing a default SQLite database solely for the tracker.
+- [ ] AC12: `linter all` exits with code `0` after the implementation.
+- [ ] AC13: Relevant automated tests and mandatory manual verification pass.
+- [ ] AC14: Acceptance criteria are re-reviewed against implementation evidence.
+
+## Verification Plan
+
+Define the final commands and test ownership in Phase 2. The implementation
+must at minimum provide the following checks.
+
+### Automatic Checks
+
+- `linter all`
+- Focused configuration tests for v3 optional database parsing and validation.
+- Focused `tracker-core` tests for database construction and migration gating.
+- Focused REST API tests for every persistence-backed route affected by the
+  approved contract.
+- Relevant workspace tests and pre-push checks when applicable.
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                                     | Command/Steps                                                                                                                              | Expected Result                                                                                                                                       | Status | Evidence                                                                                         |
+| --- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------ |
+| M1  | Start v3 without persistence                 | Start with no `[core.database]` and all persistence-backed capabilities disabled.                                                          | Startup succeeds without a database file, connection, or migration.                                                                                   | TODO   | Phase 2 defines exact configuration and evidence.                                                |
+| M2  | Reject missing required persistence          | Enable each persistence-backed capability without `[core.database]`.                                                                       | Startup fails with a precise configuration error naming the unmet requirement.                                                                        | TODO   | Phase 2 defines the complete capability matrix.                                                  |
+| M3  | Initialize configured driver                 | Start with each supported configured database driver and a required feature enabled.                                                       | Startup initializes the selected driver and applies migrations according to the approved lifecycle.                                                   | TODO   | Phase 2 defines driver environments and evidence.                                                |
+| M4  | Verify REST API contract                     | Exercise affected management endpoints with persistence disabled and enabled.                                                              | Each endpoint returns the approved, documented response rather than an unexpected runtime database error.                                             | TODO   | Phase 2 identifies routes and expected statuses.                                                 |
+| M5  | Re-run the original benchmark scenario       | Follow `baseline-e2e-verification.md` with the completed v3 runtime and no `[core.database]`.                                              | Tracker remains available without creating a database file, connecting to a database, or running migrations.                                          | TODO   | Append final command, logs, artifact inspection, and revision to `baseline-e2e-verification.md`. |
+| M6  | Verify container startup without persistence | Build or run the supported container startup path with v3 database configuration omitted and all persistence-backed capabilities disabled. | The entrypoint does not require a database-driver override, install a default SQLite database, or create a database directory solely for the tracker. | TODO   | Phase 2 defines the exact image/configuration and evidence.                                      |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                        |
+| ----- | ---------------------- | ----------------------------------------------- |
+| AC1   | TODO                   | `analysis.md` lifecycle inventory               |
+| AC2   | TODO                   | `analysis.md` consumer and API inventory        |
+| AC3   | TODO                   | `solution.md` approved contract                 |
+| AC4   | TODO                   | Implementation tests and M1 evidence            |
+| AC5   | TODO                   | Validation tests and M2 evidence                |
+| AC6   | TODO                   | REST API tests and M4 evidence                  |
+| AC7   | TODO                   | Driver/migration tests and M3 evidence          |
+| AC8   | TODO                   | EPIC and migration-document updates             |
+| AC9   | TODO                   | V2 compatibility tests/review                   |
+| AC10  | TODO                   | M5 evidence in `baseline-e2e-verification.md`   |
+| AC11  | TODO                   | M6 container-startup evidence                   |
+| AC12  | TODO                   | `linter all` output                             |
+| AC13  | TODO                   | Focused, relevant workspace, and M1–M6 evidence |
+| AC14  | TODO                   | Post-implementation acceptance review           |
+
+## Risks and Trade-offs
+
+- **Hidden persistence coupling**: A path may access a repository without an
+  obvious feature switch. Mitigation: Phase 1 traces construction and all
+  `tracker-core` repository consumers before Phase 2 chooses an API.
+- **Silent data loss or degraded private mode**: Treating persistence as
+  optional could accidentally disable a required feature. Mitigation: reject
+  invalid combinations during startup validation and test every enabled feature.
+- **Incomplete migration gating**: Connecting to a configured driver may still
+  run migrations in an unintended path. Mitigation: trace and test construction
+  and migration invocation separately for all drivers.
+- **REST API inconsistency**: Management routes may expose unavailable data or
+  fail internally. Mitigation: inventory route-to-domain dependencies and define
+  explicit endpoint behaviour before implementation.
+- **V3 activation sequencing**: The v3 runtime migration in #1980 may otherwise
+  activate a configuration contract that must change. Mitigation: Phase 2 makes
+  and records an explicit blocker decision before #1980 is completed.
+
+## References
+
+- Original issue: #999
+- Original design comment: https://github.com/torrust/torrust-tracker/issues/999#issuecomment-2273652872
+- Parent EPIC: #1978
+- V3 database-shape issue: #1490
+- V3 runtime-consumer migration: #1980
+- SQLite migrations: `packages/tracker-core/migrations/sqlite/`
+- PostgreSQL migrations: `packages/tracker-core/migrations/postgres/`

--- a/docs/issues/open/999-1978-optional-database-configuration/analysis.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/analysis.md
@@ -1,0 +1,93 @@
+---
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - packages/tracker-core/
+    - packages/configuration/src/v2_0_0/
+    - packages/configuration/src/v3_0_0/
+    - src/container.rs
+---
+
+# Phase 1 - Persistence dependency analysis
+
+## Purpose
+
+Establish evidence for the current persistence lifecycle and every dependency
+that assumes a database exists. This phase must not select the implementation
+solution or change runtime behaviour.
+
+## Required Investigation
+
+### Configuration and startup lifecycle
+
+- Trace how v2 configuration currently requires and supplies database settings.
+- Trace v3 `Core.database` parsing, defaults, and all v3-to-runtime handoff
+  paths planned under #1980.
+- Locate each database-driver construction path and identify its owner.
+- Locate each migration invocation and determine whether it is coupled to
+  construction, connection, or an explicit bootstrap operation.
+- Inspect `share/container/entry_script_sh`, the container image, and related
+  configuration/install paths. Record directory creation, default-database
+  installation, required database-driver environment variables, and any other
+  database side effect before the tracker process starts.
+- Reconcile the source-level lifecycle findings with the baseline end-to-end
+  evidence in `baseline-e2e-verification.md`.
+- Trace the configuration-consistency validation path from
+  `packages/configuration/src/validator.rs` through `Configuration::validate()`
+  and bootstrap. Record whether each database requirement is expressible as a
+  cross-field configuration rule or instead needs runtime/environment
+  validation.
+- Record separate SQLite, MySQL, and PostgreSQL behaviour, including file or
+  connection side effects and migration preconditions.
+
+### Persistence consumer inventory
+
+For every consumer, record the source location, enablement condition, repository
+or service dependency, startup dependency, runtime failure mode, and tests.
+
+| Domain / consumer                     | Enablement configuration | Persistence operations | REST API coupling | Findings |
+| ------------------------------------- | ------------------------ | ---------------------- | ----------------- | -------- |
+| Whitelist                             | TODO                     | TODO                   | TODO              | TODO     |
+| Torrent completion metrics            | TODO                     | TODO                   | TODO              | TODO     |
+| Private-tracker keys                  | TODO                     | TODO                   | TODO              | TODO     |
+| Other direct `tracker-core` consumers | TODO                     | TODO                   | TODO              | TODO     |
+| Indirect consumers and jobs           | TODO                     | TODO                   | TODO              | TODO     |
+
+The consumer inventory identifies requirements; it is not a plan to create
+independent schemas or migration streams. The tracker has one small shared
+persistence schema. Phase 1 must confirm every migration invocation, but the
+working constraint is all or nothing: no required consumers means no driver and
+no migrations; one or more required consumers means one initialized driver and
+the complete migration set.
+
+### Management REST API inventory
+
+For every route that reads or writes a persistence-backed domain, record the
+route, authorization policy, feature dependency, current response when the
+underlying domain is unavailable, and desired contract candidates. Do not decide
+the final response in this phase.
+
+| Route / operation | Domain | Current dependency path | Current unavailable behaviour | Evidence |
+| ----------------- | ------ | ----------------------- | ----------------------------- | -------- |
+| TODO              | TODO   | TODO                    | TODO                          | TODO     |
+
+### Compatibility and activation inventory
+
+- Confirm that v2 must remain unchanged and continues requiring a database.
+- Identify every default configuration, helper, example, benchmark, E2E setup,
+  and deployment document that will be affected if v3 `Core.database` becomes
+  optional.
+- Identify container entrypoint changes needed to support a no-persistence v3
+  deployment without requiring a database-driver environment variable or
+  installing a default SQLite database.
+- Identify the concrete #1980 consumer-migration tasks that may need to depend
+  on this issue.
+
+## Evidence Requirements
+
+- Link source paths, tests, logs, or focused experiment results for every
+  finding.
+- Distinguish verified findings from hypotheses.
+- Record contradictory evidence and unresolved questions explicitly.
+- Update `solution.md` only after this document provides enough evidence to
+  evaluate the alternatives.

--- a/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
@@ -20,8 +20,7 @@ persistence-backed capability is enabled.
 
 - Date: 2026-08-25
 - Revision: `f07553c0` (`develop` before this specification branch)
-- Binary: `target/debug/torrust-tracker`, built by `cargo run --bin
-torrust-tracker`
+- Binary: `target/debug/torrust-tracker`, built by `cargo run --bin torrust-tracker`
 - Configuration source: `share/default/config/tracker.udp.benchmarking.toml`
 - Schema version: `2.0.0`
 - Working directory: an isolated `.tmp/issue-999-baseline-*` directory

--- a/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
@@ -1,0 +1,123 @@
+---
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - share/default/config/tracker.udp.benchmarking.toml
+    - packages/tracker-core/migrations/sqlite/20240730183000_torrust_tracker_create_all_tables.sql
+---
+
+# Baseline end-to-end verification
+
+## Purpose
+
+Preserve a reproducible observation of the problem reported in #999 before any
+solution is implemented. The Phase 3 implementation must repeat the final
+scenario below and record that it no longer creates or initializes a database
+when the equivalent v3 configuration omits `[core.database]` and no
+persistence-backed capability is enabled.
+
+## Baseline environment
+
+- Date: 2026-08-25
+- Revision: `f07553c0` (`develop` before this specification branch)
+- Binary: `target/debug/torrust-tracker`, built by `cargo run --bin
+torrust-tracker`
+- Configuration source: `share/default/config/tracker.udp.benchmarking.toml`
+- Schema version: `2.0.0`
+- Working directory: an isolated `.tmp/issue-999-baseline-*` directory
+- Runtime limit: ten seconds; the tracker was stopped by `timeout` after
+  remaining alive, so exit status `124` is expected.
+
+The benchmarking configuration disables the known persistence settings:
+
+```toml
+[core]
+listed = false
+private = false
+tracker_usage_statistics = false
+
+[core.tracker_policy]
+persistent_torrent_completed_stat = false
+remove_peerless_torrents = false
+```
+
+## Baseline result
+
+The current v2 configuration still requires `[core.database]`. With its SQLite
+section present, the tracker starts and creates a 49,152-byte SQLite database
+file despite the persistence settings above being disabled:
+
+```toml
+[core.database]
+driver = "sqlite3"
+path = "./baseline.sqlite3.db"
+```
+
+Command:
+
+```text
+(cd "$work_dir" && \
+  TORRUST_TRACKER_CONFIG_TOML_PATH="$work_dir/tracker.with-database.toml" \
+  timeout --signal=INT --kill-after=3s 10s \
+  "$repository_root/target/debug/torrust-tracker")
+```
+
+Observed output and artifacts:
+
+```text
+EXIT_STATUS=124
+Loading extra configuration from file: `.../tracker.with-database.toml` ...
+
+baseline.sqlite3.db 49152 bytes
+```
+
+The created database contains the current SQLite migration schema. A direct
+SQLite inspection returned:
+
+```text
+_sqlx_migrations
+keys
+sqlite_sequence
+torrent_aggregate_metrics
+torrents
+whitelist
+```
+
+This includes the `whitelist`, `torrents`, and `keys` tables defined by
+`20240730183000_torrust_tracker_create_all_tables.sql` and shows that migrations
+were applied.
+
+## Missing-database control observation
+
+Removing `[core.database]` from the equivalent v2 benchmarking configuration
+does not provide a valid reproduction of the desired final state because v2
+still requires the section. In the current runtime, the process remains alive
+after configuration loading and provides no useful visible diagnostic at the
+`error` logging threshold before the ten-second timeout. This confirms why the
+implementation must preserve v2 behaviour and target v3 only; Phase 1 must
+trace the precise v2 construction and failure path separately.
+
+## Final implementation acceptance scenario
+
+After Phase 3, run this scenario using the active v3 runtime path:
+
+1. Create an isolated working directory and a v3 UDP benchmarking configuration
+   with no `[core.database]` section.
+2. Disable every persistence-backed capability identified and approved in the
+   Phase 2 capability-validation matrix.
+3. Start the tracker with a bounded timeout and capture logs.
+4. Inspect the isolated working directory and any configured/default database
+   locations.
+
+Expected result:
+
+- The tracker starts and remains alive until the bounded shutdown.
+- No SQLite database file is created.
+- No MySQL or PostgreSQL connection is attempted.
+- No migration is executed.
+- Logs contain no database initialization or migration activity.
+
+Record the exact v3 configuration, command, timeout result, logs, artifact
+inspection, and the commit or PR under test in this document. Mark the related
+manual-verification scenario in `ISSUE.md` as `DONE` only after the evidence is
+recorded.

--- a/docs/issues/open/999-1978-optional-database-configuration/solution.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/solution.md
@@ -1,0 +1,110 @@
+---
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+    - docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
+---
+
+# Phase 2 - Optional persistence solution
+
+## Status
+
+Pending Phase 1 evidence. Do not treat the preliminary direction below as an
+approved implementation decision.
+
+## Decision to Make
+
+Select a design that allows v3 `[core.database]` to be omitted when persistence
+is unused, while rejecting startup if an enabled persistence-backed capability
+requires a database. The selected design must preserve v2 behaviour unchanged.
+
+## Candidate Direction
+
+The expected configuration representation is `Option<Database>` on v3 `Core`.
+When absent, runtime construction must not create a driver, database file,
+network connection, or migration side effect. This remains subject to Phase 1:
+the analysis may identify a more suitable boundary or a prerequisite refactor.
+
+The performance objective is explicit: a public UDP tracker that enables none
+of the basic persistence-backed capabilities must run without a database. If at
+least one such capability is enabled, the selected database is a normal shared
+tracker dependency: initialize it once and apply the whole migration set. Do
+not design separate schemas or migration streams per feature.
+
+## Required Solution Content
+
+### Configuration contract
+
+- Define v3 TOML semantics for an omitted `[core.database]` section.
+- Specify whether empty or partial database sections are rejected and how their
+  errors are reported.
+- Define the v2-to-v3 migration guidance and confirm v2 remains unchanged.
+
+### Capability validation matrix
+
+For every persistence-backed capability identified in Phase 1, define its
+enablement condition and startup validation result when the database is absent.
+
+| Capability | Enabled when | Database omitted result | Error text / code | Tests |
+| ---------- | ------------ | ----------------------- | ----------------- | ----- |
+| TODO       | TODO         | TODO                    | TODO              | TODO  |
+
+When a requirement depends only on the relationship between configuration
+options, implement it as a configuration-consistency rule through `Validator`
+and `SemanticValidationError`. The precedent is
+`UselessPrivateModeSection`, which rejects `[core.private_mode]` when
+`core.private` is false. Follow the validation-layer policy in
+`docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md`:
+field-local constraints belong in typed deserialization, and filesystem,
+network, or deployment facts belong in runtime/environment validation.
+
+Keep the rule centralized at the configuration/bootstrap boundary rather than
+asking each repository or feature implementation to discover a missing database
+at runtime. Phase 2 must select and document one owner for this check, including
+why that owner matches the validation-layer policy.
+
+### Runtime lifecycle
+
+- Define the owner and timing of driver construction.
+- Define the owner and timing of migration execution.
+- Define repository/service construction when persistence is absent.
+- State whether any constructor needs refactoring to remove migration side
+  effects, based on Phase 1 evidence.
+- Define the all-or-nothing migration contract: if a database is required,
+  apply the complete shared schema migration set once; if none is required, do
+  not construct a driver or execute any migration.
+- Define container-entrypoint behaviour for deployments without persistence,
+  including database-driver environment variables, default-database installation,
+  and database-directory setup.
+
+### REST API contract
+
+For each route recorded in Phase 1, choose a deterministic outcome when
+persistence is unavailable: absence because the feature is disabled, a
+documented client error, or another explicitly justified response. The result
+must never be an accidental driver or repository failure.
+
+### EPIC ordering and activation decision
+
+State one of the following and update EPIC #1978 accordingly:
+
+1. #999 blocks #1980 and v3 activation because optional database configuration
+   is part of the required v3 runtime contract.
+2. #999 does not block activation, with documented evidence that activation
+   remains correct without this optionality.
+
+### Alternatives and trade-offs
+
+Evaluate at least these alternatives against Phase 1 evidence:
+
+- Keep the database mandatory in v3.
+- Make database configuration optional but allow runtime failures for users of
+  persistence-backed capabilities.
+- Make database configuration optional and validate capability requirements at
+  startup.
+
+## Approval Record
+
+Add the approved design, approver, UTC timestamp, decision rationale, and any
+required ADR here before Phase 3 starts.

--- a/docs/pr-reviews/pr-2094-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2094-copilot-suggestions.md
@@ -1,0 +1,37 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2094 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for <https://github.com/torrust/torrust-tracker/pull/2094>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Processing Log
+
+- 2026-08-25: Started processing suggestions.
+- 2026-08-25: Completed processing suggestions; all initially unresolved Copilot threads were replied to and resolved.
+
+## Suggestions
+
+| # | Thread ID | Path | URL | Suggestion Summary | Decision | Reply URL | Status | Thread State |
+| - | --------- | ---- | --- | ------------------ | -------- | --------- | ------ | ------------ |
+| 1 | PRRT_kwDOGp2yqc6cDyJS | `docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md` | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680576> | Keep the build command in one inline code span. | action: corrected the split command in the baseline environment list. | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852742198> | DONE | RESOLVED |
+| 2 | PRRT_kwDOGp2yqc6cDyJo | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md` | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680616> | Correct the PostgreSQL migrations directory name. | action: corrected the migration path to `postgresql`. | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852743800> | DONE | RESOLVED |
+
+## Notes
+
+- Each decision is recorded in its corresponding GitHub review reply before resolution.

--- a/docs/pr-reviews/pr-2094-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2094-copilot-suggestions.md
@@ -27,10 +27,10 @@ Status legend:
 
 ## Suggestions
 
-| # | Thread ID | Path | URL | Suggestion Summary | Decision | Reply URL | Status | Thread State |
-| - | --------- | ---- | --- | ------------------ | -------- | --------- | ------ | ------------ |
-| 1 | PRRT_kwDOGp2yqc6cDyJS | `docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md` | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680576> | Keep the build command in one inline code span. | action: corrected the split command in the baseline environment list. | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852742198> | DONE | RESOLVED |
-| 2 | PRRT_kwDOGp2yqc6cDyJo | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md` | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680616> | Correct the PostgreSQL migrations directory name. | action: corrected the migration path to `postgresql`. | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852743800> | DONE | RESOLVED |
+| #   | Thread ID             | Path                                                                                     | URL                                                                           | Suggestion Summary                                | Decision                                                              | Reply URL                                                                     | Status | Thread State |
+| --- | --------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6cDyJS | `docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md` | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680576> | Keep the build command in one inline code span.   | action: corrected the split command in the baseline environment list. | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852742198> | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6cDyJo | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                     | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852680616> | Correct the PostgreSQL migrations directory name. | action: corrected the migration path to `postgresql`.                 | <https://github.com/torrust/torrust-tracker/pull/2094#discussion_r3852743800> | DONE   | RESOLVED     |
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Adds the approved folder-based specification for issue #999, defining a three-phase path to make v3 database configuration optional when persistence is unused.

- records the current SQLite creation and migration baseline evidence;
- scopes the analysis of persistence consumers, migration lifecycle, REST API coupling, validation, and container startup behaviour;
- records the v3-only boundary, all-or-nothing migration constraint, and final implementation verification requirements;
- registers #999 as a pending subissue of EPIC #1978 after #1490.

## Validation

- `./contrib/dev-tools/git/hooks/pre-commit.sh`

Related to #999
Related to #1978