### PR TITLE
docs(configuration): define optional persistence activation plan

### DIFF
--- a/docs/issues/drafts/144-make-rest-api-persistence-aware.md
+++ b/docs/issues/drafts/144-make-rest-api-persistence-aware.md
@@ -1,0 +1,148 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: draft
+priority: p2
+epic: 144
+github-issue: null
+spec-path: docs/issues/drafts/144-make-rest-api-persistence-aware.md
+branch: null
+related-pr: null
+last-updated-utc: 2026-08-25 00:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+    - packages/rest-api-protocol/
+    - packages/rest-api-application/
+    - packages/rest-api-runtime-adapter/
+    - packages/axum-rest-api-server/
+---
+
+# Make the REST API persistence-aware
+
+## Subissue of EPIC #144 — next-major REST API work
+
+## Problem
+
+The tracker’s target architecture permits a persistence-free runtime, but the
+current REST API assumes persistence-backed whitelist and key services exist.
+It also exposes completed counters documented as historical values even when a
+value is only known for the current tracker process.
+
+The current code conflates distinct states:
+
+1. A feature is disabled deliberately by configuration.
+2. A configured database fails operationally after startup.
+3. A current/session metric exists, while its historical counterpart is
+   unavailable.
+
+A direct whitelist or key operation for a disabled capability must not become a
+misleading database failure. Likewise, a session-only completed count must not
+be documented or serialized as an undifferentiated lifetime count.
+
+Issue #999 records the source-level inventory and the approved target behavior
+in `persistence-unavailable-scenarios.md`. Its small activation follow-up keeps
+`http_api` persistence-required until this next-major REST API contract work is
+complete.
+
+## Goal
+
+Make the REST API explicitly capability-aware and persistence-aware so it can
+start in a persistence-free tracker deployment without confusing intentional
+configuration, operational failures, session values, and historical values.
+
+## Approved Contract Direction
+
+### Disabled direct capabilities
+
+When a client calls a whitelist route while `core.listed = false`, or a key
+route while `core.private = false`, return HTTP `409 Conflict` using the
+existing `ActionStatus::Err` response shape:
+
+```json
+{
+  "status": "err",
+  "reason": "Whitelist capability is disabled by configuration (`core.listed = false`)."
+}
+```
+
+The protocol/application boundary must carry a distinct
+`DisabledByConfiguration` error. It must not reuse database error variants.
+
+Configured database failures remain a distinct operational state and retain
+server-error handling; they are not configuration-disabled responses.
+
+### Completed metric semantics
+
+Keep in-memory routes available when their data is meaningful. Do not use a
+negative numeric sentinel for missing history. Replace the ambiguous historical
+meaning of `completed: u64` with an explicit next-major response model that can
+distinguish at least:
+
+- session-only value;
+- restored/persisted historical value; and
+- unavailable historical value.
+
+The final DTO names and migration policy require review during implementation.
+
+## Scope
+
+### In Scope
+
+- Add capability-aware composition for REST API services and routes.
+- Add the HTTP 409 configuration-disabled response for direct whitelist and key
+  operations.
+- Preserve the distinction between configuration-disabled and operational
+  database failure across protocol, application, runtime-adapter, and Axum
+  layers.
+- Define and implement next-major explicit completed-metric provenance/history
+  semantics for stats and torrent responses.
+- Update REST API client models, contract tests, documentation, and migration
+  guidance for the new major API contract.
+- Enable the persistence-free runtime activation follow-up to remove its
+  temporary `http_api` persistence requirement.
+
+### Out of Scope
+
+- Changing v2 tracker configuration behavior.
+- Replacing the tracker persistence schema or creating feature-specific
+  migration streams.
+- Hiding supported routes with an accidental 404 or reporting disabled
+  capabilities as authorization failures.
+- Using numeric sentinels for missing historical values.
+
+## Implementation Considerations
+
+| Area                       | Expected work                                                                           |
+| -------------------------- | --------------------------------------------------------------------------------------- |
+| `rest-api-protocol`        | Add a distinct disabled-by-configuration error and next-major response DTOs.            |
+| `rest-api-application`     | Preserve the disabled capability state through use cases.                               |
+| `rest-api-runtime-adapter` | Compose optional capability services and provide in-memory adapters where appropriate.  |
+| `axum-rest-api-server`     | Map disabled capability errors to HTTP 409 and update route contract tests.             |
+| `rest-api-client`          | Update next-major client DTOs and error handling.                                       |
+| Tracker activation         | Remove `http_api` from the persistence-required matrix once this contract is available. |
+
+## Verification
+
+- [ ] Contract tests distinguish disabled capability (409) from operational
+      database failure (server error).
+- [ ] Whitelist/key disabled routes do not attempt persistence access.
+- [ ] Stats/torrent responses explicitly describe current versus historical
+      completed values.
+- [ ] No response uses a negative numeric sentinel for unavailable history.
+- [ ] REST API starts in the persistence-free tracker scenario after its
+      composition dependencies are updated.
+- [ ] REST API client and user-facing migration documentation are updated.
+- [ ] `linter all` and relevant workspace tests pass.
+
+## References
+
+- GitHub EPIC issue #144
+- Issue #999
+- `docs/issues/open/999-1978-optional-database-configuration/solution.md`
+- `docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md`
+- `docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md`

--- a/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
@@ -89,23 +89,23 @@ version from `2.0.0` to `3.0.0`.
 
 Status values: `TODO`, `IN_PROGRESS`, `IN_REVIEW`, `BLOCKED`, `DONE`.
 
-| Order | Issue                                                                                                                                               | Local Spec                                                                                 | Status | Notes                                                                                                                                                     |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | [#1979](https://github.com/torrust/torrust-tracker/issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/closed/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`              | DONE   | Merged in PR #1999; v3 baseline and smoke tests are in `develop`                                                                                          |
-| 2     | [#1981](https://github.com/torrust/torrust-tracker/issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/closed/1981-1978-fix-tsl-config-tls-config-typo.md`                           | DONE   | Implemented for v3; v2 compatibility retained until final migration                                                                                       |
-| 3     | [#1640](https://github.com/torrust/torrust-tracker/issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/closed/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`                | DONE   | Merged in PR #2014; v3 schema slice complete; runtime consumers deferred to #1980 (subissue #12)                                                          |
-| 4     | [#1417](https://github.com/torrust/torrust-tracker/issues/1417) — Include public service URL in configuration                                       | `docs/issues/closed/1417-1978-add-public-service-url-to-configuration.md`                  | DONE   | Merged in PR #2016; typed `Option<HttpUrl>`/`Option<UdpUrl>` newtypes on `HttpTracker`, `UdpTracker`, `HttpApi`; scheme validation at deserialization     |
-| 5     | [#1415](https://github.com/torrust/torrust-tracker/issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/closed/1415-1978-use-service-binding-instead-of-socket-addr/ISSUE.md`         | DONE   | Added protocol-aware `service_binding` alongside compatible `server_socket_addr` fields in HTTP tracker, REST API, and UDP error logs; verified manually. |
-| 6     | [#1453](https://github.com/torrust/torrust-tracker/issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/closed/1453-1978-ip-bans-reset-interval-configurable/ISSUE.md`                | DONE   | V3 setting validated; one cancellation-managed bootstrap cleanup job uses the v3 default constant. Runtime configuration use is deferred to #1980.        |
-| 7     | [#1136](https://github.com/torrust/torrust-tracker/issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/closed/1136-1978-configurable-udp-connection-id-validation-policy.md`         | DONE   | PR #2032 merged; all 12 ACs met; manual verification deferred to #1980.                                                                                   |
-| 8     | [#1490](https://github.com/torrust/torrust-tracker/issues/1490) — Decompose v3 database configuration                                               | `docs/issues/open/1490-1978-decompose-database-configuration.md`                           | TODO   | After #3 and #2079; isolates the v3 password as `Secret<String>`.                                                                                         |
-| 8a    | [#999](https://github.com/torrust/torrust-tracker/issues/999) — Make v3 database configuration optional when persistence is unused                  | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                       | TODO   | Follows #1490. Analysis and solution determine persistence dependencies, REST API behaviour, and whether it blocks #1980/v3 activation.                   |
-| 9     | [#889](https://github.com/torrust/torrust-tracker/issues/889) — New config option for logging style                                                 | `docs/issues/closed/889-1978-new-config-option-for-logging-style.md`                       | DONE   | V3 schema implemented; includes negative test for removed `threshold` key. Manual verification is deferred to #1980.                                      |
-| 10    | [#1987](https://github.com/torrust/torrust-tracker/issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md`    | TODO   | After #3 and external prerequisite #1985; per-HTTP-tracker opt-in policy                                                                                  |
-| 11    | [#2083](https://github.com/torrust/torrust-tracker/issues/2083) — Move UDP connection-ID error limit to shared server configuration                 | `docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md` | TODO   | Corrects the v3 shared UDP `BanService` configuration boundary found in #2067; blocks #1980 production activation.                                        |
-| 12    | [#1980](https://github.com/torrust/torrust-tracker/issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`                       | TODO   | Must follow all implemented schema subissues, including #2083, and the secrecy release gate.                                                              |
-| 13    | [#2023](https://github.com/torrust/torrust-tracker/issues/2023) — Expose configured public URLs in runtime observability                            | `docs/issues/open/2023-1978-expose-configured-public-urls-in-runtime-observability.md`     | TODO   | Must follow #1417 and #1980; adds `public_url` to health checks, metrics, and logs without replacing ServiceBinding.                                      |
-| 14    | [#2067](https://github.com/torrust/torrust-tracker/issues/2067) — Analyze a flat heterogeneous service configuration                                | `docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md`                   | TODO   | Non-blocking analysis only; its confirmed configuration-model bug is tracked by #2083.                                                                    |
+| Order | Issue                                                                                                                                               | Local Spec                                                                                 | Status | Notes                                                                                                                                                                                   |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | [#1979](https://github.com/torrust/torrust-tracker/issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/closed/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`              | DONE   | Merged in PR #1999; v3 baseline and smoke tests are in `develop`                                                                                                                        |
+| 2     | [#1981](https://github.com/torrust/torrust-tracker/issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/closed/1981-1978-fix-tsl-config-tls-config-typo.md`                           | DONE   | Implemented for v3; v2 compatibility retained until final migration                                                                                                                     |
+| 3     | [#1640](https://github.com/torrust/torrust-tracker/issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/closed/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`                | DONE   | Merged in PR #2014; v3 schema slice complete; runtime consumers deferred to #1980 (subissue #12)                                                                                        |
+| 4     | [#1417](https://github.com/torrust/torrust-tracker/issues/1417) — Include public service URL in configuration                                       | `docs/issues/closed/1417-1978-add-public-service-url-to-configuration.md`                  | DONE   | Merged in PR #2016; typed `Option<HttpUrl>`/`Option<UdpUrl>` newtypes on `HttpTracker`, `UdpTracker`, `HttpApi`; scheme validation at deserialization                                   |
+| 5     | [#1415](https://github.com/torrust/torrust-tracker/issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/closed/1415-1978-use-service-binding-instead-of-socket-addr/ISSUE.md`         | DONE   | Added protocol-aware `service_binding` alongside compatible `server_socket_addr` fields in HTTP tracker, REST API, and UDP error logs; verified manually.                               |
+| 6     | [#1453](https://github.com/torrust/torrust-tracker/issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/closed/1453-1978-ip-bans-reset-interval-configurable/ISSUE.md`                | DONE   | V3 setting validated; one cancellation-managed bootstrap cleanup job uses the v3 default constant. Runtime configuration use is deferred to #1980.                                      |
+| 7     | [#1136](https://github.com/torrust/torrust-tracker/issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/closed/1136-1978-configurable-udp-connection-id-validation-policy.md`         | DONE   | PR #2032 merged; all 12 ACs met; manual verification deferred to #1980.                                                                                                                 |
+| 8     | [#1490](https://github.com/torrust/torrust-tracker/issues/1490) — Decompose v3 database configuration                                               | `docs/issues/open/1490-1978-decompose-database-configuration.md`                           | TODO   | After #3 and #2079; isolates the v3 password as `Secret<String>`.                                                                                                                       |
+| 8a    | [#999](https://github.com/torrust/torrust-tracker/issues/999) — Make v3 database configuration optional when persistence is unused                  | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                       | TODO   | Follows #1490. Adds v3 `Option<Database>`, optional container dependencies, and a temporary bridge for #1980; a small post-#1980 follow-up activates persistence-free runtime behavior. |
+| 9     | [#889](https://github.com/torrust/torrust-tracker/issues/889) — New config option for logging style                                                 | `docs/issues/closed/889-1978-new-config-option-for-logging-style.md`                       | DONE   | V3 schema implemented; includes negative test for removed `threshold` key. Manual verification is deferred to #1980.                                                                    |
+| 10    | [#1987](https://github.com/torrust/torrust-tracker/issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md`    | TODO   | After #3 and external prerequisite #1985; per-HTTP-tracker opt-in policy                                                                                                                |
+| 11    | [#2083](https://github.com/torrust/torrust-tracker/issues/2083) — Move UDP connection-ID error limit to shared server configuration                 | `docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md` | TODO   | Corrects the v3 shared UDP `BanService` configuration boundary found in #2067; blocks #1980 production activation.                                                                      |
+| 12    | [#1980](https://github.com/torrust/torrust-tracker/issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`                       | TODO   | Must follow all implemented schema subissues, including #2083, and the secrecy release gate.                                                                                            |
+| 13    | [#2023](https://github.com/torrust/torrust-tracker/issues/2023) — Expose configured public URLs in runtime observability                            | `docs/issues/open/2023-1978-expose-configured-public-urls-in-runtime-observability.md`     | TODO   | Must follow #1417 and #1980; adds `public_url` to health checks, metrics, and logs without replacing ServiceBinding.                                                                    |
+| 14    | [#2067](https://github.com/torrust/torrust-tracker/issues/2067) — Analyze a flat heterogeneous service configuration                                | `docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md`                   | TODO   | Non-blocking analysis only; its confirmed configuration-model bug is tracked by #2083.                                                                                                  |
 
 ### Release-gated prerequisite
 
@@ -132,7 +132,7 @@ graph TD
       sub1 --> secrecy["#2079 Secrecy"]
       sub3 --> sub8["8. #1490 Database configuration"]
       secrecy --> sub8
-      sub8 --> sub8a["8a. #999 optional database configuration"]
+      sub8 --> sub8a["8a. #999 optional DB representation"]
       sub3 --> sub10["10. #1987 Announce IP policy"]
       sub1 --> sub11["11. #2083 shared UDP error limit"]
       sub4 --> sub12["12. Final cleanup"]
@@ -143,7 +143,8 @@ graph TD
       sub9 --> sub12
       sub10 --> sub12
       sub11 --> sub12
-      sub8a -. "pending Phase 2 decision" .-> sub12
+      sub8a --> sub12["12. #1980 v3 activation with bridge"]
+      sub12 --> optionalRuntime["Post-#1980 persistence-free activation follow-up"]
       sub4 --> sub13["13. public_url runtime observability"]
       sub12 --> sub13
       sub12 --> sub14["14. Post-v3 flat-service research"]
@@ -155,7 +156,7 @@ graph TD
 1 → 2 → 3 → 4 → 12
 1 → 2 → 3 → 8 → 12
 1 → secrecy → 8 → 12
-1 → 2 → 3 → 8 → 8a → 12 (only if Phase 2 confirms #999 blocks activation)
+1 → 2 → 3 → 8 → 8a → 12 → persistence-free activation follow-up
 1 → 11 → 12
 ```
 
@@ -182,7 +183,11 @@ Subissues #5, #6, #7, #9 are independent and can run in parallel with the critic
 - **Subissue #3** (#1640) — Per-instance `Network` block in schema v3.0.0. Establishes the `Network` struct that #4 references; v3 does not support removed v2 field names.
 - **Release-gated prerequisite #2079** — Adopt `secrecy` for sensitive configuration first. It protects API tokens in v2 and v3 and establishes the `Secret<String>` convention without changing legacy database URLs.
 - **Subissue #8** (#1490) — Database enum decomposition. After #3 and the secrecy follow-up; it uses `Secret<String>` for the new isolated v3 database password.
-- **Subissue #8a** (#999) — Analyze and define v3 optional database configuration after #1490. The analysis-and-solution PR determines every persistence requirement, REST API behaviour, and whether the implementation must precede #1980.
+- **Subissue #8a** (#999) — After #1490, introduce the v3
+  `Option<Database>` representation, optional container dependencies, and a
+  tested temporary `Some(Database)` bridge. #1980 activates v3 consumers with
+  that bridge. A small post-#1980 follow-up passes actual `None`, invokes the
+  reusable validation matrix, and activates persistence-free runtime behavior.
 - **Subissue #4** (#1417) — `public_url` flat field. After #3 (depends on `Network` placement decision). ~6 files.
 - **Subissue #10** (#1987) — Opt-in use of the HTTP announce `ip` parameter. After #3 and external prerequisite #1985.
 
@@ -299,6 +304,11 @@ For each subissue implementation in this EPIC, the default completion policy is:
 - 2026-08-21 16:45 UTC - josecelano - Ordered the smaller secrecy refactor first. It protects API tokens in v2 and v3 without wrapping legacy database URLs; #1490 follows and uses the established `Secret<String>` convention for the isolated v3 database password.
 - 2026-08-21 17:00 UTC - Copilot/User - Maintainer approved and created the secrecy prerequisite as GitHub issue #2079; moved its specification to `docs/issues/open/`.
 - 2026-08-25 00:00 UTC - GitHub Copilot/User - Added #999 as a pending v3 configuration subissue after #1490. Its analysis-and-solution phase must decide whether optional database configuration blocks #1980 and v3 activation; v2 remains unchanged.
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Defined staged optional
+  persistence delivery: #999 adds v3 `Option<Database>` and optional container
+  dependencies; #1980 activates v3 with a temporary bridge; a small follow-up
+  activates the persistence-free runtime. The next-major REST API response
+  contract is separately drafted under API EPIC #144.
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
@@ -281,6 +281,26 @@ driver = "sqlite3"
 path = "/var/lib/torrust/tracker/database/sqlite3.db"
 ```
 
+### Optional database representation and staged activation
+
+**Subissue**: #999 — Optional v3 database configuration
+
+V3 accepts an omitted `[core.database]` section and represents it as no
+configured database. This is a schema/API change first; the runtime activation
+is deliberately staged:
+
+1. #999 introduces the optional representation and optional container
+   dependencies while retaining an explicit temporary database bridge.
+2. #1980 activates v3 runtime consumers with that bridge, preserving the
+   existing effective database behavior during the configuration transition.
+3. A small post-#1980 follow-up honors the omitted database at runtime when no
+   persistence-required capability is enabled.
+
+Until the activation follow-up is merged, do not interpret an omitted v3
+database section as a persistence-free running tracker. The final activation
+follow-up will document which capabilities require persistence, startup
+diagnostics, and supported container behavior.
+
 This is a breaking configuration change: MySQL and PostgreSQL URLs are not
 accepted in v3. Move their URL components into the fields above. Do not use an
 empty password: loading rejects missing and empty network database passwords.
@@ -332,6 +352,8 @@ Use this checklist to verify your configuration is ready for v3:
 - [ ] `connection_id_validation` reviewed in `[udp_tracker_server]` (optional, defaults to `"strict"`)
 - [ ] `ip_bans_reset_interval_in_secs` reviewed in `[udp_tracker_server]` (optional, defaults to `86400`)
 - [ ] Network database URLs replaced with component fields; database passwords are non-empty
+- [ ] Review the staged optional-database activation guidance before omitting
+      `[core.database]` in a deployed v3 tracker
 
 ## References
 

--- a/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
@@ -28,6 +28,10 @@ semantic-links:
     - docs/issues/open/999-1978-optional-database-configuration/analysis.md
     - docs/issues/open/999-1978-optional-database-configuration/solution.md
     - docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+    - docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
 ---
 
 # Issue #999 - Make v3 database configuration optional when persistence is unused
@@ -39,10 +43,12 @@ semantic-links:
 
 ## Goal
 
-Allow a tracker using configuration schema v3.0.0 to omit `[core.database]`
-when no enabled capability requires persistence. In that mode, startup must not
-construct a database driver, create database files, connect to network
-databases, or run migrations.
+Allow configuration schema v3.0.0 to represent an omitted `[core.database]`
+section with `Option<Database>`, while preserving the existing effective
+database dependency through the temporary v3-activation compatibility bridge.
+The post-activation follow-up drafted in this folder will make an omitted
+database suppress driver construction, database files, network connections, and
+migrations when no enabled capability requires persistence.
 
 The tracker must reject an invalid configuration at startup when an enabled
 persistence-backed capability requires a database but `[core.database]` is
@@ -82,14 +88,20 @@ inventoried.
 - Inventory direct and indirect dependencies on `tracker-core` persistence,
   including whitelist, torrent metrics, private-tracker keys, and management
   REST API operations.
-- Decide and document startup validation for every enabled capability that
-  requires persistence.
+- Prepare the bootstrap validation design for every enabled capability that
+  requires persistence; the post-activation follow-up implements it when
+  bootstrap receives the actual v3 `Option<Database>`.
 - Preserve the all-or-nothing schema lifecycle: once any enabled capability
   requires persistence, initialize the selected database and apply the complete
-  shared migration set. Do not create feature-specific database schemas or
-  feature-specific migration streams.
-- Decide and document the management REST API contract when persistence is
-  unavailable.
+  shared migration set. Feature configuration controls code behavior, not
+  schema fragments: do not create feature-specific database schemas,
+  feature-specific migration streams, or feature-specific migration selection.
+- Prepare optional persistence dependencies needed by the management REST API.
+  The post-activation follow-up keeps it persistence-required; API #144 later
+  makes it available without persistence and adds explicit
+  configuration-disabled direct-route responses.
+- Prepare a future persistence-awareness EPIC draft for remaining metric
+  provenance and broader persistence-decoupling behavior.
 - Define the implementation, regression coverage, migration documentation, and
   operational verification required by the approved solution.
 - Determine whether the change must precede #1980 and v3 activation; update
@@ -129,21 +141,30 @@ The final design must make an absent database configuration a startup
 configuration error whenever an enabled capability needs persistence. The exact
 capability inventory and validation location remain Phase 1 and Phase 2 work.
 
-The expected mechanism is a configuration-consistency rule in
-`packages/configuration/src/validator.rs`, invoked during bootstrap before
-`AppContainer` construction. The existing precedent is
-`UselessPrivateModeSection`: `[core.private_mode]` is rejected unless
-`core.private = true`. This issue must use that layer only if the approved
-database requirement is a relationship between configuration options; it must
-not use it for field-local parsing or value invariants.
+The working Phase 2 direction is one reusable bootstrap-owned
+application-composition validation step. Issue #999 implements and unit-tests
+it, owning the feature-to-database requirement matrix exactly once; the same
+rules must not be duplicated in `packages/configuration::Validator`. The
+post-#1980 activation follow-up invokes it after v3 configuration loading and
+before `AppContainer` construction, once bootstrap receives actual
+`Option<Database>` rather than the temporary bridge.
+The management REST API does not require persistence in the target architecture.
+However, the approved HTTP 409 configuration-disabled response contract is
+deferred to next-major REST API work in GitHub issue #144. Until that work is
+implemented, `http_api` remains persistence-required in the activation
+follow-up; it must not reinterpret intentionally absent persistence as an
+operational database failure.
+
+The initial persistence-required capabilities are `core.listed`, `core.private`,
+and `core.tracker_policy.persistent_torrent_completed_stat`. If implementation
+finds another persistence-required capability, it must be added to the one
+centralized bootstrap matrix and its focused tests rather than checked ad hoc
+by a repository, route, or feature.
 
 The implementation must keep feature-to-database requirements explicit at the
 application boundary. It must not distribute optional-database checks through
 repositories or feature implementation code, where a missed call site could
-become a delayed runtime failure. Phase 2 will decide whether the bootstrap
-rule is implemented through the configuration-consistency validator or a
-bootstrap-owned validation step, based on the documented validation-layer
-policy and the final configuration model.
+become a delayed runtime failure.
 
 - Related ADRs:
   `docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md`.
@@ -154,14 +175,14 @@ policy and the final configuration model.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                           | Notes / Expected Output                                                                                                 |
-| --- | ------ | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Complete persistence analysis                  | Populate `analysis.md` with evidence for the current lifecycle, all consumers, and driver-specific migration behaviour. |
-| T2  | TODO   | Approve an optional-persistence design         | Populate `solution.md` with the selected v3 contract, validation, API behaviour, compatibility, and ordering decision.  |
-| T3  | TODO   | Implement optional v3 database configuration   | Apply only the Phase 2-approved design; do not change v2.                                                               |
-| T4  | TODO   | Add regression coverage                        | Cover absent and present database configurations, required-feature validation, migrations, and REST API behaviour.      |
-| T5  | TODO   | Update migration and operational documentation | Explain the v2-to-v3 difference and any changed deployment requirements.                                                |
-| T6  | TODO   | Verify and re-review                           | Run required automatic and manual checks; update acceptance evidence.                                                   |
+| ID  | Status | Task                                           | Notes / Expected Output                                                                                                    |
+| --- | ------ | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Complete persistence analysis                  | `analysis.md` records current lifecycle, all discovered consumers, REST coupling, and driver-specific migration behaviour. |
+| T2  | DONE   | Approve an optional-persistence design         | `solution.md` records the approved v3 contract, validation, API deferrals, compatibility bridge, and staged ordering.      |
+| T3  | TODO   | Implement optional v3 database configuration   | Apply only the Phase 2-approved design; do not change v2.                                                                  |
+| T4  | TODO   | Add regression coverage                        | Cover absent and present database configurations, required-feature validation, migrations, and REST API behaviour.         |
+| T5  | TODO   | Update migration and operational documentation | Explain the v2-to-v3 difference and any changed deployment requirements.                                                   |
+| T6  | TODO   | Verify and re-review                           | Run required automatic and manual checks; update acceptance evidence.                                                      |
 
 ## Progress Tracking
 
@@ -171,7 +192,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Spec-only branch created
 - [x] Folder-based specification scaffold created
 - [x] Spec reviewed and approved by user/maintainer
-- [ ] Spec-only PR merged into `develop`
+- [x] Spec-only PR merged into `develop` (#2094, merge commit `7aad6e79`)
 - [ ] Phase 1 and Phase 2 analysis-and-solution PR merged
 - [ ] Phase 3 implementation PR merged
 - [ ] Automatic verification completed
@@ -186,6 +207,81 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
   the analysis-and-solution work precedes implementation.
 - 2026-08-25 00:00 UTC - User - Approved the specification for the spec-only
   PR.
+- 2026-08-25 00:00 UTC - GitHub Copilot - Completed Phase 1 evidence in
+  `analysis.md`: active v2/v3 configuration status, unconditional driver and
+  migration lifecycle, container side effects, persistence consumers, REST API
+  routes, validation layering, and Phase 2 questions. No runtime behavior or
+  solution decision changed.
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Recorded a working Phase 2
+  direction in `solution.md`: initial v3 persistence-free operation is limited
+  to deployments without listing, private keys, persistent completed metrics,
+  or the management REST API; bootstrap owns one requirement check; a future
+  persistence-awareness EPIC owns wider API and metric semantics. Explicit
+  Phase 2 approval remains required.
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Corrected the working direction:
+  the management REST API remains available without persistence. Phase 3 must
+  make its construction persistence-aware, return configuration-disabled
+  responses for direct disabled capabilities, and make metric history explicit.
+  Added draft ADR and future-EPIC artifacts for refinement during Phase 3.
+- 2026-08-25 00:00 UTC - User - Approved v3 `Option<Database>` for the
+  persistence-free contract. The implementation must test versioned v3
+  configuration and v3-compatible composition before #1980 activates v3
+  production consumers; it must not activate v3 early solely for testing.
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Adopted staged activation:
+  #999 adds the v3 optional representation and optional container dependencies;
+  #1980 activates v3 with an explicit temporary database bridge; a small
+  follow-up then honors `None` at runtime and completes persistence-free
+  verification. Added the follow-up issue draft.
+- 2026-08-25 00:00 UTC - User - Approved bootstrap as the single validation
+  owner. Issue #999 implements and tests the reusable requirement matrix; the
+  post-#1980 follow-up invokes it when replacing the temporary bridge with the
+  actual v3 `Option<Database>` value.
+- 2026-08-25 00:00 UTC - User - Approved the initial persistence-required
+  capability matrix: listing, private mode, and persistent completed metrics.
+  Any implementation discovery must extend the same centralized matrix and
+  tests, not introduce a feature-local missing-database check.
+- 2026-08-25 00:00 UTC - User - Approved `PersistenceRequirementError` with
+  one diagnostic per persistence-required capability. Approved the desired REST
+  configuration-disabled contract (HTTP 409, `ActionStatus::Err`, and a
+  distinct disabled-by-configuration error), but deferred its implementation
+  and historical-metric API changes to next-major REST API work in GitHub issue
+  #144. Until then, `http_api` remains persistence-required at activation.
+- 2026-08-25 00:00 UTC - User - Confirmed that session-versus-historical
+  response-field semantics are deferred to the REST API v2 subissue draft under
+  GitHub issue #144. The approved constraints remain no numeric sentinel and no
+  session-only value documented as lifetime history.
+- 2026-08-25 00:00 UTC - User - Approved the all-or-nothing persistence
+  lifecycle. Once persistence is present, initialize one driver and the full
+  shared schema; feature configuration controls code behavior only, not
+  conditional schema or migration fragments.
+- 2026-08-25 00:00 UTC - User - Approved the restart-only, non-destructive
+  persistence transition contract: disabling persistence leaves prior database
+  state untouched; re-enabling the same target reuses it; changing targets does
+  not transfer data automatically; data produced while disabled is not
+  recoverable.
+- 2026-08-25 00:00 UTC - User - Approved the container entrypoint contract:
+  defer persistence selection to actual v3 configuration, do not perform
+  persistence-specific setup when absent, and never destructively alter mounted
+  configuration or database state during transitions.
+- 2026-08-25 00:00 UTC - User - Approved `adr-draft.md` as the Phase 3 ADR
+  starting point. It must be copied to `docs/adrs/` with a timestamped filename
+  and reconciled with final code, tests, API contract, and review outcome.
+- 2026-08-25 00:00 UTC - User - Approved `persistence-awareness-epic-draft.md`
+  as the post-merge starting point. Reconcile it with merged #999, #1980,
+  persistence-free activation-follow-up, and API #144 work before creating the
+  GitHub EPIC.
+- 2026-08-25 00:00 UTC - User - Approved the staged #999 -> #1980 ->
+  persistence-free activation-follow-up ordering. EPIC #1978 and the v2-to-v3
+  migration guide record it. The activation-follow-up draft remains planning
+  only until #999/#1980 implementation evidence permits it to be refined and
+  opened.
+- 2026-08-25 00:00 UTC - User - Approved the Phase 3 implementation and
+  evidence sequence. The activation-follow-up draft records ownership across
+  #999, #1980, the later runtime activation, and API #144; do not create that
+  follow-up issue until preceding implementation evidence is reviewed.
+- 2026-08-25 00:00 UTC - User - Approved the complete Phase 2 design for the
+  analysis-and-solution PR. `solution.md` contains the approval record; Phase 3
+  implementation remains a separate delivery.
 
 ## Acceptance Criteria
 
@@ -250,22 +346,22 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                        |
-| ----- | ---------------------- | ----------------------------------------------- |
-| AC1   | TODO                   | `analysis.md` lifecycle inventory               |
-| AC2   | TODO                   | `analysis.md` consumer and API inventory        |
-| AC3   | TODO                   | `solution.md` approved contract                 |
-| AC4   | TODO                   | Implementation tests and M1 evidence            |
-| AC5   | TODO                   | Validation tests and M2 evidence                |
-| AC6   | TODO                   | REST API tests and M4 evidence                  |
-| AC7   | TODO                   | Driver/migration tests and M3 evidence          |
-| AC8   | TODO                   | EPIC and migration-document updates             |
-| AC9   | TODO                   | V2 compatibility tests/review                   |
-| AC10  | TODO                   | M5 evidence in `baseline-e2e-verification.md`   |
-| AC11  | TODO                   | M6 container-startup evidence                   |
-| AC12  | TODO                   | `linter all` output                             |
-| AC13  | TODO                   | Focused, relevant workspace, and M1–M6 evidence |
-| AC14  | TODO                   | Post-implementation acceptance review           |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                             |
+| ----- | ---------------------- | ---------------------------------------------------- |
+| AC1   | DONE                   | `analysis.md` lifecycle inventory                    |
+| AC2   | DONE                   | `analysis.md` consumer and API inventory             |
+| AC3   | DONE                   | `solution.md` approval record                        |
+| AC4   | TODO                   | Implementation tests and M1 evidence                 |
+| AC5   | TODO                   | Validation tests and M2 evidence                     |
+| AC6   | TODO                   | REST API tests and M4 evidence                       |
+| AC7   | TODO                   | Driver/migration tests and M3 evidence               |
+| AC8   | DONE                   | Approved staged ordering in EPIC and migration guide |
+| AC9   | TODO                   | V2 compatibility tests/review                        |
+| AC10  | TODO                   | M5 evidence in `baseline-e2e-verification.md`        |
+| AC11  | TODO                   | M6 container-startup evidence                        |
+| AC12  | TODO                   | `linter all` output                                  |
+| AC13  | TODO                   | Focused, relevant workspace, and M1–M6 evidence      |
+| AC14  | TODO                   | Post-implementation acceptance review                |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
@@ -1,0 +1,136 @@
+---
+status: approved-draft
+intended-destination: docs/adrs/
+related-issue: 999
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md
+---
+
+# Draft ADR - Make persistence an optional application-composition capability
+
+> **Approved Phase 2 draft:** Copy this artifact to `docs/adrs/` with its final
+> timestamped filename during Phase 3. Reconcile it with the implemented code,
+> tests, API contract, and review outcome before treating it as a final ADR.
+
+## Description
+
+The tracker historically supports an in-memory deployment, but the active v2
+runtime always constructs a database driver and applies the complete shared
+migration set during application-container initialization. The configuration
+can omit the v2 `[core.database]` TOML table only because it defaults to
+SQLite; the runtime cannot operate without persistence.
+
+Schema v3 makes the absence of `[core.database]` representable. The actual
+persistence-free runtime is delivered by the post-v3-activation follow-up:
+until then, bootstrap passes an explicit temporary database dependency to
+preserve current effective runtime behavior.
+
+The management REST API exposes both in-memory tracker information and direct
+persistence-backed capabilities. It must remain usable in a persistence-free
+deployment, without representing a disabled capability as an accidental
+database failure.
+
+## Agreement
+
+The v3 application treats persistence as an optional **application-composition
+capability**.
+
+1. `Option<Database>` represents configured persistence. An absent database
+   means persistence is unavailable by configuration.
+2. Issue #999 implements and unit-tests one reusable bootstrap-owned
+   persistence-requirement check. The activation follow-up invokes it after v3
+   configuration is loaded and before application-container construction, once
+   bootstrap receives actual `Option<Database>` rather than the temporary
+   compatibility bridge. The same feature-to-persistence matrix must not be
+   duplicated in repositories, route handlers, or
+   `packages/configuration::Validator`.
+3. Listing, private-mode keys, and persistent completed statistics require
+   configured persistence. If one is enabled without `[core.database]`, startup
+   fails with a diagnostic that names both the enabled capability and the
+   missing database configuration.
+4. When any capability requires persistence, bootstrap constructs one selected
+   driver and applies the complete shared migration set once. Feature-specific
+   schemas, migration streams, and migration selection are prohibited. Feature
+   configuration controls code behavior rather than database fragments.
+5. When no capability requires persistence, the activation follow-up's application composition constructs
+   only in-memory services and no persistence driver or migration side effect.
+6. The management REST API may start without persistence only after the
+   next-major API work tracked by GitHub issue #144 implements the approved
+   configuration-disabled response model. Until then, it remains
+   persistence-required at activation.
+7. The GitHub issue #144 API work must ensure fields do not silently present
+   session values as historical persisted values and must not use negative
+   numeric sentinels for unavailable history.
+8. Persistence configuration is evaluated at process startup only. Disabling
+   persistence never deletes or alters prior database state; re-enabling the
+   same target reuses it, and changing targets never transfers data
+   automatically.
+9. The container entrypoint defers persistence selection to actual v3
+   configuration. It does not require or default a database driver when
+   persistence is absent, and it never destructively alters mounted state
+   during a persistence transition.
+
+## Alternatives Considered
+
+### Keep a mandatory database in v3
+
+Rejected. It abandons the tracker’s explicit in-memory deployment capability
+and preserves unconditional persistence coupling.
+
+### Make persistence optional but let consumers fail when accessed
+
+Rejected. It makes configuration errors delayed runtime failures and spreads
+feature-to-persistence knowledge across consumers.
+
+### Make the REST API require persistence
+
+Rejected as the target architecture, but retained as a temporary activation
+constraint until GitHub issue #144 provides the compatibility-breaking REST
+response-model changes.
+
+### Duplicate the capability matrix in configuration validation and bootstrap
+
+Rejected. Two owners would drift as services and configuration evolve.
+Bootstrap is the application-composition boundary that knows which services are
+being constructed.
+
+## Consequences
+
+- **Positive:** #999 separates optional representation/container dependencies
+  from the later runtime behavior change, allowing #1980 to activate v3 first.
+- **Positive:** After the activation follow-up, public UDP/HTTP tracker
+  services can run without a database when persistence-backed capabilities are
+  disabled. The management API joins that mode only after API #144 implements
+  its approved next-major contract.
+- **Positive:** Missing persistence is detected deterministically before driver
+  construction rather than through a late repository failure.
+- **Positive:** The shared-schema lifecycle stays simple: zero drivers in
+  persistence-free mode, exactly one driver and complete migrations otherwise.
+- **Positive:** Future features avoid conditional schema upgrade and
+  compatibility paths even when their current persistence tables look
+  independent.
+- **Positive:** Operators can change persistence configuration without risking
+  automatic data deletion or unexpected cross-driver migration.
+- **Negative:** Application containers, REST API composition, route behavior,
+  response models, test helpers, and the container entrypoint require changes.
+- **Negative:** Some API consumers may need to adapt to explicit
+  configuration-disabled or historical-data-unavailable semantics.
+- **Negative:** State produced during a persistence-free interval is not
+  recoverable when persistence is later re-enabled.
+
+## Date
+
+Approved as a draft on 2026-08-25; finalize during Issue #999 Phase 3.
+
+## References
+
+- Issue #999
+- Configuration-overhaul EPIC #1978
+- `docs/issues/open/999-1978-optional-database-configuration/analysis.md`
+- `docs/issues/open/999-1978-optional-database-configuration/solution.md`
+- `docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md`
+- GitHub issue #144

--- a/docs/issues/open/999-1978-optional-database-configuration/analysis.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/analysis.md
@@ -2,6 +2,8 @@
 semantic-links:
   related-artifacts:
     - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+    - docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md
     - packages/tracker-core/
     - packages/configuration/src/v2_0_0/
     - packages/configuration/src/v3_0_0/
@@ -10,84 +12,331 @@ semantic-links:
 
 # Phase 1 - Persistence dependency analysis
 
-## Purpose
+## Scope and evidence status
 
-Establish evidence for the current persistence lifecycle and every dependency
-that assumes a database exists. This phase must not select the implementation
-solution or change runtime behaviour.
+This document records **verified current-state facts** as of the Phase 1
+analysis branch. It does not select an optional-persistence design, change a
+runtime contract, or decide whether #999 blocks #1980. The current runtime
+uses schema v2 aliases; the v3 types are present but are not yet handed to the
+application runtime. See `packages/configuration/src/lib.rs` and #1980's
+consumer migration map.
 
-## Required Investigation
+The pre-implementation reproduction remains preserved in
+[`baseline-e2e-verification.md`](baseline-e2e-verification.md): the v2 UDP
+benchmark configuration starts with a 49,152-byte SQLite file and the complete
+shared schema even with the known persistence features disabled.
 
-### Configuration and startup lifecycle
+## Configuration and startup lifecycle
 
-- Trace how v2 configuration currently requires and supplies database settings.
-- Trace v3 `Core.database` parsing, defaults, and all v3-to-runtime handoff
-  paths planned under #1980.
-- Locate each database-driver construction path and identify its owner.
-- Locate each migration invocation and determine whether it is coupled to
-  construction, connection, or an explicit bootstrap operation.
-- Inspect `share/container/entry_script_sh`, the container image, and related
-  configuration/install paths. Record directory creation, default-database
-  installation, required database-driver environment variables, and any other
-  database side effect before the tracker process starts.
-- Reconcile the source-level lifecycle findings with the baseline end-to-end
-  evidence in `baseline-e2e-verification.md`.
-- Trace the configuration-consistency validation path from
-  `packages/configuration/src/validator.rs` through `Configuration::validate()`
-  and bootstrap. Record whether each database requirement is expressible as a
-  cross-field configuration rule or instead needs runtime/environment
-  validation.
-- Record separate SQLite, MySQL, and PostgreSQL behaviour, including file or
-  connection side effects and migration preconditions.
+### Active v2 configuration
 
-### Persistence consumer inventory
+#### Verified facts
 
-For every consumer, record the source location, enablement condition, repository
-or service dependency, startup dependency, runtime failure mode, and tests.
+- `packages/configuration/src/lib.rs` aliases `Configuration`, `Core`, and
+  `Database` to `v2_0_0`. `src/bootstrap/config.rs` loads that alias, so this
+  is the active runtime contract.
+- `packages/configuration/src/v2_0_0/core.rs`, `Core::database`, is a
+  non-optional Rust field with `#[serde(default = "Core::default_database")]`.
+  `packages/configuration/src/v2_0_0/database.rs`, `Database::default`, uses
+  SQLite and `./storage/tracker/lib/database/sqlite3.db`.
+- Thus v2 does not require an explicitly written `[core.database]` TOML table:
+  omission resolves to the SQLite default. It remains an unconditional runtime
+  database requirement because `TrackerCoreContainer::initialize_from` always
+  initializes it. The reconciled baseline missing-database control records the
+  same distinction and does not claim an omitted v2 section is a parse error.
+- `v2_0_0::Configuration::load` first selects full TOML from
+  `TORRUST_TRACKER_CONFIG_TOML`, else the file named by
+  `TORRUST_TRACKER_CONFIG_TOML_PATH`, else bootstrap's
+  `share/default/config/tracker.development.sqlite3.toml`. It merges
+  `TORRUST_TRACKER_CONFIG_OVERRIDE_` variables split on `__` before joining
+  Rust defaults. Database overrides include
+  `CORE__DATABASE__DRIVER` and `CORE__DATABASE__PATH`.
+- V2 mandatory source values are `metadata.schema_version`,
+  `logging.threshold`, `core.private`, and `core.listed`; database settings
+  are supplied by defaults when absent. Sources:
+  `packages/configuration/src/v2_0_0/mod.rs`, `Configuration::load` and
+  `check_mandatory_options`.
 
-| Domain / consumer                     | Enablement configuration | Persistence operations | REST API coupling | Findings |
-| ------------------------------------- | ------------------------ | ---------------------- | ----------------- | -------- |
-| Whitelist                             | TODO                     | TODO                   | TODO              | TODO     |
-| Torrent completion metrics            | TODO                     | TODO                   | TODO              | TODO     |
-| Private-tracker keys                  | TODO                     | TODO                   | TODO              | TODO     |
-| Other direct `tracker-core` consumers | TODO                     | TODO                   | TODO              | TODO     |
-| Indirect consumers and jobs           | TODO                     | TODO                   | TODO              | TODO     |
+### Dormant v3 configuration and #1980 handoff
 
-The consumer inventory identifies requirements; it is not a plan to create
-independent schemas or migration streams. The tracker has one small shared
-persistence schema. Phase 1 must confirm every migration invocation, but the
-working constraint is all or nothing: no required consumers means no driver and
-no migrations; one or more required consumers means one initialized driver and
-the complete migration set.
+#### Verified facts
 
-### Management REST API inventory
+- `packages/configuration/src/v3_0_0/core.rs`, `Core::database`, is presently
+  non-optional and defaults to `Database::default()`.
+- `packages/configuration/src/v3_0_0/database.rs` defines the driver-specific
+  `Database::{Sqlite3 { path }, MySQL(ConnectionInfo), PostgreSQL(ConnectionInfo)}`.
+  SQLite defaults its path; MySQL and PostgreSQL require `host`, `user`, a
+  non-empty secret `password`, and `database`, with ports defaulting to 3306
+  and 5432 respectively. Driver-incompatible and unknown fields are rejected.
+- V3's loader uses the same TOML selection and override prefix. It removes
+  `core.database` from Figment defaults before extraction, avoiding accidental
+  merging of a default SQLite path with a supplied network-driver table.
+  Sources: `v3_0_0/mod.rs`, `Configuration::load` and `defaults_for_loading`.
+- V3 is **not** runtime-compatible with current database setup:
+  `packages/tracker-core/src/databases/setup.rs`, `initialize_database`, reads
+  `config.database.driver` and `.path`, members only on v2's `Database`.
+  No v3-to-runtime adapter exists. #1980 explicitly assigns migration of
+  `src/bootstrap/`, `src/container.rs`, tracker-core, protocol packages, test
+  helpers, examples, benchmarks, and the qBittorrent E2E builder to its
+  consumer migration work. Configuration defaults require a separate
+  compatibility review if the approved v3 optional-database contract changes
+  them.
 
-For every route that reads or writes a persistence-backed domain, record the
-route, authorization policy, feature dependency, current response when the
-underlying domain is unavailable, and desired contract candidates. Do not decide
-the final response in this phase.
+### Driver construction and migrations
 
-| Route / operation | Domain | Current dependency path | Current unavailable behaviour | Evidence |
-| ----------------- | ------ | ----------------------- | ----------------------------- | -------- |
-| TODO              | TODO   | TODO                    | TODO                          | TODO     |
+#### Verified lifecycle
 
-### Compatibility and activation inventory
+```text
+src/app.rs::run
+  -> bootstrap::app::setup
+  -> AppContainer::initialize
+  -> TrackerCoreContainer::initialize_from
+  -> databases::setup::initialize_database
+  -> selected driver construction + create_database_tables
+  -> app::start loads enabled persisted state and starts jobs
+```
 
-- Confirm that v2 must remain unchanged and continues requiring a database.
-- Identify every default configuration, helper, example, benchmark, E2E setup,
-  and deployment document that will be affected if v3 `Core.database` becomes
-  optional.
-- Identify container entrypoint changes needed to support a no-persistence v3
-  deployment without requiring a database-driver environment variable or
-  installing a default SQLite database.
-- Identify the concrete #1980 consumer-migration tasks that may need to depend
-  on this issue.
+- `src/bootstrap/app.rs::setup` loads configuration, calls
+  `Configuration::validate()`, initializes logging, and then awaits
+  `AppContainer::initialize`.
+- `packages/tracker-core/src/container.rs::TrackerCoreContainer::initialize_from`
+  unconditionally calls `initialize_database` before constructing its
+  whitelist, keys, metrics, torrent, announce, and scrape services.
+- The production `AppContainer::tracker_http_api_container` reuses that
+  prebuilt tracker-core container. Separately,
+  `packages/rest-api-runtime-adapter/src/v1/container.rs`,
+  `TrackerHttpApiCoreContainer::initialize`, constructs a new
+  `TrackerCoreContainer` and consequently performs the same database
+  initialization and migration lifecycle. This latter path is used by REST
+  server/test construction (`packages/axum-rest-api-server/src/server.rs` and
+  `src/bootstrap/jobs/tracker_apis.rs` tests), not the main application startup.
+- `initialize_database` creates one concrete driver, immediately calls
+  `SchemaMigrator::create_database_tables()`, then exposes that one driver as
+  narrow `SchemaMigrator`, `TorrentMetricsStore`, `WhitelistStore`, and
+  `AuthKeyStore` trait objects in `DatabaseStores`. It uses `expect`; malformed
+  connection input, unavailable network database, authentication/DDL failure,
+  or migration failure is a startup panic.
+- SQLite (`driver/sqlite/mod.rs`) uses lazy SQLx pooling with
+  `SqliteConnectOptions::filename(...).create_if_missing(true)`. The immediate
+  migration query causes a configured missing file to be created at startup.
+- MySQL (`driver/mysql/mod.rs`) parses the v2 DSN with
+  `MySqlConnectOptions::from_str`; PostgreSQL (`driver/postgres/mod.rs`) uses
+  `PgConnectOptions::from_str`. Both pools are lazy, but the immediate migration
+  requires a reachable database server at startup.
+- All drivers embed and apply their full backend migration set through
+  `migrations/{sqlite,mysql,postgresql}`. SQLx records applied migrations in
+  `_sqlx_migrations`; repeated completed runs are idempotent. SQLite and MySQL
+  schema migrators contain legacy pre-v4 bootstrap logic, including rejection
+  of partially migrated legacy schemas. PostgreSQL runs embedded migrations
+  directly because its schema migrator documents no pre-v4 PostgreSQL legacy
+  database. Sources: the three driver `schema_migrator.rs` files and
+  `packages/tracker-core/migrations/`.
 
-## Evidence Requirements
+### Container lifecycle
 
-- Link source paths, tests, logs, or focused experiment results for every
-  finding.
-- Distinguish verified findings from hypotheses.
-- Record contradictory evidence and unresolved questions explicitly.
-- Update `solution.md` only after this document provides enough evidence to
-  evaluate the alternatives.
+#### Verified facts
+
+- `Containerfile` supplies
+  `TORRUST_TRACKER_CONFIG_OVERRIDE_CORE__DATABASE__DRIVER=sqlite3` and uses
+  `share/container/entry_script_sh` as the entrypoint. Its tester image creates
+  a packaged empty SQLite file with `sqlite3 ... "VACUUM;"`.
+- Before executing the tracker, `entry_script_sh` unconditionally creates
+  `/var/lib/torrust/tracker/database/` and `/etc/torrust/tracker/`, applies
+  ownership and mode changes, and exits if the driver override is absent.
+- It selects a SQLite, MySQL, or PostgreSQL default config from the driver
+  override. For SQLite it also selects the packaged empty database. `inst`
+  installs only when the target does not exist, so mounted prior config/database
+  files persist across later starts; changing only the driver variable does not
+  replace them.
+- The v2 container configs are
+  `tracker.container.{sqlite3,mysql,postgresql}.toml`; each includes a v2
+  database contract. SQLite uses the container database path; MySQL and
+  PostgreSQL use DSNs. Therefore the entrypoint has independent persistence
+  side effects before application configuration validation.
+
+## Persistence-consumer inventory
+
+The following requirements are **facts about current behavior**, not Phase 2
+decisions. All persistence objects are currently constructed before any feature
+condition is inspected.
+
+### Whitelist
+
+- **Enabled by:** `core.listed`, which controls announce and scrape enforcement.
+- **Dependency path:** `DatabaseStores.whitelist_store` ->
+  `DatabaseWhitelist` -> `WhitelistManager`.
+- **Current behavior:** writes persist before in-memory mutation; a store
+  failure returns a database error.
+- **Startup and tests:** `src/app.rs::load_whitelisted_torrents` reads the
+  database only when listed, although the service is always constructed. See
+  `whitelist/repository/persisted.rs` and `whitelist/manager.rs` tests.
+- **REST API coupling:** direct add, remove, and reload routes, not gated by
+  `core.listed`; see the route inventory below.
+
+### Private-tracker keys
+
+- **Enabled by:** `core.private`, which controls authentication.
+- **Dependency path:** `auth_key_store` -> `DatabaseKeyRepository` ->
+  `KeysHandler`.
+- **Current behavior:** add, generate, and remove persist before in-memory
+  mutation. Store errors are returned; no in-memory-only fallback exists.
+- **Startup and tests:** `load_peer_keys` reads only when private, although the
+  service is always constructed. See `authentication/handler.rs` and
+  `authentication/key/repository/persisted.rs` tests.
+- **REST API coupling:** direct key add, generate, delete, and reload routes,
+  not gated by `core.private`; see the route inventory below.
+
+### Persistent completed metrics
+
+- **Enabled by:** `core.tracker_policy.persistent_torrent_completed_stat`.
+- **Dependency path:** `torrent_metrics_store` ->
+  `DatabaseDownloadsMetricRepository`.
+- **Current behavior:** the announce path conditionally loads a torrent's
+  completed count. Completion handling reads, then inserts or updates, both a
+  per-torrent count and the aggregate count.
+- **Startup and tests:** `load_torrent_metrics` restores only the global
+  aggregate metric when enabled. `TorrentsManager::load_torrents_from_database`
+  has no production startup call; `AnnounceHandler` lazily loads a per-torrent
+  count on its first announce. Pre-load errors propagate, while event write
+  failures are logged and processing continues. See persistence/restart cases
+  in `tracker-core/tests/integration.rs` and
+  `statistics/persisted/downloads.rs`.
+- **REST API coupling:** indirect only. Torrent, stats, and metrics routes read
+  in-memory values that may have been seeded from persistence.
+
+### In-memory torrent, swarm, and usage metrics
+
+- **Enabled by:** `tracker_usage_statistics` controls some jobs, but does not
+  alone require persistence.
+- **Dependency path:** `InMemoryTorrentRepository`, the swarm registry, and
+  metric repositories have no database constructor dependency.
+- **Current behavior:** a torrent can receive a persisted completed count only
+  when persistent completion metrics are enabled. `torrent_cleanup` and
+  activity jobs are in-memory. `tracker_core_event_listener` starts when usage
+  statistics **or** persistent completion metrics are enabled; only the latter
+  causes persistence writes.
+- **REST API coupling:** torrent, stats, and metrics routes do not directly
+  query the database.
+
+### REST management service
+
+- **Enabled by:** `http_api.is_some()`.
+- **Dependency path:** API construction receives the already-created
+  `TrackerCoreContainer`; it has no unavailable-store representation.
+- **Startup:** `src/app.rs::start_the_http_api` runs after unconditional
+  database creation.
+- **Persistence coupling:** direct persistence routes are always assembled
+  while the API is enabled.
+
+Other direct `initialize_database` callers identified by exact search are
+test helpers, repository/manager tests, protocol tests and benchmarks, and the
+explicit `packages/persistence-benchmark` tool. They are not production
+application construction paths. `TrackerHttpApiCoreContainer::initialize` is
+the additional REST server/test construction path described above. Main
+production construction is the container lifecycle above.
+
+`packages/test-helpers/src/configuration.rs::ephemeral_configuration` always
+provisions an ephemeral SQLite database and assigns its path to the v2 core
+configuration. Its public, private, and listed helpers derive from that base.
+Consequently, these test environments—including REST API environments—exercise
+configured SQLite even when their feature flag is disabled; they do not provide
+coverage for absent persistence.
+
+## Management REST API inventory
+
+### Shared API facts
+
+`http_api` is optional, but when present `src/app.rs::start_the_http_api`
+constructs `TrackerHttpApiCoreContainer` from the full tracker-core container.
+`packages/axum-rest-api-server/src/routes.rs` applies the shared token
+middleware to v1 routes. `v1/middlewares/auth.rs` accepts Bearer or query-token
+authentication (header wins); configured tokens have equal privilege. This is
+the current authorization policy, not a persistence feature gate.
+
+In the active v2 runtime, a database driver and its shared schema are always
+initialized before the REST API starts. Therefore, the existing database-error
+handling on direct whitelist and key routes is a defense against a configured
+database becoming unavailable or failing after startup; it is not behavior for
+an omitted database configuration. That state is not representable in the
+current application.
+
+| Route / operation                                         | Domain                             | Current dependency path                                                                          | Current unavailable behavior and evidence                                                                                                                                                                                                               |
+| --------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POST /api/v1/whitelist/{info_hash}`                      | Whitelist write                    | `WhitelistApiService` -> `TrackerWhitelistAdapter` -> `WhitelistManager` -> `DatabaseWhitelist`. | `WhitelistError::Database` becomes the existing generic failure response documented/tested as 500. No absent-persistence branch exists. Sources: `v1/context/whitelist/{routes,handlers}.rs`, runtime adapter, application use case, and contract test. |
+| `DELETE /api/v1/whitelist/{info_hash}`                    | Whitelist write                    | Same manager/repository chain.                                                                   | Same generic database failure mapping; not gated by `core.listed`.                                                                                                                                                                                      |
+| `GET /api/v1/whitelist/reload`                            | Whitelist read                     | `WhitelistManager::load_whitelist_from_database`.                                                | Same database failure mapping; directly accesses persistence even when `core.listed` is false.                                                                                                                                                          |
+| `POST /api/v1/keys`                                       | Authentication-key write           | `AuthKeyApiService` -> `TrackerAuthKeyAdapter` -> `KeysHandler` -> `DatabaseKeyRepository`.      | `AuthKeyError::Database` follows the existing failure response path; no unavailable-store branch. Sources: `v1/context/auth_key/{routes,handlers}.rs`, adapter, use case, contract test.                                                                |
+| `POST /api/v1/key/{seconds_valid_or_key}`                 | Deprecated expiring-key generation | `KeysHandler::generate_expiring_peer_key` -> key repository.                                     | Existing generation failure response on database error; not gated by `core.private`.                                                                                                                                                                    |
+| `DELETE /api/v1/key/{seconds_valid_or_key}`               | Authentication-key deletion        | `KeysHandler::remove_peer_key` -> key repository.                                                | Existing failure response on database error; not gated by `core.private`.                                                                                                                                                                               |
+| `GET /api/v1/keys/reload`                                 | Authentication-key read            | `KeysHandler::load_peer_keys_from_database`.                                                     | Existing failure response on database error; directly accesses persistence even when `core.private` is false.                                                                                                                                           |
+| `GET /api/v1/torrent/{info_hash}`, `GET /api/v1/torrents` | Torrent reads                      | In-memory torrent repository.                                                                    | No handler database access. A completed count can have originated from persistence when that feature is enabled. Sources: `v1/context/torrent/*` and adapter/tests.                                                                                     |
+| `GET /api/v1/stats`, `GET /api/v1/metrics`                | Statistics reads                   | In-memory metric repositories.                                                                   | No handler database access. The completed metric may be seeded or updated by persistence-backed completion metrics. Sources: `v1/context/stats/*` and adapter/tests.                                                                                    |
+
+The whitelist and auth-key contract tests force database failures by dropping
+schema tables through `packages/axum-rest-api-server/tests/server/mod.rs`,
+`force_database_error`. They test a configured-but-failing database, not an
+absent database configuration.
+
+**Phase 2 constraints evidenced by this inventory:** direct persistence routes
+are currently built independently of `listed` and `private`, and the code only
+represents a database that succeeds or fails. An absent database must therefore
+be represented or excluded deliberately before runtime activation; final route
+availability and status semantics are not selected here.
+
+## Validation-layer and activation compatibility inventory
+
+### Current validation path
+
+- `packages/configuration/src/validator.rs` defines the cross-field
+  `Validator` trait and presently only
+  `SemanticValidationError::UselessPrivateModeSection`.
+- Both `v2_0_0::Core::validate` and `v3_0_0::Core::validate` reject a supplied
+  `private_mode` section when `private` is false. Each version's
+  `Configuration::validate` delegates to `Core::validate`.
+- `src/bootstrap/app.rs::setup` invokes `configuration.validate()` before
+  `AppContainer::initialize` and therefore before driver construction.
+- The validation-layer ADR classifies a database requirement induced by
+  `core.private`, `core.listed`, or
+  `core.tracker_policy.persistent_torrent_completed_stat` as a **cross-field
+  configuration relationship** if the final model needs only those settings.
+  Database reachability, DDL permission, filesystem access, and credentials
+  remain **runtime/environment facts**. No new rule is selected in Phase 1.
+
+### #1980 and v3 activation surfaces
+
+The #1980 consumer migration map identifies all runtime users of configuration
+types, including `src/app.rs`, `src/container.rs`, bootstrap, tracker-core
+database setup and protocol consumers, REST adapter container, test helpers,
+examples, benchmarks, and the qBittorrent E2E builder. Its T1/T9/T10 tasks and
+the v2-to-v3 migration guide are affected by any approved v3 optional-database
+contract. `share/default/config/`, `docs/containers.md`, container defaults,
+and the entrypoint also need a later compatibility review because they currently
+encode or install the v2 database lifecycle.
+
+**Unresolved Phase 2 question:** #1980 is the planned runtime activation point,
+but Phase 1 does not decide whether v3 optional database configuration must be
+implemented before that migration. The decision requires maintainer approval of
+the v3 contract and the direct REST API behavior above.
+
+## Reconciliation and unresolved questions
+
+1. The baseline result is consistent with source: an unconditional call to
+   `initialize_database` runs before any persistence feature condition, and
+   SQLite migration activates `create_if_missing`.
+2. The one shared migration lifecycle is already enforced by one driver object
+   exposed as all narrow stores; Phase 1 found no feature-specific schema or
+   migration stream.
+3. Confirm the staged direction in `solution.md`: #999 adds `Option<Database>`
+   and optional container dependencies, while the active bootstrap deliberately
+   supplies a temporary `Some(Database)` bridge.
+4. Confirm the initial capability matrix and exact diagnostics for the small
+   post-activation follow-up that replaces the bridge with actual v3
+   configuration.
+5. Define the container-entrypoint changes required by that follow-up for a
+   v3 persistence-free startup without its current driver variable, database
+   directory, or packaged SQLite install.
+6. Approve the ADR draft and refine it during Phase 3; retain the activation
+   follow-up and future persistence-awareness EPIC drafts for their respective
+   post-#1980 and post-#999 planning work.
+7. Confirm the staged #999 -> #1980 -> activation-follow-up ordering and update
+   EPIC #1978 and the v2-to-v3 migration guidance during Phase 2.

--- a/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md
@@ -42,9 +42,10 @@ remove_peerless_torrents = false
 
 ## Baseline result
 
-The current v2 configuration still requires `[core.database]`. With its SQLite
-section present, the tracker starts and creates a 49,152-byte SQLite database
-file despite the persistence settings above being disabled:
+The active v2 runtime unconditionally initializes a database. This baseline
+supplies an explicit SQLite section, and the tracker starts and creates a
+49,152-byte SQLite database file despite the persistence settings above being
+disabled:
 
 ```toml
 [core.database]
@@ -89,12 +90,19 @@ were applied.
 ## Missing-database control observation
 
 Removing `[core.database]` from the equivalent v2 benchmarking configuration
-does not provide a valid reproduction of the desired final state because v2
-still requires the section. In the current runtime, the process remains alive
-after configuration loading and provides no useful visible diagnostic at the
-`error` logging threshold before the ten-second timeout. This confirms why the
-implementation must preserve v2 behaviour and target v3 only; Phase 1 must
-trace the precise v2 construction and failure path separately.
+does not provide a valid reproduction of the desired final state. The v2
+`Core::database` field has a serde default, so the TOML section itself is not
+mandatory: omission resolves to the default SQLite configuration. The active
+runtime then still unconditionally constructs that default database and applies
+migrations before it evaluates feature enablement.
+
+In the recorded control run, the process remained alive after configuration
+loading and provided no useful visible diagnostic at the `error` logging
+threshold before the ten-second timeout. The control did not inspect the
+default database location, so it does not independently prove whether that
+location was created. This confirms why the implementation must preserve v2
+behaviour and target v3 only; Phase 1 traces the precise v2 construction path
+in `analysis.md`.
 
 ## Final implementation acceptance scenario
 

--- a/docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
@@ -1,0 +1,151 @@
+---
+doc-type: epic
+status: approved-draft
+intended-destination: docs/issues/drafts/
+github-issue: null
+related-issue: 999
+related-github-issue: 144
+last-updated-utc: 2026-08-25 00:00
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
+    - docs/issues/drafts/144-make-rest-api-persistence-aware.md
+---
+
+# Draft EPIC - Progressively make tracker capabilities persistence-aware
+
+> **Approved Phase 2 draft:** Refine this document against the merged #999,
+> Issue #1980, and persistence-free activation-follow-up implementations. Then
+> move it to `docs/issues/drafts/`, update the scope from final evidence, and
+> create the GitHub EPIC. Do not create it during #999 Phase 2 or Phase 3 unless
+> its scope becomes a blocker.
+
+## Goal
+
+Progressively remove implicit persistence assumptions from tracker capabilities
+after the explicit v3 persistence-free deployment is activated by the small
+post-#1980 follow-up drafted alongside #999.
+Every capability, API response, configuration option, and test fixture should
+make clear whether it needs persistence, uses session-only state, exposes
+historical state, or is unavailable by configuration.
+
+## Why This Is Needed
+
+Issue #999 introduces optional v3 representation and optional container
+dependencies. Its post-#1980 activation follow-up makes the tracker and
+public UDP/HTTP services run without a database. The management REST API
+remains persistence-required until the next-major API work under GitHub issue
+144 implements its approved disabled-capability contract. The existing system
+has broader historical coupling:
+
+- management routes currently assume persistence-backed whitelist and key
+  services exist;
+- completed metrics can represent session and persisted history differently;
+- torrent and statistics responses can expose in-memory values seeded from
+  persistence without explicitly identifying their provenance;
+- tests, examples, container artifacts, and deployment documentation often
+  provision SQLite by default.
+
+Those concerns require staged API, model, test, and operational changes. The
+next-major REST API compatibility work is drafted in
+`docs/issues/drafts/144-make-rest-api-persistence-aware.md` under GitHub issue 144. This EPIC must coordinate with it and must not delay the
+configuration-overhaul EPIC once #999 and its activation follow-up supply a
+safe persistence-free UDP/HTTP-tracker baseline.
+
+## Scope
+
+### In Scope
+
+- Make application and REST API composition explicitly capability-aware.
+- Standardize API behavior for a capability disabled by configuration.
+- Make session and historical metric semantics explicit in API models.
+- Expand persistence-free coverage across unit, integration, container, example,
+  benchmark, and operational paths.
+- Identify and remove remaining implicit persistence assumptions incrementally.
+
+### Out of Scope
+
+- Reverting the #999 v3 persistence-free boundary.
+- Changing v2 configuration behavior.
+- Creating separate feature-specific schemas or migration streams.
+- Requiring all possible persistence-related improvements to land in one PR.
+
+## Candidate Subissues
+
+These are intentionally detailed candidates, not yet-created GitHub issues.
+Refine ordering and boundaries after #999 merges, coordinating API contract
+work with GitHub issue #144.
+
+| Order | Candidate subissue                            | Problem to solve                                                                        | Expected outcome                                                                                    |
+| ----- | --------------------------------------------- | --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| 1     | Inventory remaining persistence assumptions   | #999 will identify a known baseline, but merged code/tests may reveal more assumptions. | Evidence-backed follow-up plan with ownership and priorities.                                       |
+| 2     | Standardize disabled-capability API responses | Routes should distinguish disabled-by-configuration from database operational failure.  | Shared response model/status policy and contract tests.                                             |
+| 3     | Refine REST capability composition            | Remove remaining direct route/service assumptions that a persistence store exists.      | Routes receive only the capability services they may use; disabled routes do not reach persistence. |
+| 4     | Define metric provenance                      | Current-process counters and restored historical values have different meanings.        | Explicit session/historical fields or metadata, no numeric sentinels.                               |
+| 5     | Define per-torrent completed semantics        | In-memory torrent counts can be lazily seeded from persisted counts.                    | Documented session versus lifetime semantics and compatible API model.                              |
+| 6     | Expand persistence-free test infrastructure   | Existing helpers commonly create SQLite regardless of capability configuration.         | Reusable no-database fixtures and focused regression coverage.                                      |
+| 7     | Audit operational artifacts                   | Examples, benchmarks, container paths, and docs may silently assume SQLite.             | Accurate deployment guidance and only intentional persistence setup.                                |
+
+## Delivery Strategy
+
+1. Start after #999 and the configuration-overhaul EPIC have merged or are no
+   longer affected by the work.
+2. Begin with an evidence refresh based on the merged #999 implementation.
+3. Establish one API contract for configuration-disabled capabilities before
+   changing individual routes.
+4. Deliver metric-provenance changes as explicitly versioned API work with
+   migration guidance where needed.
+5. Keep each subissue independently testable and avoid reintroducing feature
+   checks scattered through repositories.
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Draft created as a follow-up artifact for Issue #999.
+- [x] Draft approved as a post-merge starting point.
+- [ ] #999 implementation merged and draft reconciled with its final behavior.
+- [ ] #1980 and persistence-free activation follow-up merged and draft
+      reconciled with their final behavior.
+- [ ] Epic specification moved to `docs/issues/drafts/` and approved.
+- [ ] GitHub EPIC created and linked.
+- [ ] Candidate subissues refined, created, and linked.
+
+### Progress Log
+
+- 2026-08-25 00:00 UTC - GitHub Copilot/User - Created initial follow-up EPIC
+  draft while defining #999’s persistence-free v3 direction. The draft is not a
+  created GitHub issue and must not block #999 or #1980.
+- 2026-08-25 00:00 UTC - User - Approved this draft as the post-merge starting
+  point. Its scope must be reconciled with merged #999, #1980, activation, and
+  API #144 work before the GitHub EPIC is created.
+
+## Acceptance Criteria
+
+- [ ] The merged #999 implementation is the documented baseline for follow-up work.
+- [ ] Every remaining persistence assumption has an explicit disposition.
+- [ ] API semantics distinguish disabled capability, operational persistence
+      failure, session-only values, and historical values.
+- [ ] Persistence-free regression coverage does not silently provision SQLite.
+- [ ] Operational artifacts accurately describe optional persistence.
+
+## Risks and Trade-offs
+
+- **API compatibility:** More explicit metric semantics can require client
+  changes. Mitigation: version and document response-model changes deliberately.
+- **Scope growth:** Persistence touches several layers. Mitigation: maintain
+  small capability-focused subissues and an explicit order.
+- **Behavior drift:** Configuration-aware checks can be duplicated. Mitigation:
+  keep each capability decision at its composition boundary and cover it with
+  contract tests.
+
+## References
+
+- Related issues: #999, #144
+- Configuration-overhaul EPIC #1978
+- `docs/issues/open/999-1978-optional-database-configuration/analysis.md`
+- `docs/issues/open/999-1978-optional-database-configuration/solution.md`
+- `docs/issues/open/999-1978-optional-database-configuration/adr-draft.md`

--- a/docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
@@ -1,0 +1,122 @@
+---
+doc-type: issue
+status: draft
+intended-destination: docs/issues/drafts/
+github-issue: null
+related-issues:
+  - 999
+  - 1980
+last-updated-utc: 2026-08-25 00:00
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+---
+
+# Draft follow-up - Activate the v3 persistence-free runtime
+
+> **Approved planning draft:** Do not create this GitHub issue immediately.
+> After Issue #999 and Issue #1980 merge, refine this document against their
+> final implementation evidence and any newly discovered constraints. Then move
+> it to `docs/issues/drafts/`, obtain approval, and create the GitHub issue.
+> Create it earlier only if the staged compatibility bridge cannot remain small.
+
+## Goal
+
+Replace the temporary bootstrap `Some(Database)` compatibility bridge with the
+actual v3 `core.database: Option<Database>` value. A v3 tracker with no enabled
+persistence-backed capability and no `[core.database]` must run without a
+persistence driver, database file, network database connection, migration, or
+persistence-backed service.
+
+## Background
+
+Issue #999 makes the v3 database representation and container dependencies
+optional, but leaves an explicit temporary database dependency in bootstrap
+while the application still transitions from v2 aliases to v3 consumers. Issue
+1980 activates v3 consumers with that bridge in place. This follow-up changes
+the runtime behavior without changing the public v3 configuration shape.
+
+## Scope
+
+### In Scope
+
+- Use actual `v3_0_0::Core.database` at the bootstrap/container boundary.
+- Invoke the bootstrap-owned capability-to-persistence requirement check
+  implemented and unit-tested by Issue #999 before application-container
+  construction.
+- Reject enabled listing, private mode, or persistent completed metrics when no
+  database is configured.
+- Construct no persistence driver, stores, or migrations when persistence is
+  absent and no capability requires it.
+- Keep `http_api` persistence-required until the next-major REST API work in
+  GitHub issue #144 implements the approved HTTP 409 configuration-disabled
+  response model and historical metric semantics.
+- Update the container entrypoint so no-persistence v3 deployments do not
+  require a driver override, database directory, or packaged SQLite install.
+- Defer persistence selection to actual v3 configuration; do not retain a
+  separate entrypoint driver default or override that can contradict it.
+- Preserve operator-managed database state across configuration transitions:
+  never delete, overwrite, or migrate an unselected database target; do not
+  automatically transfer state between database drivers or locations.
+- Execute and record Issue #999 manual scenarios M1–M6.
+
+### Out of Scope
+
+- Changing v2 behavior.
+- Redesigning the complete REST API beyond the minimum persistence-free
+  contract.
+- Creating feature-specific schemas or migration streams.
+- The broader persistence-awareness work captured by
+  `persistence-awareness-epic-draft.md`.
+
+## Implementation Plan
+
+| ID  | Status | Task                                      | Notes                                                                                                                       |
+| --- | ------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Remove temporary bootstrap bridge         | Pass actual v3 `Option<Database>` to optional composition.                                                                  |
+| T2  | TODO   | Invoke bootstrap requirement validation   | Reuse the #999 implementation; do not duplicate its feature matrix.                                                         |
+| T3  | TODO   | Gate persistence composition              | No driver/stores/migrations in persistence-free mode.                                                                       |
+| T4  | TODO   | Preserve REST API persistence requirement | Do not attempt the #144 response-model redesign in this activation follow-up.                                               |
+| T6  | TODO   | Adapt container entrypoint                | Defer persistence to v3 config; permit no-persistence deployment without SQLite setup or destructive mounted-state changes. |
+| T7  | TODO   | Add regression coverage                   | Configuration, bootstrap, container, E2E, and restart-transition coverage.                                                  |
+| T8  | TODO   | Run M1–M6 and update docs                 | Record evidence in Issue #999 artifacts.                                                                                    |
+
+## Evidence ownership and sequence
+
+| Stage                           | Owner                    | Required evidence                                                                                                             | Follow-up handoff                                                                   |
+| ------------------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| V3 optional representation      | Issue #999 Phase 3       | V3 parsing tests prove omitted `[core.database]` is `None`; configured drivers retain their behavior.                         | Preserve the temporary bridge and document that runtime persistence remains active. |
+| Optional dependency composition | Issue #999 Phase 3       | Container/constructor tests prove optional persistence dependencies are accepted; bootstrap passes explicit `Some(Database)`. | Provide the reusable validation matrix and final ADR.                               |
+| V3 consumer activation          | Issue #1980              | Consumer migration activates v3 while retaining the temporary bridge.                                                         | Record that omitted database is not yet honored at runtime.                         |
+| Persistence-free runtime        | This follow-up           | Actual `None` reaches composition; no driver/migration artifacts; M1–M6 and transition/container evidence pass.               | Update Issue #999 acceptance evidence and finalize operational guidance.            |
+| Persistence-free REST API       | API #144 next-major work | Disabled direct routes use HTTP 409; historical/session semantics are explicit.                                               | Remove the temporary `http_api` persistence requirement after review.               |
+
+The exact issue is intentionally not created until the preceding #999/#1980
+implementation evidence is reviewed. Before it is opened, reconcile this draft
+with the merged code, replace assumptions with verified behavior, and identify
+any newly discovered persistence consumer in the centralized matrix.
+
+## Acceptance Criteria
+
+- [ ] Omitted v3 `[core.database]` is honored at runtime when no capability
+      requires persistence.
+- [ ] No persistence artifacts are created in the persistence-free scenario.
+- [ ] Each enabled persistence-backed capability fails startup clearly when the
+      database is absent.
+- [ ] The activation follow-up documents that `http_api` remains
+      persistence-required until GitHub issue #144 delivers the approved
+      next-major REST API contract.
+- [ ] The supported container path works without persistence configuration.
+- [ ] Disabling persistence on restart leaves the previously selected database
+      target unchanged; re-enabling the same target reuses its data and
+      migrations; changing targets does not copy data automatically.
+- [ ] Issue #999 M1–M6 evidence is completed.
+
+## References
+
+- Issue #999
+- Issue #1980
+- `docs/issues/open/999-1978-optional-database-configuration/solution.md`
+- `docs/issues/open/999-1978-optional-database-configuration/adr-draft.md`

--- a/docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
@@ -1,0 +1,65 @@
+---
+status: draft
+purpose: persistence-unavailable-scenario-catalog
+related-issue: 999
+related-github-issue: 144
+last-updated-utc: 2026-08-25 00:00
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/999-1978-optional-database-configuration/analysis.md
+    - docs/issues/open/999-1978-optional-database-configuration/solution.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
+      - docs/issues/drafts/144-make-rest-api-persistence-aware.md
+---
+
+# Persistence-unavailable scenario catalog
+
+> **Planning catalog:** This is a case log for Issue #999 and its follow-ups.
+> It distinguishes intentional absence of persistence from operational database
+> failure. Update it when implementation finds a new case; do not substitute it
+> for authoritative API contracts, tests, or issue specifications.
+
+## State vocabulary
+
+| State                | Meaning                                                                |
+| -------------------- | ---------------------------------------------------------------------- |
+| Persistence absent   | V3 `[core.database]` is omitted and the activation path honors `None`. |
+| Capability disabled  | A feature is intentionally off in configuration.                       |
+| Persistence required | An enabled capability needs a configured database.                     |
+| Operational failure  | A configured database fails after startup or during an operation.      |
+| Session-only data    | A value exists only for the current process lifetime.                  |
+| Historical data      | A value is restored from or maintained in persistence.                 |
+
+## Scenario catalog
+
+| ID  | Situation                                                                     | Required behavior                                                                                                                   | Delivery owner                                             | Status                    |
+| --- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------- |
+| S1  | `core.listed = true`, but persistence is absent                               | Bootstrap reports `ListedRequiresDatabase` before container or driver construction.                                                 | #999 implements/tests; activation follow-up invokes.       | Approved                  |
+| S2  | `core.private = true`, but persistence is absent                              | Bootstrap reports `PrivateRequiresDatabase` before container or driver construction.                                                | #999 implements/tests; activation follow-up invokes.       | Approved                  |
+| S3  | Persistent completed metrics enabled, but persistence is absent               | Bootstrap reports `PersistentTorrentCompletedStatRequiresDatabase` before container or driver construction.                         | #999 implements/tests; activation follow-up invokes.       | Approved                  |
+| S4  | No persistence-required capability is enabled, and persistence is absent      | Public UDP/HTTP tracker starts with no driver, file, connection, migration, or persistence stores.                                  | Activation follow-up.                                      | Planned                   |
+| S5  | Direct whitelist route called while listing is disabled                       | Do not attempt a database operation. Target contract: HTTP 409 plus `ActionStatus::Err` and `DisabledByConfiguration`.              | Draft `144-make-rest-api-persistence-aware.md`.            | Approved target; deferred |
+| S6  | Direct key route called while private mode is disabled                        | Do not attempt a database operation. Target contract: HTTP 409 plus `ActionStatus::Err` and `DisabledByConfiguration`.              | Draft `144-make-rest-api-persistence-aware.md`.            | Approved target; deferred |
+| S7  | A configured database fails during whitelist/key operation                    | Preserve operational database-failure behavior; do not report this as configuration-disabled.                                       | Existing behavior; review when API #144 changes responses. | Current                   |
+| S8  | Stats/torrent endpoint returns a current value with no historical persistence | Keep the endpoint available, but do not represent a session-only count as an undifferentiated lifetime count. No negative sentinel. | Draft `144-make-rest-api-persistence-aware.md`.            | Approved target; deferred |
+| S9  | Stats/torrent endpoint returns a value restored from persistence              | Represent historical/provenance semantics explicitly and consistently with S8.                                                      | Draft `144-make-rest-api-persistence-aware.md`.            | Approved target; deferred |
+| S10 | `http_api` configured before API #144 is delivered                            | Temporary activation constraint: require persistence; do not claim API works without it.                                            | Activation follow-up.                                      | Planned                   |
+| S11 | `http_api` configured after API #144 is delivered                             | API may start without persistence; direct disabled capabilities follow S5/S6.                                                       | API #144 work and later activation review.                 | Planned                   |
+| S12 | Operator restarts from persistence-enabled to persistence-free configuration  | Do not open, migrate, write, delete, or otherwise alter the previously selected database target.                                    | Activation follow-up and operational docs.                 | Approved                  |
+| S13 | Operator restarts from persistence-free to persistence-required configuration | Require a selected database; initialize its complete shared schema and reuse data if the target already exists.                     | Activation follow-up and operational docs.                 | Approved                  |
+| S14 | Operator changes database driver or location                                  | Initialize/migrate the new target; never copy or delete historical data automatically.                                              | Activation follow-up and operational docs.                 | Approved                  |
+| S15 | Container starts with persistence absent                                      | Do not require a driver override or install/create persistence-specific SQLite configuration, file, or directory.                   | Activation follow-up container work.                       | Approved                  |
+| S16 | Container starts with persistence configured                                  | Follow actual v3 configuration; retain non-destructive driver-specific setup only when selected.                                    | Activation follow-up container work.                       | Approved                  |
+
+## Rules for new discoveries
+
+1. Classify the new case using the state vocabulary.
+2. Add it here with source evidence and an owner.
+3. If it is a persistence-required capability, also add it to the centralized
+   bootstrap requirement matrix and focused tests.
+4. If it changes a public REST contract, coordinate it with
+   `docs/issues/drafts/144-make-rest-api-persistence-aware.md` and GitHub
+   issue #144.
+5. Never reuse an operational database error for an intentionally disabled
+   capability.

--- a/docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
@@ -9,7 +9,7 @@ semantic-links:
     - docs/issues/open/999-1978-optional-database-configuration/analysis.md
     - docs/issues/open/999-1978-optional-database-configuration/solution.md
     - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
-    - docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
+      - docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
       - docs/issues/drafts/144-make-rest-api-persistence-aware.md
 ---
 

--- a/docs/issues/open/999-1978-optional-database-configuration/solution.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/solution.md
@@ -18,11 +18,11 @@ Phase 1 evidence and the Phase 2 design are approved. The approved design is
 ready for the analysis-and-solution PR. Phase 3 implementation remains a
 separate delivery and must follow this approved contract.
 
-## Decision to Make
+## Approved decision
 
-Select a design that allows v3 `[core.database]` to be omitted when persistence
+The approved design allows v3 `[core.database]` to be omitted when persistence
 is unused, while rejecting startup if an enabled persistence-backed capability
-requires a database. The selected design must preserve v2 behaviour unchanged.
+requires a database. It preserves v2 behaviour unchanged.
 
 ## Approved design
 

--- a/docs/issues/open/999-1978-optional-database-configuration/solution.md
+++ b/docs/issues/open/999-1978-optional-database-configuration/solution.md
@@ -4,14 +4,19 @@ semantic-links:
     - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
     - docs/issues/open/999-1978-optional-database-configuration/analysis.md
     - docs/issues/open/1978-configuration-overhaul-epic/configuration-v2-to-v3-migration.md
+    - docs/issues/open/999-1978-optional-database-configuration/adr-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-awareness-epic-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md
 ---
 
 # Phase 2 - Optional persistence solution
 
 ## Status
 
-Pending Phase 1 evidence. Do not treat the preliminary direction below as an
-approved implementation decision.
+Phase 1 evidence and the Phase 2 design are approved. The approved design is
+ready for the analysis-and-solution PR. Phase 3 implementation remains a
+separate delivery and must follow this approved contract.
 
 ## Decision to Make
 
@@ -19,18 +24,56 @@ Select a design that allows v3 `[core.database]` to be omitted when persistence
 is unused, while rejecting startup if an enabled persistence-backed capability
 requires a database. The selected design must preserve v2 behaviour unchanged.
 
-## Candidate Direction
+## Approved design
 
 The expected configuration representation is `Option<Database>` on v3 `Core`.
-When absent, runtime construction must not create a driver, database file,
-network connection, or migration side effect. This remains subject to Phase 1:
-the analysis may identify a more suitable boundary or a prerequisite refactor.
+An omitted `[core.database]` table deserializes as `None`; configured drivers
+retain the existing v3 driver-specific representation.
 
-The performance objective is explicit: a public UDP tracker that enables none
-of the basic persistence-backed capabilities must run without a database. If at
-least one such capability is enabled, the selected database is a normal shared
-tracker dependency: initialize it once and apply the whole migration set. Do
-not design separate schemas or migration streams per feature.
+This issue prepares optional persistence at the configuration and
+application-container boundaries. While the crate-root runtime aliases remain
+v2, bootstrap deliberately passes `Some(Database)` to the optional container
+dependency. This preserves the existing effective database dependency during
+the v3 activation transition. It is a named, tested compatibility bridge—not
+the final persistence-free runtime behavior.
+
+### Test and activation sequencing
+
+V3 is not yet the globally active runtime configuration: that migration remains
+Issue #1980's responsibility. Issue #999 must not activate v3 merely to test
+this contract.
+
+Phase 3 must instead test the contract at two levels:
+
+1. **Versioned configuration tests:** construct and deserialize
+   `v3_0_0::Configuration` directly to prove that an omitted
+   `[core.database]` becomes `None` and that configured SQLite, MySQL, and
+   PostgreSQL variants retain their driver-specific behavior.
+2. **Optional-container tests:** exercise the container constructors with an
+   explicit persistence dependency and prove that the temporary bootstrap
+   bridge passes `Some(Database)` while v2 remains active. These tests confirm
+   the containers can receive `None`, but do not claim a persistence-free main
+   runtime yet.
+
+Issue #1980 activates v3 consumers using the temporary compatibility database
+dependency. A small follow-up issue, drafted in
+`persistence-free-runtime-activation-draft.md`, then replaces that explicit
+`Some(Database)` with the actual v3 `core.database` value, runs the capability
+requirement validation, and delivers the full persistence-free runtime
+guarantee. The final M1–M6 end-to-end evidence belongs to that follow-up.
+
+The intended activation-follow-up persistence-free deployment includes a public
+UDP tracker and/or public HTTP tracker. Listing, private mode, persistent
+completed statistics, and the management REST API remain disabled. The REST API
+can join a later persistence-free deployment only after API #144 implements its
+approved next-major contract. This deployment is the scope of the activation
+follow-up, not the effective runtime result of #999.
+
+This issue makes containers capable of representing absent persistence. The
+activation follow-up owns the minimum configuration-aware REST API behavior
+needed for persistence-free operation. The detailed drafts for the Phase 3 ADR,
+the activation follow-up, and a future persistence-awareness EPIC are in this
+issue folder.
 
 ## Required Solution Content
 
@@ -40,59 +83,185 @@ not design separate schemas or migration streams per feature.
 - Specify whether empty or partial database sections are rejected and how their
   errors are reported.
 - Define the v2-to-v3 migration guidance and confirm v2 remains unchanged.
+- Define the temporary explicit database bridge used through v3 activation and
+  the follow-up removal plan.
 
 ### Capability validation matrix
 
-For every persistence-backed capability identified in Phase 1, define its
-enablement condition and startup validation result when the database is absent.
+Issue #999 implements and unit-tests one reusable bootstrap-owned
+application-composition check. It is the **only** owner of the
+feature-to-persistence matrix; do not duplicate the rule in
+`packages/configuration::Validator`.
 
-| Capability | Enabled when | Database omitted result | Error text / code | Tests |
-| ---------- | ------------ | ----------------------- | ----------------- | ----- |
-| TODO       | TODO         | TODO                    | TODO              | TODO  |
+The active bootstrap path does not invoke this check while it deliberately
+passes the temporary `Some(Database)` bridge. The activation follow-up invokes
+the already-implemented check after v3 configuration loading and before
+`AppContainer` or `TrackerCoreContainer` construction, using the actual v3
+`Option<Database>` value.
 
-When a requirement depends only on the relationship between configuration
-options, implement it as a configuration-consistency rule through `Validator`
-and `SemanticValidationError`. The precedent is
-`UselessPrivateModeSection`, which rejects `[core.private_mode]` when
-`core.private` is false. Follow the validation-layer policy in
-`docs/adrs/20260723184019_separate_configuration_value_invariants_from_consistency_validation.md`:
-field-local constraints belong in typed deserialization, and filesystem,
-network, or deployment facts belong in runtime/environment validation.
+The configuration crate continues to validate field-local values and its own
+cross-field consistency. The persistence requirement is application policy: it
+depends on the services bootstrap constructs and may shrink as the follow-up
+refactoring decouples further capabilities.
 
-Keep the rule centralized at the configuration/bootstrap boundary rather than
-asking each repository or feature implementation to discover a missing database
-at runtime. Phase 2 must select and document one owner for this check, including
-why that owner matches the validation-layer policy.
+The initial matrix below is authoritative for Phase 3. If implementation finds
+another capability that requires a persistence store, add it to this centralized
+matrix, the reusable validation implementation, its focused tests, and the
+activation-follow-up draft before merging. Do not add an ad hoc repository or
+route-level missing-database check.
+
+The reusable check returns `PersistenceRequirementError` with one stable variant
+per approved capability:
+
+| Variant                                          | Diagnostic                                                                                                                              |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `ListedRequiresDatabase`                         | `Configuration requires persistence for \`core.listed\`, but \`[core.database]\` is missing.`                                           |
+| `PrivateRequiresDatabase`                        | `Configuration requires persistence for \`core.private\`, but \`[core.database]\` is missing.`                                          |
+| `PersistentTorrentCompletedStatRequiresDatabase` | `Configuration requires persistence for \`core.tracker_policy.persistent_torrent_completed_stat\`, but \`[core.database]\` is missing.` |
+
+The error type belongs beside the reusable bootstrap requirement-check function,
+not in `packages/configuration::Validator`. Phase 3 tests each variant and its
+diagnostic independently.
+
+| Capability                   | Enabled when                                                   | Final activation-follow-up result                                                                                     | Initial test expectation                                                                                    |
+| ---------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Whitelist                    | `core.listed = true`                                           | Startup fails before container construction.                                                                          | Error names `core.listed` and missing `[core.database]`.                                                    |
+| Private keys                 | `core.private = true`                                          | Startup fails before container construction.                                                                          | Error names `core.private` and missing `[core.database]`.                                                   |
+| Persistent completed metrics | `core.tracker_policy.persistent_torrent_completed_stat = true` | Startup fails before container construction.                                                                          | Error names the setting and missing `[core.database]`.                                                      |
+| Management REST API          | `http_api` is configured                                       | Remains persistence-required until the next-major API #144 work implements the approved disabled-capability contract. | Activation follow-up documents the temporary requirement; API #144 tests the persistence-free API contract. |
+| Persistence-free tracker     | None of the persistence-backed conditions apply                | Startup succeeds without driver construction, migrations, database file, or network connection.                       | Activation follow-up proves no persistence artifacts.                                                       |
+
+This becomes deterministic startup validation when the activation follow-up
+calls the already-implemented check; it is not a late runtime failure. Database
+reachability, filesystem permissions, credentials, and DDL permission remain
+runtime/environment failures after configuration has passed validation.
 
 ### Runtime lifecycle
 
-- Define the owner and timing of driver construction.
-- Define the owner and timing of migration execution.
-- Define repository/service construction when persistence is absent.
-- State whether any constructor needs refactoring to remove migration side
-  effects, based on Phase 1 evidence.
-- Define the all-or-nothing migration contract: if a database is required,
-  apply the complete shared schema migration set once; if none is required, do
-  not construct a driver or execute any migration.
-- Define container-entrypoint behaviour for deployments without persistence,
-  including database-driver environment variables, default-database installation,
-  and database-directory setup.
+The lifecycle is all or nothing:
+
+1. **Persistence absent and permitted:** construct no driver, database stores,
+   database file, network connection, or migration.
+2. **Persistence configured or required:** construct the selected driver once
+   and apply the complete shared migration set once before persistence-backed
+   services are constructed.
+
+Feature configuration controls code behavior, not schema fragments. Do not add
+feature-specific database schemas, migration streams, or migration selection.
+Although the current persistence features are relatively independent, managing
+conditional migrations would increase upgrade, compatibility, and test
+complexity as future features share data or evolve.
+
+### Persistence configuration transitions
+
+Persistence configuration is evaluated only when the tracker process starts.
+Changing configuration requires a restart; the tracker does not dynamically add
+or remove persistence while running.
+
+| Previous process    | Next process configuration                   | Required behavior                                                                               |
+| ------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Persistence-free    | Persistence-free                             | Start without persistence artifacts.                                                            |
+| Persistence-free    | A persistence-required capability is enabled | Require a configured database, then initialize its complete shared schema.                      |
+| Persistence-enabled | Persistence-free                             | Do not open, migrate, write, delete, or otherwise alter the previous database.                  |
+| Persistence-enabled | Persistence-enabled, same target             | Reuse the selected database and apply the complete migrations; completed migrations are no-ops. |
+| Persistence-enabled | Different driver or database location        | Initialize and migrate the newly selected target; do not automatically copy historical data.    |
+
+Existing database state is operator-managed durable state. Disabling
+persistence prevents the next process from using that state but never drops
+tables or deletes files/records. Re-enabling persistence against the same target
+reuses its state; data produced while persistence was disabled is intentionally
+not recoverable. Enabling a different target is not an automatic data migration
+between drivers or locations.
+
+### Container entrypoint contract
+
+The activation follow-up changes the supported container entrypoint as follows:
+
+1. **No persistence:** do not require a database-driver override, create the
+   tracker database directory solely for persistence, or install a packaged
+   SQLite database or database-specific default configuration.
+2. **Persistence configured:** retain driver-specific setup only when the
+   actual v3 configuration selects persistence; do not force a driver through a
+   default environment override.
+3. **Mounted state:** never overwrite or delete mounted `/etc` configuration or
+   `/var/lib` database files merely because the next configuration disables
+   persistence.
+4. **Target change:** never copy or delete a prior database automatically when
+   the configured driver or location changes.
+
+The entrypoint must defer persistence selection to the v3 configuration rather
+than independently inventing a database default. User identity, non-database
+configuration installation, and runtime directory permissions remain separate
+entrypoint responsibilities.
+
+Phase 3 defines the owner/timing of driver construction and the optional
+repository/service constructors. The activation follow-up proves the
+persistence-free branch after it replaces the temporary bridge. It also defines
+container-entrypoint behavior for no-persistence deployments, including driver
+overrides, database directories, and packaged SQLite installation.
 
 ### REST API contract
 
-For each route recorded in Phase 1, choose a deterministic outcome when
-persistence is unavailable: absence because the feature is disabled, a
-documented client error, or another explicitly justified response. The result
-must never be an accidental driver or repository failure.
+The approved desired REST behavior is an explicit configuration-disabled
+response for a direct route whose capability is disabled. It uses HTTP `409
+Conflict` and the existing `ActionStatus::Err` response shape, for example:
+
+```json
+{
+  "status": "err",
+  "reason": "Whitelist capability is disabled by configuration (`core.listed = false`)."
+}
+```
+
+Protocol/application layers must represent this as a distinct
+`DisabledByConfiguration` error; it must not reuse the existing database error
+path. Existing generic 500 database failures remain reserved for a configured
+database that fails operationally after startup.
+
+This response-model change is deferred to the next-major REST API subissue
+draft `docs/issues/drafts/144-make-rest-api-persistence-aware.md`, under
+GitHub EPIC issue #144. Therefore the post-#1980 persistence-free activation
+follow-up does not include the management REST API: it delivers a public UDP
+and/or HTTP tracker with no persistence. Until that subissue implements the
+approved REST contract, `http_api` remains a persistence-required capability in
+the activation follow-up.
+
+The same #144 work must make persistence-dependent historical values explicit
+rather than silently presenting session values as lifetime values. Do not use a
+negative numeric sentinel for unavailable history. This response-field work is
+explicitly deferred to REST API v2 rather than being implemented by #999 or its
+activation follow-up.
+
+### Follow-up persistence-awareness EPIC
+
+Create a detailed future EPIC before closing Phase 2. It must not block #1980
+or require subissues to be created immediately. Its initial work inventory is:
+
+- distinguish session counters from historical persisted counters in API models;
+- expose metric provenance or historical-data availability without sentinels;
+- decide session versus lifetime semantics for per-torrent completed counts;
+- add persistence-free test helpers, integration tests, examples, and benchmarks;
+- remove remaining implicit database assumptions from application composition,
+  container artifacts, and deployment documentation.
+
+The API response-model work is coordinated with GitHub issue #144, which owns
+the next-major REST API compatibility changes.
+
+`persistence-unavailable-scenarios.md` is the cross-layer case log for these
+states. It distinguishes intentional absence, disabled capability, and
+operational database failure, and assigns each case to its delivery issue.
 
 ### EPIC ordering and activation decision
 
-State one of the following and update EPIC #1978 accordingly:
+Issue #999 is a prerequisite for Issue #1980 because it introduces the v3
+optional representation and optional container dependencies. It does **not**
+by itself deliver the persistence-free runtime guarantee. Issue #1980 activates
+v3 with the named temporary database bridge, and the small activation follow-up
+removes that bridge. The future persistence-awareness EPIC does not block either
+issue.
 
-1. #999 blocks #1980 and v3 activation because optional database configuration
-   is part of the required v3 runtime contract.
-2. #999 does not block activation, with documented evidence that activation
-   remains correct without this optionality.
+EPIC #1978 and the v2-to-v3 migration guidance record the approved three-stage
+ordering.
 
 ### Alternatives and trade-offs
 
@@ -104,7 +273,18 @@ Evaluate at least these alternatives against Phase 1 evidence:
 - Make database configuration optional and validate capability requirements at
   startup.
 
+The working direction rejects the first two alternatives: the first abandons
+the explicit in-memory deployment capability, and the second permits delayed
+failures and hidden feature-to-database coupling.
+
 ## Approval Record
 
-Add the approved design, approver, UTC timestamp, decision rationale, and any
-required ADR here before Phase 3 starts.
+| Field         | Record                                                                                                                                                                                                                                                               |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Status        | Approved                                                                                                                                                                                                                                                             |
+| Approver      | User/maintainer                                                                                                                                                                                                                                                      |
+| Approved at   | 2026-08-25 UTC                                                                                                                                                                                                                                                       |
+| Decision      | Implement v3 `Option<Database>`, optional container dependencies, the reusable bootstrap requirement matrix, and a temporary bridge in #999; activate v3 with the bridge in #1980; activate the actual persistence-free runtime in the refined post-#1980 follow-up. |
+| Rationale     | This stages a non-breaking configuration representation and composition refactor before runtime activation, preserves the in-memory design goal, and avoids activating an untested `None` path prematurely.                                                          |
+| Deferred work | Persistence-free REST API behavior and historical metric response semantics are next-major API work under EPIC #144.                                                                                                                                                 |
+| ADR           | `adr-draft.md` is approved for Phase 3 reconciliation and timestamped publication in `docs/adrs/`.                                                                                                                                                                   |

--- a/docs/pr-reviews/pr-2098-copilot-suggestions.md
+++ b/docs/pr-reviews/pr-2098-copilot-suggestions.md
@@ -1,0 +1,52 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2098 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for
+<https://github.com/torrust/torrust-tracker/pull/2098>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-08-25: Started processing suggestions.
+- 2026-08-25: Applied both documentation fixes in `8ec13600`, replied to each thread, and resolved both threads.
+
+## Suggestions
+
+| #   | Thread ID               | Path                                                                                             | URL                                                                           | Suggestion Summary                                                     | Decision                                                      | Reply URL                                                                     | Status | Thread State |
+| --- | ----------------------- | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6cK5GS` | `docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md` | <https://github.com/torrust/torrust-tracker/pull/2098#discussion_r3855456490> | Correct malformed `related-artifacts` YAML indentation.                | action — corrected to sibling list indentation in `8ec13600`. | <https://github.com/torrust/torrust-tracker/pull/2098#discussion_r3855539292> | DONE   | RESOLVED     |
+| 2   | `PRRT_kwDOGp2yqc6cK5G8` | `docs/issues/open/999-1978-optional-database-configuration/solution.md`                          | <https://github.com/torrust/torrust-tracker/pull/2098#discussion_r3855456550> | Align the approved design heading and wording with the Status section. | action — updated to approved-tense wording in `8ec13600`.     | <https://github.com/torrust/torrust-tracker/pull/2098#discussion_r3855542195> | DONE   | RESOLVED     |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.


### PR DESCRIPTION
## Summary

Defines the approved Phase 1/2 plan for Issue #999 without changing runtime behavior.

- Documents the current v2/v3 persistence lifecycle, all discovered consumers, REST API coupling, driver migration behavior, and container side effects.
- Approves the staged delivery: v3 `Option<Database>` and optional container dependencies in #999; v3 activation with a temporary bridge in #1980; a refined post-#1980 follow-up for actual persistence-free runtime behavior.
- Adds approved ADR, scenario-catalog, activation-follow-up, persistence-awareness EPIC, and API #144 subissue planning drafts.
- Updates EPIC #1978 and the v2-to-v3 migration guide with the staged ordering.

## Validation

- `git diff --check`
- `linter all`
- Mandatory pre-commit hook
- Independent documentation consistency review

## Scope

Documentation and planning only. This PR does not change production runtime behavior, configuration runtime activation, migrations, containers, or REST API responses.

Related to #999; does not close it.