### PR TITLE
docs(issues): add specification for #2107

### DIFF
--- a/docs/copilot-pr-reviews/pr-2108-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2108-copilot-suggestions.md
@@ -1,0 +1,53 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2108 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for <https://github.com/torrust/torrust-tracker/pull/2108>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-08-28: Started processing the Copilot suggestion.
+- 2026-08-28: Applied the critical-path fix in commit `8a5fa28d`, replied to the
+  thread, and resolved it after the pre-commit and pre-push gates passed.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                      | URL                                                                           | Suggestion Summary                                            | Decision                                                                                             | Reply URL                                                                     | Status | Thread State |
+| --- | --------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6dImuj | docs/issues/open/1978-configuration-overhaul-epic/EPIC.md | <https://github.com/torrust/torrust-tracker/pull/2108#discussion_r3879786847> | Reference the explicit #2107 subissue on both critical paths. | action: replaced both generic follow-up references with tracked subissue #2107 in commit `8a5fa28d`. | <https://github.com/torrust/torrust-tracker/pull/2108#discussion_r3879967463> | DONE   | RESOLVED     |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
@@ -21,6 +21,7 @@ semantic-links:
     - docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md
     - docs/issues/open/1490-1978-decompose-database-configuration.md
     - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/2107-1978-activate-persistence-free-v3-runtime-composition.md
     - docs/issues/open/2079-adopt-secrecy-for-sensitive-configuration.md
     - docs/adrs/20260617093046_reject_wildcard_external_ip.md
 ---
@@ -89,23 +90,24 @@ version from `2.0.0` to `3.0.0`.
 
 Status values: `TODO`, `IN_PROGRESS`, `IN_REVIEW`, `BLOCKED`, `DONE`.
 
-| Order | Issue                                                                                                                                               | Local Spec                                                                                 | Status    | Notes                                                                                                                                                     |
-| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1     | [#1979](https://github.com/torrust/torrust-tracker/issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/closed/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`              | DONE      | Merged in PR #1999; v3 baseline and smoke tests are in `develop`                                                                                          |
-| 2     | [#1981](https://github.com/torrust/torrust-tracker/issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/closed/1981-1978-fix-tsl-config-tls-config-typo.md`                           | DONE      | Implemented for v3; v2 compatibility retained until final migration                                                                                       |
-| 3     | [#1640](https://github.com/torrust/torrust-tracker/issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/closed/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`                | DONE      | Merged in PR #2014; v3 schema slice complete; runtime consumers deferred to #1980 (subissue #12)                                                          |
-| 4     | [#1417](https://github.com/torrust/torrust-tracker/issues/1417) — Include public service URL in configuration                                       | `docs/issues/closed/1417-1978-add-public-service-url-to-configuration.md`                  | DONE      | Merged in PR #2016; typed `Option<HttpUrl>`/`Option<UdpUrl>` newtypes on `HttpTracker`, `UdpTracker`, `HttpApi`; scheme validation at deserialization     |
-| 5     | [#1415](https://github.com/torrust/torrust-tracker/issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/closed/1415-1978-use-service-binding-instead-of-socket-addr/ISSUE.md`         | DONE      | Added protocol-aware `service_binding` alongside compatible `server_socket_addr` fields in HTTP tracker, REST API, and UDP error logs; verified manually. |
-| 6     | [#1453](https://github.com/torrust/torrust-tracker/issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/closed/1453-1978-ip-bans-reset-interval-configurable/ISSUE.md`                | DONE      | One cancellation-managed bootstrap cleanup job reads the active v3 interval after #1980 runtime activation.                                               |
-| 7     | [#1136](https://github.com/torrust/torrust-tracker/issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/closed/1136-1978-configurable-udp-connection-id-validation-policy.md`         | DONE      | PR #2032 merged; all 12 ACs met; manual verification deferred to #1980.                                                                                   |
-| 8     | [#1490](https://github.com/torrust/torrust-tracker/issues/1490) — Decompose v3 database configuration                                               | `docs/issues/open/1490-1978-decompose-database-configuration.md`                           | DONE      | V3 uses driver-specific database fields and secret passwords.                                                                                             |
-| 8a    | [#999](https://github.com/torrust/torrust-tracker/issues/999) — Make v3 database configuration optional when persistence is unused                  | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                       | DONE      | V3 `Option<Database>` and the temporary bridge are implemented; the later runtime-activation follow-up remains pending.                                   |
-| 9     | [#889](https://github.com/torrust/torrust-tracker/issues/889) — New config option for logging style                                                 | `docs/issues/closed/889-1978-new-config-option-for-logging-style.md`                       | DONE      | V3 schema implemented; includes negative test for removed `threshold` key. Manual verification is deferred to #1980.                                      |
-| 10    | [#1987](https://github.com/torrust/torrust-tracker/issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md`    | DONE      | Per-HTTP-tracker opt-in policy is active and enabled-v3 manual evidence is recorded.                                                                      |
-| 11    | [#2083](https://github.com/torrust/torrust-tracker/issues/2083) — Move UDP connection-ID error limit to shared server configuration                 | `docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md` | DONE      | V3 global policy is active; #1980 added two-listener, order-independent runtime coverage.                                                                 |
-| 12    | [#1980](https://github.com/torrust/torrust-tracker/issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`                       | IN_REVIEW | Draft PR #2103 contains active v3 runtime configuration, migration guidance, automatic verification, and manual evidence.                                 |
-| 13    | [#2023](https://github.com/torrust/torrust-tracker/issues/2023) — Expose configured public URLs in runtime observability                            | `docs/issues/open/2023-1978-expose-configured-public-urls-in-runtime-observability.md`     | TODO      | Must follow #1417 and #1980; adds `public_url` to health checks, metrics, and logs without replacing ServiceBinding.                                      |
-| 14    | [#2067](https://github.com/torrust/torrust-tracker/issues/2067) — Analyze a flat heterogeneous service configuration                                | `docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md`                   | TODO      | Non-blocking analysis only; its confirmed configuration-model bug is tracked by #2083.                                                                    |
+| Order | Issue                                                                                                                                               | Local Spec                                                                                 | Status | Notes                                                                                                                                                     |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1     | [#1979](https://github.com/torrust/torrust-tracker/issues/1979) — Copy `v2_0_0` → `v3_0_0` as baseline                                              | `docs/issues/closed/1979-1978-copy-configuration-schema-v2-to-v3-baseline.md`              | DONE   | Merged in PR #1999; v3 baseline and smoke tests are in `develop`                                                                                          |
+| 2     | [#1981](https://github.com/torrust/torrust-tracker/issues/1981) — Fix `tsl_config` → `tls_config` typo                                              | `docs/issues/closed/1981-1978-fix-tsl-config-tls-config-typo.md`                           | DONE   | Implemented for v3; v2 compatibility retained until final migration                                                                                       |
+| 3     | [#1640](https://github.com/torrust/torrust-tracker/issues/1640) — Support per-HTTP-tracker `on_reverse_proxy` setting                               | `docs/issues/closed/1640-1978-per-http-tracker-on-reverse-proxy-setting.md`                | DONE   | Merged in PR #2014; v3 schema slice complete; runtime consumers deferred to #1980 (subissue #12)                                                          |
+| 4     | [#1417](https://github.com/torrust/torrust-tracker/issues/1417) — Include public service URL in configuration                                       | `docs/issues/closed/1417-1978-add-public-service-url-to-configuration.md`                  | DONE   | Merged in PR #2016; typed `Option<HttpUrl>`/`Option<UdpUrl>` newtypes on `HttpTracker`, `UdpTracker`, `HttpApi`; scheme validation at deserialization     |
+| 5     | [#1415](https://github.com/torrust/torrust-tracker/issues/1415) — Use `ServiceBinding` instead of bare `SocketAddr` for service identity            | `docs/issues/closed/1415-1978-use-service-binding-instead-of-socket-addr/ISSUE.md`         | DONE   | Added protocol-aware `service_binding` alongside compatible `server_socket_addr` fields in HTTP tracker, REST API, and UDP error logs; verified manually. |
+| 6     | [#1453](https://github.com/torrust/torrust-tracker/issues/1453) — IP bans reset interval configurable + fix duplicate cleanup                       | `docs/issues/closed/1453-1978-ip-bans-reset-interval-configurable/ISSUE.md`                | DONE   | One cancellation-managed bootstrap cleanup job reads the active v3 interval after #1980 runtime activation.                                               |
+| 7     | [#1136](https://github.com/torrust/torrust-tracker/issues/1136) — Add configurable UDP connection ID validation policy                              | `docs/issues/closed/1136-1978-configurable-udp-connection-id-validation-policy.md`         | DONE   | PR #2032 merged; all 12 ACs met; manual verification deferred to #1980.                                                                                   |
+| 8     | [#1490](https://github.com/torrust/torrust-tracker/issues/1490) — Decompose v3 database configuration                                               | `docs/issues/open/1490-1978-decompose-database-configuration.md`                           | DONE   | V3 uses driver-specific database fields and secret passwords.                                                                                             |
+| 8a    | [#999](https://github.com/torrust/torrust-tracker/issues/999) — Make v3 database configuration optional when persistence is unused                  | `docs/issues/open/999-1978-optional-database-configuration/ISSUE.md`                       | DONE   | V3 `Option<Database>` and the temporary bridge are implemented; the later runtime-activation follow-up remains pending.                                   |
+| 9     | [#889](https://github.com/torrust/torrust-tracker/issues/889) — New config option for logging style                                                 | `docs/issues/closed/889-1978-new-config-option-for-logging-style.md`                       | DONE   | V3 schema implemented; includes negative test for removed `threshold` key. Manual verification is deferred to #1980.                                      |
+| 10    | [#1987](https://github.com/torrust/torrust-tracker/issues/1987) — Use peer IP from the HTTP announce `ip` parameter when configured                 | `docs/issues/open/1987-add-config-option-to-use-ip-from-announce-query-string/ISSUE.md`    | DONE   | Per-HTTP-tracker opt-in policy is active and enabled-v3 manual evidence is recorded.                                                                      |
+| 11    | [#2083](https://github.com/torrust/torrust-tracker/issues/2083) — Move UDP connection-ID error limit to shared server configuration                 | `docs/issues/open/2083-1978-move-max-connection-id-errors-per-ip-to-udp-tracker-server.md` | DONE   | V3 global policy is active; #1980 added two-listener, order-independent runtime coverage.                                                                 |
+| 12    | [#1980](https://github.com/torrust/torrust-tracker/issues/1980) — Final cleanup: remove global re-exports, migrate consumers to explicit v3 imports | `docs/issues/open/1980-1978-configuration-overhaul-final-cleanup.md`                       | DONE   | PR #2103 merged; active runtime uses v3 configuration while the temporary SQLite compatibility bridge retains persistence.                                |
+| 13    | [#2107](https://github.com/torrust/torrust-tracker/issues/2107) — Activate persistence-free v3 runtime composition                                  | `docs/issues/open/2107-1978-activate-persistence-free-v3-runtime-composition.md`           | TODO   | Follows #999 and #1980; activates absent-database composition while keeping REST API routes capability-aware.                                             |
+| 14    | [#2023](https://github.com/torrust/torrust-tracker/issues/2023) — Expose configured public URLs in runtime observability                            | `docs/issues/open/2023-1978-expose-configured-public-urls-in-runtime-observability.md`     | TODO   | Must follow #1417 and #1980; adds `public_url` to health checks, metrics, and logs without replacing ServiceBinding.                                      |
+| 15    | [#2067](https://github.com/torrust/torrust-tracker/issues/2067) — Analyze a flat heterogeneous service configuration                                | `docs/issues/open/2067-1978-analyze-flat-service-configuration/ISSUE.md`                   | TODO   | Non-blocking analysis only; its confirmed configuration-model bug is tracked by #2083.                                                                    |
 
 ### Release-gated prerequisite
 
@@ -144,10 +146,10 @@ graph TD
       sub10 --> sub12
       sub11 --> sub12
       sub8a --> sub12["12. #1980 v3 activation with bridge"]
-      sub12 --> optionalRuntime["Post-#1980 persistence-free activation follow-up"]
-      sub4 --> sub13["13. public_url runtime observability"]
-      sub12 --> sub13
-      sub12 --> sub14["14. Post-v3 flat-service research"]
+      sub12 --> sub13["13. #2107 persistence-free runtime activation"]
+      sub4 --> sub14["14. public_url runtime observability"]
+      sub12 --> sub14
+      sub12 --> sub15["15. Post-v3 flat-service research"]
 ```
 
 ### Critical path
@@ -206,13 +208,14 @@ These can run in any order or in parallel branches:
 ### Phase 3: Integration
 
 - **Subissue #12** (#1980) — Final cleanup: remove global re-exports, migrate all ~30 consumers to explicit `v3_0_0` imports, activate the v3 shared UDP error limit, and remove crate-root `logging.rs`. Keep `v2_0_0` module deprecated. It follows the secrecy release gate and #2083.
-- **Subissue #13** (#2023) — After #12, expose optional v3 `public_url` values in health checks,
+- **Subissue #13** (#2107) — After #999 and #1980, activate the persistence-free v3 runtime composition. It preserves the REST API while returning controlled HTTP 409 responses from disabled whitelist and key-management routes.
+- **Subissue #14** (#2023) — After #12, expose optional v3 `public_url` values in health checks,
   metrics, and logs. Preserve the distinction between configured bind address, post-bind
   `ServiceBinding`, and `public_url`; do not implement `internal_service_url`.
 
 ### Phase 4: Post-v3 Research
 
-- **Subissue #14** (#2067) — Analyze a possible successor schema that represents heterogeneous
+- **Subissue #15** (#2067) — Analyze a possible successor schema that represents heterogeneous
   listener services in one ordered collection. This non-blocking research does not implement a
   schema or runtime change and must not delay #1980. Any implementation recommendation must be
   tracked separately and account for #1490.
@@ -298,6 +301,10 @@ For each subissue implementation in this EPIC, the default completion policy is:
   resolving the discrepancy with this specification. Created approved Task #2067 as the thirteenth
   native sub-issue for non-blocking research into a possible post-v3 flat heterogeneous service
   configuration; any implementation remains separate from this EPIC delivery.
+- 2026-08-28 00:00 UTC - GitHub Copilot/User - Created approved feature subissue #2107 for
+  persistence-free v3 runtime activation and linked it natively to this EPIC. It follows #999 and
+  #1980, preserves REST API availability, and makes disabled whitelist/key routes return controlled
+  HTTP 409 responses.
 - 2026-08-20 16:44 UTC - Copilot - Renamed #2067's folder-based subissue specification to include
   the parent EPIC number, following the open-issues naming convention.
 - 2026-08-21 16:30 UTC - Copilot/User - Split #1490's schema-decomposition and secret-typing work. #1490 now defines the final v3 database configuration shape; a release-gated `secrecy` prerequisite was drafted.

--- a/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+++ b/docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
@@ -158,7 +158,7 @@ graph TD
 1 → 2 → 3 → 4 → 12
 1 → 2 → 3 → 8 → 12
 1 → secrecy → 8 → 12
-1 → 2 → 3 → 8 → 8a → 12 → persistence-free activation follow-up
+1 → 2 → 3 → 8 → 8a → 12 → 13 (#2107 persistence-free runtime activation)
 1 → 11 → 12
 ```
 
@@ -188,8 +188,8 @@ Subissues #5, #6, #7, #9 are independent and can run in parallel with the critic
 - **Subissue #8a** (#999) — After #1490, introduce the v3
   `Option<Database>` representation, optional container dependencies, and a
   tested temporary `Some(Database)` bridge. #1980 activates v3 consumers with
-  that bridge. A small post-#1980 follow-up passes actual `None`, invokes the
-  reusable validation matrix, and activates persistence-free runtime behavior.
+  that bridge. #2107 passes actual `None`, invokes the reusable validation
+  matrix, and activates persistence-free runtime behavior.
 - **Subissue #4** (#1417) — `public_url` flat field. After #3 (depends on `Network` placement decision). ~6 files.
 - **Subissue #10** (#1987) — Opt-in use of the HTTP announce `ip` parameter. After #3 and external prerequisite #1985.
 

--- a/docs/issues/open/2107-1978-activate-persistence-free-v3-runtime-composition.md
+++ b/docs/issues/open/2107-1978-activate-persistence-free-v3-runtime-composition.md
@@ -1,0 +1,297 @@
+---
+doc-type: issue
+issue-type: feature
+status: planned
+priority: p2
+epic: 1978
+github-issue: 2107
+spec-path: docs/issues/open/2107-1978-activate-persistence-free-v3-runtime-composition.md
+branch: "2107-activate-persistence-free-v3-runtime-composition"
+related-pr: null
+depends-on:
+  - 999
+  - 1980
+last-updated-utc: 2026-08-28 00:00
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - docs/issues/open/1978-configuration-overhaul-epic/EPIC.md
+    - docs/issues/open/999-1978-optional-database-configuration/ISSUE.md
+    - docs/issues/open/999-1978-optional-database-configuration/persistence-free-runtime-activation-draft.md
+    - docs/adrs/20260825193119_make_persistence_an_optional_application_composition_capability.md
+    - packages/configuration/docs/migrate-v2-to-v3.md
+    - src/bootstrap/app.rs
+    - src/bootstrap/persistence.rs
+    - src/container.rs
+    - packages/tracker-core/src/container.rs
+    - share/container/entry_script_sh
+---
+
+# Issue #2107 - Activate persistence-free v3 runtime composition
+
+> **EPIC position:** Configuration-overhaul subissue of EPIC #1978. This issue
+> follows #999 and #1980, which respectively introduced v3
+> `Option<Database>` and activated v3 at runtime with a temporary fixed-SQLite
+> compatibility bridge.
+
+## Goal
+
+Honor an omitted v3 `[core.database]` at runtime when no enabled capability
+requires persistence. A persistence-free public HTTP and/or UDP tracker must
+start without a database driver, database file, database connection, migration,
+persistence store, or database-backed service.
+
+## Background
+
+V3 configuration already represents `core.database` as `Option<Database>`, but
+runtime composition currently substitutes `Database::default()` when the field
+is absent. Consequently, an omitted database table still starts SQLite
+persistence and executes the full shared migration set.
+
+The existing bootstrap validation function is also preparatory only: it is not
+called by active startup and covers the three core capabilities that require
+persistence. The management REST API is a critical operational feature and
+must remain available without persistence. Its key and whitelist routes must
+instead honor their associated feature configuration, rather than reaching a
+database merely because the routes are registered.
+
+Further, `TrackerCoreContainer::initialize_from(..., None)` currently returns
+no container rather than a usable persistence-free service graph. The HTTP and
+UDP containers, startup jobs, and tracker-core handlers therefore require a
+composition refactor, not merely removal of the temporary bridge.
+
+## Scope
+
+### In Scope
+
+- Remove the fixed-SQLite compatibility bridge and compose from the actual v3
+  `core.database: Option<Database>` value.
+- Invoke the bootstrap-owned persistence requirement matrix after configuration
+  validation but before global or application-container construction.
+- Preserve the existing matrix entries for `core.listed`, `core.private`, and
+  `core.tracker_policy.persistent_torrent_completed_stat`.
+- Construct a usable persistence-free application graph for public HTTP and/or
+  UDP tracker listeners. Resolve optionality at explicit composition seams;
+  do not create a no-op database implementation or propagate an `Option`
+  through unrelated consumers.
+- In the persistence-free branch, construct no concrete database driver,
+  `DatabaseStores`, migration runner, database-backed repository, key handler,
+  whitelist manager, or database-backed torrent-metrics service.
+- Adapt tracker-core services and jobs whose constructor signatures currently
+  require database-backed metric repositories even when persistent completed
+  metrics are disabled, including the default-enabled tracker usage statistics
+  event listener.
+- Keep the management REST API available in persistence-free operation. Its
+  whitelist and key-management routes must remain registered but return a
+  controlled HTTP `409 Conflict` response when `core.listed` or `core.private`
+  is disabled, respectively. These requests must not construct or access
+  persistence services.
+- Keep torrent, statistics, and metrics routes available from their in-memory
+  data. Document that completed-count values are process-local when persistence
+  is absent; a later API version may add explicit historical-data provenance
+  without changing this release's response shape.
+- Preserve current server-error behavior for a configured database that fails
+  operationally. Disabled-by-configuration responses must be distinct from
+  database failures.
+- Preserve the enabled-persistence lifecycle: a configured database selects one
+  driver and runs the complete shared migration set before its required stores
+  and services are built. Do not introduce feature-specific schemas, migration
+  streams, or migration selection.
+- Make the supported container entrypoint configuration-driven. A documented
+  v3 no-persistence configuration source must start without a database-driver
+  environment override, a packaged SQLite installation, or creation of the
+  tracker database directory solely for persistence.
+- Preserve operator-managed database state across restart/configuration
+  transitions. The tracker must not delete, overwrite, migrate, copy, or
+  otherwise alter an unselected database target.
+- Execute and record the applicable #999 manual scenarios and update its
+  acceptance evidence, migration guide, and operational documentation.
+
+### Out of Scope
+
+- Changing v2 configuration behavior, defaults, validation, or database
+  lifecycle.
+- Changing the REST API response shape or adding a completed-count provenance
+  field; a later API version may make that distinction explicit.
+- Feature-specific database schemas or partial migration streams.
+- Automatically moving data between configured database targets.
+- Persistence-awareness work not necessary for the initial public HTTP/UDP
+  tracker composition.
+
+## Architectural Decisions
+
+- Related ADR: `docs/adrs/20260825193119_make_persistence_an_optional_application_composition_capability.md`.
+- The bootstrap layer owns the requirement matrix exactly once. It must not be
+  duplicated in configuration validation, route handlers, or repositories.
+- `http_api` alone does not require persistence. The API remains available;
+  individual routes represent disabled `listed` and `private` capabilities as
+  controlled `409 Conflict` responses. This corrects the current behavior,
+  which permits those routes to mutate persistent state even when their tracker
+  feature is disabled.
+- Disabled-capability responses must use the established `ActionStatus::Err`
+  shape and a distinct `DisabledByConfiguration`-style domain error. They must
+  not reuse an operational database error, which continues to map to the
+  existing server-error response.
+- The persistence-free path must be a real composition branch. A no-op database
+  driver or repository is not acceptable because it can conceal unexpected
+  persistence access.
+- An important new architecture decision discovered during implementation must
+  be recorded in a new ADR before it is finalized. No additional ADR is known
+  to be required at drafting time.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                      | Notes / Expected Output                                                                                                                                                   |
+| --- | ------ | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Activate persistence validation           | Invoke the centralized bootstrap check from active v3 bootstrap after configuration validation and before globals or containers are built.                                |
+| T2  | TODO   | Compose capability-aware REST API         | Keep API-wide routes available without persistence; return controlled disabled-capability responses from key and whitelist routes without persistence access.             |
+| T3  | TODO   | Build persistence-free core graph         | Refactor tracker-core composition, handlers, managers, and jobs so public HTTP/UDP operation does not require persistence services.                                       |
+| T4  | TODO   | Preserve persistence-enabled composition  | Verify configured SQLite, MySQL, and PostgreSQL retain one-driver, complete-migration lifecycle and existing required dependencies.                                       |
+| T5  | TODO   | Adapt supported container startup         | Define and test a no-persistence v3 configuration source; remove mandatory driver override/default SQLite installation while retaining non-persistence entrypoint duties. |
+| T6  | TODO   | Add regression and transition tests       | Cover no-side-effect startup, public protocol behavior, validation failures, configured drivers, and non-destructive restart transitions.                                 |
+| T7  | TODO   | Execute manual evidence and documentation | Run M1-M6 as scoped below; update #999 evidence, migration guidance, container documentation, and progress records.                                                       |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Draft copied from the #999 activation-follow-up planning artifact
+- [x] Draft reconciled with merged #1980 runtime behavior
+- [x] Draft reviewed and approved by user/maintainer
+- [x] GitHub issue #2107 created, linked as a subissue of EPIC #1978, and number added to this spec
+- [ ] Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and applicable pre-push checks)
+- [ ] Manual verification scenarios executed and recorded
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Issue closed and specification moved to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-08-28 00:00 UTC - GitHub Copilot - Copied the post-#1980 activation-follow-up draft from #999 and reconciled it with merged runtime code. Confirmed that bridge removal alone cannot produce a usable persistence-free tracker; expanded planned scope to real public tracker composition and bootstrap validation. Initial draft temporarily classified `http_api` as persistence-required pending maintainer review.
+- 2026-08-28 00:00 UTC - User/GitHub Copilot - Approved keeping the management REST API available without persistence. This issue now corrects disabled whitelist/key endpoint behavior through controlled HTTP 409 responses while preserving API-wide availability; a later API version may add a response-field distinction between session and historical completed counts.
+- 2026-08-28 00:00 UTC - GitHub Copilot - User approved the refined specification. Created GitHub issue #2107 and linked it as a native subissue of EPIC #1978.
+
+## Acceptance Criteria
+
+- [ ] AC1: Active v3 bootstrap evaluates the centralized persistence-requirement
+      matrix before application composition.
+- [ ] AC2: With no `[core.database]`, each enabled required capability fails
+      deterministically before containers are constructed: `core.listed`,
+      `core.private`, and persistent completed metrics.
+- [ ] AC3: `http_api` alone is usable without `[core.database]`; no API-wide
+      startup rejection or late composition panic occurs.
+- [ ] AC4: A v3 public HTTP and/or UDP tracker with no required capability and
+      no `[core.database]` constructs and serves protocol traffic successfully.
+- [ ] AC5: The persistence-free composition constructs no concrete driver,
+      database stores, migrations, database-backed repositories, database file,
+      or network database connection.
+- [ ] AC6: Persistence-free operation works when
+      `core.tracker_usage_statistics = true`, which is the current default.
+- [ ] AC7: With `[core.database]`, SQLite, MySQL, and PostgreSQL retain the
+      all-or-nothing driver and complete shared migration lifecycle.
+- [ ] AC8: V2 configuration and runtime behavior remain unchanged.
+- [ ] AC9: Whitelist and key-management routes remain registered but return
+      HTTP `409 Conflict` with `ActionStatus::Err` when their respective
+      feature is disabled, without database access. Configured operational
+      database failures remain distinguishable server errors.
+- [ ] AC10: Torrent, statistics, and metrics routes remain available in
+      persistence-free operation. Documentation does not claim an across-restart
+      lifetime interpretation for completed counts without persistence.
+- [ ] AC11: The supported container startup path runs a documented v3
+      no-persistence configuration without a database-driver override, packaged
+      SQLite setup, or a tracker database directory created solely for
+      persistence.
+- [ ] AC12: Persistence configuration restart transitions leave unselected
+      database targets unchanged and never copy data automatically.
+- [ ] AC13: #999 manual evidence and acceptance verification are updated
+      truthfully, including API-disabled-capability evidence.
+- [ ] AC14: `linter all` exits with code `0`, relevant automated tests pass,
+      and acceptance criteria are re-reviewed against observed evidence.
+
+## Verification Plan
+
+### Automatic Checks
+
+- Focused bootstrap tests for the persistence-requirement matrix.
+- REST API contract tests for disabled whitelist/key capabilities, API-wide
+  persistence-free startup, and retained operational-database-failure behavior.
+- Focused tracker-core, HTTP-core, UDP-core, and startup-job tests for an
+  operational persistence-free service graph.
+- Protocol integration tests proving public HTTP announce/scrape and UDP
+  connect/announce/scrape work without `[core.database]`.
+- Driver and migration tests for SQLite, MySQL, and PostgreSQL with persistence
+  configured.
+- Container entrypoint/image tests for both no-persistence and configured
+  persistence startup paths.
+- Restart-transition tests that inspect selected and unselected storage
+  targets.
+- `cargo machete`, `linter all`, documentation tests, the mandatory pre-commit
+  gate, and relevant workspace/pre-push checks.
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`, `DEFERRED`.
+
+| ID  | Scenario                                      | Command/Steps                                                                                                                                | Expected Result                                                                                                                                   | Status | Evidence                                                                          |
+| --- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | --------------------------------------------------------------------------------- |
+| M1  | Start public v3 tracker without persistence   | Start an ephemeral public HTTP and/or UDP tracker with no `[core.database]`, no required capabilities, and tracker usage statistics enabled. | Startup and protocol traffic succeed with no persistence artifacts.                                                                               | TODO   | Record configuration, command, logs, and artifact inspection in #999 evidence.    |
+| M2  | Reject all missing-persistence combinations   | Independently enable listing, private mode, and persistent completed metrics without `[core.database]`.                                      | Each configuration fails before composition with its stable requirement diagnostic.                                                               | TODO   | Record commands and output in #999 evidence.                                      |
+| M3  | Initialize configured drivers                 | Start each supported configured driver with a persistence-required capability enabled.                                                       | The selected driver and complete shared migrations initialize normally.                                                                           | TODO   | Record driver-specific environment and evidence in #999 artifacts.                |
+| M4  | REST API persistence-free route contract      | Start `http_api` with no persistence, exercise torrent/stats/metrics routes and disabled whitelist/key routes.                               | API starts; in-memory routes remain available; disabled direct capability routes return controlled HTTP 409 responses without persistence access. | TODO   | Record configuration, requests, responses, and no-persistence evidence.           |
+| M5  | Repeat baseline no-persistence run            | Follow `baseline-e2e-verification.md` with the active v3 runtime and no `[core.database]`.                                                   | Tracker remains available without a database file, connection, or migration.                                                                      | TODO   | Append command, logs, artifact inspection, and revision to the baseline artifact. |
+| M6  | Start supported container without persistence | Build/run the normal image using the documented no-persistence v3 configuration and no driver override.                                      | Entrypoint does not select/install SQLite or create its database directory solely for tracker persistence.                                        | TODO   | Record image/configuration, output, and mounted-state inspection.                 |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                      |
+| ----- | ---------------------- | ------------------------------------------------------------- |
+| AC1   | TODO                   | Focused bootstrap tests and startup integration test          |
+| AC2   | TODO                   | One test and manual record per matrix capability              |
+| AC3   | TODO                   | Persistence-free REST API startup test                        |
+| AC4   | TODO                   | HTTP/UDP protocol integration evidence                        |
+| AC5   | TODO                   | Constructor tests plus isolated artifact inspection           |
+| AC6   | TODO                   | Persistence-free startup test with default statistics enabled |
+| AC7   | TODO                   | Driver/migration test evidence                                |
+| AC8   | TODO                   | V2 regression coverage and review                             |
+| AC9   | TODO                   | REST API disabled-capability contract tests and M4 evidence   |
+| AC10  | TODO                   | In-memory API tests and documentation review                  |
+| AC11  | TODO                   | M6 container evidence                                         |
+| AC12  | TODO                   | Restart-transition test and manual inspection                 |
+| AC13  | TODO                   | Updated #999 scenario and acceptance records                  |
+| AC14  | TODO                   | Validation command output and post-implementation review      |
+
+## Risks and Trade-offs
+
+- **Composition breadth:** Existing container fields and constructors make
+  persistence mandatory. Mitigation: introduce explicit persistence-enabled and
+  persistence-free composition branches, retaining non-optional dependencies in
+  the enabled branch.
+- **API compatibility:** Disabled endpoints previously operate against the
+  database even when their feature is disabled. Mitigation: retain their route
+  paths and response envelope, but make the behavior explicit as HTTP 409;
+  document this breaking correction in the v3 migration guidance.
+- **Hidden side effects:** A no-op implementation could prevent visible driver
+  setup while retaining unexpected database-shaped services. Mitigation: assert
+  absence at construction seams and inspect isolated runtime artifacts.
+- **Entrypoint ambiguity:** Removing the driver override without defining a
+  configuration source can leave container startup unspecified. Mitigation:
+  explicitly document and test one supported v3 no-persistence source.
+- **Data loss:** Restart changes can accidentally alter old targets. Mitigation:
+  test checksums/state before and after disable, re-enable, and target-change
+  transitions.
+
+## References
+
+- Parent EPIC: #1978
+- Prerequisite issue: #999
+- V3 runtime activation: #1980
+- Future REST API evolution: #144
+- `docs/issues/open/999-1978-optional-database-configuration/analysis.md`
+- `docs/issues/open/999-1978-optional-database-configuration/solution.md`
+- `docs/issues/open/999-1978-optional-database-configuration/persistence-unavailable-scenarios.md`
+- `docs/issues/open/999-1978-optional-database-configuration/baseline-e2e-verification.md`
+- `docs/adrs/20260825193119_make_persistence_an_optional_application_composition_capability.md`


### PR DESCRIPTION
## Summary

- add the approved specification for #2107, persistence-free v3 runtime composition
- record #2107 as a native subissue of configuration-overhaul EPIC #1978
- update the EPIC delivery graph and #1980 status after PR #2103 merged

## Scope

Documentation only: the implementation of persistence-free composition, capability-aware REST API responses, and container behavior is intentionally not included.

## Validation

- installed pre-commit hook: `cargo machete --with-metadata`, `cargo deny check bans`, `linter all`, and `cargo test --doc --workspace`
- `git diff --check`

Related to #2107
