### PR TITLE
docs(issues): complete RFC 5424 logging research

### DIFF
--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
@@ -11,11 +11,23 @@ semantic-links:
   related-artifacts:
     - https://github.com/torrust/torrust-tracker/issues/387
     - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
+    - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/questions.md
 ---
 
 # Issue #387 - Implement Logging Using RFC 5424 Syslog Format
 
 > **Source**: GitHub issue [#387](https://github.com/torrust/torrust-tracker/issues/387), opened by [Cameron (da2ce7)](https://github.com/da2ce7) on 2023-08-27. The issue content below is preserved verbatim, apart from this source note and Markdown link normalization.
+
+## Research Outcome
+
+Research completed on 2026-08-26 concludes that RFC 5424 support should not be implemented, either completely or partially, at this time. The tracker should retain its existing `tracing`-based logging and operator-managed log collection.
+
+The current tracker architecture scales a process vertically around process-local, in-memory swarm state. It is not currently deployed as a horizontally interchangeable fleet of tracker replicas, which is the main scenario where direct syslog delivery and central correlation are compelling. For the expected single-instance deployment, the container runtime, host logger, or operator log agent can collect stderr and forward it to central infrastructure when required.
+
+No implementation subissues or `tracing-rfc-5424` integration should be created now. Reconsider the issue only when a concrete deployment or customer requires the tracker process itself to send RFC 5424 records directly to a syslog daemon. Cameron should decide whether to close #387 as out of current priorities or retain it as a deferred enhancement.
+
+- [Current-state analysis](rfc-5424-current-state-analysis.md)
+- [Research questions](questions.md)
 
 ## Implement Logging
 

--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
@@ -1,0 +1,60 @@
+---
+doc-type: issue
+issue-type: enhancement
+status: open
+github-issue: 387
+spec-path: docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+branch: "387-rfc-5424-syslog-logging"
+related-pr: null
+last-updated-utc: 2026-08-26
+semantic-links:
+  related-artifacts:
+    - https://github.com/torrust/torrust-tracker/issues/387
+    - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
+---
+
+# Issue #387 - Implement Logging Using RFC 5424 Syslog Format
+
+> **Source**: GitHub issue [#387](https://github.com/torrust/torrust-tracker/issues/387), opened by [Cameron (da2ce7)](https://github.com/da2ce7) on 2023-08-27. The issue content below is preserved verbatim, apart from this source note and Markdown link normalization.
+
+## Implement Logging
+
+Enhance the program's logging functionality by adopting the [RFC 5424 syslog format](https://tools.ietf.org/html/rfc5424). This format ensures structured, consistent log entries that align with industry best practices. Follow these steps to implement the update:
+
+### Integrate RFC 5424 Format:
+
+Revise the logging mechanism to adhere to the `RFC 5424`, ensuring each log entry includes priority level, timestamp, hostname, program name, and structured data when applicable.
+
+### Manage Severity Levels:
+
+Implement the recommended severity levels (e.g., emergency, alert, warning, notice, info, debug) to accurately reflect the importance of log messages.
+
+### Configure Log Rotation:
+
+Develop a log rotation strategy to control log file size and retention, preventing excessive disk space consumption.
+
+### Define Log Directory:
+
+Designate a dedicated directory (e.g., `/var/log/torrust/tracker`) for log files, maintaining alignment with Linux directory structure conventions.
+
+### Enforce Permissions:
+
+Apply appropriate permissions and ownership to log files and directories to ensure authorized access and modification.
+
+### Dynamic Log Levels:
+
+Enable log level configuration (e.g., INFO, DEBUG, ERROR) to control verbosity based on configuration settings.
+
+### Test and Document:
+
+Thoroughly test the updated logging mechanism, verifying adherence to `RFC 5424` and proper handling of structured data. Document the changes for clarity.
+
+## Expected Outcomes:
+
+- Consistent and structured log entries following `RFC 5424`.
+- Efficient log file management with rotation and controlled disk space usage.
+- Improved program monitoring and troubleshooting through enhanced log data.
+
+## Related Discussion
+
+- [torrust/torrust-demo#4](https://github.com/torrust/torrust-demo/issues/4)

--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
@@ -2,13 +2,17 @@
 doc-type: issue
 issue-type: enhancement
 status: open
+priority: p2
 github-issue: 387
 spec-path: docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
 branch: "387-rfc-5424-syslog-logging"
 related-pr: null
 last-updated-utc: 2026-08-26
 semantic-links:
+  skill-links:
+    - create-issue
   related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
     - https://github.com/torrust/torrust-tracker/issues/387
     - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
     - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/questions.md

--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/questions.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/questions.md
@@ -1,0 +1,75 @@
+---
+doc-type: research-questions
+status: open
+related-issue: 387
+last-updated-utc: 2026-08-26
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+    - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
+    - https://www.rfc-editor.org/rfc/rfc5424.txt
+---
+
+# Research Questions for Issue #387
+
+This document records the questions that must be answered before deciding whether RFC 5424 support is worth implementing. It is deliberately separate from the issue description and current-state analysis so the research can remain open-ended.
+
+## Q1. Why does RFC 5424 matter?
+
+### Short answer
+
+RFC 5424 matters when an operator needs the tracker to send interoperable, machine-readable records directly to a syslog daemon or collector. It standardizes the record header, severity, facility, timestamp, application identity, and optional structured data so that syslog-aware infrastructure can route, parse, retain, and alert on tracker messages consistently.
+
+It is not inherently a better way for the tracker to create diagnostic events. The tracker already uses `tracing`, which provides structured events, levels, spans, and subscriber layers. RFC 5424 is an output and interoperability standard for one particular logging ecosystem.
+
+### Benefits if implemented
+
+- **Direct syslog integration**: The tracker could send logs to compatible syslog daemons and collectors over established syslog transports rather than relying on stdout/stderr capture.
+- **Portable record envelope**: A receiving system can read standard `PRI`, timestamp, hostname, application name, process identifier, message identifier, and structured-data fields without tracker-specific parsing rules.
+- **Facility-based routing**: Operators could use the syslog facility and severity to route tracker logs separately from other services, choose retention policies, or trigger alerting rules.
+- **Structured-data interoperability**: If the tracker defined a stable RFC 5424 structured-data schema, syslog-aware tools could query tracker attributes without parsing free-form text.
+- **Compatibility with existing operations tooling**: Some organizations standardize on syslog relays, SIEM products, and central log collectors that accept RFC 5424 directly.
+
+### Capabilities the tracker does not have today
+
+The current tracker logging setup does not itself provide:
+
+- A standards-compliant RFC 5424 message envelope with `PRI`, facility, syslog protocol version, and syslog header fields.
+- A built-in syslog client transport to a daemon through UDP, TCP, or a Unix-domain socket.
+- A tracker-defined RFC 5424 structured-data schema for fields such as torrent hash, client label, protocol, or request context.
+- A standard syslog facility by which an operator can route the tracker independently in syslog infrastructure.
+
+### Capabilities the tracker already has
+
+The absence of RFC 5424 does not mean the tracker lacks logging or observability:
+
+- `tracing` provides severity filtering and structured event fields to the configured subscriber.
+- The current configuration supports dynamic filtering; the newer v3 schema also supports multiple human-readable and JSON output styles.
+- Operators can capture stdout/stderr using their chosen runtime, system logger, container platform, or log collector.
+- Torrust Tracker Deployer and the Tracker Demo already keep rotation, file retention, directory, ownership, and permissions in deployment infrastructure, where those policies belong.
+- Events, metrics, and health checks remain separate observability mechanisms; RFC 5424 would not replace them.
+
+### Decision implication
+
+The relevant question is not whether RFC 5424 is objectively better than `tracing`. The relevant question is whether a current or planned deployment needs **direct, standards-based syslog delivery** strongly enough to justify a new sink, configuration, dependency review, and ongoing support.
+
+Absent that requirement, the current `tracing` output plus operator-managed collection keeps the tracker simpler while preserving its existing logging capabilities.
+
+## Q2. Does the current tracker deployment model need direct syslog delivery?
+
+### Answer
+
+Not as a general capability. Direct RFC 5424 delivery is most useful for a horizontally distributed service fleet, where many instances send records to common syslog infrastructure for correlation, routing, retention, and alerting.
+
+The current tracker architecture does not use horizontally interchangeable tracker replicas. Each tracker process owns in-memory swarm state that is not separated into an independently shared coordination layer. A larger deployment therefore scales one tracker process vertically rather than running multiple equivalent tracker instances behind a load balancer.
+
+For the expected single-instance tracker deployment, the host, container runtime, or operator-managed log agent can collect the existing stderr output and forward it to a central syslog service, SIEM, or another log collector. That supplies centralized retention and analysis without requiring the tracker to become a syslog client.
+
+### Decision implication
+
+The current deployment model does not justify implementing RFC 5424 support, either as a complete formatter or as a partial `tracing-rfc-5424` integration. The issue should remain research only. Reconsider it only if a real deployment or customer requirement needs the tracker itself to deliver RFC 5424 records directly to a syslog daemon.
+
+### Evidence
+
+- RFC 5424 defines the syslog message format and header fields: <https://www.rfc-editor.org/rfc/rfc5424.txt>
+- Current tracker logging and RFC gap assessment: `rfc-5424-current-state-analysis.md`

--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
@@ -1,0 +1,108 @@
+---
+doc-type: analysis
+status: draft
+related-issue: 387
+last-updated-utc: 2026-08-26
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/ISSUE.md
+    - packages/configuration/src/v3_0_0/logging.rs
+    - docs/adrs/20260519000000_define_global_cli_output_contract.md
+    - docs/adrs/20260727000000_events_are_objective_facts.md
+    - docs/adrs/20260822094338_adopt_secrecy_for_sensitive_values.md
+    - https://www.rfc-editor.org/rfc/rfc5424.txt
+---
+
+# RFC 5424 Current-State Analysis for Issue #387
+
+## Purpose
+
+This analysis checks whether issue #387 remains meaningful against the tracker as of 2026-08-26. It compares the issue with RFC 5424, the current logging implementation, and relevant architecture decisions. It is not an implementation plan.
+
+## Conclusion
+
+Issue #387 remains valid, but its requested outcome combines three distinct concerns that should be decided separately before implementation:
+
+1. RFC 5424 message serialization and transport.
+2. Logging destination and lifecycle, including files, rotation, directory, and permissions.
+3. Application log-level semantics and configuration.
+
+The tracker has partially implemented the third concern. It has not implemented RFC 5424 messages, a syslog transport, application-managed log files, rotation, or file-permission policy.
+
+## RFC 5424 Requirements Relevant to This Issue
+
+RFC 5424 section 6 defines a syslog message as:
+
+```text
+SYSLOG-MSG = HEADER SP STRUCTURED-DATA [SP MSG]
+HEADER = PRI VERSION SP TIMESTAMP SP HOSTNAME SP APP-NAME SP PROCID SP MSGID
+```
+
+The header uses seven-bit ASCII. `PRI` is `<facility * 8 + severity>`; facility values are in $0..=23$ and severity values in $0..=7$. RFC 5424 defines severities `Emergency` (0), `Alert` (1), `Critical` (2), `Error` (3), `Warning` (4), `Notice` (5), `Informational` (6), and `Debug` (7). The RFC's version is `1`.
+
+`TIMESTAMP`, `HOSTNAME`, `APP-NAME`, `PROCID`, and `MSGID` may use the nil value (`-`) when unavailable. `STRUCTURED-DATA` is either `-` or one or more bracketed elements. Structured-data parameter values must escape `"`, `\\`, and `]`.
+
+RFC 5424 specifies a message format. It does not mandate that an application writes local log files, rotates them, creates `/var/log/torrust/tracker`, or changes Unix ownership and permissions. Those are deployment and operational-policy decisions.
+
+## Current Tracker State
+
+### Logging implementation
+
+`packages/configuration/src/v3_0_0/logging.rs` configures a `tracing_subscriber` formatter once per process. It provides these `trace_filter` values: `off`, `error`, `warn`, `info`, `debug`, and `trace`; the default is `info`. It provides `full`, `pretty`, `compact`, and `json` output styles; the default is `full`.
+
+The `Json` style produces tracing-subscriber JSON, not RFC 5424 syslog messages. None of the configured styles emits RFC 5424's `PRI`, protocol version, `HOSTNAME`, `APP-NAME`, `PROCID`, `MSGID`, or RFC 5424 `STRUCTURED-DATA` grammar.
+
+The current threshold vocabulary is tracing's six filters. It does not model the RFC 5424 facility, and does not expose all RFC severity concepts, notably `Emergency`, `Alert`, `Critical`, and `Notice`. `warn` is broadly comparable to RFC `Warning`, `info` to `Informational`, and `debug` to `Debug`, but that resemblance is insufficient for RFC 5424 compliance because `PRI` requires both facility and severity.
+
+There is no current logging configuration for an output destination, a syslog endpoint, file path, rotation policy, retention policy, directory creation, ownership, or permissions.
+
+### Existing observability and safety guidance
+
+The event ADR requires event variants to describe objective facts and keeps enforcement policy at the consumer or enforcement point. An RFC 5424 formatter should therefore serialize existing tracing events and fields without reshaping domain events to suit a log sink.
+
+The secrecy ADR requires sensitive values to remain redacted in tracing, `Debug`, `Display`, errors, and diagnostics. Any RFC 5424 structured-data encoder must preserve that invariant and must not stringify secret wrappers through an unsafe display path.
+
+The global CLI output contract says the long-running `torrust-tracker` daemon sends tracing diagnostics to stderr. The current v3 logging module's documentation says stdout, and its subscriber setup does not explicitly choose a production writer. The desired output stream must be clarified before introducing a syslog destination or file sink.
+
+## Gap Assessment
+
+| Issue #387 request                                           | Current state                                             | Gap                                                                               |
+| ------------------------------------------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| RFC 5424 format                                              | Full, pretty, compact, and JSON tracing formats           | Not implemented                                                                   |
+| Priority, timestamp, hostname, program name, structured data | Tracing metadata, timestamp, and fields vary by formatter | RFC header, PRI calculation, and RFC structured-data encoding are not implemented |
+| RFC severity levels                                          | `off`, `error`, `warn`, `info`, `debug`, `trace` filters  | No facility; no complete RFC severity mapping                                     |
+| Log rotation                                                 | No application logging-to-file implementation             | Not implemented; RFC 5424 does not require it                                     |
+| `/var/log/torrust/tracker` log directory                     | No configured log directory                               | Not implemented; should be deployment-policy driven                               |
+| Permissions and ownership                                    | No application-managed log files                          | Not implemented; should account for containers and non-root execution             |
+| Dynamic log level                                            | `logging.trace_filter` configuration                      | Partially implemented                                                             |
+| Test and documentation                                       | Unit tests cover configuration values                     | RFC conformance, transport/sink, and deployment tests/docs are absent             |
+
+## Decisions Required Before an Implementation Plan
+
+1. Is the intended product an RFC 5424 formatter for stdout/stderr, a syslog client transport, or both?
+2. Should production deployments delegate file persistence, rotation, ownership, and permissions to systemd/journald, Docker/Podman, or an external syslog daemon rather than the tracker process?
+3. Which RFC 5424 facility should the tracker use by default, and should it be configurable?
+4. How should tracing levels and the RFC severity values map, especially `trace`, `off`, `Critical`, `Alert`, and `Emergency`?
+5. Which stable `APP-NAME`, `PROCID`, and `MSGID` values should the tracker emit?
+6. Which tracing fields become RFC structured data, what enterprise ID or namespacing is used for `SD-ID`, and how are malformed/non-ASCII keys and values handled?
+7. Does the daemon continue to send normal diagnostics to stderr as required by the CLI output ADR, or does a selected syslog sink replace that stream?
+8. Which deployment modes must be supported: native package/service, rootless container, privileged container, and manual executable invocation?
+
+## Recommended Issue Reshaping
+
+Retain issue #387 as an umbrella or research issue. Split the implementation work only after the decisions above are recorded:
+
+1. Define the logging-output architecture and RFC 5424 configuration contract.
+2. Implement and test a standards-compliant RFC 5424 formatter and severity/facility mapping.
+3. Add an optional syslog transport or integrate with the selected platform logger.
+4. Document deployment-owned file rotation, directory, and permissions; only add application-managed files if a supported deployment requires them.
+
+This avoids making the tracker responsible for OS-level policy where the container runtime, systemd/journald, or syslog daemon is the appropriate owner.
+
+## Sources
+
+- RFC 5424, sections 6, 6.2, and 6.3: <https://www.rfc-editor.org/rfc/rfc5424.txt>
+- Current v3 logging setup: `packages/configuration/src/v3_0_0/logging.rs`
+- CLI output contract: `docs/adrs/20260519000000_define_global_cli_output_contract.md`
+- Events principle: `docs/adrs/20260727000000_events_are_objective_facts.md`
+- Sensitive-data logging policy: `docs/adrs/20260822094338_adopt_secrecy_for_sensitive_values.md`

--- a/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
+++ b/docs/issues/open/387-implement-logging-using-rfc-5424-syslog-format/rfc-5424-current-state-analysis.md
@@ -1,6 +1,6 @@
 ---
 doc-type: analysis
-status: draft
+status: complete
 related-issue: 387
 last-updated-utc: 2026-08-26
 semantic-links:
@@ -11,23 +11,35 @@ semantic-links:
     - docs/adrs/20260727000000_events_are_objective_facts.md
     - docs/adrs/20260822094338_adopt_secrecy_for_sensitive_values.md
     - https://www.rfc-editor.org/rfc/rfc5424.txt
+    - https://crates.io/crates/tracing-rfc-5424
+    - https://github.com/sp1ff/syslog-tracing
 ---
 
 # RFC 5424 Current-State Analysis for Issue #387
 
 ## Purpose
 
-This analysis checks whether issue #387 remains meaningful against the tracker as of 2026-08-26. It compares the issue with RFC 5424, the current logging implementation, and relevant architecture decisions. It is not an implementation plan.
+This analysis checks whether issue #387 remains meaningful against the tracker as of 2026-08-26. It compares the issue with RFC 5424, the current logging implementation, and relevant architecture decisions. It gives a hypothetical remaining-effort estimate; it is not an implementation plan.
 
 ## Conclusion
 
-Issue #387 remains valid, but its requested outcome combines three distinct concerns that should be decided separately before implementation:
+Issue #387 remains valid, but its requested outcome combines three distinct concerns:
 
 1. RFC 5424 message serialization and transport.
 2. Logging destination and lifecycle, including files, rotation, directory, and permissions.
 3. Application log-level semantics and configuration.
 
-The tracker has partially implemented the third concern. It has not implemented RFC 5424 messages, a syslog transport, application-managed log files, rotation, or file-permission policy.
+The tracker has partially implemented the third concern. It has not implemented RFC 5424 messages or a syslog transport. The tracker deliberately does not own log files, rotation, directory creation, ownership, or permissions: those are infrastructure concerns managed by the tracker operator. Torrust Tracker Deployer configures them for production deployments; the Tracker Demo uses Docker Compose log rotation.
+
+### Recommendation
+
+Do not implement RFC 5424 support now, either completely or partially. The existing `tracing`-based logging is adequate for the tracker and avoids creating and maintaining a custom logging subsystem solely to satisfy a complex standard without a demonstrated operational requirement.
+
+The tracker should continue to use `tracing` and `tracing_subscriber` as its logging abstraction. Strict RFC 5424 output would require either a custom `tracing_subscriber` formatter or layer, or an additional maintained crate that provides the required behavior. This work can remain at the logging-output boundary and does not require changes to domain events, servers, or the tracker architecture. However, it would introduce a new formatting contract, configuration, conformance tests, and ongoing compatibility work with the tracing ecosystem.
+
+The primary scenario in which direct syslog delivery is valuable is a distributed fleet of services or tracker instances whose logs need central collection and correlation. That is not a likely current tracker deployment: each tracker process owns process-local, in-memory swarm state, so the current architecture scales vertically rather than as horizontally interchangeable replicas. For the expected single-instance deployment, the runtime, host logger, or operator log agent can collect the existing stderr output and forward it centrally without making the tracker a syslog client.
+
+Retain issue #387 as research only and let Cameron decide whether the remaining benefit warrants that cost. Until a concrete deployment, integration, or customer requirement needs direct RFC 5424 records, no implementation subissues should be created.
 
 ## RFC 5424 Requirements Relevant to This Issue
 
@@ -48,13 +60,13 @@ RFC 5424 specifies a message format. It does not mandate that an application wri
 
 ### Logging implementation
 
-`packages/configuration/src/v3_0_0/logging.rs` configures a `tracing_subscriber` formatter once per process. It provides these `trace_filter` values: `off`, `error`, `warn`, `info`, `debug`, and `trace`; the default is `info`. It provides `full`, `pretty`, `compact`, and `json` output styles; the default is `full`.
+The running tracker daemon initializes logging once during bootstrap through `packages/configuration/src/logging.rs`. The public configuration currently aliases the v2 schema, whose `[logging]` section has one `threshold` setting with values `off`, `error`, `warn`, `info`, `debug`, and `trace`; the default is `info`. The active setup uses the default `tracing_subscriber` formatter, not a configurable style.
 
-The `Json` style produces tracing-subscriber JSON, not RFC 5424 syslog messages. None of the configured styles emits RFC 5424's `PRI`, protocol version, `HOSTNAME`, `APP-NAME`, `PROCID`, `MSGID`, or RFC 5424 `STRUCTURED-DATA` grammar.
+`packages/configuration/src/v3_0_0/logging.rs` is a newer, not-yet-active configuration schema. It adds `trace_filter` and the `full`, `pretty`, `compact`, and `json` styles. Its `Json` style produces tracing-subscriber JSON, not RFC 5424 syslog messages. None of the configured styles emits RFC 5424's `PRI`, protocol version, `HOSTNAME`, `APP-NAME`, `PROCID`, `MSGID`, or RFC 5424 `STRUCTURED-DATA` grammar.
 
 The current threshold vocabulary is tracing's six filters. It does not model the RFC 5424 facility, and does not expose all RFC severity concepts, notably `Emergency`, `Alert`, `Critical`, and `Notice`. `warn` is broadly comparable to RFC `Warning`, `info` to `Informational`, and `debug` to `Debug`, but that resemblance is insufficient for RFC 5424 compliance because `PRI` requires both facility and severity.
 
-There is no current logging configuration for an output destination, a syslog endpoint, file path, rotation policy, retention policy, directory creation, ownership, or permissions.
+There is no current logging configuration for an output destination or syslog endpoint. There is intentionally no application configuration for a file path, rotation policy, retention policy, directory creation, ownership, or permissions; these belong to the deployment configuration selected by the operator.
 
 ### Existing observability and safety guidance
 
@@ -71,37 +83,98 @@ The global CLI output contract says the long-running `torrust-tracker` daemon se
 | RFC 5424 format                                              | Full, pretty, compact, and JSON tracing formats           | Not implemented                                                                   |
 | Priority, timestamp, hostname, program name, structured data | Tracing metadata, timestamp, and fields vary by formatter | RFC header, PRI calculation, and RFC structured-data encoding are not implemented |
 | RFC severity levels                                          | `off`, `error`, `warn`, `info`, `debug`, `trace` filters  | No facility; no complete RFC severity mapping                                     |
-| Log rotation                                                 | No application logging-to-file implementation             | Not implemented; RFC 5424 does not require it                                     |
-| `/var/log/torrust/tracker` log directory                     | No configured log directory                               | Not implemented; should be deployment-policy driven                               |
-| Permissions and ownership                                    | No application-managed log files                          | Not implemented; should account for containers and non-root execution             |
+| Log rotation                                                 | Managed by the deployment infrastructure                  | Not a tracker application responsibility; RFC 5424 does not require it            |
+| `/var/log/torrust/tracker` log directory                     | Managed by the deployment infrastructure                  | Not a tracker application responsibility                                          |
+| Permissions and ownership                                    | Managed by the deployment infrastructure                  | Not a tracker application responsibility; account for containers and non-root use |
 | Dynamic log level                                            | `logging.trace_filter` configuration                      | Partially implemented                                                             |
 | Test and documentation                                       | Unit tests cover configuration values                     | RFC conformance, transport/sink, and deployment tests/docs are absent             |
 
-## Decisions Required Before an Implementation Plan
+## RFC 5424 Facility
+
+The facility is the source category encoded in the RFC 5424 `PRI` value. It is not the same as a log level. For example, a facility of `local0` has numeric value 16; an `Informational` severity has numeric value 6; together they produce `<134>` because $16 \times 8 + 6 = 134$.
+
+Facilities let a syslog receiver route records from different applications or subsystems. The standard reserves `local0` through `local7` for local policy. A tracker implementation should select one `local*` facility, normally as a fixed product decision, unless operators have a demonstrated need to configure it. This decision matters only if the tracker emits RFC 5424 records or sends them to a syslog receiver.
+
+## `tracing-rfc-5424` Crate Assessment
+
+The [`tracing-rfc-5424`](https://crates.io/crates/tracing-rfc-5424) crate, from [`sp1ff/syslog-tracing`](https://github.com/sp1ff/syslog-tracing), is an existing `tracing_subscriber::Layer`. It formats tracing events as RFC 5424 or RFC 3164 syslog messages and sends them to a syslog daemon through UDP, TCP, or Unix-domain socket transports. It can be composed with the tracker's existing `tracing_subscriber` formatter rather than replacing the tracker logging architecture.
+
+This means that a future tracker integration could use a maintained implementation for the RFC message grammar and transport instead of implementing those low-level details itself. The crate's default is RFC 5424 over UDP to a local syslog daemon on port 514; therefore, using it would add an optional network or Unix-socket logging sink and a deployment dependency on a syslog daemon. It would not configure file rotation, retention, directory creation, ownership, or permissions, which remain operator concerns.
+
+The crate is not a drop-in replacement for the tracker's current human-readable stderr output:
+
+- Its supplied `TrivialTracingFormatter` extracts only the tracing event's `message` field. It does not preserve arbitrary tracker fields such as `client`, `torrent`, and `error` in the emitted message.
+- It can emit RFC 5424 structured data for selected tracing metadata, such as source file and line number. It does not supply the tracker-specific field mapping described above, so preserving arbitrary tracing fields would still require a custom formatter or an upstream contribution.
+- Its published roadmap describes the `0.2.x` series as preliminary and lists broader tracing-field mapping, span support, asynchronous transports, and additional documentation as future work. A logging call may therefore perform synchronous transport work, and transport failure and backpressure behavior would need explicit evaluation.
+- The crate is licensed `GPL-3.0-or-later`. The tracker is `AGPL-3.0-only`; a future dependency proposal must include the repository's normal license-compatibility review before adoption.
+
+The absence of a specific `MSGID` mapping does not itself prevent valid RFC 5424 output because the RFC permits `-` as the nil value. Similarly, RFC 5424 permits `-` instead of structured data. Consequently, the crate may be sufficient for a narrow future requirement such as sending basic compliant event messages to a local syslog daemon. It is not sufficient for a requirement to preserve the full structured tracker context without further work.
+
+**Recommendation:** do not add the crate now. If a concrete deployment requires RFC 5424 delivery to a syslog daemon, perform a small, time-boxed compatibility spike first. It should verify tracker MSRV/dependency compatibility, license approval, non-blocking behavior under an unavailable or slow daemon, the selected facility and transport, and whether losing arbitrary tracing fields is acceptable.
+
+## Requirements if the Issue Is Reopened
 
 1. Is the intended product an RFC 5424 formatter for stdout/stderr, a syslog client transport, or both?
-2. Should production deployments delegate file persistence, rotation, ownership, and permissions to systemd/journald, Docker/Podman, or an external syslog daemon rather than the tracker process?
-3. Which RFC 5424 facility should the tracker use by default, and should it be configurable?
-4. How should tracing levels and the RFC severity values map, especially `trace`, `off`, `Critical`, `Alert`, and `Emergency`?
-5. Which stable `APP-NAME`, `PROCID`, and `MSGID` values should the tracker emit?
-6. Which tracing fields become RFC structured data, what enterprise ID or namespacing is used for `SD-ID`, and how are malformed/non-ASCII keys and values handled?
-7. Does the daemon continue to send normal diagnostics to stderr as required by the CLI output ADR, or does a selected syslog sink replace that stream?
-8. Which deployment modes must be supported: native package/service, rootless container, privileged container, and manual executable invocation?
+2. Which RFC 5424 facility should the tracker use by default, and should it be configurable?
+3. How should tracing levels and the RFC severity values map, especially `trace`, `off`, `Critical`, `Alert`, and `Emergency`?
+4. Which stable `APP-NAME`, `PROCID`, and `MSGID` values should the tracker emit?
+5. Which tracing fields become RFC structured data, what enterprise ID or namespacing is used for `SD-ID`, and how are malformed/non-ASCII keys and values handled?
+6. Does the daemon continue to send normal diagnostics to stderr as required by the CLI output ADR, or does a selected syslog sink replace that stream?
 
-## Recommended Issue Reshaping
+### Structured-Data Field Mapping
 
-Retain issue #387 as an umbrella or research issue. Split the implementation work only after the decisions above are recorded:
+Requirement 5 concerns the difference between a tracing event and an RFC 5424 record. The tracker can emit arbitrary named tracing fields, for example:
 
-1. Define the logging-output architecture and RFC 5424 configuration contract.
-2. Implement and test a standards-compliant RFC 5424 formatter and severity/facility mapping.
-3. Add an optional syslog transport or integrate with the selected platform logger.
-4. Document deployment-owned file rotation, directory, and permissions; only add application-managed files if a supported deployment requires them.
+```rust
+tracing::info!(client = client_label, torrent = %hash, "torrent is absent");
+```
+
+An RFC 5424 formatter must decide whether those fields are omitted, added only to the free-form message, or translated to `STRUCTURED-DATA`. A possible translation is:
+
+```text
+<134>1 2026-08-26T10:00:00Z tracker.example torrust-tracker 1234 - [torrust@PEN client="qbittorrent" torrent="abc..."] torrent is absent
+```
+
+This example is illustrative only. `torrust@PEN` would need a valid structured-data identifier: `torrust` is the element name and `PEN` would need to be replaced by Torrust's IANA Private Enterprise Number. The formatter must also define stable parameter names such as `client` and `torrent`. Once deployed, log collectors, dashboards, alerts, and parsers may depend on those names, so changing them becomes a compatibility concern.
+
+The formatter would additionally need rules for tracing fields that RFC 5424 cannot represent directly. Structured-data names are restricted to printable ASCII and exclude spaces, `=`, `]`, and `"`; parameter values must escape `"`, `\\`, and `]`. Tracing field names or values that are non-ASCII, contain invalid characters, are nested, or are not meaningful operational attributes require a deliberate policy: reject them, omit them, encode them, or retain them only in the free-form message.
+
+Finally, the mapping must preserve the secrecy ADR. Fields containing credentials, tokens, client-identifying data, or other sensitive values must remain redacted before a formatter serializes them. This is why strict RFC 5424 output is more than changing the timestamp or severity label: it introduces a public schema and serializer for every selected tracing field.
+
+## Hypothetical Remaining-Effort Estimate
+
+The following estimate applies only to a custom RFC 5424 formatter that emits records to the existing stderr stream. It leaves persistence, rotation, and permissions to the deployment infrastructure.
+
+| Work item                                               | Estimated effort | Notes                                                                                                                           |
+| ------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Decide the RFC field contract and tracing-level mapping | 1-2 days         | Covers facility, application/process/message identifiers, `trace`/`off`, structured-data namespace, and secret-redaction review |
+| Implement an RFC 5424 tracing formatter                 | 3-5 days         | Includes header generation, `PRI`, RFC escaping, timestamp handling, and preserving existing tracing fields                     |
+| Add configuration, migration, and documentation         | 1-2 days         | Must target the active v2 schema or be coordinated with the v3 configuration migration                                          |
+| Unit, integration, and conformance tests                | 2-3 days         | Covers deterministic formatting, escaping, severity/facility mapping, configuration, and stderr output                          |
+| Review and contingency                                  | 1-2 days         | Covers tracing-subscriber extension constraints and compatibility fixes                                                         |
+
+**Total for a custom formatter: 8-14 engineering days.** A separate syslog network transport, TLS support, reconnection/backpressure policy, or multiple destination support is a separate feature and would materially increase the estimate. Application-owned file rotation is explicitly out of scope.
+
+Using `tracing-rfc-5424` changes the future research path, not the current recommendation. A 1-2 day compatibility spike could establish whether the crate's basic RFC 5424 messages, daemon transport, synchronous behavior, GPL license, and loss of arbitrary tracing fields are acceptable for a specific deployment. If they are, the subsequent integration is likely smaller than a custom formatter. If full tracker field preservation is required, the crate does not eliminate the custom formatter or upstream-contribution work.
+
+## Recommended Issue Outcome
+
+Retain issue #387 as a research issue. Do not create implementation subissues and do not perform a partial crate integration now. Cameron can decide whether to close it as out of current priorities or leave it open as a deferred enhancement after reviewing this analysis.
+
+If a future requirement makes RFC 5424 support worthwhile, the likely work is:
+
+1. Run the `tracing-rfc-5424` compatibility spike against the concrete deployment requirement.
+2. Define the logging-output architecture and RFC 5424 configuration contract only if the spike shows that the crate is insufficient or unsuitable.
+3. Adopt and test the crate for the narrow syslog-delivery use case, or implement a standards-compliant formatter and field mapping if full tracker context is required.
+4. Keep rotation, directory, ownership, and permissions documented and implemented in Torrust Tracker Deployer or equivalent operator infrastructure.
 
 This avoids making the tracker responsible for OS-level policy where the container runtime, systemd/journald, or syslog daemon is the appropriate owner.
 
 ## Sources
 
 - RFC 5424, sections 6, 6.2, and 6.3: <https://www.rfc-editor.org/rfc/rfc5424.txt>
+- `tracing-rfc-5424` v0.2.1 crate metadata and documentation: <https://crates.io/crates/tracing-rfc-5424>
+- `sp1ff/syslog-tracing` source and roadmap: <https://github.com/sp1ff/syslog-tracing>
 - Current v3 logging setup: `packages/configuration/src/v3_0_0/logging.rs`
 - CLI output contract: `docs/adrs/20260519000000_define_global_cli_output_contract.md`
 - Events principle: `docs/adrs/20260727000000_events_are_objective_facts.md`

--- a/project-words.txt
+++ b/project-words.txt
@@ -79,6 +79,7 @@ Registar
 Rustls
 Ryzen
 SHLVL
+SIEM
 Seedable
 Shareaza
 Signedness
@@ -133,6 +134,7 @@ autolinks
 automock
 autoremove
 backlinks
+backpressure
 bdecode
 behaviour
 behavioural


### PR DESCRIPTION
## Summary

Adds the local specification and evidence-based research for GitHub issue #387.

- Preserves Cameron's original issue proposal in a local issue spec.
- Compares RFC 5424 with the current `tracing` logging implementation and relevant ADRs.
- Assesses the `tracing-rfc-5424` crate as a future compatibility-spike option.
- Records the recommendation not to implement RFC 5424 support, completely or partially, for the current vertically scaled, process-local in-memory tracker architecture.
- Keeps rotation, retention, permissions, and log collection in deployment/operator infrastructure.

## Decision

Issue #387 remains open for Cameron to decide whether to close it as out of current priorities or retain it as a deferred enhancement. This PR deliberately does not use an auto-closing issue keyword.

## Validation

- `linter all`
- Pre-commit hook: `cargo machete`, `cargo deny check bans`, lint suite, hadolint, documentation tests
- Pre-push hook: nightly format/check/docs and full test suite