### PR TITLE
docs(issues): add package testing specifications (#1347)

### DIFF
--- a/docs/copilot-pr-reviews/pr-2128-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2128-copilot-suggestions.md
@@ -1,0 +1,53 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2128 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2128
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-01 19:20 UTC: Started processing suggestions.
+- 2026-09-01 19:22 UTC: Resolved all three Copilot suggestions after the documentation fix was pushed; the final unresolved-thread check returned no output.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                                                 | URL                                                                         | Suggestion Summary                                     | Decision | Reply URL                                                                   | Status | Thread State |
+| --- | --------------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------ | -------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6ePPv- | `docs/issues/open/1347-overhaul-packages-testing/EPIC.md`            | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907468393 | Use the EPIC file convention and matching `spec-path`. | action   | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907590389 | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6ePPwj | `docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md`     | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907468437 | Remove the timezone suffix from `last-updated-utc`.    | action   | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907592913 | DONE   | RESOLVED     |
+| 3   | PRRT_kwDOGp2yqc6ePPw6 | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md` | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907468474 | Remove the timezone suffix from `last-updated-utc`.    | action   | https://github.com/torrust/torrust-tracker/pull/2128#discussion_r3907594724 | DONE   | RESOLVED     |
+
+## Notes
+
+- This is a spec-only PR. The review changes are limited to issue-specification conventions.
+- PR references remain non-closing: no `Fixes`, `Closes`, or `Resolves` keywords are introduced.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -2,9 +2,9 @@
 doc-type: epic
 status: open
 github-issue: 1347
-spec-path: docs/issues/open/1347-overhaul-packages-testing/ISSUE.md
+spec-path: docs/issues/open/1347-overhaul-packages-testing/EPIC.md
 epic-owner: josecelano
-last-updated-utc: 2026-09-01 17:48 UTC
+last-updated-utc: 2026-09-01 17:48
 semantic-links:
   skill-links:
     - create-issue

--- a/docs/issues/open/1347-overhaul-packages-testing/ISSUE.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/ISSUE.md
@@ -1,0 +1,139 @@
+---
+doc-type: epic
+status: open
+github-issue: 1347
+spec-path: docs/issues/open/1347-overhaul-packages-testing/ISSUE.md
+epic-owner: josecelano
+last-updated-utc: 2026-09-01 17:48 UTC
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+---
+
+<!-- skill-link: create-issue -->
+
+# EPIC #1347 - Overhaul: Packages Testing
+
+## Goal
+
+Improve maintainable automated test coverage across the current Torrust Tracker workspace packages, prioritizing critical behavior and making the published crates robust and reliable for consumers.
+
+## Why This Is Needed
+
+The repository was reorganized through package refactoring and extraction work. Its end-to-end suite provides valuable broad coverage, but packages also need focused unit tests that exercise their responsibilities in isolation. Test work should reveal design and refactoring opportunities while preserving readable tests that serve as behavioral contracts. The resulting package-local safety nets support contributors who make focused changes to independently publishable packages.
+
+## Scope
+
+### In Scope
+
+- Establish and record a coverage baseline for each package addressed by a subissue, then aim to increase it by testing critical behavior.
+- Add maintainable, fast, responsibility-oriented unit tests close to the code they protect, using Arrange, Act, Assert (AAA) structure where appropriate.
+- Add integration tests, runnable examples, or end-to-end tests when they provide valuable package-level regression protection.
+- Use `tracker-core` as a reference for effective package-level test coverage.
+- Create and track additional package-testing subissues when a maintainer or contributor identifies a need.
+- Set qualitative, risk-based coverage objectives per subissue and document the rationale and exceptions; do not require a numeric percentage target.
+
+### Out of Scope
+
+- A uniform coverage-percentage threshold for every package.
+- Replacing the existing end-to-end test suite.
+- Unrelated production refactoring not justified by improving testability.
+- Treating coverage percentage as proof of correct behavior.
+
+## Subissues
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| Order | Issue                                                 | Local Spec                                                            | Status | Notes                                                          |
+| ----- | ----------------------------------------------------- | --------------------------------------------------------------------- | ------ | -------------------------------------------------------------- |
+| 1     | #1348 - Add tests to the axum-http-server package     | `docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md`      | TODO   | Existing subissue; package-level test work.                    |
+| 2     | #1349 - Add tests to the axum-rest-api-server package | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md`  | TODO   | Existing subissue; package-level test work.                    |
+| 3     | Additional package-testing subissues                  | Create a folder-style spec when a concrete package need is identified | TODO   | Permitted but not required upfront; retain scope in this EPIC. |
+
+## Delivery Strategy
+
+Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior.
+
+For each subissue implementation, the completion policy is:
+
+1. Run automatic checks (`linter all`, relevant tests, pre-push checks when applicable).
+2. Run and record manual verification scenarios.
+3. Re-review acceptance criteria against observed behavior and update evidence.
+
+### Phase 1
+
+- Outcome: Existing package-testing issues have repository-local specs with clear scope, baselines, and qualitative risk-based coverage objectives.
+- Exit criteria: Specs for #1348 and #1349 are approved, and their status is represented accurately in this EPIC.
+
+### Phase 2
+
+- Outcome: Package-scoped testing improvements are delivered incrementally through implementation PRs.
+- Exit criteria: Each completed subissue has passing automated-check, manual-verification, and acceptance-review evidence.
+
+### Phase 3
+
+- Outcome: The EPIC’s package coverage objective is assessed and any remaining package needs are represented by tracked subissues or explicit, documented deferrals.
+- Exit criteria: All required package-testing work is completed, deferred with rationale, or tracked by a successor issue.
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Epic spec created in `docs/issues/open/` for existing GitHub issue #1347
+- [x] Initial epic-scope, subissue-policy, and risk-based coverage-target feedback collected from user/maintainer
+- [x] Epic spec reviewed and approved by user/maintainer
+- [x] Existing GitHub epic issue number added to this spec
+- [x] Existing subissues linked in this spec
+- [ ] Subissue statuses kept up to date in the `Subissues` table
+- [ ] For each implemented subissue: automatic checks completed and recorded
+- [ ] For each implemented subissue: manual verification completed and recorded
+- [ ] For each implemented subissue: acceptance criteria reviewed post-implementation
+- [ ] Epic acceptance criteria reviewed and checked off
+- [ ] Epic issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-09-01 17:48 UTC - GitHub Copilot - Created repository-local EPIC specification from GitHub issue #1347 and recorded maintainer feedback: cover all current workspace packages, allow additional subissues as needs are identified, and use baselines with risk-based targets. - https://github.com/torrust/torrust-tracker/issues/1347
+- 2026-09-01 18:00 UTC - User/maintainer - Approved the EPIC direction and clarified that each package should build a local safety net: establish and increase the coverage baseline, prioritize fast tests close to the code, and use unit, integration, or end-to-end tests whenever they provide valuable regression protection. - https://github.com/torrust/torrust-tracker/issues/1347
+
+## Acceptance Criteria
+
+- [ ] All required package-testing subissues are created and linked.
+- [x] Implementation order and package-scoped delivery strategy are explicit.
+- [x] Coverage policy requires a recorded baseline, an aim to increase it, and prioritization of critical behavior over an arbitrary percentage for each subissue.
+- [ ] Dependencies, blockers, and remaining package needs are documented and current.
+- [ ] Epic status reflects actual state of linked subissues.
+- [ ] Every completed subissue includes automated verification evidence.
+- [ ] Every completed subissue includes manual verification evidence.
+- [ ] Every completed subissue includes post-implementation acceptance criteria review.
+- [ ] Documentation and governance updates are included when required.
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                   |
+| ----- | ---------------------- | ------------------------------------------ |
+| AC1   | TODO                   | EPIC subissue table and GitHub issue links |
+| AC2   | DONE                   | Delivery strategy in this spec             |
+| AC3   | DONE                   | Scope and delivery strategy in this spec   |
+| AC4   | TODO                   | Subissue specs and progress logs           |
+| AC5   | TODO                   | Subissue verification records              |
+| AC6   | TODO                   | Subissue verification records              |
+| AC7   | TODO                   | Subissue acceptance-verification records   |
+| AC8   | TODO                   | Relevant PRs and documentation             |
+
+## Risks and Trade-offs
+
+- Coverage percentage can incentivize low-value tests; mitigate it by recording it as a baseline and prioritizing critical responsibilities and valuable regression protection.
+- Testing may expose design seams that are difficult to isolate; make small testability refactorings only when justified and keep unrelated refactoring out of scope.
+- New packages or package extractions can change the inventory during the EPIC; add concrete subissues as needs are identified and record deferrals explicitly before closing the EPIC.
+
+## References
+
+- GitHub EPIC: https://github.com/torrust/torrust-tracker/issues/1347
+- Related issues: #1348, #1349
+- Package inventory: `docs/packages.md`
+- Reference package: `packages/tracker-core/`
+- Coverage tooling: `cargo llvm-cov`
+- Related historical work: #753, #1181, #1226, #1266

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -8,7 +8,7 @@ github-issue: 1348
 spec-path: docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
 branch: "1348-add-tests-axum-http-server"
 related-pr: null
-last-updated-utc: 2026-09-01 18:00 UTC
+last-updated-utc: 2026-09-01 18:00
 semantic-links:
   skill-links:
     - create-issue

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -1,0 +1,146 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+epic: 1347
+github-issue: 1348
+spec-path: docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+branch: "1348-add-tests-axum-http-server"
+related-pr: null
+last-updated-utc: 2026-09-01 18:00 UTC
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1348 - Add Tests to the Axum HTTP Server Package
+
+Parent EPIC: #1347 - Overhaul: Packages Testing
+
+## Goal
+
+Improve maintainable test coverage for `torrust-tracker-axum-http-server`, concentrating on a fast, package-local safety net for its HTTP tracker transport contracts, listener lifecycle, and protocol-response boundary.
+
+## Background
+
+`axum-http-server` implements the BitTorrent HTTP tracker transport, including announce, scrape, health-check routes, server lifecycle, and HTTP middleware. Historical high-level tests cover much of this behavior, but contributors changing this independently publishable package need a stronger, faster safety net close to the code. This issue records a package-specific coverage baseline, aims to increase it, and closes material gaps through valuable unit, integration, or end-to-end tests.
+
+## Scope
+
+### In Scope
+
+- Record the starting package coverage baseline and the coverage increase achieved while testing critical behavior.
+- Prefer fast unit tests close to the implementation whenever they provide the appropriate regression boundary.
+- Review and improve tests for HTTP/HTTPS listener binding, startup registration cleanup, and graceful shutdown.
+- Test route availability and transport behavior for announce, scrape, health checks, request IDs, timeouts, and client address handling where gaps exist.
+- Test compact versus non-compact announce responses and service-error-to-BitTorrent-failure response mapping where gaps exist.
+- Reuse the existing test environment and shared test helpers where they fit the test boundary.
+
+### Out of Scope
+
+- Unrelated production refactoring; a small refactoring is allowed only when needed to create a clear test seam.
+- Arbitrary coverage-percentage targets that displace testing of critical behavior.
+
+## Architectural Decisions
+
+- Related ADRs: `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`
+- ADRs to create: None known. Create one if implementation requires a lasting transport-architecture decision.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                            | Notes / Expected Output                                                                                                                                               |
+| --- | ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Establish the baseline          | Run package coverage and identify critical untested paths.                                                                                                            |
+| T2  | TODO   | Plan coverage improvement       | Identify critical behavior and record the coverage increase achieved without pursuing an arbitrary percentage.                                                        |
+| T3  | TODO   | Add lifecycle and routing tests | Cover meaningful listener, route, and middleware gaps; prefer fast tests close to the code when appropriate.                                                          |
+| T4  | TODO   | Add protocol-boundary tests     | Cover announce/scrape response selection and error mapping, including behavior already exercised only at higher levels when package-level tests add regression value. |
+| T5  | TODO   | Review test design              | Simplify duplicated setup when justified; retain readable AAA-style tests and valuable package integration coverage.                                                  |
+| T6  | TODO   | Verify and record evidence      | Complete automated checks, manual scenarios, and the post-implementation AC review.                                                                                   |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Repository-local folder-style spec created for existing GitHub issue #1348
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed
+- [ ] Manual verification scenarios executed and recorded
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-09-01 18:00 UTC - GitHub Copilot - Created a repository-local folder-style specification from GitHub issue #1348 and EPIC #1347. - https://github.com/torrust/torrust-tracker/issues/1348
+- 2026-09-01 18:00 UTC - User/maintainer - Clarified that the work should increase the recorded coverage baseline by testing critical behavior, prioritize fast unit tests close to package code, and retain or add valuable package-level integration and end-to-end tests. - https://github.com/torrust/torrust-tracker/issues/1348
+
+## Acceptance Criteria
+
+- [ ] A coverage baseline and the coverage increase achieved are recorded, with critical behavior prioritized over an arbitrary percentage.
+- [ ] Tests cover all identified critical `axum-http-server` transport gaps, including behavior previously covered only at a higher level when package-level coverage provides regression value.
+- [ ] Lifecycle, routing/middleware, and announce/scrape protocol-boundary tests are added or explicitly justified as already covered.
+- [ ] Tests reuse appropriate fixtures and remain readable and maintainable.
+- [ ] `linter all` exits with code `0`.
+- [ ] Relevant tests pass.
+- [ ] Manual verification scenarios are executed and documented.
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [ ] Documentation is updated when behavior or workflow changes.
+
+## Verification Plan
+
+### Automatic Checks
+
+- `cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --summary-only`
+- `cargo test -p torrust-tracker-axum-http-server`
+- `cargo test -p torrust-tracker-axum-http-server --test integration`
+- `linter all`
+- Pre-push checks when applicable
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                             | Command/Steps                                                                         | Expected Result                                                                                                 | Status | Evidence                              |
+| --- | ------------------------------------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------- |
+| M1  | HTTP tracker announce contract       | Start the test environment and issue valid compact and non-compact announce requests. | Both requests produce valid bencoded tracker responses with the selected peer representation.                   | TODO   | To be recorded during implementation. |
+| M2  | Scrape and failure response contract | Issue valid scrape and invalid announce requests against the test environment.        | Scrape data is returned when available; invalid announce input is represented as a BitTorrent failure response. | TODO   | To be recorded during implementation. |
+| M3  | Server lifecycle                     | Start and stop the test environment using an ephemeral listener.                      | The server registers, accepts a health check, and stops cleanly.                                                | TODO   | To be recorded during implementation. |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                          |
+| ----- | ---------------------- | ------------------------------------------------- |
+| AC1   | TODO                   | Coverage command output recorded in progress log. |
+| AC2   | TODO                   | Added test paths and test output.                 |
+| AC3   | TODO                   | Test output and review notes.                     |
+| AC4   | TODO                   | Code review of test fixtures and assertions.      |
+| AC5   | TODO                   | `linter all` output.                              |
+| AC6   | TODO                   | Package test output.                              |
+| AC7   | TODO                   | Manual-verification table and evidence.           |
+| AC8   | TODO                   | Post-implementation review entry.                 |
+| AC9   | TODO                   | Relevant documentation diff.                      |
+
+## Risks and Trade-offs
+
+- End-to-end-style fixture tests can be slow and costly to compose; prefer direct router or focused unit tests where they cover the intended boundary, while keeping higher-level tests that provide distinct value.
+- Testing implementation details creates brittle tests; assert public HTTP and bencoded protocol contracts instead.
+- TLS health checks require appropriately configured trust in tests; use the injectable client seam rather than weakening production TLS behavior.
+
+## References
+
+- GitHub issue: https://github.com/torrust/torrust-tracker/issues/1348
+- Parent EPIC: #1347
+- Package: `packages/axum-http-server/`
+- Test environment: `packages/axum-http-server/src/testing/environment.rs`
+- Protocol/domain boundary ADR: `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`
+- Historical test-environment work: `docs/issues/closed/1904-1669-si-24-relocate-http-server-test-environment.md`

--- a/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
+++ b/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
@@ -8,7 +8,7 @@ github-issue: 1349
 spec-path: docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
 branch: "1349-add-tests-axum-rest-api-server"
 related-pr: null
-last-updated-utc: 2026-09-01 18:00 UTC
+last-updated-utc: 2026-09-01 18:00
 semantic-links:
   skill-links:
     - create-issue

--- a/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
+++ b/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
@@ -1,0 +1,147 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+epic: 1347
+github-issue: 1349
+spec-path: docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
+branch: "1349-add-tests-axum-rest-api-server"
+related-pr: null
+last-updated-utc: 2026-09-01 18:00 UTC
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #1349 - Add Tests to the Axum REST API Server Package
+
+Parent EPIC: #1347 - Overhaul: Packages Testing
+
+## Goal
+
+Improve maintainable test coverage for `torrust-tracker-axum-rest-api-server`, building a fast, package-local safety net for its internal REST transport contracts, authentication, configuration-gated routing, and lifecycle behavior.
+
+## Background
+
+`axum-rest-api-server` exposes the tracker management API below `/api/v1`, applies token authentication, and composes context-specific routes. Historical high-level tests cover much of this behavior, but contributors changing this independently publishable package need a stronger, faster safety net close to the code. This issue establishes a package coverage baseline, aims to increase it, and adds valuable unit, integration, or end-to-end coverage at the implementation boundary.
+
+## Scope
+
+### In Scope
+
+- Record the starting package coverage baseline and the coverage increase achieved while testing critical behavior.
+- Prefer fast unit tests close to the implementation whenever they provide the appropriate regression boundary.
+- Review and improve tests for HTTP/HTTPS startup, registration failure cleanup, listener errors, and graceful shutdown.
+- Test public routing and middleware contracts: unauthenticated health checks, protected API routes, token sources and precedence, and transport headers.
+- Test private and listed configuration-gated route composition and unavailable-route behavior.
+- Test response serialization, extraction, and error mapping where those transport contracts are not already adequately covered.
+
+### Out of Scope
+
+- Unrelated production refactoring; a small refactoring is allowed only when needed to create a clear test seam.
+- Arbitrary coverage-percentage targets that displace testing of critical behavior.
+
+## Architectural Decisions
+
+- Related ADRs: `docs/adrs/20260623200526_adopt_contract-first_architecture_for_rest_api.md`
+- ADRs to create: None known. Create one if implementation requires a lasting REST transport-architecture decision.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                  | Notes / Expected Output                                                                                                                                                                  |
+| --- | ------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | TODO   | Establish the baseline                | Run package coverage and identify critical untested paths.                                                                                                                               |
+| T2  | TODO   | Plan coverage improvement             | Identify critical behavior and record the coverage increase achieved without pursuing an arbitrary percentage.                                                                           |
+| T3  | TODO   | Add routing and authentication tests  | Cover public health checks, protection, token semantics, and middleware gaps; prefer fast tests close to the code when appropriate.                                                      |
+| T4  | TODO   | Add configuration and lifecycle tests | Cover configuration-gated routes and meaningful server lifecycle gaps, including behavior otherwise covered only at higher levels when package-level coverage provides regression value. |
+| T5  | TODO   | Review transport boundaries           | Cover behavior at the level it is implemented; simplify setup only when justified and retain valuable package integration coverage.                                                      |
+| T6  | TODO   | Verify and record evidence            | Complete automated checks, manual scenarios, and the post-implementation AC review.                                                                                                      |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Repository-local folder-style spec created for existing GitHub issue #1349
+- [ ] Spec reviewed and approved by user/maintainer
+- [ ] Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed
+- [ ] Manual verification scenarios executed and recorded
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved to `docs/issues/closed/`
+
+### Progress Log
+
+- 2026-09-01 18:00 UTC - GitHub Copilot - Created a repository-local folder-style specification from GitHub issue #1349 and EPIC #1347. - https://github.com/torrust/torrust-tracker/issues/1349
+- 2026-09-01 18:00 UTC - User/maintainer - Clarified that the work should increase the recorded coverage baseline by testing critical behavior, prioritize fast unit tests close to package code, and retain or add valuable package-level integration and end-to-end tests. - https://github.com/torrust/torrust-tracker/issues/1349
+
+## Acceptance Criteria
+
+- [ ] A coverage baseline and the coverage increase achieved are recorded, with critical behavior prioritized over an arbitrary percentage.
+- [ ] Tests cover identified critical REST-server transport gaps, including behavior previously covered only at a higher level when package-level coverage provides regression value.
+- [ ] Authentication, public/protected routing, configuration-gated routes, and lifecycle behavior are tested or explicitly justified as already covered.
+- [ ] Tests reuse appropriate fixtures and remain readable and maintainable.
+- [ ] `linter all` exits with code `0`.
+- [ ] Relevant tests pass.
+- [ ] Manual verification scenarios are executed and documented.
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [ ] Documentation is updated when behavior or workflow changes.
+
+## Verification Plan
+
+### Automatic Checks
+
+- `cargo llvm-cov -p torrust-tracker-axum-rest-api-server --all-features --summary-only`
+- `cargo test -p torrust-tracker-axum-rest-api-server`
+- `cargo test -p torrust-tracker-axum-rest-api-server --test integration`
+- `linter all`
+- Pre-push checks when applicable
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                     | Command/Steps                                                                                                       | Expected Result                                                                       | Status | Evidence                              |
+| --- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------ | ------------------------------------- |
+| M1  | Public and protected routes  | Start the test environment, request `/api/health_check`, then a protected API route with and without a valid token. | Health check succeeds without authentication; protected routes require a valid token. | TODO   | To be recorded during implementation. |
+| M2  | Token precedence             | Request a protected route with conflicting bearer-header and query-string tokens.                                   | The header token takes precedence and the response reflects its validity.             | TODO   | To be recorded during implementation. |
+| M3  | Configuration-gated contexts | Start private/listed and disabled-mode configurations, then call auth-key and whitelist routes.                     | Routes are available only in their enabled configuration modes.                       | TODO   | To be recorded during implementation. |
+| M4  | Server lifecycle             | Start and stop the test environment using an ephemeral listener.                                                    | The API server accepts a health check and stops cleanly.                              | TODO   | To be recorded during implementation. |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                          |
+| ----- | ---------------------- | ------------------------------------------------- |
+| AC1   | TODO                   | Coverage command output recorded in progress log. |
+| AC2   | TODO                   | Added test paths and test output.                 |
+| AC3   | TODO                   | Test output and review notes.                     |
+| AC4   | TODO                   | Code review of test fixtures and assertions.      |
+| AC5   | TODO                   | `linter all` output.                              |
+| AC6   | TODO                   | Package test output.                              |
+| AC7   | TODO                   | Manual-verification table and evidence.           |
+| AC8   | TODO                   | Post-implementation review entry.                 |
+| AC9   | TODO                   | Relevant documentation diff.                      |
+
+## Risks and Trade-offs
+
+- The existing REST server fixture composes multiple services and can make contract tests expensive; prefer direct router tests when they exercise the correct transport boundary, while keeping higher-level tests that provide distinct value.
+- Tests that reach into private authentication helpers may constrain refactoring; favor HTTP-level authentication contracts unless a narrow unit test has clear value.
+- Configuration matrices can multiply test time; cover meaningful route-composition distinctions without duplicating equivalent endpoint tests.
+
+## References
+
+- GitHub issue: https://github.com/torrust/torrust-tracker/issues/1349
+- Parent EPIC: #1347
+- Package: `packages/axum-rest-api-server/`
+- Test environment: `packages/axum-rest-api-server/src/testing/environment.rs`
+- REST contract-first ADR: `docs/adrs/20260623200526_adopt_contract-first_architecture_for_rest_api.md`
+- Historical test-environment work: `docs/issues/closed/1903-1669-si-23-relocate-axum-rest-api-server-test-environment.md`


### PR DESCRIPTION
## Summary

- Add a folder-style repository-local specification for EPIC #1347, covering the package-testing strategy.
- Add folder-style specifications for subissues #1348 and #1349, covering the Axum HTTP server and Axum REST API server packages.
- Record the approved approach: establish and increase package coverage baselines, prioritize critical behavior and fast local tests, and retain valuable integration and end-to-end coverage.

## Scope

Documentation only: three new issue specifications under `docs/issues/open/`.

## Validation

- `linter all`
- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh`
- Staged diff review and whitespace validation with `git diff --cached --check`

Related to #1347
Related to #1348
Related to #1349