### PR TITLE
chore: update dependencies and GitHub Actions

### DIFF
--- a/.github/skills/dev/maintenance/update-dependencies/SKILL.md
+++ b/.github/skills/dev/maintenance/update-dependencies/SKILL.md
@@ -20,6 +20,8 @@ Use `.github/skills/dev/maintenance/add-rust-dependency/SKILL.md` when introduci
 This skill is for updating already-declared dependencies.
 Use `.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md` for GitHub Actions
 workflow dependency updates and organization action-allowlist synchronization.
+When updating crates and workflow actions together, complete the crate update first and use the
+same dedicated branch for the subsequent workflow-action update.
 
 Delivery policy:
 

--- a/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
+++ b/.github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
@@ -25,13 +25,15 @@ For Cargo dependency updates, use
 - Never push directly to `develop` or `main`.
 - Open a pull request to `torrust/torrust-tracker:develop` from a branch in the configured fork remote.
 - Keep actions on explicit versions. Do not replace an exact action version with a moving major tag solely to work around an allowlist failure.
+- Keep workflow actions updated to current safe versions to receive their security fixes.
+- When this work accompanies a Cargo dependency update, use its dedicated branch and update workflow actions only after the Cargo update has been validated.
 
 ## Update Workflow
 
 1. Start from an up-to-date `develop` branch and create a dedicated branch.
 2. Identify every matching action reference and review the action's release notes for compatibility or security implications.
 3. Update all intended `.github/workflows/*.yaml` references consistently. Dependabot manages GitHub Actions updates through `.github/dependabot.yaml`; preserve its explicit version format.
-4. Before opening the pull request, update the Torrust organization allowed-actions policy at [Organization Actions settings](https://github.com/organizations/torrust/settings/actions).
+4. Before opening the pull request, amend the Torrust organization allowed-actions policy at [Organization Actions settings](https://github.com/organizations/torrust/settings/actions). The allowlist is organization-wide: preserve entries used by other repositories and never replace it with an inventory from this repository alone. A missing entry from the configured list may be authorized by a broader organization policy, such as GitHub-owned or verified Marketplace actions; do not infer that it must be added from a repository scan. If a complete replacement list is requested, obtain an organization-wide inventory first; otherwise, provide only the required additions and replacements. If the required reference is not allowed and the agent cannot change the organization policy, tell the user that a GitHub organization administrator must update the allowed-actions list before the workflow can run.
    - Add an allowlist pattern that permits the versioned reference, such as `owner/action@v2.*`.
    - Prefer a scoped, stable pattern over a moving `owner/action@v2` tag when Dependabot updates exact versions.
    - Confirm that the configured pattern matches the full `uses:` reference, including its version.

--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -3,6 +3,9 @@ name: Container
 # issue: #2107
 # Before changing container validation, review the deferred persistence-transition
 # test and entrypoint refactor plan in #2107.
+
+# skill-link: update-github-workflow-actions
+
 # Path policy: skip this workflow when every changed file is documentation.
 # See .github/workflows/docs-lint.yaml for the lightweight docs-only workflow.
 on:
@@ -208,7 +211,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
@@ -260,7 +263,7 @@ jobs:
 
       - id: login
         name: Login to Docker Hub
-        uses: docker/login-action@v4.5.2
+        uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@v2.87.2
         with:
           tool: grcov,cargo-llvm-cov
 

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@v2.87.2
         with:
           tool: grcov,cargo-llvm-cov
 

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,5 +1,7 @@
 name: Security Scan
 
+# skill-link: update-github-workflow-actions
+
 on:
   push:
     branches: [main, develop]
@@ -35,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Scheduled scans use the pre-built develop image from Docker Hub.
       # Push/PR triggers on Containerfile changes need to build from source.
@@ -85,7 +87,7 @@ jobs:
           scanners: "vuln"
 
       - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v4.37.4
+        uses: github/codeql-action/upload-sarif@v4.37.9
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - id: tools
         name: Install Tools
-        uses: taiki-e/install-action@v2.85.5
+        uses: taiki-e/install-action@v2.87.2
         with:
           tool: cargo-llvm-cov, cargo-nextest
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,12 +621,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -842,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1370,12 +1370,13 @@ checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1632,7 +1633,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1696,9 +1697,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -1798,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2047,9 +2048,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2274,9 +2275,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -2368,9 +2369,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3699,7 +3700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde_core",
@@ -3711,7 +3712,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -3782,7 +3783,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -3822,7 +3823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -3844,7 +3845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -3986,7 +3987,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
  "memchr",
  "native-tls",
@@ -4526,7 +4527,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4568,7 +4569,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4582,7 +4583,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -4737,7 +4738,7 @@ dependencies = [
  "derive_more 2.1.1",
  "tokio",
  "torrust-net-primitives",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
 ]
 
@@ -4810,7 +4811,7 @@ dependencies = [
  "torrust-tracker-primitives",
  "torrust-tracker-test-helpers",
  "torrust-tracker-udp-server",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
  "url",
 ]
@@ -4848,7 +4849,7 @@ dependencies = [
  "torrust-tracker-swarm-coordination-registry",
  "torrust-tracker-test-helpers",
  "tower",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
  "uuid",
 ]
@@ -4888,7 +4889,7 @@ dependencies = [
  "torrust-tracker-udp-core",
  "torrust-tracker-udp-server",
  "tower",
- "tower-http 0.7.0",
+ "tower-http 0.7.1",
  "tracing",
  "url",
  "uuid",
@@ -5301,7 +5302,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5332,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+checksum = "08a05a66a4fdd61cbbe0a1d755ffe0ca6aba159dd4820936a0ff8a8278245b9c"
 dependencies = [
  "async-compression",
  "bitflags 2.13.1",
@@ -5540,9 +5541,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6108,6 +6109,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"


### PR DESCRIPTION
## Summary

- Update the Cargo.lock dependency graph to the latest Rust 1.88-compatible releases.
- Update GitHub Actions pins to current safe versions and document the action-update workflow, including global allowlist and administrator-escalation requirements.

## Scope

- Cargo.lock
- GitHub Actions workflows and dependency-maintenance skills

## Organization Action Policy

- Update the organization-wide allowed-actions entry from `taiki-e/install-action@v2.85.5` to `taiki-e/install-action@v2.87.2` before affected workflows run.
- Preserve entries used by other repositories; do not rebuild the global allowlist from this repository.

## Validation

- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`
- `linter yaml`
- `linter markdown`
- `git diff --check`

## cargo update output

```text
    Updating crates.io index
     Locking 11 packages to latest Rust 1.88 compatible versions
    Updating chacha20 v0.10.1 -> v0.10.2
    Updating cpufeatures v0.3.0 -> v0.3.1
    Updating flate2 v1.1.9 -> v1.1.10
    Updating hermit-abi v0.5.2 -> v0.5.3
    Updating hyper v1.11.0 -> v1.11.1
    Updating indexmap v2.14.0 -> v2.14.1
    Updating libredox v0.1.20 -> v0.1.21
    Updating miniz_oxide v0.8.9 -> v0.9.1
    Updating tower-http v0.7.0 -> v0.7.1
    Updating uuid v1.25.0 -> v1.26.0
      Adding zlib-rs v0.6.7
note: pass `--verbose` to see 10 unchanged dependencies behind latest
```
