### PR TITLE
docs(adrs): place ADRs by decision scope (#2116)

### DIFF
--- a/.github/skills/dev/planning/create-adr/SKILL.md
+++ b/.github/skills/dev/planning/create-adr/SKILL.md
@@ -24,7 +24,10 @@ date -u +"%Y%m%d%H%M%S"
 
 # 3. Create the ADR file
 # Format: YYYYMMDDHHMMSS_snake_case_title.md
+# Root ADR:
 touch docs/adrs/20241115093012_your_decision_title.md
+# Package-local ADR:
+touch packages/<package>/docs/adrs/20241115093012_your_decision_title.md
 
 # 4. Update the owning collection's index
 # Add a root ADR to docs/adrs/index.md; add a local ADR only to its local index

--- a/.github/skills/dev/planning/create-adr/SKILL.md
+++ b/.github/skills/dev/planning/create-adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-adr
-description: Guide for creating Architectural Decision Records (ADRs) in the torrust-tracker project. Covers the timestamp-based file naming convention, free-form structure, index registration in the docs/adrs/README.md index table, and commit workflow. Use when documenting architectural decisions, recording design choices, or adding decision records. Triggers on "create ADR", "add ADR", "new decision record", "architectural decision", "document decision", or "add decision".
+description: Guide for creating Architectural Decision Records (ADRs) in the torrust-tracker project. Covers decision-scope placement, timestamp-based names, free-form structure, collection-specific index registration, and commit workflow. Use when documenting architectural decisions, recording design choices, or adding decision records. Triggers on "create ADR", "add ADR", "new decision record", "architectural decision", "document decision", or "add decision".
 metadata:
   author: torrust
   version: "1.0"
@@ -18,14 +18,18 @@ metadata:
 date -u +"%Y%m%d%H%M%S"
 # e.g. 20241115093012
 
-# 2. Create the ADR file
+# 2. Choose the ADR collection by decision scope
+# Repository-wide, multi-package, and inter-package: docs/adrs/
+# Package-owned and extractable: packages/<package>/docs/adrs/
+
+# 3. Create the ADR file
 # Format: YYYYMMDDHHMMSS_snake_case_title.md
 touch docs/adrs/20241115093012_your_decision_title.md
 
-# 3. Update the index
-# Add entry to docs/adrs/index.md
+# 4. Update the owning collection's index
+# Add a root ADR to docs/adrs/index.md; add a local ADR only to its local index
 
-# 4. Validate and commit
+# 5. Validate and commit
 linter markdown
 linter cspell
 git commit -S -m "docs(adrs): add ADR for {short description}"
@@ -57,7 +61,26 @@ date -u +"%Y%m%d%H%M%S"
 - `20240227164834_use_plural_for_modules_containing_collections.md`
 - `20241115093012_adopt_axum_for_http_server.md`
 
-Location: `docs/adrs/`
+## ADR Placement
+
+Choose the collection according to the scope of the decision, not the paths changed by the
+implementation:
+
+| Decision scope                                            | Location                        |
+| --------------------------------------------------------- | ------------------------------- |
+| Repository-wide, multi-package, or inter-package contract | `docs/adrs/`                    |
+| Solely owned by an extractable package                    | `packages/<package>/docs/adrs/` |
+
+Shared configuration, protocol behavior, dependency policy, workspace conventions, and other
+cross-package contracts require a root ADR even if one package contains all immediate code changes.
+
+Every package-local collection needs a `README.md` and an `index.md`. Register an ADR only in the
+index for its owning collection; root indexes do not duplicate local entries. When a package-local
+decision becomes repository-wide, create a root ADR that links to and supersedes the local ADR,
+then retain the local ADR and its local index entry as historical context.
+
+The tracker-client CLI I/O ADR and the later root global CLI output ADR demonstrate this
+local-placement and root-supersession pattern.
 
 ## ADR Structure
 
@@ -86,11 +109,12 @@ Only add a `- Status:` header for special terminal states:
 ```bash
 PREFIX=$(date -u +"%Y%m%d%H%M%S")
 TITLE="your_decision_title"   # snake_case
-echo "docs/adrs/${PREFIX}_${TITLE}.md"
+echo "docs/adrs/${PREFIX}_${TITLE}.md"  # Or packages/<package>/docs/adrs/ for a local decision.
 ```
 
 ### Step 2: Write the ADR
 
+- **Scope**: State whether the decision is root or package-local and why
 - **Description**: Explain the problem thoroughly — enough context for future contributors
 - **Agreement**: State clearly what was decided and why
 - **Date**: Today's date (`date -u +"%Y-%m-%d"`)
@@ -98,7 +122,7 @@ echo "docs/adrs/${PREFIX}_${TITLE}.md"
 
 ### Step 3: Update the Index
 
-Add a row to the index table in `docs/adrs/index.md`:
+Add a row to the selected collection's `index.md` table:
 
 ```markdown
 | [YYYYMMDDHHMMSS](YYYYMMDDHHMMSS_your_title.md) | YYYY-MM-DD | Short Title | One-sentence description. |
@@ -126,7 +150,7 @@ linter markdown
 linter cspell
 linter all   # full check
 
-git add docs/adrs/
+git add docs/adrs/  # Include a package-local ADR path instead when applicable.
 git commit -S -m "docs(adrs): add ADR for {short description}"
 git push {your-fork-remote} {branch}
 ```

--- a/.github/skills/dev/planning/create-issue/SKILL.md
+++ b/.github/skills/dev/planning/create-issue/SKILL.md
@@ -108,7 +108,12 @@ The draft must also include a verification policy that is explicit and enforceab
 
 During implementation, create an ADR when an important architectural decision
 emerges, even if the issue draft did not anticipate it. Link the ADR from the
-issue specification and update the architectural-decisions section.
+issue specification and update the architectural-decisions section. For each
+planned ADR, identify its expected root or package-local collection by decision
+scope: use `docs/adrs/` for repository-wide, multi-package, and inter-package
+decisions, and `packages/<package>/docs/adrs/` only for decisions owned solely
+by an extractable package. Do not choose placement only from the implementation
+paths expected to change.
 
 Use **placeholders** for the issue number until after creation (for example `github-issue: null`
 or `[To be assigned]` in the heading/body content).

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -41,13 +41,20 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 
 | Artifact type                                  | Target location                                                                                                                     |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| New ADR                                        | `docs/adrs/` — filename format: `YYYYMMDDHHMMSS_<short-slug>.md`                                                                    |
+| New root ADR                                   | `docs/adrs/` — for repository-wide, multi-package, or inter-package decisions                                                       |
+| New package-local ADR                          | `packages/<package>/docs/adrs/` — for decisions owned only by an extractable package                                                |
 | New issue spec (before GitHub issue exists)    | `docs/issues/drafts/`                                                                                                               |
 | New issue spec (after GitHub issue created)    | `docs/issues/open/<number>-<short-slug>.md`, or `docs/issues/open/<number>-<short-slug>/ISSUE.md` when it has issue-local artifacts |
 | New refactor plan (before GitHub issue exists) | `docs/refactor-plans/drafts/`                                                                                                       |
 | New refactor plan (after GitHub issue created) | `docs/refactor-plans/open/<number>-<short-slug>.md`                                                                                 |
 | New document template                          | `docs/templates/`                                                                                                                   |
 | New diagram or screenshot                      | `docs/media/` (or the relevant subdirectory)                                                                                        |
+
+Choose ADR placement by the decision's architectural scope, not the paths modified by the
+implementation. Root ADRs cover shared configuration, protocols, dependency policy, workspace
+conventions, and other cross-package contracts. A package-local ADR collection contains its own
+`README.md` and `index.md`; do not duplicate its entries in the root ADR index. See
+[`docs/adrs/20260830124000_place_adrs_by_decision_scope.md`](adrs/20260830124000_place_adrs_by_decision_scope.md).
 
 ## Markdown Frontmatter
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -41,8 +41,8 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 
 | Artifact type                                  | Target location                                                                                                                     |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| New root ADR                                   | `docs/adrs/` — for repository-wide, multi-package, or inter-package decisions                                                       |
-| New package-local ADR                          | `packages/<package>/docs/adrs/` — for decisions owned only by an extractable package                                                |
+| New root ADR                                   | `docs/adrs/YYYYMMDDHHMMSS_snake_case_title.md` — for repository-wide, multi-package, or inter-package decisions                     |
+| New package-local ADR                          | `packages/<package>/docs/adrs/YYYYMMDDHHMMSS_snake_case_title.md` — for decisions owned only by an extractable package              |
 | New issue spec (before GitHub issue exists)    | `docs/issues/drafts/`                                                                                                               |
 | New issue spec (after GitHub issue created)    | `docs/issues/open/<number>-<short-slug>.md`, or `docs/issues/open/<number>-<short-slug>/ISSUE.md` when it has issue-local artifacts |
 | New refactor plan (before GitHub issue exists) | `docs/refactor-plans/drafts/`                                                                                                       |

--- a/docs/adrs/20260830124000_place_adrs_by_decision_scope.md
+++ b/docs/adrs/20260830124000_place_adrs_by_decision_scope.md
@@ -1,0 +1,107 @@
+---
+semantic-links:
+  skill-links:
+    - create-adr
+  related-artifacts:
+    - docs/AGENTS.md
+    - docs/adrs/README.md
+    - docs/adrs/index.md
+    - docs/templates/ADR.md
+    - .github/skills/dev/planning/create-adr/SKILL.md
+    - console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md
+    - docs/adrs/20260519000000_define_global_cli_output_contract.md
+---
+
+# Place ADRs by Decision Scope
+
+## Description
+
+The repository currently collects ADRs in `docs/adrs/`, but workspace packages are intended to
+be independently extractable. An ADR whose decision is owned solely by one package must travel
+with that package; otherwise, extraction separates the implementation from its rationale.
+
+The paths changed by an implementation do not reliably determine this ownership. A change in one
+package can establish a repository policy, alter shared configuration or a protocol, or define an
+inter-package contract. Such decisions need one repository-level record even when their immediate
+implementation is local.
+
+The tracker client provides the established precedent. Its original CLI I/O decision lives in
+`console/tracker-client/docs/adrs/`, because extraction was anticipated. The later root ADR,
+`20260519000000_define_global_cli_output_contract.md`, expanded the contract to all first-party
+binaries and superseded the local ADR without removing its historical context.
+
+## Agreement
+
+### Placement criteria
+
+Place an ADR in `packages/<package>/docs/adrs/` when all of the following apply:
+
+- The decision is limited to that package's architecture, behavior, or public contract.
+- The package owns the decision and its rationale.
+- The ADR should remain with the package when it is extracted into its own repository.
+
+Place an ADR in `docs/adrs/` when the decision governs the repository, affects multiple packages,
+or defines an inter-package contract. Root placement is required for decisions about shared
+configuration, protocol behavior, dependency policy, workspace-wide conventions, or another
+cross-package interface, even if the implementation change initially touches one package.
+
+When scope is uncertain, use root placement or resolve the scope during review. Do not infer scope
+solely from the paths of affected implementation files.
+
+### Local ADR collections
+
+Each package-local ADR collection must contain:
+
+- `README.md`, describing the collection's package ownership and its relationship to root ADRs.
+- `index.md`, listing ADRs owned by that package.
+- Timestamp-prefixed ADR files using `YYYYMMDDHHMMSS_snake_case_title.md`.
+
+Root and package-local indexes are separate. List each ADR only in its owning collection's index;
+do not duplicate package-local ADR rows in `docs/adrs/index.md`. Package documentation should link
+to its local collection so the ADRs remain discoverable from the package entry point.
+
+The established `console/tracker-client/docs/adrs/` collection follows the same ownership model
+for an extractable application that is not under `packages/`.
+
+### Supersession
+
+When a package-local decision becomes repository-wide, create a root ADR. The root ADR must link
+to the local ADR and explain the expanded scope. Update the local ADR with a `Status: Superseded`
+link to the root ADR, while retaining the local ADR and its local index entry as historical
+context. Do not move or duplicate the local ADR merely because it was superseded.
+
+## Alternatives Considered
+
+**Keep every ADR in `docs/adrs/`.** Rejected because package extraction would separate
+package-owned implementation from the decision rationale that explains it.
+
+**Place ADRs by implementation-file location.** Rejected because local implementation can carry
+repository-wide consequences, especially for configuration, protocols, and shared contracts.
+
+**Copy package-local ADRs into the root index.** Rejected because duplicated registry entries
+create ambiguous ownership and drift.
+
+**Move a local ADR to the root when its scope expands.** Rejected because the original local
+decision remains useful historical context and should remain with an extracted package.
+
+## Consequences
+
+Package-owned rationale remains portable with extractable packages. Contributors must make an
+explicit scope judgment when authoring ADRs, and reviewers must verify that judgment. Root ADR
+navigation does not enumerate every package-local decision, so package documentation must expose
+its own ADR collection.
+
+This ADR does not itself migrate existing ADRs. Existing migrations, including the UDP-core ADR,
+are completed by their owning implementation work after this policy is accepted.
+
+## Date
+
+2026-08-30
+
+## References
+
+- Issue: [#2116](https://github.com/torrust/torrust-tracker/issues/2116)
+- Tracker-client local precedent:
+  `console/tracker-client/docs/adrs/20260512080000_define_tracker_cli_io_contract_and_error_handling.md`
+- Root supersession example:
+  `docs/adrs/20260519000000_define_global_cli_output_contract.md`

--- a/docs/adrs/20260830124000_place_adrs_by_decision_scope.md
+++ b/docs/adrs/20260830124000_place_adrs_by_decision_scope.md
@@ -14,6 +14,11 @@ semantic-links:
 
 # Place ADRs by Decision Scope
 
+## Scope
+
+Root ADR. This decision establishes a repository-wide policy for placing ADRs across root and
+package-local collections.
+
 ## Description
 
 The repository currently collects ADRs in `docs/adrs/`, but workspace packages are intended to

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -10,13 +10,13 @@ semantic-links:
 
 # Architectural Decision Records (ADRs)
 
-This directory contains the architectural decision records (ADRs) for the project.
+This directory contains the repository-level architectural decision records (ADRs) for the project.
 ADRs document architectural decisions — what was decided, why, and what alternatives
 were considered.
 
 More info: <https://adr.github.io/>.
 
-See [index.md](index.md) for the full list of ADRs.
+See [index.md](index.md) for the full list of root ADRs.
 
 ## How to Add a New ADR
 
@@ -26,13 +26,28 @@ Generate the timestamp prefix (UTC):
 date -u +"%Y%m%d%H%M%S"
 ```
 
-Create a new Markdown file using the format `YYYYMMDDHHMMSS_snake_case_title.md`:
+First choose the ADR collection by the decision's architectural scope:
+
+- `docs/adrs/` for repository-wide, multi-package, and inter-package decisions.
+- `packages/<package>/docs/adrs/` for decisions owned solely by an extractable package.
+
+Shared configuration, protocol behavior, dependency policy, workspace conventions, and
+inter-package contracts are root decisions even when only one package's implementation changes.
+Do not choose a location solely from the paths touched by the change.
+
+Create a new Markdown file in the selected collection using the format
+`YYYYMMDDHHMMSS_snake_case_title.md`:
 
 ```shell
 20230510152112_title.md
 ```
 
-Then add a row to the [Index](index.md) table.
+Then add a row only to that collection's index. Every package-local collection requires its own
+`README.md` and `index.md`; do not duplicate local ADRs in the root [Index](index.md) table.
+
+When a local decision becomes repository-wide, create a root ADR that links to and supersedes the
+local ADR. Keep the local ADR and its local index entry as historical context. The tracker-client
+CLI I/O ADR and the root global CLI output ADR are the existing example.
 
 There is no rigid template. A typical ADR includes:
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -39,7 +39,7 @@ Create a new Markdown file in the selected collection using the format
 `YYYYMMDDHHMMSS_snake_case_title.md`:
 
 ```shell
-20230510152112_title.md
+20230510152112_example_decision.md
 ```
 
 Then add a row only to that collection's index. Every package-local collection requires its own

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -8,7 +8,12 @@ semantic-links:
     - docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
 ---
 
-# ADR Index
+# Root ADR Index
+
+This index lists repository-level ADRs only. Package-local ADRs are listed in their owning
+package's `docs/adrs/index.md` and are not duplicated here. See
+[Place ADRs by Decision Scope](20260830124000_place_adrs_by_decision_scope.md) for placement and
+supersession rules.
 
 | ADR                                                                                                     | Date       | Title                                                               | Short Description                                                                                                                                                                                                                                     |
 | ------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -34,6 +39,7 @@ semantic-links:
 | [20260822094338](20260822094338_adopt_secrecy_for_sensitive_values.md)                                  | 2026-08-22 | Adopt secrecy for sensitive values                                  | Use the current stable `secrecy::SecretString` directly for credentials; deserialize existing configuration syntax with serde, serialize only at explicit persistence boundaries, and expose values only at immediate runtime-consumption boundaries. |
 | [20260825193119](20260825193119_make_persistence_an_optional_application_composition_capability.md)     | 2026-08-25 | Make persistence an optional application-composition capability     | Schema v3 represents absent persistence with `Option<Database>` and resolves it at tracker-core composition while retaining tracker-core schema and migration ownership.                                                                              |
 | [20260826124959](20260826124959_use_explicit_identifiers_for_test_log_assertions.md)                    | 2026-08-26 | Use explicit identifiers for test log assertions                    | Keep the repository-owned bounded log-capture helper and use test-selected identifiers instead of automatic span propagation through concurrent execution.                                                                                            |
+| [20260830124000](20260830124000_place_adrs_by_decision_scope.md)                                        | 2026-08-30 | Place ADRs by decision scope                                        | Keep package-owned decisions with extractable packages; record repository-wide, multi-package, and inter-package decisions in the root collection.                                                                                                    |
 
 ## ADR Lifecycle
 

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -11,7 +11,7 @@ semantic-links:
 # Root ADR Index
 
 This index lists repository-level ADRs only. Package-local ADRs are listed in their owning
-package's `docs/adrs/index.md` and are not duplicated here. See
+`packages/<package>/docs/adrs/index.md` and are not duplicated here. See
 [Place ADRs by Decision Scope](20260830124000_place_adrs_by_decision_scope.md) for placement and
 supersession rules.
 

--- a/docs/copilot-pr-reviews/pr-2118-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2118-copilot-suggestions.md
@@ -1,0 +1,56 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2118 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2118
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-08-30: Started processing five unresolved Copilot suggestions.
+- 2026-08-30: Applied and pushed five documentation fixes; post-push fetch found no unresolved Copilot threads.
+- 2026-08-30: Completed processing suggestions.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                     | URL                                                                         | Suggestion Summary                                               | Decision                                                                  | Reply URL                                                                   | Status | Thread State |
+| --- | --------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6dhJiM | docs/AGENTS.md                                           | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889411155 | Restore ADR filename-format guidance in the placement table.     | action: restored the required filename format in both ADR placement rows. | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889556017 | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6dhJiZ | docs/adrs/index.md                                       | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889411169 | Clarify the package-local ADR index's canonical repository path. | action: stated the full package-local index path.                         | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889558757 | DONE   | RESOLVED     |
+| 3   | PRRT_kwDOGp2yqc6dhJie | docs/adrs/README.md                                      | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889411176 | Align the example ADR filename with the documented format.       | action: replaced the incomplete sample with a valid filename.             | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889565132 | DONE   | RESOLVED     |
+| 4   | PRRT_kwDOGp2yqc6dhJii | .github/skills/dev/planning/create-adr/SKILL.md          | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889411183 | Make the ADR creation command respect the selected scope.        | action: provided separate root and package-local creation commands.       | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889572655 | DONE   | RESOLVED     |
+| 5   | PRRT_kwDOGp2yqc6dhJis | docs/adrs/20260830124000_place_adrs_by_decision_scope.md | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889411201 | Add an explicit scope statement to the placement-policy ADR.     | action: added a root scope statement for the placement policy.            | https://github.com/torrust/torrust-tracker/pull/2118#discussion_r3889574629 | DONE   | RESOLVED     |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,10 +55,10 @@ complement ADRs, which record accepted architectural decisions.
 
 Records of significant architectural decisions, including context and consequences.
 
-| Document                         | Description                                        |
-| -------------------------------- | -------------------------------------------------- |
-| [adrs/README.md](adrs/README.md) | Index of all ADRs and guidance on writing new ones |
-| [adrs/index.md](adrs/index.md)   | Quick-reference table of every ADR                 |
+| Document                         | Description                                              |
+| -------------------------------- | -------------------------------------------------------- |
+| [adrs/README.md](adrs/README.md) | Root ADR guidance, including placement by decision scope |
+| [adrs/index.md](adrs/index.md)   | Quick-reference table of repository-level ADRs           |
 
 ## Issue Specifications
 

--- a/docs/issues/open/2116-adr-placement-policy.md
+++ b/docs/issues/open/2116-adr-placement-policy.md
@@ -8,7 +8,7 @@ github-issue: 2116
 spec-path: docs/issues/open/2116-adr-placement-policy.md
 branch: "2116-adr-placement-policy"
 related-pr: null
-last-updated-utc: 2026-08-30 10:55
+last-updated-utc: 2026-08-30 12:31
 semantic-links:
   skill-links:
     - create-issue
@@ -96,13 +96,13 @@ policy, and inter-package contracts as root-ADR criteria.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                              | Notes / Expected Output                                                                                                        |
-| --- | ------ | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| T1  | TODO   | Create the root ADR               | Records placement criteria, rationale, alternatives, local-index boundary, extraction consequence, and supersession procedure. |
-| T2  | TODO   | Update ADR guidance and template  | Align `docs/AGENTS.md`, `docs/adrs/README.md`, `docs/adrs/index.md`, `docs/templates/ADR.md`, and the `create-adr` skill.      |
-| T3  | TODO   | Update issue-authoring guidance   | Ensure planned ADR references in issue specifications identify root or package-local placement by decision scope.              |
-| T4  | TODO   | Update navigation and skill links | Make package-local discovery explicit and synchronize artifacts carrying `skill-link:` markers with their linked skills.       |
-| T5  | TODO   | Validate documentation            | Run required linters and manually verify the tracker-client placement and supersession example remains accurate.               |
+| ID  | Status | Task                              | Notes / Expected Output                                                                                                          |
+| --- | ------ | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Create the root ADR               | Added ADR `20260830124000_place_adrs_by_decision_scope.md` with placement, indexing, extraction, and supersession rules.         |
+| T2  | DONE   | Update ADR guidance and template  | Updated `docs/AGENTS.md`, root ADR guidance/index, the ADR template, and the `create-adr` skill.                                 |
+| T3  | DONE   | Update issue-authoring guidance   | Updated the `create-issue` skill to require planned ADR placement by decision scope.                                             |
+| T4  | DONE   | Update navigation and skill links | Updated documentation navigation and synchronized `docs/AGENTS.md` and root ADR guidance with the `create-adr` skill.            |
+| T5  | DONE   | Validate documentation            | Focused and full lint suites passed; manual review confirmed scope criteria and the tracker-client index/supersession precedent. |
 
 ## Progress Tracking
 
@@ -111,12 +111,12 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Spec drafted in `docs/issues/drafts/`
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue created and issue number added to this spec
-- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
+- [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [x] Implementation completed
 - [x] Focused specification validation completed (`linter markdown`, `linter cspell`, and `git diff --check`)
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [ ] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
@@ -126,26 +126,28 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-08-30 10:55 UTC - GitHub Copilot - Drafted from the ADR placement policy hand-off; awaiting maintainer approval before GitHub issue creation.
 - 2026-08-30 10:56 UTC - GitHub Copilot - Maintainer approved the draft; created GitHub issue #2116 and moved this specification to `docs/issues/open/`.
 - 2026-08-30 11:20 UTC - GitHub Copilot - Recovered after an interrupted session; verified GitHub issue #2116 and ran focused Markdown, spelling, and whitespace validation successfully.
+- 2026-08-30 12:30 UTC - GitHub Copilot - Implemented the root ADR placement policy and synchronized canonical ADR, documentation, and issue-authoring guidance; focused Markdown, spelling, and whitespace validation passed.
+- 2026-08-30 12:31 UTC - GitHub Copilot - `linter all` passed. Manual review verified root/package scope criteria, the tracker-client local index and supersession status, and absence of the local ADR from the root index.
 
 ## Acceptance Criteria
 
-- [ ] AC1: A root ADR defines root versus package-local ADR placement according to decision scope.
-- [ ] AC2: The policy explicitly treats shared configuration, protocols, dependency policy, and
+- [x] AC1: A root ADR defines root versus package-local ADR placement according to decision scope.
+- [x] AC2: The policy explicitly treats shared configuration, protocols, dependency policy, and
       inter-package contracts as root-ADR criteria even when implementation changes are local.
-- [ ] AC3: Package-local ADR collections require `README.md` and `index.md`, and local ADRs are
+- [x] AC3: Package-local ADR collections require `README.md` and `index.md`, and local ADRs are
       not duplicated in the root ADR index.
-- [ ] AC4: The policy defines how a root ADR supersedes a package-local ADR while retaining the
+- [x] AC4: The policy defines how a root ADR supersedes a package-local ADR while retaining the
       local ADR as historical context.
-- [ ] AC5: `docs/AGENTS.md`, the root ADR README and index, ADR template, ADR skill, and relevant
+- [x] AC5: `docs/AGENTS.md`, the root ADR README and index, ADR template, ADR skill, and relevant
       issue-authoring guidance consistently describe the placement policy.
-- [ ] AC6: The tracker-client ADR and the global CLI output ADR are cited as the existing local
+- [x] AC6: The tracker-client ADR and the global CLI output ADR are cited as the existing local
       placement and root-supersession example.
-- [ ] AC7: The UDP ADR migration is excluded from this policy change.
-- [ ] `linter all` exits with code `0`.
-- [ ] Relevant documentation checks pass.
-- [ ] Manual verification scenarios are executed and documented (status + evidence).
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
-- [ ] Documentation is updated when behavior or workflow changes.
+- [x] AC7: The UDP ADR migration is excluded from this policy change.
+- [x] `linter all` exits with code `0`.
+- [x] Relevant documentation checks pass.
+- [x] Manual verification scenarios are executed and documented (status + evidence).
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [x] Documentation is updated when behavior or workflow changes.
 
 ## Verification Plan
 
@@ -161,11 +163,11 @@ Define verification before implementation starts and execute it before closing t
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario               | Command/Steps                                                                         | Expected Result                                                   | Status | Evidence                                        |
-| --- | ---------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------ | ----------------------------------------------- |
-| M1  | Verify scope criteria  | Review the root ADR and updated guidance for package-only and cross-package examples. | Package ownership and root criteria are unambiguous.              | TODO   | Review notes in this spec.                      |
-| M2  | Verify local precedent | Read the tracker-client local ADR and the global CLI output ADR.                      | The local ADR is preserved and the root ADR records supersession. | TODO   | Links recorded in the ADR and updated guidance. |
-| M3  | Verify index boundary  | Review root and a package-local ADR index after implementation.                       | Each ADR appears only in its owning collection's index.           | TODO   | Index links.                                    |
+| ID  | Scenario               | Command/Steps                                                                         | Expected Result                                                   | Status | Evidence                                                |
+| --- | ---------------------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ------ | ------------------------------------------------------- |
+| M1  | Verify scope criteria  | Review the root ADR and updated guidance for package-only and cross-package examples. | Package ownership and root criteria are unambiguous.              | DONE   | ADR placement criteria and updated authoring guidance.  |
+| M2  | Verify local precedent | Read the tracker-client local ADR and the global CLI output ADR.                      | The local ADR is preserved and the root ADR records supersession. | DONE   | Local ADR supersession status and root ADR description. |
+| M3  | Verify index boundary  | Review root and a package-local ADR index after implementation.                       | Each ADR appears only in its owning collection's index.           | DONE   | Root and tracker-client ADR index review.               |
 
 Notes:
 
@@ -174,15 +176,15 @@ Notes:
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                                  |
-| ----- | ---------------------- | --------------------------------------------------------- |
-| AC1   | TODO                   | Root placement-policy ADR.                                |
-| AC2   | TODO                   | Root placement-policy ADR and updated authoring guidance. |
-| AC3   | TODO                   | Updated authoring guidance and local ADR structure.       |
-| AC4   | TODO                   | Root placement-policy ADR.                                |
-| AC5   | TODO                   | Updated canonical documentation and skills.               |
-| AC6   | TODO                   | References to the tracker-client and global CLI ADRs.     |
-| AC7   | TODO                   | Policy-only diff review.                                  |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                |
+| ----- | ---------------------- | ----------------------------------------------------------------------- |
+| AC1   | DONE                   | `docs/adrs/20260830124000_place_adrs_by_decision_scope.md`.             |
+| AC2   | DONE                   | ADR placement criteria and `create-adr` guidance.                       |
+| AC3   | DONE                   | ADR policy, root index boundary, and tracker-client local index review. |
+| AC4   | DONE                   | ADR supersession section and tracker-client precedent.                  |
+| AC5   | DONE                   | Updated documentation, template, and authoring skills.                  |
+| AC6   | DONE                   | Root ADR references and manual precedent review.                        |
+| AC7   | DONE                   | Documentation-only diff; no UDP ADR migration.                          |
 
 ## Risks and Trade-offs
 

--- a/docs/templates/ADR.md
+++ b/docs/templates/ADR.md
@@ -10,6 +10,13 @@ semantic-links:
 
 # [Title]
 
+## Scope
+
+State whether this is a repository-level or package-local decision and why that scope determines
+its ADR collection. Use `docs/adrs/` for repository-wide, multi-package, and inter-package
+decisions. Use `packages/<package>/docs/adrs/` only for a decision owned solely by that extractable
+package; implementation-file paths alone do not determine scope.
+
 ## Description
 
 What is the issue motivating this decision? Provide enough context for future


### PR DESCRIPTION
## Summary

- Add a root ADR that places decisions by architectural scope: package-owned decisions remain with extractable packages, while repository-wide, multi-package, and inter-package decisions belong in the root collection.
- Define package-local collection structure, separate index ownership, and the root-ADR supersession procedure.
- Synchronize ADR authoring, issue-authoring, template, and documentation navigation guidance.
- Record completed verification evidence in the issue specification.

## Scope

- Touched: root ADR documentation, planning skills, ADR template, documentation navigation, and `docs/issues/open/2116-adr-placement-policy.md`.
- The existing UDP ADR is not moved; its migration remains owned by the separate UDP implementation work.

## Validation

- `linter markdown`
- `linter cspell`
- `linter all`
- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh`
- Manual review of root/package scope criteria, the tracker-client local index, root-index boundary, and local ADR supersession.

Closes #2116