### PR TITLE
test(axum-http-server): add package-local transport tests (#1348)

### DIFF
--- a/.github/skills/dev/planning/create-issue/SKILL.md
+++ b/.github/skills/dev/planning/create-issue/SKILL.md
@@ -106,6 +106,21 @@ The draft must also include a verification policy that is explicit and enforceab
 - Manual verification scenarios with status + evidence tracking (mandatory)
 - A post-implementation acceptance criteria review step
 
+For testing or coverage-focused issue specs, also require:
+
+- an issue-local, human-readable coverage-evidence document when coverage is measured;
+- the exact reproducible coverage command and a statement of what paths and code types it includes;
+- aggregate baseline/current values **and** per-file coverage plus prioritized uncovered functions,
+  regions, or behavior gaps; and
+- a policy to retain concise Markdown evidence rather than raw generated JSON, LCOV, or HTML
+  artifacts unless the artifact itself has a documented human-review purpose.
+
+When the plan adds or changes tests, include a progressive test-development loop: make the smallest
+behavior-focused increment, review its design and focused validation before the next test-producing
+task, and stop for maintainer review after the final increment before final verification, commit, or
+pull request. Direct test authors to the `write-unit-test` skill and the test refactoring-pattern
+catalog when applicable.
+
 During implementation, create an ADR when an important architectural decision
 emerges, even if the issue draft did not anticipate it. Link the ADR from the
 issue specification and update the architectural-decisions section. For each

--- a/.github/skills/dev/testing/write-unit-test/SKILL.md
+++ b/.github/skills/dev/testing/write-unit-test/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: write-unit-test
 description: Guide for writing unit tests following project conventions including behavior-driven naming (it*should*\*), AAA pattern, MockClock for deterministic time testing, and parameterized tests with rstest. Use when adding tests for domain entities, value objects, utilities, or tracker logic. Triggers on "write unit test", "add test", "test coverage", "unit testing", or "add unit tests".
+semantic-links:
+  related-artifacts:
+    - docs/testing/README.md
+    - docs/testing/refactoring-patterns/README.md
 metadata:
   author: torrust
   version: "1.0"
@@ -236,6 +240,14 @@ torrust-tracker-test-helpers = { workspace = true }
 ```
 
 Check the package for available mock servers, fixture generators, and utility types.
+
+## Reusable Refactoring Patterns
+
+Before adding a bespoke helper or refactoring generated test code, consult the
+[test refactoring-pattern catalog](../../../../../docs/testing/refactoring-patterns/README.md).
+It contains repository-native examples with their problem, selected pattern, and constraints.
+Prefer an existing catalog pattern when it fits. Add a focused entry when a reviewed refactor
+establishes a reusable pattern for future tests.
 
 ## Quick Checklist
 

--- a/.github/skills/dev/testing/write-unit-test/SKILL.md
+++ b/.github/skills/dev/testing/write-unit-test/SKILL.md
@@ -73,6 +73,33 @@ practical.
 - **Isolated** — no shared mutable state between tests
 - **Fast** — unit tests run in milliseconds
 
+### Make Arrange State-Centered
+
+Before writing or refactoring an Arrange section, ask: **what is the one difference in initial
+state that makes this Act behave differently?** Make that causal condition visible to the reader.
+
+Pick the Arrange tool that states that condition most directly:
+
+- **Inline values** when a literal or a single constructor call already says it.
+- **Test builders** when a readable call chain in the test body names the choice, e.g.
+  `configuration().private().with_expired_key(...)`. Builders fit when each test varies one or two
+  named options on the same object.
+- **Scenario fixtures** when the condition emerges from several coordinated steps across objects,
+  resources, or registries, and no chain reads as clearly. Name the fixture for the resulting state,
+  such as `ServerStartWithDuplicateRegistration`. The fixture owns incidental mechanics (resource
+  allocation, configuration mutation, dependency construction, state seeding); the test keeps the
+  production Act and observable assertions visible. Focused fixtures form a catalog of important
+  system scenarios.
+
+These tools compose: a fixture may use builders internally, and a scenario may expose a small
+builder for the few variations it legitimately supports. Apply the pattern that fits the moment;
+none of them is a rule against the others.
+
+Whatever the tool, do not hide the Act or assertions inside it, let it accumulate unrelated optional
+components, or derive an expected outcome using production code under test. For the full
+constraints and example, see
+[Scenario fixtures for causal initial state](../../../../../docs/testing/refactoring-patterns/scenario-fixtures-for-causal-initial-state.md).
+
 ## Phase 1: Basic Unit Test
 
 ### Naming Convention

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,6 +7,7 @@ semantic-links:
     - docs/architecture/README.md
     - docs/adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md
     - docs/skills/semantic-skill-link-convention.md
+    - docs/testing/README.md
 ---
 
 # `docs/` — Documentation Directory
@@ -33,6 +34,7 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 | `refactor-plans/`                                                                         | Refactor plan specifications (same lifecycle as issue specs)                       |
 | `copilot-pr-reviews/`                                                                     | Copilot PR review records and suggestion threads                                   |
 | `skills/`                                                                                 | Internal conventions used by humans and AI agents                                  |
+| `testing/`                                                                                | Durable testing guidance and test-design refactoring pattern catalog               |
 | `templates/`                                                                              | Canonical document templates (ADR, EPIC, issue, refactor plan)                     |
 | `media/`                                                                                  | Images, diagrams, flamegraphs, benchmark reports, sample torrents                  |
 | `licenses/`                                                                               | Full license texts (AGPL-3.0, MIT-0)                                               |
@@ -47,6 +49,7 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 | New issue spec (after GitHub issue created)    | `docs/issues/open/<number>-<short-slug>.md`, or `docs/issues/open/<number>-<short-slug>/ISSUE.md` when it has issue-local artifacts |
 | New refactor plan (before GitHub issue exists) | `docs/refactor-plans/drafts/`                                                                                                       |
 | New refactor plan (after GitHub issue created) | `docs/refactor-plans/open/<number>-<short-slug>.md`                                                                                 |
+| Durable testing guide or pattern catalog       | `docs/testing/`                                                                                                                     |
 | New document template                          | `docs/templates/`                                                                                                                   |
 | New diagram or screenshot                      | `docs/media/` (or the relevant subdirectory)                                                                                        |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ semantic-links:
     - docs/packages.md
     - docs/profiling.md
     - docs/release_process.md
+    - docs/testing/README.md
     - docs/adrs/README.md
     - docs/adrs/index.md
     - docs/issues/README.md
@@ -30,17 +31,18 @@ source code, see the [crate docs on docs.rs][docs].
 
 Operational and development guides for working with the tracker.
 
-| Document                                                                                                                                                                           | Description                                                          |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| [application-jobs.md](application-jobs.md)                                                                                                                                         | Current background-job ownership, lifecycle, and shutdown behavior   |
-| [benchmarking.md](benchmarking.md)                                                                                                                                                 | How to run and interpret the torrent-repository benchmarks           |
-| [containers.md](containers.md)                                                                                                                                                     | Building and running the tracker with Docker / Podman                |
-| [git-hooks.md](git-hooks.md)                                                                                                                                                       | Hook behavior and SSH idle-timeout troubleshooting                   |
-| [packages.md](packages.md)                                                                                                                                                         | Workspace package catalog, architecture layers, and dependency rules |
-| [Configuration v2-to-v3 migration guide](../packages/configuration/docs/migrate-v2-to-v3.md)                                                                                       | Upgrade tracker configuration files to active schema v3              |
-| [profiling.md](profiling.md)                                                                                                                                                       | CPU and memory profiling with Valgrind / kcachegrind                 |
-| [release_process.md](release_process.md)                                                                                                                                           | Branch strategy, versioning, and the staging → main release pipeline |
-| [adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md](adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md) | Governance for portable AI-agent workflows and retained context      |
+| Document                                                                                                                                                                           | Description                                                                |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| [application-jobs.md](application-jobs.md)                                                                                                                                         | Current background-job ownership, lifecycle, and shutdown behavior         |
+| [benchmarking.md](benchmarking.md)                                                                                                                                                 | How to run and interpret the torrent-repository benchmarks                 |
+| [containers.md](containers.md)                                                                                                                                                     | Building and running the tracker with Docker / Podman                      |
+| [git-hooks.md](git-hooks.md)                                                                                                                                                       | Hook behavior and SSH idle-timeout troubleshooting                         |
+| [packages.md](packages.md)                                                                                                                                                         | Workspace package catalog, architecture layers, and dependency rules       |
+| [Configuration v2-to-v3 migration guide](../packages/configuration/docs/migrate-v2-to-v3.md)                                                                                       | Upgrade tracker configuration files to active schema v3                    |
+| [profiling.md](profiling.md)                                                                                                                                                       | CPU and memory profiling with Valgrind / kcachegrind                       |
+| [release_process.md](release_process.md)                                                                                                                                           | Branch strategy, versioning, and the staging → main release pipeline       |
+| [testing/README.md](testing/README.md)                                                                                                                                             | Testing guidance and a catalog of durable test-design refactoring patterns |
+| [adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md](adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md) | Governance for portable AI-agent workflows and retained context            |
 
 ## Runtime Architecture
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -69,7 +69,7 @@ whether a subissue has adequately covered critical behavior.
 
 | Package                            | Subissue                                               | Baseline                                          | Latest                                            | Change                                                  | Evidence                                                                       |
 | ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `torrust-tracker-axum-http-server` | [#1348](1348-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.22%; regions: 92.96%; functions: 91.58% | Lines: +1.40 pp; regions: +1.30 pp; functions: +2.04 pp | [Coverage evidence](1348-1347-add-tests-axum-http-server/coverage-evidence.md) |
+| `torrust-tracker-axum-http-server` | [#1348](1348-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.07%; regions: 92.99%; functions: 90.86% | Lines: +1.25 pp; regions: +1.33 pp; functions: +1.32 pp | [Coverage evidence](1348-1347-add-tests-axum-http-server/coverage-evidence.md) |
 
 ## Delivery Strategy
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -57,9 +57,21 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | 2     | #1349 - Add tests to the axum-rest-api-server package | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md`  | TODO   | Existing subissue; package-level test work.                                                                          |
 | 3     | Additional package-testing subissues                  | Create a folder-style spec when a concrete package need is identified | TODO   | Permitted but not required upfront; retain scope in this EPIC.                                                       |
 
+## Package Coverage Tracking
+
+Add a row only when work begins on a package subissue. Record its baseline before adding tests and
+its latest measurement after implementation. Link each row to the subissue's issue-local
+`coverage-evidence.md`, which remains the source of truth for measurement scope, per-file detail,
+and prioritized gaps. These aggregate values show progress across the EPIC; they do not determine
+whether a subissue has adequately covered critical behavior.
+
+| Package                            | Subissue                                               | Baseline                                          | Latest                                            | Change                                                  | Evidence                                                                       |
+| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `torrust-tracker-axum-http-server` | [#1348](1348-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.00%; regions: 93.10%; functions: 91.06% | Lines: +1.18 pp; regions: +1.44 pp; functions: +1.52 pp | [Coverage evidence](1348-1347-add-tests-axum-http-server/coverage-evidence.md) |
+
 ## Delivery Strategy
 
-Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Store the coverage evidence in an issue-local human-readable document, rather than committing large raw coverage artifacts. State which source paths and code types the measurement includes, because test-inclusive totals are not production-only coverage. Use aggregate percentages only for navigation; prioritize behavior by examining per-file coverage and uncovered functions or regions.
+Implement independently reviewable, package-scoped subissues. When work begins on a package, add it to the Package Coverage Tracking table and record its starting coverage before adding tests. After implementation, update the row with the latest measurement and percentage-point change. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Store the coverage evidence in an issue-local human-readable document, rather than committing large raw coverage artifacts. State which source paths and code types the measurement includes, because test-inclusive totals are not production-only coverage. Use aggregate percentages only for navigation; prioritize behavior by examining per-file coverage and uncovered functions or regions.
 
 Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior. Record reusable test-design refactors in the [testing refactoring-pattern catalog](../../../testing/refactoring-patterns/README.md) so later subissues can apply proven patterns without restating their rationale.
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -32,12 +32,13 @@ The repository was reorganized through package refactoring and extraction work. 
 
 ### In Scope
 
-- Establish and record a coverage baseline for each package addressed by a subissue, then aim to increase it by testing critical behavior.
+- Establish and record a coverage baseline for each package addressed by a subissue, then aim to increase it by testing critical behavior. Record an issue-local, human-readable coverage-evidence document with the command, measurement scope, aggregate comparison, per-file results, and prioritized uncovered areas.
 - Add maintainable, fast, responsibility-oriented unit tests close to the code they protect, using Arrange, Act, Assert (AAA) structure where appropriate.
 - Add integration tests, runnable examples, or end-to-end tests when they provide valuable package-level regression protection.
 - Use `tracker-core` as a reference for effective package-level test coverage.
 - Create and track additional package-testing subissues when a maintainer or contributor identifies a need.
 - Set qualitative, risk-based coverage objectives per subissue and document the rationale and exceptions; do not require a numeric percentage target.
+- Review every test-producing increment before beginning the next one, then stop for maintainer review after the final test-producing increment and before final verification, committing, or opening a pull request.
 
 ### Out of Scope
 
@@ -58,7 +59,19 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 ## Delivery Strategy
 
-Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior. Record reusable test-design refactors in the [testing refactoring-pattern catalog](../../../testing/refactoring-patterns/README.md) so later subissues can apply proven patterns without restating their rationale.
+Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Store the coverage evidence in an issue-local human-readable document, rather than committing large raw coverage artifacts. State which source paths and code types the measurement includes, because test-inclusive totals are not production-only coverage. Use aggregate percentages only for navigation; prioritize behavior by examining per-file coverage and uncovered functions or regions.
+
+Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior. Record reusable test-design refactors in the [testing refactoring-pattern catalog](../../../testing/refactoring-patterns/README.md) so later subissues can apply proven patterns without restating their rationale.
+
+For every test-producing task, apply this development loop:
+
+1. Add the smallest behavior-focused test increment.
+2. Review the changed tests before beginning the next test-producing task: remove duplication, extract only justified mechanical helpers, improve naming and AAA structure, and prefer expressive assertions.
+3. Run focused tests and correct failures.
+4. After the final test-producing task, stop and request maintainer review before final verification, committing, or opening a pull request.
+5. Address review feedback, then complete verification and acceptance review.
+
+For multi-input protocol behavior, scenarios should own every related artifact that describes the example, including selector request fields, domain input, and independently specified expected output. Builders may hide irrelevant fields of an individual artifact. Do not derive expected values by calling production mapping or serialization code under test. Keep the production-boundary invocation, concrete expected representation, and final actual-versus-expected assertion visible; helpers may encapsulate only repeated mechanics such as successful-response decoding.
 
 For each subissue implementation, the completion policy is:
 
@@ -131,7 +144,8 @@ For each subissue implementation, the completion policy is:
 
 ## Risks and Trade-offs
 
-- Coverage percentage can incentivize low-value tests; mitigate it by recording it as a baseline and prioritizing critical responsibilities and valuable regression protection.
+- Coverage percentage can conceal critical low-coverage files behind strong aggregate results; mitigate it by maintaining per-file and uncovered-area evidence, then selecting behavior by risk rather than pursuing a percentage target.
+- Raw coverage formats can be too large or tool-oriented for code review; mitigate this by committing a concise, human-readable issue-local evidence document and retaining the reproducible command instead.
 - Testing may expose design seams that are difficult to isolate; make small testability refactorings only when justified and keep unrelated refactoring out of scope.
 - New packages or package extractions can change the inventory during the EPIC; add concrete subissues as needs are identified and record deferrals explicitly before closing the EPIC.
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -48,7 +48,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | Order | Issue                                                 | Local Spec                                                            | Status | Notes                                                          |
 | ----- | ----------------------------------------------------- | --------------------------------------------------------------------- | ------ | -------------------------------------------------------------- |
-| 1     | #1348 - Add tests to the axum-http-server package     | `docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md`      | TODO   | Existing subissue; package-level test work.                    |
+| 1     | #1348 - Add tests to the axum-http-server package     | `docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md`      | DONE   | Added fast package-local response, request-ID, and lifecycle tests; verification and final review evidence recorded. |
 | 2     | #1349 - Add tests to the axum-rest-api-server package | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md`  | TODO   | Existing subissue; package-level test work.                    |
 | 3     | Additional package-testing subissues                  | Create a folder-style spec when a concrete package need is identified | TODO   | Permitted but not required upfront; retain scope in this EPIC. |
 
@@ -86,10 +86,10 @@ For each subissue implementation, the completion policy is:
 - [x] Epic spec reviewed and approved by user/maintainer
 - [x] Existing GitHub epic issue number added to this spec
 - [x] Existing subissues linked in this spec
-- [ ] Subissue statuses kept up to date in the `Subissues` table
-- [ ] For each implemented subissue: automatic checks completed and recorded
-- [ ] For each implemented subissue: manual verification completed and recorded
-- [ ] For each implemented subissue: acceptance criteria reviewed post-implementation
+- [x] Subissue statuses kept up to date in the `Subissues` table
+- [x] For each implemented subissue: automatic checks completed and recorded
+- [x] For each implemented subissue: manual verification completed and recorded
+- [x] For each implemented subissue: acceptance criteria reviewed post-implementation
 - [ ] Epic acceptance criteria reviewed and checked off
 - [ ] Epic issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
@@ -97,6 +97,7 @@ For each subissue implementation, the completion policy is:
 
 - 2026-09-01 17:48 UTC - GitHub Copilot - Created repository-local EPIC specification from GitHub issue #1347 and recorded maintainer feedback: cover all current workspace packages, allow additional subissues as needs are identified, and use baselines with risk-based targets. - https://github.com/torrust/torrust-tracker/issues/1347
 - 2026-09-01 18:00 UTC - User/maintainer - Approved the EPIC direction and clarified that each package should build a local safety net: establish and increase the coverage baseline, prioritize fast tests close to the code, and use unit, integration, or end-to-end tests whenever they provide valuable regression protection. - https://github.com/torrust/torrust-tracker/issues/1347
+- 2026-09-01 - GitHub Copilot - Completed #1348 with fast package-local response-adapter, request-ID middleware, and registration-cleanup tests; automated checks, directly invoked real-server verification scenarios, and final review evidence are recorded in its subissue specification. - https://github.com/torrust/torrust-tracker/issues/1348
 
 ## Acceptance Criteria
 
@@ -104,11 +105,11 @@ For each subissue implementation, the completion policy is:
 - [x] Implementation order and package-scoped delivery strategy are explicit.
 - [x] Coverage policy requires a recorded baseline, an aim to increase it, and prioritization of critical behavior over an arbitrary percentage for each subissue.
 - [ ] Dependencies, blockers, and remaining package needs are documented and current.
-- [ ] Epic status reflects actual state of linked subissues.
-- [ ] Every completed subissue includes automated verification evidence.
-- [ ] Every completed subissue includes manual verification evidence.
-- [ ] Every completed subissue includes post-implementation acceptance criteria review.
-- [ ] Documentation and governance updates are included when required.
+- [x] Epic status reflects actual state of linked subissues.
+- [x] Every completed subissue includes automated verification evidence.
+- [x] Every completed subissue includes manual verification evidence.
+- [x] Every completed subissue includes post-implementation acceptance criteria review.
+- [x] Documentation and governance updates are included when required.
 
 ### Acceptance Verification
 
@@ -118,10 +119,11 @@ For each subissue implementation, the completion policy is:
 | AC2   | DONE                   | Delivery strategy in this spec             |
 | AC3   | DONE                   | Scope and delivery strategy in this spec   |
 | AC4   | TODO                   | Subissue specs and progress logs           |
-| AC5   | TODO                   | Subissue verification records              |
-| AC6   | TODO                   | Subissue verification records              |
-| AC7   | TODO                   | Subissue acceptance-verification records   |
-| AC8   | TODO                   | Relevant PRs and documentation             |
+| AC5   | DONE                   | #1348 status in the subissues table and its specification |
+| AC6   | DONE                   | #1348 automatic-verification records       |
+| AC7   | DONE                   | #1348 manual-verification records          |
+| AC8   | DONE                   | #1348 post-implementation acceptance-verification record |
+| AC9   | DONE                   | #1348 specification and this EPIC update; no additional behavior, workflow, or governance documentation was required. |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -8,8 +8,12 @@ last-updated-utc: 2026-09-01 17:48
 semantic-links:
   skill-links:
     - create-issue
+    - write-unit-test
   related-artifacts:
     - .github/skills/dev/planning/create-issue/SKILL.md
+    - .github/skills/dev/testing/write-unit-test/SKILL.md
+    - docs/testing/README.md
+    - docs/testing/refactoring-patterns/README.md
 ---
 
 <!-- skill-link: create-issue -->
@@ -46,15 +50,15 @@ The repository was reorganized through package refactoring and extraction work. 
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| Order | Issue                                                 | Local Spec                                                            | Status | Notes                                                          |
-| ----- | ----------------------------------------------------- | --------------------------------------------------------------------- | ------ | -------------------------------------------------------------- |
+| Order | Issue                                                 | Local Spec                                                            | Status | Notes                                                                                                                |
+| ----- | ----------------------------------------------------- | --------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
 | 1     | #1348 - Add tests to the axum-http-server package     | `docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md`      | DONE   | Added fast package-local response, request-ID, and lifecycle tests; verification and final review evidence recorded. |
-| 2     | #1349 - Add tests to the axum-rest-api-server package | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md`  | TODO   | Existing subissue; package-level test work.                    |
-| 3     | Additional package-testing subissues                  | Create a folder-style spec when a concrete package need is identified | TODO   | Permitted but not required upfront; retain scope in this EPIC. |
+| 2     | #1349 - Add tests to the axum-rest-api-server package | `docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md`  | TODO   | Existing subissue; package-level test work.                                                                          |
+| 3     | Additional package-testing subissues                  | Create a folder-style spec when a concrete package need is identified | TODO   | Permitted but not required upfront; retain scope in this EPIC.                                                       |
 
 ## Delivery Strategy
 
-Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior.
+Implement independently reviewable, package-scoped subissues. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior. Record reusable test-design refactors in the [testing refactoring-pattern catalog](../../../testing/refactoring-patterns/README.md) so later subissues can apply proven patterns without restating their rationale.
 
 For each subissue implementation, the completion policy is:
 
@@ -113,16 +117,16 @@ For each subissue implementation, the completion policy is:
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                   |
-| ----- | ---------------------- | ------------------------------------------ |
-| AC1   | TODO                   | EPIC subissue table and GitHub issue links |
-| AC2   | DONE                   | Delivery strategy in this spec             |
-| AC3   | DONE                   | Scope and delivery strategy in this spec   |
-| AC4   | TODO                   | Subissue specs and progress logs           |
-| AC5   | DONE                   | #1348 status in the subissues table and its specification |
-| AC6   | DONE                   | #1348 automatic-verification records       |
-| AC7   | DONE                   | #1348 manual-verification records          |
-| AC8   | DONE                   | #1348 post-implementation acceptance-verification record |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                              |
+| ----- | ---------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| AC1   | TODO                   | EPIC subissue table and GitHub issue links                                                                            |
+| AC2   | DONE                   | Delivery strategy in this spec                                                                                        |
+| AC3   | DONE                   | Scope and delivery strategy in this spec                                                                              |
+| AC4   | TODO                   | Subissue specs and progress logs                                                                                      |
+| AC5   | DONE                   | #1348 status in the subissues table and its specification                                                             |
+| AC6   | DONE                   | #1348 automatic-verification records                                                                                  |
+| AC7   | DONE                   | #1348 manual-verification records                                                                                     |
+| AC8   | DONE                   | #1348 post-implementation acceptance-verification record                                                              |
 | AC9   | DONE                   | #1348 specification and this EPIC update; no additional behavior, workflow, or governance documentation was required. |
 
 ## Risks and Trade-offs
@@ -139,3 +143,4 @@ For each subissue implementation, the completion policy is:
 - Reference package: `packages/tracker-core/`
 - Coverage tooling: `cargo llvm-cov`
 - Related historical work: #753, #1181, #1226, #1266
+- Test-pattern catalog: `docs/testing/refactoring-patterns/README.md`

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -14,6 +14,7 @@ semantic-links:
     - .github/skills/dev/testing/write-unit-test/SKILL.md
     - docs/testing/README.md
     - docs/testing/refactoring-patterns/README.md
+    - docs/skills/semantic-skill-link-convention.md
 ---
 
 <!-- skill-link: create-issue -->
@@ -35,6 +36,7 @@ The repository was reorganized through package refactoring and extraction work. 
 - Establish and record a coverage baseline for each package addressed by a subissue, then aim to increase it by testing critical behavior. Record an issue-local, human-readable coverage-evidence document with the command, measurement scope, aggregate comparison, per-file results, and prioritized uncovered areas.
 - Add maintainable, fast, responsibility-oriented unit tests close to the code they protect, using Arrange, Act, Assert (AAA) structure where appropriate.
 - Add integration tests, runnable examples, or end-to-end tests when they provide valuable package-level regression protection.
+- When a package behavior is impractical to cover with a unit test, select the narrowest stable test boundary that can cover it: package-local integration or end-to-end tests first, then root `tests/` integration tests or `packages/e2e-tools/` only when the behavior is necessarily composed at that level. Record the chosen boundary and its rationale in the subissue evidence.
 - Use `tracker-core` as a reference for effective package-level test coverage.
 - Create and track additional package-testing subissues when a maintainer or contributor identifies a need.
 - Set qualitative, risk-based coverage objectives per subissue and document the rationale and exceptions; do not require a numeric percentage target.
@@ -74,6 +76,14 @@ whether a subissue has adequately covered critical behavior.
 Implement independently reviewable, package-scoped subissues. When work begins on a package, add it to the Package Coverage Tracking table and record its starting coverage before adding tests. After implementation, update the row with the latest measurement and percentage-point change. Each subissue records its starting coverage, the critical responsibilities assessed, the coverage increase achieved where practical, verification evidence, and any explicitly justified exclusions. Store the coverage evidence in an issue-local human-readable document, rather than committing large raw coverage artifacts. State which source paths and code types the measurement includes, because test-inclusive totals are not production-only coverage. Use aggregate percentages only for navigation; prioritize behavior by examining per-file coverage and uncovered functions or regions.
 
 Prioritize fast unit tests close to the code being changed, while retaining or adding integration, runnable-example, and end-to-end tests when they provide valuable regression protection. Coverage percentage informs the work but does not replace testing critical behavior. Record reusable test-design refactors in the [testing refactoring-pattern catalog](../../../testing/refactoring-patterns/README.md) so later subissues can apply proven patterns without restating their rationale.
+
+When a package behavior is covered outside its package, add a high-signal semantic link from the
+subissue specification to the external test artifact using the
+[Semantic Skill Link Convention](../../../skills/semantic-skill-link-convention.md). In Markdown
+frontmatter, add the stable repository-relative test path under
+`semantic-links.related-artifacts`; use an issue number rather than a moving issue-spec path when
+the external artifact must refer back to the subissue. Do not add broad directory links or markers
+for incidental mentions: the link must identify the test that provides the coverage evidence.
 
 For every test-producing task, apply this development loop:
 

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -67,7 +67,7 @@ whether a subissue has adequately covered critical behavior.
 
 | Package                            | Subissue                                               | Baseline                                          | Latest                                            | Change                                                  | Evidence                                                                       |
 | ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `torrust-tracker-axum-http-server` | [#1348](1348-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.00%; regions: 93.10%; functions: 91.06% | Lines: +1.18 pp; regions: +1.44 pp; functions: +1.52 pp | [Coverage evidence](1348-1347-add-tests-axum-http-server/coverage-evidence.md) |
+| `torrust-tracker-axum-http-server` | [#1348](1348-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.22%; regions: 92.96%; functions: 91.58% | Lines: +1.40 pp; regions: +1.30 pp; functions: +2.04 pp | [Coverage evidence](1348-1347-add-tests-axum-http-server/coverage-evidence.md) |
 
 ## Delivery Strategy
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -57,44 +57,50 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                            | Notes / Expected Output                                                                                                                                               |
 | --- | ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Establish the baseline          | Run package coverage and identify critical untested paths.                                                                                                            |
-| T2  | TODO   | Plan coverage improvement       | Identify critical behavior and record the coverage increase achieved without pursuing an arbitrary percentage.                                                        |
-| T3  | TODO   | Add lifecycle and routing tests | Cover meaningful listener, route, and middleware gaps; prefer fast tests close to the code when appropriate.                                                          |
-| T4  | TODO   | Add protocol-boundary tests     | Cover announce/scrape response selection and error mapping, including behavior already exercised only at higher levels when package-level tests add regression value. |
-| T5  | TODO   | Review test design              | Simplify duplicated setup when justified; retain readable AAA-style tests and valuable package integration coverage.                                                  |
-| T6  | TODO   | Verify and record evidence      | Complete automated checks, manual scenarios, and the post-implementation AC review.                                                                                   |
+| T1  | DONE   | Establish the baseline          | Baseline recorded: 1,229 lines, 1,153 covered (93.82%); 1,763 regions, 1,616 covered (91.66%); 153 functions, 137 covered (89.54%).                                  |
+| T2  | DONE   | Plan coverage improvement       | The response adapters were the smallest direct package seam: previous higher-level tests exercised them, but no focused tests decoded the handlers' returned bencode. |
+| T3  | DONE   | Add lifecycle and routing tests | Added fast router tests for propagated and generated request IDs, plus a lifecycle test that proves failed registration releases the HTTP listener. |
+| T4  | DONE   | Add protocol-boundary tests     | Added fast handler tests that decode accepted, omitted, and non-compact announce responses and scrape responses from domain data. |
+| T5  | DONE   | Review test design              | Tests use the existing `PeerBuilder`, protocol deserializers, AAA comments, direct handler-response seams, and an in-process router; no production refactor was needed. |
+| T6  | DONE   | Verify and record evidence      | Automated and manually invoked real-server verification evidence is recorded below; final independent review and acceptance review passed. |
 
 ## Progress Tracking
 
 ### Workflow Checkpoints
 
 - [x] Repository-local folder-style spec created for existing GitHub issue #1348
-- [ ] Spec reviewed and approved by user/maintainer
-- [ ] Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
-- [ ] Automatic verification completed
-- [ ] Manual verification scenarios executed and recorded
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
-- [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Committer verified spec progress is up to date before commit
+- [x] Spec reviewed and approved by user/maintainer
+- [x] Spec-only PR merged into `develop` before implementation
+- [x] Implementation completed
+- [x] Automatic verification completed
+- [x] Manual verification scenarios executed and recorded
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Reviewer validated acceptance criteria and updated checkboxes
+- [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved to `docs/issues/closed/`
 
 ### Progress Log
 
 - 2026-09-01 18:00 UTC - GitHub Copilot - Created a repository-local folder-style specification from GitHub issue #1348 and EPIC #1347. - https://github.com/torrust/torrust-tracker/issues/1348
 - 2026-09-01 18:00 UTC - User/maintainer - Clarified that the work should increase the recorded coverage baseline by testing critical behavior, prioritize fast unit tests close to package code, and retain or add valuable package-level integration and end-to-end tests. - https://github.com/torrust/torrust-tracker/issues/1348
+- 2026-09-01 - GitHub Copilot - Measured package-source coverage with `cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json`, summing the `summary` objects for files beneath `packages/axum-http-server/src/`: baseline: 1,229 lines / 1,153 covered (93.82%), 1,763 regions / 1,616 covered (91.66%), and 153 functions / 137 covered (89.54%). Final: 1,441 lines / 1,368 covered (94.93%), 2,072 regions / 1,930 covered (93.15%), and 172 functions / 156 covered (90.70%). These package-source totals include test code and are not a production-only coverage measurement; the new tests directly assert previously high-level-only response-adapter, request-ID middleware, and registration-cleanup behavior.
+- 2026-09-01 - GitHub Copilot - Automatic verification passed: `cargo test -p torrust-tracker-axum-http-server` (30 unit tests and 55 integration tests), `cargo test -p torrust-tracker-axum-http-server --test integration` (55 tests), `linter all`, and `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`. The complexity audit found all added tests and helpers to have cyclomatic complexity 1, nesting depth 0, and fewer than 50 lines. `cargo clippy --package torrust-tracker-axum-http-server -- -W clippy::cognitive_complexity -D warnings` was blocked only by two pre-existing high-complexity diagnostics in `torrust-tracker-swarm-coordination-registry`; the normal Clippy validation included in `linter all` passed.
+- 2026-09-01 - Task Reviewer - Independently reviewed the focused response-adapter tests. The compact-response test name was corrected to state that it verifies the omitted-parameter default. Review identified follow-up work: use reproducible package-source coverage totals, complete manual verification, and keep EPIC/subissue progress state aligned. The focused tests themselves passed review.
+- 2026-09-01 - GitHub Copilot - Added fast in-process router tests for client-supplied and generated request IDs, a listener-release test for registration failure, and an explicit accepted-compact response test. Re-ran focused real-server announce, scrape, health-check, and start/stop scenarios successfully.
+- 2026-09-01 - Task Reviewer - Focused tests passed review. Follow-up review identified documentation-evidence alignment work, which was corrected before final review.
+- 2026-09-01 - Task Reviewer - Final independent review passed after verifying focused test scope, reproducible coverage evidence, manually invoked real-server scenarios, and documentation consistency.
 
 ## Acceptance Criteria
 
-- [ ] A coverage baseline and the coverage increase achieved are recorded, with critical behavior prioritized over an arbitrary percentage.
-- [ ] Tests cover all identified critical `axum-http-server` transport gaps, including behavior previously covered only at a higher level when package-level coverage provides regression value.
-- [ ] Lifecycle, routing/middleware, and announce/scrape protocol-boundary tests are added or explicitly justified as already covered.
-- [ ] Tests reuse appropriate fixtures and remain readable and maintainable.
-- [ ] `linter all` exits with code `0`.
-- [ ] Relevant tests pass.
-- [ ] Manual verification scenarios are executed and documented.
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
-- [ ] Documentation is updated when behavior or workflow changes.
+- [x] A coverage baseline and the coverage increase achieved are recorded, with critical behavior prioritized over an arbitrary percentage.
+- [x] Tests cover all identified critical `axum-http-server` transport gaps, including behavior previously covered only at a higher level when package-level coverage provides regression value.
+- [x] Lifecycle, routing/middleware, and announce/scrape protocol-boundary tests are added or explicitly justified as already covered.
+- [x] Tests reuse appropriate fixtures and remain readable and maintainable.
+- [x] `linter all` exits with code `0`.
+- [x] Relevant tests pass.
+- [x] Manual verification scenarios are executed and documented.
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [x] Documentation is updated when behavior or workflow changes.
 
 ## Verification Plan
 
@@ -112,23 +118,25 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 | ID  | Scenario                             | Command/Steps                                                                         | Expected Result                                                                                                 | Status | Evidence                              |
 | --- | ------------------------------------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------- |
-| M1  | HTTP tracker announce contract       | Start the test environment and issue valid compact and non-compact announce requests. | Both requests produce valid bencoded tracker responses with the selected peer representation.                   | TODO   | To be recorded during implementation. |
-| M2  | Scrape and failure response contract | Issue valid scrape and invalid announce requests against the test environment.        | Scrape data is returned when available; invalid announce input is represented as a BitTorrent failure response. | TODO   | To be recorded during implementation. |
-| M3  | Server lifecycle                     | Start and stop the test environment using an ephemeral listener.                      | The server registers, accepts a health check, and stops cleanly.                                                | TODO   | To be recorded during implementation. |
+| M1  | HTTP tracker announce contract       | Invoke the specified real-server integration tests for compact and non-compact announce requests. | Both requests produce valid bencoded tracker responses with the selected peer representation.                   | DONE   | Invoked `should_return_the_compact_response` and `should_return_the_list_of_previously_announced_peers`; both passed. |
+| M2  | Scrape and failure response contract | Invoke the specified real-server integration tests for valid scrape and invalid announce requests. | Scrape data is returned when available; invalid announce input is represented as a BitTorrent failure response. | DONE   | Invoked `should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download` and `should_fail_when_the_url_query_component_is_empty`; both passed. |
+| M3  | Server lifecycle                     | Invoke the specified real-server integration tests for health checks and start/stop. | The server registers, accepts a health check, and stops cleanly.                                                | DONE   | Invoked `health_check_endpoint_should_return_ok_if_the_http_tracker_is_running` and `it_should_start_and_stop`; both passed. |
 
 ### Acceptance Verification
 
 | AC ID | Status (`TODO`/`DONE`) | Evidence                                          |
 | ----- | ---------------------- | ------------------------------------------------- |
-| AC1   | TODO                   | Coverage command output recorded in progress log. |
-| AC2   | TODO                   | Added test paths and test output.                 |
-| AC3   | TODO                   | Test output and review notes.                     |
-| AC4   | TODO                   | Code review of test fixtures and assertions.      |
-| AC5   | TODO                   | `linter all` output.                              |
-| AC6   | TODO                   | Package test output.                              |
-| AC7   | TODO                   | Manual-verification table and evidence.           |
-| AC8   | TODO                   | Post-implementation review entry.                 |
-| AC9   | TODO                   | Relevant documentation diff.                      |
+| AC1   | DONE                   | Coverage command output recorded in progress log. |
+| AC2   | DONE                   | Added test paths and test output.                 |
+| AC3   | DONE                   | Test output and review notes.                     |
+| AC4   | DONE                   | Code review of test fixtures and assertions.      |
+| AC5   | DONE                   | `linter all` output.                              |
+| AC6   | DONE                   | Package test output.                              |
+| AC7   | DONE                   | Manual-verification table and evidence.           |
+| AC8   | DONE                   | Post-implementation review entry.                 |
+| AC9   | DONE                   | Relevant documentation diff.                      |
+
+All planned work is complete and has independent review evidence recorded above. No public behavior, workflow, or governance change required documentation beyond this issue specification and the EPIC progress update.
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -87,7 +87,9 @@ Implementation begins only after maintainer review of the current file's plan.
 - [Scrape handler tests](test-refactor-plans/scrape-tests.md) — complete.
 - [Routes tests](test-refactor-plans/routes-tests.md) — complete.
 - [Authentication-key extractor tests](test-refactor-plans/authentication-key-extractor-tests.md)
-  — proposed; do not implement until reviewed.
+  — complete.
+- [HTTP server tests](test-refactor-plans/server-tests.md) — proposed; do not implement until
+  reviewed.
 
 ## Progress Tracking
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -57,12 +57,22 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                            | Notes / Expected Output                                                                                                                                               |
 | --- | ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | DONE   | Establish the baseline          | Baseline recorded: 1,229 lines, 1,153 covered (93.82%); 1,763 regions, 1,616 covered (91.66%); 153 functions, 137 covered (89.54%).                                  |
+| T1  | DONE   | Establish the baseline          | Baseline recorded: 1,229 lines, 1,153 covered (93.82%); 1,763 regions, 1,616 covered (91.66%); 153 functions, 137 covered (89.54%).                                   |
 | T2  | DONE   | Plan coverage improvement       | The response adapters were the smallest direct package seam: previous higher-level tests exercised them, but no focused tests decoded the handlers' returned bencode. |
-| T3  | DONE   | Add lifecycle and routing tests | Added fast router tests for propagated and generated request IDs, plus a lifecycle test that proves failed registration releases the HTTP listener. |
-| T4  | DONE   | Add protocol-boundary tests     | Added fast handler tests that decode accepted, omitted, and non-compact announce responses and scrape responses from domain data. |
-| T5  | DONE   | Review test design              | Tests use the existing `PeerBuilder`, protocol deserializers, AAA comments, direct handler-response seams, and an in-process router; no production refactor was needed. |
-| T6  | DONE   | Verify and record evidence      | Automated and manually invoked real-server verification evidence is recorded below; final independent review and acceptance review passed. |
+| T3  | DONE   | Add lifecycle and routing tests | Added fast router tests for propagated and generated request IDs, plus a lifecycle test that proves failed registration releases the HTTP listener.                   |
+| T4  | DONE   | Add protocol-boundary tests     | Added fast handler tests that decode accepted, omitted, and non-compact announce responses and scrape responses from domain data.                                     |
+
+### Test Development Loop
+
+Apply this loop to **every implementation-plan task that adds or changes tests**; it is not a separate sequential implementation-plan task.
+
+1. Add the smallest test increment that covers the intended behavior.
+2. Review the changed tests before starting the next test-producing task. Remove duplication, extract justified helpers, improve naming and Arrange/Act/Assert structure, and use expressive assertions.
+3. Run the focused tests for that increment and correct failures.
+4. After the final test-producing task, stop and ask the user/maintainer to review the generated tests before final verification, committing, or opening a pull request.
+5. Address requested test refactorings, then complete the full verification and acceptance review.
+
+The completed tests use the existing `PeerBuilder`, protocol deserializers, direct handler-response seams, and an in-process router; no production refactor was needed.
 
 ## Progress Tracking
 
@@ -89,6 +99,8 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-01 - GitHub Copilot - Added fast in-process router tests for client-supplied and generated request IDs, a listener-release test for registration failure, and an explicit accepted-compact response test. Re-ran focused real-server announce, scrape, health-check, and start/stop scenarios successfully.
 - 2026-09-01 - Task Reviewer - Focused tests passed review. Follow-up review identified documentation-evidence alignment work, which was corrected before final review.
 - 2026-09-01 - Task Reviewer - Final independent review passed after verifying focused test scope, reproducible coverage evidence, manually invoked real-server scenarios, and documentation consistency.
+- 2026-09-02 - User/maintainer - Clarified the required test-development workflow: review test design progressively after each test-producing task, then stop after all planned tests are complete and request maintainer review before final verification, commit, or PR creation. Prioritize removing duplication, extracting justified helpers, using expressive assertions, and making test intent easy to read.
+- 2026-09-02 - GitHub Copilot - Applied the progressive test-design review to the announce response tests: extracted expected normal and compact response fixtures and replaced repeated field assertions with whole-response assertions. Maintainer review confirmed that direct `assert_eq!(actual, expected)` comparisons are preferred to a custom assertion wrapper for these `PartialEq` response types.
 
 ## Acceptance Criteria
 
@@ -116,11 +128,11 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                             | Command/Steps                                                                         | Expected Result                                                                                                 | Status | Evidence                              |
-| --- | ------------------------------------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------- |
-| M1  | HTTP tracker announce contract       | Invoke the specified real-server integration tests for compact and non-compact announce requests. | Both requests produce valid bencoded tracker responses with the selected peer representation.                   | DONE   | Invoked `should_return_the_compact_response` and `should_return_the_list_of_previously_announced_peers`; both passed. |
+| ID  | Scenario                             | Command/Steps                                                                                      | Expected Result                                                                                                 | Status | Evidence                                                                                                                                                                              |
+| --- | ------------------------------------ | -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| M1  | HTTP tracker announce contract       | Invoke the specified real-server integration tests for compact and non-compact announce requests.  | Both requests produce valid bencoded tracker responses with the selected peer representation.                   | DONE   | Invoked `should_return_the_compact_response` and `should_return_the_list_of_previously_announced_peers`; both passed.                                                                 |
 | M2  | Scrape and failure response contract | Invoke the specified real-server integration tests for valid scrape and invalid announce requests. | Scrape data is returned when available; invalid announce input is represented as a BitTorrent failure response. | DONE   | Invoked `should_return_the_file_with_the_incomplete_peer_when_there_is_one_peer_with_bytes_pending_to_download` and `should_fail_when_the_url_query_component_is_empty`; both passed. |
-| M3  | Server lifecycle                     | Invoke the specified real-server integration tests for health checks and start/stop. | The server registers, accepts a health check, and stops cleanly.                                                | DONE   | Invoked `health_check_endpoint_should_return_ok_if_the_http_tracker_is_running` and `it_should_start_and_stop`; both passed. |
+| M3  | Server lifecycle                     | Invoke the specified real-server integration tests for health checks and start/stop.               | The server registers, accepts a health check, and stops cleanly.                                                | DONE   | Invoked `health_check_endpoint_should_return_ok_if_the_http_tracker_is_running` and `it_should_start_and_stop`; both passed.                                                          |
 
 ### Acceptance Verification
 
@@ -143,6 +155,7 @@ All planned work is complete and has independent review evidence recorded above.
 - End-to-end-style fixture tests can be slow and costly to compose; prefer direct router or focused unit tests where they cover the intended boundary, while keeping higher-level tests that provide distinct value.
 - Testing implementation details creates brittle tests; assert public HTTP and bencoded protocol contracts instead.
 - TLS health checks require appropriately configured trust in tests; use the injectable client seam rather than weakening production TLS behavior.
+- AI-generated tests can be difficult to maintain or understand; mitigate this by requiring progressive design review and a maintainer review checkpoint before finalizing the implementation.
 
 ## References
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -82,14 +82,13 @@ Implementation begins only after maintainer review of the current file's plan.
 
 - [Shared test-refactor-plan guidance](test-refactor-plans/README.md)
 - [Announce handler tests](test-refactor-plans/announce-tests.md) — complete.
-- [Draft shared handler test bootstrap](test-refactor-plans/drafts/shared-handler-test-bootstrap.md)
-  — future cross-file assessment only; no extraction is approved.
+- [Shared handler test bootstrap assessment](test-refactor-plans/drafts/shared-handler-test-bootstrap.md)
+  — complete; local bootstraps are retained because the consumers do not share a cohesive capability.
 - [Scrape handler tests](test-refactor-plans/scrape-tests.md) — complete.
 - [Routes tests](test-refactor-plans/routes-tests.md) — complete.
 - [Authentication-key extractor tests](test-refactor-plans/authentication-key-extractor-tests.md)
   — complete.
-- [HTTP server tests](test-refactor-plans/server-tests.md) — proposed; do not implement until
-  reviewed.
+- [HTTP server tests](test-refactor-plans/server-tests.md) — complete.
 
 ## Progress Tracking
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -81,8 +81,11 @@ problems, then orders proposed refactorings from high-impact/low-effort to low-i
 Implementation begins only after maintainer review of the current file's plan.
 
 - [Shared test-refactor-plan guidance](test-refactor-plans/README.md)
-- [Announce handler tests](test-refactor-plans/announce-tests.md) — proposed; do not implement
-  until reviewed.
+- [Announce handler tests](test-refactor-plans/announce-tests.md) — complete.
+- [Draft shared handler test bootstrap](test-refactor-plans/drafts/shared-handler-test-bootstrap.md)
+  — future cross-file assessment only; no extraction is approved.
+- [Scrape handler tests](test-refactor-plans/scrape-tests.md) — proposed; do not implement until
+  reviewed.
 
 ## Progress Tracking
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -57,7 +57,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                            | Notes / Expected Output                                                                                                                                               |
 | --- | ------ | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | DONE   | Establish the baseline          | Baseline recorded: 1,229 lines, 1,153 covered (93.82%); 1,763 regions, 1,616 covered (91.66%); 153 functions, 137 covered (89.54%).                                   |
+| T1  | DONE   | Establish the baseline          | Baseline and latest per-file evidence are recorded in [coverage-evidence.md](coverage-evidence.md).                                                                   |
 | T2  | DONE   | Plan coverage improvement       | The response adapters were the smallest direct package seam: previous higher-level tests exercised them, but no focused tests decoded the handlers' returned bencode. |
 | T3  | DONE   | Add lifecycle and routing tests | Added fast router tests for propagated and generated request IDs, plus a lifecycle test that proves failed registration releases the HTTP listener.                   |
 | T4  | DONE   | Add protocol-boundary tests     | Added fast handler tests that decode accepted, omitted, and non-compact announce responses and scrape responses from domain data.                                     |
@@ -93,7 +93,7 @@ The completed tests use the existing `PeerBuilder`, protocol deserializers, dire
 
 - 2026-09-01 18:00 UTC - GitHub Copilot - Created a repository-local folder-style specification from GitHub issue #1348 and EPIC #1347. - https://github.com/torrust/torrust-tracker/issues/1348
 - 2026-09-01 18:00 UTC - User/maintainer - Clarified that the work should increase the recorded coverage baseline by testing critical behavior, prioritize fast unit tests close to package code, and retain or add valuable package-level integration and end-to-end tests. - https://github.com/torrust/torrust-tracker/issues/1348
-- 2026-09-01 - GitHub Copilot - Measured package-source coverage with `cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json`, summing the `summary` objects for files beneath `packages/axum-http-server/src/`: baseline: 1,229 lines / 1,153 covered (93.82%), 1,763 regions / 1,616 covered (91.66%), and 153 functions / 137 covered (89.54%). Final: 1,441 lines / 1,368 covered (94.93%), 2,072 regions / 1,930 covered (93.15%), and 172 functions / 156 covered (90.70%). These package-source totals include test code and are not a production-only coverage measurement; the new tests directly assert previously high-level-only response-adapter, request-ID middleware, and registration-cleanup behavior.
+- 2026-09-01 - GitHub Copilot - Measured package-source coverage with `cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json`. The baseline, current aggregate comparison, per-file coverage, uncovered-function locations, method, and scope limitations are maintained in [coverage-evidence.md](coverage-evidence.md). The new tests directly assert previously high-level-only response-adapter, request-ID middleware, and registration-cleanup behavior.
 - 2026-09-01 - GitHub Copilot - Automatic verification passed: `cargo test -p torrust-tracker-axum-http-server` (30 unit tests and 55 integration tests), `cargo test -p torrust-tracker-axum-http-server --test integration` (55 tests), `linter all`, and `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`. The complexity audit found all added tests and helpers to have cyclomatic complexity 1, nesting depth 0, and fewer than 50 lines. `cargo clippy --package torrust-tracker-axum-http-server -- -W clippy::cognitive_complexity -D warnings` was blocked only by two pre-existing high-complexity diagnostics in `torrust-tracker-swarm-coordination-registry`; the normal Clippy validation included in `linter all` passed.
 - 2026-09-01 - Task Reviewer - Independently reviewed the focused response-adapter tests. The compact-response test name was corrected to state that it verifies the omitted-parameter default. Review identified follow-up work: use reproducible package-source coverage totals, complete manual verification, and keep EPIC/subissue progress state aligned. The focused tests themselves passed review.
 - 2026-09-01 - GitHub Copilot - Added fast in-process router tests for client-supplied and generated request IDs, a listener-release test for registration failure, and an explicit accepted-compact response test. Re-ran focused real-server announce, scrape, health-check, and start/stop scenarios successfully.
@@ -136,17 +136,17 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                          |
-| ----- | ---------------------- | ------------------------------------------------- |
-| AC1   | DONE                   | Coverage command output recorded in progress log. |
-| AC2   | DONE                   | Added test paths and test output.                 |
-| AC3   | DONE                   | Test output and review notes.                     |
-| AC4   | DONE                   | Code review of test fixtures and assertions.      |
-| AC5   | DONE                   | `linter all` output.                              |
-| AC6   | DONE                   | Package test output.                              |
-| AC7   | DONE                   | Manual-verification table and evidence.           |
-| AC8   | DONE                   | Post-implementation review entry.                 |
-| AC9   | DONE                   | Relevant documentation diff.                      |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                      |
+| ----- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| AC1   | DONE                   | [Coverage evidence](coverage-evidence.md) records the command, baseline, latest totals, per-file detail, and follow-up queue. |
+| AC2   | DONE                   | Added test paths and test output.                                                                                             |
+| AC3   | DONE                   | Test output and review notes.                                                                                                 |
+| AC4   | DONE                   | Code review of test fixtures and assertions.                                                                                  |
+| AC5   | DONE                   | `linter all` output.                                                                                                          |
+| AC6   | DONE                   | Package test output.                                                                                                          |
+| AC7   | DONE                   | Manual-verification table and evidence.                                                                                       |
+| AC8   | DONE                   | Post-implementation review entry.                                                                                             |
+| AC9   | DONE                   | Relevant documentation diff.                                                                                                  |
 
 All planned work is complete and has independent review evidence recorded above. No public behavior, workflow, or governance change required documentation beyond this issue specification and the EPIC progress update.
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -84,8 +84,8 @@ Implementation begins only after maintainer review of the current file's plan.
 - [Announce handler tests](test-refactor-plans/announce-tests.md) — complete.
 - [Draft shared handler test bootstrap](test-refactor-plans/drafts/shared-handler-test-bootstrap.md)
   — future cross-file assessment only; no extraction is approved.
-- [Scrape handler tests](test-refactor-plans/scrape-tests.md) — proposed; do not implement until
-  reviewed.
+- [Scrape handler tests](test-refactor-plans/scrape-tests.md) — complete.
+- [Routes tests](test-refactor-plans/routes-tests.md) — proposed; do not implement until reviewed.
 
 ## Progress Tracking
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -74,6 +74,16 @@ Apply this loop to **every implementation-plan task that adds or changes tests**
 
 The completed tests use the existing `PeerBuilder`, protocol deserializers, direct handler-response seams, and an in-process router; no production refactor was needed.
 
+### Test Refactor Plans
+
+Test-bearing package files are reviewed one at a time. Each plan first identifies file-specific
+problems, then orders proposed refactorings from high-impact/low-effort to low-impact/high-effort.
+Implementation begins only after maintainer review of the current file's plan.
+
+- [Shared test-refactor-plan guidance](test-refactor-plans/README.md)
+- [Announce handler tests](test-refactor-plans/announce-tests.md) — proposed; do not implement
+  until reviewed.
+
 ## Progress Tracking
 
 ### Workflow Checkpoints

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/ISSUE.md
@@ -85,7 +85,9 @@ Implementation begins only after maintainer review of the current file's plan.
 - [Draft shared handler test bootstrap](test-refactor-plans/drafts/shared-handler-test-bootstrap.md)
   — future cross-file assessment only; no extraction is approved.
 - [Scrape handler tests](test-refactor-plans/scrape-tests.md) — complete.
-- [Routes tests](test-refactor-plans/routes-tests.md) — proposed; do not implement until reviewed.
+- [Routes tests](test-refactor-plans/routes-tests.md) — complete.
+- [Authentication-key extractor tests](test-refactor-plans/authentication-key-extractor-tests.md)
+  — proposed; do not implement until reviewed.
 
 ## Progress Tracking
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
@@ -1,0 +1,76 @@
+---
+doc-type: coverage-evidence
+issue: 1348
+package: torrust-tracker-axum-http-server
+measured-commit: 312ad07e
+measured-utc: 2026-09-02
+---
+
+# Coverage Evidence
+
+This document records the reproducible coverage baseline and the latest detailed package-source
+report for Issue #1348. Aggregate percentages are only a navigation aid: use the per-file results
+and uncovered-function locations to decide which critical behavior needs more coverage.
+
+## Measurement Method
+
+The report was generated at commit `312ad07e` with:
+
+```text
+cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json
+```
+
+The tables sum the JSON `summary` objects for files below `packages/axum-http-server/src/`. This
+includes test code, so it is not a production-only coverage measure. The full machine-readable
+JSON is intentionally not versioned because it is a generated 66 MB artifact; rerun the command
+above to inspect line- and region-level detail for the measured revision.
+
+## Package Coverage Comparison
+
+| Measurement                           |                  Lines |                Regions |          Functions |
+| ------------------------------------- | ---------------------: | ---------------------: | -----------------: |
+| Baseline (before Issue #1348 changes) | 1,153 / 1,229 (93.82%) | 1,616 / 1,763 (91.66%) | 137 / 153 (89.54%) |
+| Latest (commit `312ad07e`)            | 1,387 / 1,460 (95.00%) | 1,915 / 2,057 (93.10%) | 163 / 179 (91.06%) |
+
+## Latest Detailed File Report
+
+Files are ordered by ascending line coverage to highlight likely follow-up candidates.
+
+| Source file                           |              Lines |            Regions |         Functions | Coverage interpretation                                                                                          |
+| ------------------------------------- | -----------------: | -----------------: | ----------------: | ---------------------------------------------------------------------------------------------------------------- |
+| `v1/extractors/authentication_key.rs` |   36 / 46 (78.26%) |   53 / 62 (85.48%) |    7 / 8 (87.50%) | Lowest line coverage; review path-extraction and error-mapping branches.                                         |
+| `server.rs`                           | 262 / 306 (85.62%) | 428 / 524 (81.68%) |  23 / 35 (65.71%) | Lowest function and region coverage; prioritize lifecycle, TLS, health-check, and startup-failure paths by risk. |
+| `v1/extractors/client_ip_sources.rs`  |   13 / 14 (92.86%) |   20 / 21 (95.24%) |   2 / 2 (100.00%) | Small residual branch gap.                                                                                       |
+| `v1/routes.rs`                        | 128 / 137 (93.43%) | 209 / 223 (93.72%) |  14 / 17 (82.35%) | Request-layer branches remain partially uncovered.                                                               |
+| `v1/handlers/announce.rs`             | 410 / 415 (98.80%) | 470 / 477 (98.53%) | 48 / 48 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
+| `v1/handlers/scrape.rs`               | 292 / 295 (98.98%) | 413 / 422 (97.87%) | 31 / 31 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
+| `testing/environment.rs`              | 110 / 111 (99.10%) | 128 / 134 (95.52%) | 17 / 17 (100.00%) | Remaining regions are test-environment alternatives.                                                             |
+| `lib.rs`                              |    5 / 5 (100.00%) |    6 / 6 (100.00%) |   1 / 1 (100.00%) | Fully covered.                                                                                                   |
+| `v1/extractors/announce_request.rs`   |  60 / 60 (100.00%) |  86 / 86 (100.00%) |   8 / 8 (100.00%) | Fully covered.                                                                                                   |
+| `v1/extractors/scrape_request.rs`     |  67 / 67 (100.00%) |  98 / 98 (100.00%) | 10 / 10 (100.00%) | Fully covered.                                                                                                   |
+| `v1/handlers/health_check.rs`         |    4 / 4 (100.00%) |    4 / 4 (100.00%) |   2 / 2 (100.00%) | Fully covered.                                                                                                   |
+
+## Uncovered Function Areas
+
+The coverage tool identifies the following source areas with at least one uncovered function.
+These locations are a review queue, not a requirement to test every implementation detail.
+
+| Area                                  | Uncovered function locations                                                             | Follow-up focus                                                                                 |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `server.rs`                           | 116, 117, 131, 140, 142, 155, 247, 252, 274, 281, 286, 323, 325, 329, 345, 354, 359, 369 | Server launch variants, registration/startup cleanup, stop flow, and health-check client paths. |
+| `testing/environment.rs`              | 30, 45, 79, 89, 121, 133, 154, 164, 180, 209                                             | Test environment construction, lifecycle alternatives, and initialization.                      |
+| `v1/extractors/authentication_key.rs` | 65, 77, 78, 90, 111                                                                      | Key parsing and extraction-rejection mapping.                                                   |
+| `v1/routes.rs`                        | 142, 160                                                                                 | Request-layer composition and middleware branches.                                              |
+| `v1/extractors/announce_request.rs`   | 52, 53                                                                                   | Axum extractor trait entry point; parser behavior is fully covered.                             |
+| `v1/extractors/scrape_request.rs`     | 52, 53                                                                                   | Axum extractor trait entry point; parser behavior is fully covered.                             |
+| `v1/extractors/client_ip_sources.rs`  | 58, 59                                                                                   | Axum extractor trait entry point.                                                               |
+| `v1/handlers/announce.rs`             | 25, 29, 38, 43, 53, 59                                                                   | Public Axum handler entry points and delegation; focused adapter and error behavior is covered. |
+| `v1/handlers/scrape.rs`               | 25, 29, 40, 45, 51, 57                                                                   | Public Axum handler entry points and delegation; focused adapter and error behavior is covered. |
+| `v1/handlers/health_check.rs`         | 5                                                                                        | Handler entry point.                                                                            |
+
+## Coverage Decision
+
+Issue #1348 closes the highest-value direct gaps: announce and scrape response adaptation,
+request-ID middleware behavior, and registration-failure listener release. Future work should
+consider `server.rs` and authentication-key extraction first, but only where a stable,
+behavior-focused package test provides regression value.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
@@ -2,19 +2,16 @@
 doc-type: coverage-evidence
 issue: 1348
 package: torrust-tracker-axum-http-server
-measured-commit: 3e424fec
-measured-utc: 2026-09-02
+measured-commit: b9437375
+measured-utc: 2026-09-03
 ---
 
 # Coverage Evidence
 
 This document records the reproducible coverage baseline and the latest detailed package-source
-report for Issue #1348. Aggregate percentages are only a navigation aid: use the per-file results
-and uncovered-function locations to decide which critical behavior needs more coverage.
+report for Issue #1348.
 
 ## Measurement Method
-
-The report was generated at commit `3e424fec` with:
 
 ```text
 cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json
@@ -30,7 +27,7 @@ above to inspect line- and region-level detail for the measured revision.
 | Measurement                           |                  Lines |                Regions |          Functions |
 | ------------------------------------- | ---------------------: | ---------------------: | -----------------: |
 | Baseline (before Issue #1348 changes) | 1,153 / 1,229 (93.82%) | 1,616 / 1,763 (91.66%) | 137 / 153 (89.54%) |
-| Latest (commit `3e424fec`)            | 1,433 / 1,505 (95.22%) | 1,850 / 1,990 (92.96%) | 174 / 190 (91.58%) |
+| Latest (commit `b9437375`)            | 1,467 / 1,543 (95.07%) | 1,911 / 2,055 (92.99%) | 179 / 197 (90.86%) |
 
 ## Latest Detailed File Report
 
@@ -38,10 +35,10 @@ Files are ordered by ascending line coverage to highlight likely follow-up candi
 
 | Source file                           |              Lines |            Regions |         Functions | Coverage interpretation                                                                                          |
 | ------------------------------------- | -----------------: | -----------------: | ----------------: | ---------------------------------------------------------------------------------------------------------------- |
-| `v1/extractors/authentication_key.rs` |   36 / 46 (78.26%) |   53 / 62 (85.48%) |    7 / 8 (87.50%) | Lowest line coverage; review path-extraction and error-mapping branches.                                         |
+| `v1/extractors/authentication_key.rs` |   70 / 84 (83.33%) | 112 / 125 (89.60%) |  12 / 15 (80.00%) | Added parsing and wire contracts increased line/region coverage; remaining functions are extractor internals.    |
 | `server.rs`                           | 262 / 306 (85.62%) | 428 / 524 (81.68%) |  23 / 35 (65.71%) | Lowest function and region coverage; prioritize lifecycle, TLS, health-check, and startup-failure paths by risk. |
 | `v1/extractors/client_ip_sources.rs`  |   13 / 14 (92.86%) |   20 / 21 (95.24%) |   2 / 2 (100.00%) | Small residual branch gap.                                                                                       |
-| `v1/routes.rs`                        | 128 / 137 (93.43%) | 209 / 223 (93.72%) |  14 / 17 (82.35%) | Request-layer branches remain partially uncovered.                                                               |
+| `v1/routes.rs`                        | 128 / 137 (93.43%) | 211 / 225 (93.78%) |  14 / 17 (82.35%) | Request-layer branches remain partially uncovered.                                                               |
 | `v1/handlers/announce.rs`             | 409 / 414 (98.79%) | 440 / 447 (98.43%) | 49 / 49 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
 | `v1/handlers/scrape.rs`               | 339 / 341 (99.41%) | 378 / 385 (98.18%) | 41 / 41 (100.00%) | Response adapter, error mapping, and multi-file mapping paths have strong package-level coverage.                |
 | `testing/environment.rs`              | 110 / 111 (99.10%) | 128 / 134 (95.52%) | 17 / 17 (100.00%) | Remaining regions are test-environment alternatives.                                                             |
@@ -59,7 +56,7 @@ These locations are a review queue, not a requirement to test every implementati
 | ------------------------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `server.rs`                           | 116, 117, 131, 140, 142, 155, 247, 252, 274, 281, 286, 323, 325, 329, 345, 354, 359, 369 | Server launch variants, registration/startup cleanup, stop flow, and health-check client paths. |
 | `testing/environment.rs`              | 30, 45, 79, 89, 121, 133, 154, 164, 180, 209                                             | Test environment construction, lifecycle alternatives, and initialization.                      |
-| `v1/extractors/authentication_key.rs` | 65, 77, 78, 90, 111                                                                      | Key parsing and extraction-rejection mapping.                                                   |
+| `v1/extractors/authentication_key.rs` | 77, 78, 111, 138                                                                         | Axum extractor trait entry point, rejection mapping, and test-only route helper.                |
 | `v1/routes.rs`                        | 142, 160                                                                                 | Request-layer composition and middleware branches.                                              |
 | `v1/extractors/announce_request.rs`   | 52, 53                                                                                   | Axum extractor trait entry point; parser behavior is fully covered.                             |
 | `v1/extractors/scrape_request.rs`     | 52, 53                                                                                   | Axum extractor trait entry point; parser behavior is fully covered.                             |

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
@@ -2,7 +2,7 @@
 doc-type: coverage-evidence
 issue: 1348
 package: torrust-tracker-axum-http-server
-measured-commit: 312ad07e
+measured-commit: 3e424fec
 measured-utc: 2026-09-02
 ---
 
@@ -14,7 +14,7 @@ and uncovered-function locations to decide which critical behavior needs more co
 
 ## Measurement Method
 
-The report was generated at commit `312ad07e` with:
+The report was generated at commit `3e424fec` with:
 
 ```text
 cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json
@@ -30,7 +30,7 @@ above to inspect line- and region-level detail for the measured revision.
 | Measurement                           |                  Lines |                Regions |          Functions |
 | ------------------------------------- | ---------------------: | ---------------------: | -----------------: |
 | Baseline (before Issue #1348 changes) | 1,153 / 1,229 (93.82%) | 1,616 / 1,763 (91.66%) | 137 / 153 (89.54%) |
-| Latest (commit `312ad07e`)            | 1,387 / 1,460 (95.00%) | 1,915 / 2,057 (93.10%) | 163 / 179 (91.06%) |
+| Latest (commit `3e424fec`)            | 1,433 / 1,505 (95.22%) | 1,850 / 1,990 (92.96%) | 174 / 190 (91.58%) |
 
 ## Latest Detailed File Report
 
@@ -42,8 +42,8 @@ Files are ordered by ascending line coverage to highlight likely follow-up candi
 | `server.rs`                           | 262 / 306 (85.62%) | 428 / 524 (81.68%) |  23 / 35 (65.71%) | Lowest function and region coverage; prioritize lifecycle, TLS, health-check, and startup-failure paths by risk. |
 | `v1/extractors/client_ip_sources.rs`  |   13 / 14 (92.86%) |   20 / 21 (95.24%) |   2 / 2 (100.00%) | Small residual branch gap.                                                                                       |
 | `v1/routes.rs`                        | 128 / 137 (93.43%) | 209 / 223 (93.72%) |  14 / 17 (82.35%) | Request-layer branches remain partially uncovered.                                                               |
-| `v1/handlers/announce.rs`             | 410 / 415 (98.80%) | 470 / 477 (98.53%) | 48 / 48 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
-| `v1/handlers/scrape.rs`               | 292 / 295 (98.98%) | 413 / 422 (97.87%) | 31 / 31 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
+| `v1/handlers/announce.rs`             | 409 / 414 (98.79%) | 440 / 447 (98.43%) | 49 / 49 (100.00%) | Response adapter and handler error paths have strong package-level coverage.                                     |
+| `v1/handlers/scrape.rs`               | 339 / 341 (99.41%) | 378 / 385 (98.18%) | 41 / 41 (100.00%) | Response adapter, error mapping, and multi-file mapping paths have strong package-level coverage.                |
 | `testing/environment.rs`              | 110 / 111 (99.10%) | 128 / 134 (95.52%) | 17 / 17 (100.00%) | Remaining regions are test-environment alternatives.                                                             |
 | `lib.rs`                              |    5 / 5 (100.00%) |    6 / 6 (100.00%) |   1 / 1 (100.00%) | Fully covered.                                                                                                   |
 | `v1/extractors/announce_request.rs`   |  60 / 60 (100.00%) |  86 / 86 (100.00%) |   8 / 8 (100.00%) | Fully covered.                                                                                                   |

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -14,7 +14,8 @@ responsibility.
 - [Announce handler tests](announce-tests.md) — complete
 - [Scrape handler tests](scrape-tests.md) — complete
 - [Routes tests](routes-tests.md) — complete
-- [Authentication-key extractor tests](authentication-key-extractor-tests.md) — proposed
+- [Authentication-key extractor tests](authentication-key-extractor-tests.md) — complete
+- [HTTP server tests](server-tests.md) — proposed
 
 ## Shared Purpose
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -1,0 +1,48 @@
+# Test Refactor Plan Guidance
+
+This folder contains one proposed refactor plan for each test-bearing file in
+`packages/axum-http-server/`. Create, review, and implement plans one file at a time. Do not begin
+a plan for the next file until the current plan's approved work has been completed and reviewed.
+
+## Shared Purpose
+
+Each plan improves tests without changing production behavior. Its scope is deliberately limited to
+the target file. Review and approve the plan before implementing any item.
+
+## Shared Quality Goals
+
+The refactoring must improve or preserve:
+
+- **Expressiveness:** a test tells the reader the behavior and its relevant inputs.
+- **Readability:** a reader can distinguish setup, action, actual result, and expected result.
+- **Maintainability:** a behavior change has one intentional fixture or helper to update.
+- **One behavior-focused contract:** each test asserts one observable contract; a failure should
+  make that contract clear. This does not mean a wire-boundary test has literally one possible
+  internal defect.
+- **Coverage:** retain existing valuable coverage and add coverage only for identified,
+  behavior-focused gaps.
+
+The refactoring must reduce or avoid:
+
+- **Flakiness:** no sleeps, retries, wall-clock dependencies, uncontrolled network I/O, or shared
+  mutable state.
+- **Duplication:** share only genuinely repeated mechanical setup or decoding.
+- **Complexity:** helpers must not hide behavior selection, expected-value construction, or the
+  system under test (SUT).
+
+## Plan Structure
+
+Every file plan must contain:
+
+1. **Phase 1 — Identify Problems:** evidence-based, file-specific opportunities and strengths to
+   preserve.
+2. **Phase 2 — Proposed Refactorings:** items ordered from high-impact/low-effort to
+   low-impact/high-effort, including behavior and abstraction guardrails.
+3. **Progress Tracking:** a status checklist, progress log, and validation evidence for the plan.
+4. **Non-Goals, validation, and completion criteria:** constraints that prevent speculative work
+   and preserve the user-review checkpoint.
+
+Use `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`, or `DEFERRED` for each proposed refactoring. Update
+one item at a time: record its review decision, implementation outcome, and focused validation
+before beginning the next item. Do not mark the plan complete until the maintainer has reviewed all
+approved changes.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -12,8 +12,9 @@ responsibility.
 
 - [Draft shared handler test bootstrap](drafts/shared-handler-test-bootstrap.md)
 - [Announce handler tests](announce-tests.md) — complete
-- [Scrape handler tests](scrape-tests.md) — proposed
-- [Routes tests](routes-tests.md) — proposed
+- [Scrape handler tests](scrape-tests.md) — complete
+- [Routes tests](routes-tests.md) — complete
+- [Authentication-key extractor tests](authentication-key-extractor-tests.md) — proposed
 
 ## Shared Purpose
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -10,12 +10,12 @@ responsibility.
 
 ## Plans
 
-- [Draft shared handler test bootstrap](drafts/shared-handler-test-bootstrap.md)
+- [Shared handler test bootstrap assessment](drafts/shared-handler-test-bootstrap.md) — complete
 - [Announce handler tests](announce-tests.md) — complete
 - [Scrape handler tests](scrape-tests.md) — complete
 - [Routes tests](routes-tests.md) — complete
 - [Authentication-key extractor tests](authentication-key-extractor-tests.md) — complete
-- [HTTP server tests](server-tests.md) — proposed
+- [HTTP server tests](server-tests.md) — complete
 
 ## Shared Purpose
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -4,6 +4,16 @@ This folder contains one proposed refactor plan for each test-bearing file in
 `packages/axum-http-server/`. Create, review, and implement plans one file at a time. Do not begin
 a plan for the next file until the current plan's approved work has been completed and reviewed.
 
+Draft cross-file plans belong in `drafts/`. They assess a shared concern without authorizing a
+cross-file extraction; promote one only after maintainer review establishes a cohesive common
+responsibility.
+
+## Plans
+
+- [Draft shared handler test bootstrap](drafts/shared-handler-test-bootstrap.md)
+- [Announce handler tests](announce-tests.md) — complete
+- [Scrape handler tests](scrape-tests.md) — proposed
+
 ## Shared Purpose
 
 Each plan improves tests without changing production behavior. Its scope is deliberately limited to

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/README.md
@@ -13,6 +13,7 @@ responsibility.
 - [Draft shared handler test bootstrap](drafts/shared-handler-test-bootstrap.md)
 - [Announce handler tests](announce-tests.md) — complete
 - [Scrape handler tests](scrape-tests.md) — proposed
+- [Routes tests](routes-tests.md) — proposed
 
 ## Shared Purpose
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
@@ -165,13 +165,17 @@ beginning the next.
 
 ### R4 — Consider an error scenario only if needed
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / medium effort
 - **Addresses:** Remaining duplication after R1
 - **Change:** Extract a small scenario fixture only if R1 leaves meaningful duplication.
 - **Guardrail:** A scenario must own configuration selector, request, client-IP sources, key, and
   expected failure contract. It must not accumulate optional variants or hide the behavior.
-- **Done when:** the plan records an approved scenario design or a no-change decision.
+- **Decision:** No change. R1 removed the only repeated mechanical fixture. The remaining test
+  statements express different configuration modes, distinct inputs, and different failure-reason
+  contracts. A shared scenario would need optional configuration, key, client-IP, and expected
+  error fields, which would hide the behavior each nested module currently makes explicit.
+- **Done when:** the no-change decision is recorded.
 
 ## Progress Tracking
 
@@ -181,11 +185,11 @@ beginning the next.
 - [x] Phase 2 refactorings ordered by impact and effort
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
-- [ ] R2 implemented, reviewed, and validated
-- [ ] R3 implemented, reviewed, and validated
-- [ ] R4 implemented or no-change decision recorded
-- [ ] Maintainer reviewed all approved changes
-- [ ] Plan completed and ready for commit
+- [x] R2 assessment completed and decision recorded
+- [x] R3 assessment completed and decision recorded
+- [x] R4 assessment completed and decision recorded
+- [x] Maintainer reviewed all approved changes
+- [x] Plan completed and ready for commit
 
 ### Progress Log
 
@@ -204,6 +208,11 @@ beginning the next.
   coverage: the router binds the public handlers to `/announce` and `/announce/{key}`, and the
   integration suite exercises those routes across configuration and error contracts. No additional
   direct wiring test would add an unobserved behavior.
+- 2026-09-02 - GitHub Copilot - Completed R4 assessment. After R1, no repeated mechanical setup
+  remains. Retained the explicit error tests because a shared scenario would require optional,
+  behavior-hiding fields across unrelated configuration and failure contracts.
+- 2026-09-02 - User/maintainer - Reviewed and approved the R4 no-change decision and completion
+  of the announce-handler test refactor plan.
 
 ### Validation Evidence
 
@@ -213,7 +222,7 @@ beginning the next.
 | R1                 | DONE   | `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, `git diff --check`, and editor diagnostics passed.         |
 | R2                 | DONE   | `cargo test -p torrust-tracker-axum-http-server --lib v1::handlers::announce::tests -- --nocapture`: 8 passed in 0.02 seconds after compilation. |
 | R3                 | DONE   | Inspected `v1::routes::router` and the existing real-server announce contract suite; no unique observable wiring contract was found.             |
-| R4                 | TODO   | Not started.                                                                                                                                     |
+| R4                 | DONE   | Inspected the post-R1 error tests; their remaining differences are behavior-specific, so a scenario would add optional, opaque fields.           |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
@@ -132,14 +132,17 @@ beginning the next.
 
 ### R2 — Assess fixture cost before changing it
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / low effort
 - **Addresses:** P5
 - **Change:** Measure focused test duration and inspect existing seams. Record a no-change decision
   unless a smaller existing seam preserves the same observable behavior.
 - **Guardrail:** Do not add mocks or refactor production based on speculation.
-- **Done when:** the plan records the evidence and either the retained fixture rationale or an
-  approved focused improvement.
+- **Decision:** No change. The focused `announce` test module ran 8 tests in 0.02 seconds after
+  compilation. The current fixture exercises the real `AnnounceService` boundary with its required
+  authorization, repository, and configuration collaborators. No smaller existing seam preserves
+  those error-path contracts without replacing the behavior with mocks or adding production seams.
+- **Done when:** the retained-fixture rationale and timing evidence are recorded.
 
 ### R3 — Assess missing handler-entry behavior
 
@@ -185,16 +188,20 @@ beginning the next.
 - 2026-09-02 - GitHub Copilot - Completed R1. The five error tests now share
   `sample_http_service_binding()`, use explicit actual-error names, and retain their distinct
   configuration and input in visible Arrange sections.
+- 2026-09-02 - GitHub Copilot - Completed R2 assessment. Focused `announce` tests passed 8 tests
+  in 0.02 seconds after compilation. Retained the real-service fixture because no smaller existing
+  seam preserves the authorization and client-IP error contracts without speculative mocks or
+  production changes.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                               |
-| ------------------ | ------ | -------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
-| R1                 | DONE   | `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, `git diff --check`, and editor diagnostics passed. |
-| R2                 | TODO   | Not started.                                                                           |
-| R3                 | TODO   | Not started.                                                                           |
-| R4                 | TODO   | Not started.                                                                           |
+| Increment          | Status | Evidence                                                                                                                                         |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                           |
+| R1                 | DONE   | `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, `git diff --check`, and editor diagnostics passed.         |
+| R2                 | DONE   | `cargo test -p torrust-tracker-axum-http-server --lib v1::handlers::announce::tests -- --nocapture`: 8 passed in 0.02 seconds after compilation. |
+| R3                 | TODO   | Not started.                                                                                                                                     |
+| R4                 | TODO   | Not started.                                                                                                                                     |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
@@ -1,0 +1,220 @@
+---
+doc-type: test-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-file: packages/axum-http-server/src/v1/handlers/announce.rs
+status: proposed
+---
+
+# Announce Handler Test Refactor Plan
+
+Follow the shared [purpose, quality goals, and plan structure](README.md). This plan applies them
+only to `packages/axum-http-server/src/v1/handlers/announce.rs`.
+
+## Phase 1 — Identify Problems
+
+### Current strengths to preserve
+
+1. The compact-response tests use `AnnounceResponseScenario<TExpectedResponse>`. Each scenario
+   owns the request selector, domain `AnnounceData`, and independently specified expected decoded
+   response.
+2. `decode_successful_bencoded_response` centralizes repeated response mechanics while retaining
+   the `build_response` SUT call, concrete response type, and final actual-versus-expected
+   assertion in each test.
+3. The response fixtures are deterministic: fixed peer, addresses, protocol values, and no
+   listener or clock.
+4. Error tests separate authorization and client-IP behaviors into nested modules named for their
+   configuration context.
+
+### Problems and opportunities
+
+#### P1 — Repeated HTTP service-binding setup
+
+**Problem.** Five `handle_announce` error tests construct the same loopback HTTP
+`ServiceBinding`.
+
+**Why it matters.** The repeated setup obscures each test's behavior-specific input and creates
+multiple update sites if the common binding changes.
+
+**Evidence.** Each nested error-test module constructs
+`SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070)` and
+`ServiceBinding::new(Protocol::HTTP, ...)`.
+
+**Opportunity.** Extract a deterministic `sample_http_service_binding()` fixture, while retaining
+each test's configuration, request, client-IP source, and key in the test body.
+
+#### P2 — Inconsistent Arrange, Act, Assert structure
+
+**Problem.** The error tests do not consistently separate their setup, SUT invocation, and
+assertion preparation.
+
+**Why it matters.** Readers must infer which statements describe the scenario, execute the SUT,
+or prepare the assertion.
+
+**Evidence.** The nested authorization and reverse-proxy tests have no AAA comments, unlike the
+response-adapter tests.
+
+**Opportunity.** Add concise comments around the existing logical phases only; do not add a
+comment between every statement.
+
+#### P3 — Error result has a response-like name
+
+**Problem.** `response` holds a `Result<DomainAnnounceData, HttpAnnounceError>` that is
+immediately unwrapped as an error.
+
+**Why it matters.** The name suggests a successful HTTP response instead of the expected failure.
+
+**Evidence.** Every nested error test assigns `.await.unwrap_err()` to `response`.
+
+**Opportunity.** Name it `actual_error`, then map it to `actual_error_response` before asserting
+the stable failure-reason contract.
+
+#### P4 — Failure-reason helper name is too broad
+
+**Problem.** `assert_error_response` accepts a failure-reason substring but does not state that
+specific contract in its name.
+
+**Why it matters.** A generic name can encourage vague assertions.
+
+**Evidence.** The helper is called as `assert_error_response(&error_response, ...)`.
+
+**Opportunity.** Rename it to `assert_failure_reason_contains`, retain the full diagnostic output,
+and assert only stable behavior-relevant fragments.
+
+#### P5 — Error-test fixture is substantial
+
+**Problem.** Initialization builds real core and persistence services for each error test.
+
+**Why it matters.** The tests are fast today, but this composition can become costly or fragile as
+the service graph evolves.
+
+**Evidence.** `initialize_core_tracker_services` initializes a database, event bus, repositories,
+authorization, and service.
+
+**Opportunity.** Measure focused test duration and inspect existing seams first. Do not introduce
+mocks or production refactors without evidence that cost or fragility is material.
+
+#### P6 — Uncovered handler-entry wiring
+
+**Problem.** Public Axum handler entry points and delegation paths are uncovered despite strong
+overall file coverage.
+
+**Why it matters.** Aggregate coverage can hide missing transport wiring, but direct coverage may
+duplicate router or integration coverage.
+
+**Evidence.** `coverage-evidence.md` lists uncovered locations 25, 29, 38, 43, 53, and 59 in
+`announce.rs`, even though file line coverage is 98.80%.
+
+**Opportunity.** Inspect existing router and real-server tests. Add a focused extractor-to-handler
+test only for an unobserved contract; otherwise document why direct coverage is deferred.
+
+## Phase 2 — Proposed Refactorings
+
+Apply items in order. Complete one increment—including review and focused validation—before
+beginning the next.
+
+### R1 — Clarify error-test setup and failure contracts
+
+- **Status:** TODO
+- **Priority:** High impact / low effort
+- **Addresses:** P1, P2, P3, P4
+- **Change:** Apply the related readability improvements as one atomic increment:
+  1. add `sample_http_service_binding()` and replace the repeated loopback binding setup in the
+     five `handle_announce` error tests;
+  2. rename values to `actual_error` and `actual_error_response`;
+  3. rename `assert_error_response` to `assert_failure_reason_contains`; and
+  4. add concise AAA comments around the existing logical phases.
+- **Guardrails:** Keep each test's unique configuration and input visible. Preserve the helper's
+  complete diagnostic output and stable failure-reason fragments. Add only phase comments; avoid
+  comment noise.
+- **Done when:** one deterministic common fixture replaces all repeated bindings, each test makes
+  its error outcome explicit, and the Act/Assert flow is scannable.
+
+### R2 — Assess fixture cost before changing it
+
+- **Status:** TODO
+- **Priority:** Medium impact / low effort
+- **Addresses:** P5
+- **Change:** Measure focused test duration and inspect existing seams. Record a no-change decision
+  unless a smaller existing seam preserves the same observable behavior.
+- **Guardrail:** Do not add mocks or refactor production based on speculation.
+- **Done when:** the plan records the evidence and either the retained fixture rationale or an
+  approved focused improvement.
+
+### R3 — Assess missing handler-entry behavior
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P6
+- **Change:** Compare the uncovered paths with existing router and real-server tests. Add one
+  focused transport-wiring test only if it proves an unobserved contract.
+- **Guardrail:** Prefer an in-process router seam; do not add tests merely to turn lines green or
+  duplicate integration coverage.
+- **Done when:** the plan records either a behavior-justified test or a concrete deferral rationale.
+
+### R4 — Consider an error scenario only if needed
+
+- **Status:** TODO
+- **Priority:** Low impact / medium effort
+- **Addresses:** Remaining duplication after R1
+- **Change:** Extract a small scenario fixture only if R1 leaves meaningful duplication.
+- **Guardrail:** A scenario must own configuration selector, request, client-IP sources, key, and
+  expected failure contract. It must not accumulate optional variants or hide the behavior.
+- **Done when:** the plan records an approved scenario design or a no-change decision.
+
+## Progress Tracking
+
+### Plan Checklist
+
+- [x] Phase 1 findings reviewed against the current file
+- [x] Phase 2 refactorings ordered by impact and effort
+- [ ] Maintainer approved implementation of R1
+- [ ] R1 implemented, reviewed, and validated
+- [ ] R2 implemented, reviewed, and validated
+- [ ] R3 implemented, reviewed, and validated
+- [ ] R4 implemented or no-change decision recorded
+- [ ] Maintainer reviewed all approved changes
+- [ ] Plan completed and ready for commit
+
+### Progress Log
+
+- 2026-09-02 - GitHub Copilot - Created the proposed plan from the current
+  `announce.rs` tests and the issue's coverage evidence. No refactoring has been implemented.
+
+### Validation Evidence
+
+| Increment          | Status | Evidence                                                                               |
+| ------------------ | ------ | -------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
+| R1                 | TODO   | Not started.                                                                           |
+| R2                 | TODO   | Not started.                                                                           |
+| R3                 | TODO   | Not started.                                                                           |
+| R4                 | TODO   | Not started.                                                                           |
+
+## Non-Goals
+
+- Do not replace direct full-value `assert_eq!` in the announce-response tests with a custom
+  assertion helper.
+- Do not merge compact and non-compact response tests into a parameterized test if doing so hides
+  their different decoded response types or expected wire representations.
+- Do not add retries, sleeps, or broad test-timeout increases to mask failures.
+- Do not pursue uncovered lines that correspond only to generated trait glue or already-covered
+  integration wiring without a missing observable behavior.
+- Do not change production behavior as part of this plan.
+
+## Validation Per Approved Increment
+
+- `cargo fmt --all -- --check`
+- `cargo test -p torrust-tracker-axum-http-server --lib`
+- `git diff --check`
+- Run `linter markdown` if this plan changes.
+- Review the updated coverage evidence only after a behavior-adding test, not for a readability-only
+  refactor.
+
+## Completion Criteria
+
+- Every approved item preserves deterministic, behavior-focused tests.
+- Common mechanics are reduced without hiding scenarios, the SUT call, expected type, or final
+  behavior assertion.
+- Any coverage addition is justified by a missing observable contract, not an aggregate percentage.
+- The maintainer reviews the completed increment before a commit or the next file's plan.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
@@ -115,7 +115,7 @@ beginning the next.
 
 ### R1 — Clarify error-test setup and failure contracts
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / low effort
 - **Addresses:** P1, P2, P3, P4
 - **Change:** Apply the related readability improvements as one atomic increment:
@@ -168,8 +168,8 @@ beginning the next.
 
 - [x] Phase 1 findings reviewed against the current file
 - [x] Phase 2 refactorings ordered by impact and effort
-- [ ] Maintainer approved implementation of R1
-- [ ] R1 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R1
+- [x] R1 implemented, reviewed, and validated
 - [ ] R2 implemented, reviewed, and validated
 - [ ] R3 implemented, reviewed, and validated
 - [ ] R4 implemented or no-change decision recorded
@@ -180,13 +180,18 @@ beginning the next.
 
 - 2026-09-02 - GitHub Copilot - Created the proposed plan from the current
   `announce.rs` tests and the issue's coverage evidence. No refactoring has been implemented.
+- 2026-09-02 - User/maintainer - Approved R1 after reviewing the shared binding fixture, explicit
+  error-path names, failure-reason assertion name, and AAA structure.
+- 2026-09-02 - GitHub Copilot - Completed R1. The five error tests now share
+  `sample_http_service_binding()`, use explicit actual-error names, and retain their distinct
+  configuration and input in visible Arrange sections.
 
 ### Validation Evidence
 
 | Increment          | Status | Evidence                                                                               |
 | ------------------ | ------ | -------------------------------------------------------------------------------------- |
 | Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
-| R1                 | TODO   | Not started.                                                                           |
+| R1                 | DONE   | `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, `git diff --check`, and editor diagnostics passed. |
 | R2                 | TODO   | Not started.                                                                           |
 | R3                 | TODO   | Not started.                                                                           |
 | R4                 | TODO   | Not started.                                                                           |

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/announce-tests.md
@@ -146,14 +146,22 @@ beginning the next.
 
 ### R3 — Assess missing handler-entry behavior
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P6
 - **Change:** Compare the uncovered paths with existing router and real-server tests. Add one
   focused transport-wiring test only if it proves an unobserved contract.
 - **Guardrail:** Prefer an in-process router seam; do not add tests merely to turn lines green or
   duplicate integration coverage.
-- **Done when:** the plan records either a behavior-justified test or a concrete deferral rationale.
+- **Decision:** No change. `v1::routes::router` registers `handle_without_key` on `/announce` and
+  `handle_with_key` on `/announce/{key}`. The existing real-server announce contract suite invokes
+  those routes across public, private, and whitelisted configurations, including successful,
+  malformed, missing-key, invalid-key, and client-IP failure behavior. A new direct
+  extractor-to-handler test would exercise the same route wiring while adding a second, less
+  representative fixture path. The uncovered entry-point locations are therefore not a missing
+  observable contract for this issue.
+- **Done when:** the router and real-server coverage assessment and no-change rationale are
+  recorded.
 
 ### R4 — Consider an error scenario only if needed
 
@@ -192,6 +200,10 @@ beginning the next.
   in 0.02 seconds after compilation. Retained the real-service fixture because no smaller existing
   seam preserves the authorization and client-IP error contracts without speculative mocks or
   production changes.
+- 2026-09-02 - GitHub Copilot - Completed R3 assessment. Retained existing route and real-server
+  coverage: the router binds the public handlers to `/announce` and `/announce/{key}`, and the
+  integration suite exercises those routes across configuration and error contracts. No additional
+  direct wiring test would add an unobserved behavior.
 
 ### Validation Evidence
 
@@ -200,7 +212,7 @@ beginning the next.
 | Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                           |
 | R1                 | DONE   | `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, `git diff --check`, and editor diagnostics passed.         |
 | R2                 | DONE   | `cargo test -p torrust-tracker-axum-http-server --lib v1::handlers::announce::tests -- --nocapture`: 8 passed in 0.02 seconds after compilation. |
-| R3                 | TODO   | Not started.                                                                                                                                     |
+| R3                 | DONE   | Inspected `v1::routes::router` and the existing real-server announce contract suite; no unique observable wiring contract was found.             |
 | R4                 | TODO   | Not started.                                                                                                                                     |
 
 ## Non-Goals

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -131,7 +131,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 ### R4 — Assess the in-process malformed-key wire contract
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P4
 - **Change:** Determine whether one minimal router test adds value beyond the real-server announce
@@ -164,7 +164,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 - [x] R2 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R3
 - [x] R3 implemented, reviewed, and validated
-- [ ] R4 assessment completed and decision recorded
+- [x] R4 assessment completed and decision recorded
 - [ ] R5 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
@@ -185,6 +185,10 @@ identifies a stable missing classification. Otherwise record the deferral.
   contract.
 - 2026-09-02 - GitHub Copilot - Completed R3. Added one fixed valid path-key example and asserted
   the `parse_key` result equals the independently parsed expected domain key.
+- 2026-09-03 - User/maintainer - Approved R4 after reviewing the in-process malformed-path-key
+  wire contract and its response-decoding helper.
+- 2026-09-03 - GitHub Copilot - Completed R4. A minimal route requiring `Extract` proves an invalid
+  path key returns HTTP `200 OK` with a bencoded invalid-key-format failure response.
 
 ### Validation Evidence
 
@@ -194,7 +198,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 | R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
 | R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
 | R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (33 passed), and `git diff --check` passed. |
-| R4                 | TODO   | Not started.                                                                                                                                         |
+| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed. |
 | R5                 | TODO   | Not started.                                                                                                                                         |
 
 ## Non-Goals

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -109,7 +109,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 ### R2 — Make malformed-key mapping explicit
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / trivial effort
 - **Addresses:** P1, P3
 - **Change:** Rename the failure test for the invalid-key-format mapping and rename the local helper
@@ -160,8 +160,8 @@ identifies a stable missing classification. Otherwise record the deferral.
 - [x] Phase 2 refactorings ordered by impact and effort
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R2
-- [ ] R2 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R2
+- [x] R2 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R3
 - [ ] R3 implemented, reviewed, and validated
 - [ ] R4 assessment completed and decision recorded
@@ -177,17 +177,21 @@ identifies a stable missing classification. Otherwise record the deferral.
 - 2026-09-02 - User/maintainer - Approved R1 after reviewing the documentation correction.
 - 2026-09-02 - GitHub Copilot - Completed R1. The extractor documentation now states the actual
   bencoded HTTP `200 OK` failure-response contract.
+- 2026-09-02 - User/maintainer - Approved R2 after reviewing the explicit malformed-key mapping
+  test and failure-reason assertion name.
+- 2026-09-02 - GitHub Copilot - Completed R2. The direct parsing test and its assertion helper now
+  name the stable invalid-key-format authentication failure contract.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                                                                            |
-| ------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                              |
-| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed. |
-| R2                 | TODO   | Not started.                                                                                                                        |
-| R3                 | TODO   | Not started.                                                                                                                        |
-| R4                 | TODO   | Not started.                                                                                                                        |
-| R5                 | TODO   | Not started.                                                                                                                        |
+| Increment          | Status | Evidence                                                                                                                                             |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
+| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
+| R3                 | TODO   | Not started.                                                                                                                                         |
+| R4                 | TODO   | Not started.                                                                                                                                         |
+| R5                 | TODO   | Not started.                                                                                                                                         |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -98,7 +98,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 ### R1 — Correct the extractor response-status documentation
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / trivial effort
 - **Addresses:** P5
 - **Change:** Replace the stale `500` wording with the actual bencoded HTTP `200 OK` failure
@@ -158,8 +158,8 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 - [x] Phase 1 findings reviewed against the current file and package coverage evidence
 - [x] Phase 2 refactorings ordered by impact and effort
-- [ ] Maintainer approved implementation of R1
-- [ ] R1 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R1
+- [x] R1 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R2
 - [ ] R2 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R3
@@ -174,17 +174,20 @@ identifies a stable missing classification. Otherwise record the deferral.
 - 2026-09-02 - GitHub Copilot - Created the proposed plan from the extractor tests, current package
   coverage evidence, HTTP-protocol response contract, and existing private-mode real-server tests.
   No refactoring has been implemented.
+- 2026-09-02 - User/maintainer - Approved R1 after reviewing the documentation correction.
+- 2026-09-02 - GitHub Copilot - Completed R1. The extractor documentation now states the actual
+  bencoded HTTP `200 OK` failure-response contract.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                     |
-| ------------------ | ------ | ---------------------------- |
-| Plan documentation | TODO   | Not run after plan creation. |
-| R1                 | TODO   | Not started.                 |
-| R2                 | TODO   | Not started.                 |
-| R3                 | TODO   | Not started.                 |
-| R4                 | TODO   | Not started.                 |
-| R5                 | TODO   | Not started.                 |
+| Increment          | Status | Evidence                                                                                                                            |
+| ------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                              |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed. |
+| R2                 | TODO   | Not started.                                                                                                                        |
+| R3                 | TODO   | Not started.                                                                                                                        |
+| R4                 | TODO   | Not started.                                                                                                                        |
+| R5                 | TODO   | Not started.                                                                                                                        |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -1,0 +1,205 @@
+---
+doc-type: test-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-file: packages/axum-http-server/src/v1/extractors/authentication_key.rs
+status: proposed
+semantic-links:
+  related-artifacts:
+    - packages/axum-http-server/src/v1/extractors/authentication_key.rs
+    - packages/axum-http-server/tests/server/v1/contract/configured_as_private.rs
+    - docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
+---
+
+# Authentication-Key Extractor Test Refactor Plan
+
+Follow the shared [purpose, quality goals, and plan structure](README.md). This plan applies only
+to `packages/axum-http-server/src/v1/extractors/authentication_key.rs`.
+
+## Phase 1 — Identify Problems
+
+### Strengths to preserve
+
+1. The current `parse_key` failure test is fast and deterministic: it needs no router, listener,
+   clock, database, or mock.
+2. The HTTP-protocol error response is asserted through its stable failure-reason text rather than
+   unstable caller-location data.
+3. Existing real-server private-mode tests exercise malformed path keys through both announce and
+   scrape routes, as recorded in the related-artifact link.
+
+### P1 — The failure test does not name its protocol classification
+
+**Problem.** The current test name says a key cannot be parsed, but not that malformed path text
+maps to the invalid-key-format authentication failure.
+
+**Why it matters.** A syntactically valid but unregistered key is a different contract. Naming the
+protocol classification prevents those two failure modes from being conflated.
+
+**Opportunity.** Rename the test to state the invalid-key-format mapping while retaining the direct
+`parse_key` seam and stable failure-reason assertion.
+
+### P2 — The valid key branch lacks a direct test
+
+**Problem.** The module verifies invalid input but not that a syntactically valid path key produces
+a `Key`.
+
+**Why it matters.** The success branch is a small, deterministic contract that complements the
+existing invalid-format mapping test.
+
+**Opportunity.** Add one fixed valid-key test that asserts the parsed key equals the expected domain
+value. Do not test `KeyParam::value()` cloning as a separate behavior.
+
+### P3 — The local helper name does not state its partial assertion
+
+**Problem.** `assert_error_response` checks that a failure reason contains a stable fragment.
+
+**Why it matters.** The generic helper name hides the intentionally partial contract and can
+encourage vague assertions.
+
+**Opportunity.** Rename it to `assert_failure_reason_contains`, retaining the current full debug
+diagnostic when the assertion fails.
+
+### P4 — Extractor wire behavior is covered only generically at a higher level
+
+**Problem.** The `FromRequestParts` implementation turns extraction failure into a bencoded HTTP
+`200 OK` response. Real-server private-mode tests prove a generic authentication failure through
+both routes, but do not explicitly retain the extractor's invalid-key-format classification.
+
+**Why it matters.** The package owns this HTTP response boundary, while general bencode serialization
+belongs to `http-protocol`.
+
+**Opportunity.** Add one minimal in-process router test only if maintainer review accepts the
+specific wire-level contract: malformed `{key}` becomes HTTP `200 OK` and a valid bencoded error
+whose failure reason contains the stable invalid-format classification.
+
+### P5 — Module documentation contradicts the implementation
+
+**Problem.** The documentation says the extractor returns a `500` response, but the implementation
+returns `StatusCode::OK`; the same module later documents HTTP `200` for authentication failures.
+
+**Why it matters.** It misstates the BitTorrent wire contract and conflicts with the protocol error
+response documentation.
+
+**Opportunity.** Correct the stale `500` text as a documentation-only increment. Avoid copying
+sample messages containing unstable source locations.
+
+### P6 — Low coverage should not require synthetic Axum rejection tests
+
+**Problem.** The coverage report identifies lower coverage in this file, including the Axum trait
+entry point and rejection mapping.
+
+**Why it matters.** Constructing every `PathRejection` variant would test Axum internals more than a
+tracker-owned observable contract.
+
+**Opportunity.** Assess direct `custom_error` tests only when a concrete route-parameter regression
+identifies a stable missing classification. Otherwise record the deferral.
+
+## Phase 2 — Proposed Refactorings
+
+### R1 — Correct the extractor response-status documentation
+
+- **Status:** TODO
+- **Priority:** High impact / trivial effort
+- **Addresses:** P5
+- **Change:** Replace the stale `500` wording with the actual bencoded HTTP `200 OK` failure
+  response contract.
+- **Guardrails:** Documentation only. Do not assert or document unstable caller-location strings as
+  response contracts.
+- **Done when:** module documentation agrees with its implementation and the protocol error type.
+
+### R2 — Make malformed-key mapping explicit
+
+- **Status:** TODO
+- **Priority:** Medium impact / trivial effort
+- **Addresses:** P1, P3
+- **Change:** Rename the failure test for the invalid-key-format mapping and rename the local helper
+  to `assert_failure_reason_contains`.
+- **Guardrails:** Preserve the direct `parse_key` seam; assert only stable semantic text, not full
+  dynamic failure messages.
+- **Done when:** the test and helper names reveal the actual failure contract.
+
+### R3 — Add a valid-key parsing contract
+
+- **Status:** TODO
+- **Priority:** Medium impact / trivial effort
+- **Addresses:** P2
+- **Change:** Add one deterministic test with a fixed syntactically valid key, asserting the parsed
+  domain `Key` equals the expected value.
+- **Guardrails:** Do not use generated values, test clone implementation details, or duplicate
+  authentication-service tests for unregistered/expired keys.
+- **Done when:** valid and invalid format branches each have one focused direct test.
+
+### R4 — Assess the in-process malformed-key wire contract
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P4
+- **Change:** Determine whether one minimal router test adds value beyond the real-server announce
+  and scrape contracts. If it does, assert HTTP `200 OK`, valid bencode, and the stable
+  invalid-key-format failure reason for one malformed path key.
+- **Guardrails:** Use `oneshot`; do not create a listener, database, service mock, timeout, or
+  log-capture assertion. Do not test both routes because the extractor is shared.
+- **Done when:** the plan records either one behavior-justified test or a concrete no-change
+  rationale referencing the higher-level coverage.
+
+### R5 — Assess direct Axum path-rejection coverage
+
+- **Status:** TODO
+- **Priority:** Low impact / medium effort
+- **Addresses:** P6
+- **Change:** Assess whether a concrete tracker-owned path-rejection contract remains untested after
+  R4.
+- **Guardrails:** Do not manufacture Axum rejection variants merely to improve coverage.
+- **Done when:** the plan records a behavior-justified test or a deferral rationale.
+
+## Progress Tracking
+
+### Plan Checklist
+
+- [x] Phase 1 findings reviewed against the current file and package coverage evidence
+- [x] Phase 2 refactorings ordered by impact and effort
+- [ ] Maintainer approved implementation of R1
+- [ ] R1 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R2
+- [ ] R2 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R3
+- [ ] R3 implemented, reviewed, and validated
+- [ ] R4 assessment completed and decision recorded
+- [ ] R5 assessment completed and decision recorded
+- [ ] Maintainer reviewed all approved changes
+- [ ] Plan completed and ready for commit
+
+### Progress Log
+
+- 2026-09-02 - GitHub Copilot - Created the proposed plan from the extractor tests, current package
+  coverage evidence, HTTP-protocol response contract, and existing private-mode real-server tests.
+  No refactoring has been implemented.
+
+### Validation Evidence
+
+| Increment          | Status | Evidence                     |
+| ------------------ | ------ | ---------------------------- |
+| Plan documentation | TODO   | Not run after plan creation. |
+| R1                 | TODO   | Not started.                 |
+| R2                 | TODO   | Not started.                 |
+| R3                 | TODO   | Not started.                 |
+| R4                 | TODO   | Not started.                 |
+| R5                 | TODO   | Not started.                 |
+
+## Non-Goals
+
+- Do not test every Axum `PathRejection` variant or Axum path-extraction internals.
+- Do not duplicate real-server malformed-key, missing-key, unregistered-key, or scrape-zeroed-data
+  contracts.
+- Do not add a listener, database, mocks, wall-clock waits, retries, or log assertions.
+- Do not share the tiny local assertion helper across extractor files solely to remove duplication.
+- Do not refactor `KeyParam::value()` or other production implementation details through this test
+  plan.
+
+## Validation Per Approved Increment
+
+- `cargo fmt --all -- --check`
+- `cargo test -p torrust-tracker-axum-http-server --lib`
+- `git diff --check`
+- `linter markdown` when this plan changes
+- Refresh `coverage-evidence.md` only after an approved behavior-adding test.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -120,7 +120,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 ### R3 — Add a valid-key parsing contract
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / trivial effort
 - **Addresses:** P2
 - **Change:** Add one deterministic test with a fixed syntactically valid key, asserting the parsed
@@ -162,8 +162,8 @@ identifies a stable missing classification. Otherwise record the deferral.
 - [x] R1 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R2
 - [x] R2 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R3
-- [ ] R3 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R3
+- [x] R3 implemented, reviewed, and validated
 - [ ] R4 assessment completed and decision recorded
 - [ ] R5 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
@@ -181,6 +181,10 @@ identifies a stable missing classification. Otherwise record the deferral.
   test and failure-reason assertion name.
 - 2026-09-02 - GitHub Copilot - Completed R2. The direct parsing test and its assertion helper now
   name the stable invalid-key-format authentication failure contract.
+- 2026-09-02 - User/maintainer - Approved R3 after reviewing the deterministic valid-key parsing
+  contract.
+- 2026-09-02 - GitHub Copilot - Completed R3. Added one fixed valid path-key example and asserted
+  the `parse_key` result equals the independently parsed expected domain key.
 
 ### Validation Evidence
 
@@ -189,7 +193,7 @@ identifies a stable missing classification. Otherwise record the deferral.
 | Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
 | R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
 | R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
-| R3                 | TODO   | Not started.                                                                                                                                         |
+| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (33 passed), and `git diff --check` passed. |
 | R4                 | TODO   | Not started.                                                                                                                                         |
 | R5                 | TODO   | Not started.                                                                                                                                         |
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/authentication-key-extractor-tests.md
@@ -144,13 +144,18 @@ identifies a stable missing classification. Otherwise record the deferral.
 
 ### R5 — Assess direct Axum path-rejection coverage
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / medium effort
 - **Addresses:** P6
 - **Change:** Assess whether a concrete tracker-owned path-rejection contract remains untested after
   R4.
 - **Guardrails:** Do not manufacture Axum rejection variants merely to improve coverage.
-- **Done when:** the plan records a behavior-justified test or a deferral rationale.
+- **Decision:** Deferred. R4 covers the tracker-owned invalid-key-format response for a malformed
+  path value. The remaining `custom_error` alternatives depend on Axum `PathRejection` variants;
+  no package contract identifies a distinct externally observable behavior for them. A route without
+  a `{key}` segment is a routing concern rather than an extractor invocation. Constructing
+  framework rejection values would increase implementation coupling merely to cover branches.
+- **Done when:** the deferral rationale is recorded.
 
 ## Progress Tracking
 
@@ -165,9 +170,9 @@ identifies a stable missing classification. Otherwise record the deferral.
 - [x] Maintainer approved implementation of R3
 - [x] R3 implemented, reviewed, and validated
 - [x] R4 assessment completed and decision recorded
-- [ ] R5 assessment completed and decision recorded
-- [ ] Maintainer reviewed all approved changes
-- [ ] Plan completed and ready for commit
+- [x] R5 assessment completed and decision recorded
+- [x] Maintainer reviewed all approved changes
+- [x] Plan completed and ready for commit
 
 ### Progress Log
 
@@ -189,17 +194,22 @@ identifies a stable missing classification. Otherwise record the deferral.
   wire contract and its response-decoding helper.
 - 2026-09-03 - GitHub Copilot - Completed R4. A minimal route requiring `Extract` proves an invalid
   path key returns HTTP `200 OK` with a bencoded invalid-key-format failure response.
+- 2026-09-03 - GitHub Copilot - Completed R5 assessment. Deferred direct Axum path-rejection
+  tests: R4 covers the tracker-owned malformed-key contract, while remaining variants are framework
+  extraction details without a distinct documented external behavior.
+- 2026-09-03 - User/maintainer - Reviewed and approved R5's deferral decision and completion of
+  the authentication-key extractor test refactor plan.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                                                                                             |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
-| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
-| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
-| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (33 passed), and `git diff --check` passed. |
-| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed. |
-| R5                 | TODO   | Not started.                                                                                                                                         |
+| Increment          | Status | Evidence                                                                                                                                                            |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                                              |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests (32 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                                 |
+| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed.                |
+| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (33 passed), and `git diff --check` passed.                |
+| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed.                |
+| R5                 | DONE   | Inspected `custom_error`, HTTP protocol error types, and existing malformed-key coverage; no tracker-owned behavior justifies constructing Axum rejection variants. |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
@@ -5,6 +5,7 @@ package: torrust-tracker-axum-http-server
 target-files:
   - packages/axum-http-server/src/v1/handlers/announce.rs
   - packages/axum-http-server/src/v1/handlers/scrape.rs
+  - packages/axum-http-server/src/server.rs
 status: draft
 ---
 
@@ -19,6 +20,22 @@ file-local announce and scrape test plans.
 Assess whether the duplicated **test infrastructure** in the announce and scrape handler modules
 can be reduced without hiding the distinct dependencies of `AnnounceService` and `ScrapeService`.
 This is not a plan to create a generic service factory.
+
+### Why the tests do not reuse the production bootstrap
+
+The test bootstraps deliberately duplicate composition instead of calling the production container
+factories (for example `HttpTrackerCoreContainer::initialize_from_tracker_core`). This decision was
+made when the tests were written and remains valid:
+
+- **Fewer dependencies per test.** A test instantiates only the services it exercises, instead of
+  the whole tracker with its persistence, statistics, and coordination dependencies.
+- **Explicit coupling.** The test setup shows exactly which dependencies the unit under test needs,
+  which documents (and pressures) its real coupling.
+- **Faster execution.** Constructing fewer services keeps unit tests cheap.
+
+Any shared test bootstrap must preserve these properties. Reusing production composition is a
+non-goal; the goal is to remove duplicated _construction detail_ while each test still selects and
+constructs only what it needs.
 
 ## Phase 1 — Identify Problems
 
@@ -48,6 +65,19 @@ retains it.
 
 **Effect.** Statistics initialization is not a cohesive cross-file responsibility. Any future shared
 context must not reintroduce listener work into scrape tests that do not assert it.
+
+### B4 — `server.rs` is a third bootstrap consumer with a different shape
+
+`server.rs::initialize_container` is a third near-duplicate bootstrap. Unlike the handler modules,
+it must produce a complete `HttpTrackerCoreContainer` because `HttpServer::start` consumes the whole
+container. It therefore composes the statistics event bus and optional listener, the swarm
+coordination registry, the persistence-backed `TrackerCoreContainer`, and both services.
+
+**Effect.** This is the "third consumer" trigger named in B2. The overlap with the handler
+bootstraps is real (configuration selection, instance ID, `TrackerCoreContainer` ingredients,
+`*Service::new_with_http_tracker_config` calls), but the required output differs: the server needs
+everything, while the handler tests need one service each. A shared helper must be composable so
+that handler tests can still stop early and skip what they do not use.
 
 ## Phase 2 — Proposed Refactorings
 
@@ -81,7 +111,20 @@ context must not reintroduce listener work into scrape tests that do not assert 
 - **Decision:** Deferred. B1 found no cohesive shared responsibility that would make both modules
   clearer today. Revisit only if a third consumer needs the same test infrastructure or if a
   concrete shared capability emerges without optional fields.
-- **Done when:** a future concrete trigger justifies reassessment.
+- **Reassessment (B4 trigger):** `server.rs` is now the third consumer, so B2 must be reassessed.
+  The candidate shape is **layered, composable helpers** rather than one context object, so each
+  test stops at the layer it needs:
+  1. `selected_http_tracker_config(&Configuration) -> (Arc<HttpTracker>, ConfigurationInstanceId)`
+     — the configuration selection every consumer repeats.
+  2. In-memory core ingredients (repositories, authentication, whitelist authorization, handlers)
+     built without persistence — used by handler tests.
+  3. Service constructors stay **at the call site** in each test module so service-specific
+     dependencies remain visible.
+  4. Only `server.rs` composes the full `HttpTrackerCoreContainer` from the layers above, because
+     only it needs the whole container.
+     Statistics sender/listener remain an explicit per-test choice (`None` where not asserted). This
+     is still a proposal; implementation requires a separate approval after the server plan closes.
+- **Done when:** the layered shape is approved or rejected and the decision is recorded.
 
 ### B3 — Retain local mode and behavior fixtures unless separately justified
 
@@ -104,6 +147,9 @@ context must not reintroduce listener work into scrape tests that do not assert 
 - [x] B2 deferred with a concrete reassessment trigger.
 - [x] B3 assessment completed.
 - [x] Maintainer reviewed the assessment decisions.
+- [x] B4 recorded `server.rs` as the third consumer and documented why tests avoid the production
+      bootstrap.
+- [ ] Maintainer approved or rejected the layered-helper shape proposed under B2.
 
 ### Progress Log
 
@@ -115,10 +161,15 @@ context must not reintroduce listener work into scrape tests that do not assert 
   trigger.
 - 2026-09-02 - User/maintainer - Reviewed and approved the deferred assessment. Revisit only when
   a concrete shared test capability or a third consumer justifies it.
+- 2026-09-03 - GitHub Copilot - Recorded `server.rs::initialize_container` as the third bootstrap
+  consumer (B4) and documented the maintainer's rationale for not reusing the production container
+  factories. Proposed a layered-helper shape under B2 for later approval; nothing implemented.
 
 ## Non-Goals
 
 - Do not create a universal handler or service factory.
 - Do not move production bootstrap code merely to make tests shorter.
+- Do not replace test bootstraps with the production container factories; tests must keep
+  constructing only the services they need.
 - Do not introduce shared mutable state, listeners without lifecycle ownership, retries, or sleeps.
 - Do not merge this draft into a file-local plan without maintainer approval.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
@@ -6,7 +6,7 @@ target-files:
   - packages/axum-http-server/src/v1/handlers/announce.rs
   - packages/axum-http-server/src/v1/handlers/scrape.rs
   - packages/axum-http-server/src/server.rs
-status: draft
+status: completed
 ---
 
 # Draft Plan — Shared Handler Test Bootstrap
@@ -98,33 +98,31 @@ that handler tests can still stop early and skip what they do not use.
   capability.
 - **Done when:** the remaining shared setup and explicit no-extraction rationale are recorded.
 
-### B2 — Prototype a narrow test-only context only if B1 supports it
+### B2 — Reassess cross-file test bootstrap extraction
 
-- **Status:** DEFERRED
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
-- **Change:** If a cohesive boundary exists, introduce a private test-only context that owns only
-  common infrastructure: core configuration, selected HTTP tracker configuration and instance ID,
-  in-memory repositories, authentication, and necessary statistics sender/lifecycle.
+- **Change:** Compare the completed `server.rs` scenarios with the announce and scrape handler
+  bootstraps, then either identify a cohesive cross-file capability or reject extraction.
 - **Guardrail:** Each handler module must still visibly construct its own handler and service with
-  service-specific dependencies. The context must not expose a generic `build_service` API or
-  optional fields for unrelated behavior.
-- **Decision:** Deferred. B1 found no cohesive shared responsibility that would make both modules
-  clearer today. Revisit only if a third consumer needs the same test infrastructure or if a
-  concrete shared capability emerges without optional fields.
-- **Reassessment (B4 trigger):** `server.rs` is now the third consumer, so B2 must be reassessed.
-  The candidate shape is **layered, composable helpers** rather than one context object, so each
-  test stops at the layer it needs:
-  1. `selected_http_tracker_config(&Configuration) -> (Arc<HttpTracker>, ConfigurationInstanceId)`
-     — the configuration selection every consumer repeats.
-  2. In-memory core ingredients (repositories, authentication, whitelist authorization, handlers)
-     built without persistence — used by handler tests.
-  3. Service constructors stay **at the call site** in each test module so service-specific
-     dependencies remain visible.
-  4. Only `server.rs` composes the full `HttpTrackerCoreContainer` from the layers above, because
-     only it needs the whole container.
-     Statistics sender/listener remain an explicit per-test choice (`None` where not asserted). This
-     is still a proposal; implementation requires a separate approval after the server plan closes.
-- **Done when:** the layered shape is approved or rejected and the decision is recorded.
+  service-specific dependencies. Do not introduce a generic `build_service` API, optional fields
+  for unrelated behavior, or a shared fixture merely because setup statements look similar.
+- **Decision:** Reject extraction. The third consumer did not establish a shared test-infrastructure layer:
+  - `announce.rs` constructs in-memory repositories, authentication, whitelist authorization, an
+    `AnnounceHandler`, and a database-backed download-metrics repository.
+  - `scrape.rs` constructs only its in-memory repositories, authentication, whitelist
+    authorization, and `ScrapeHandler`; it intentionally omits statistics infrastructure.
+  - `server.rs` scenario fixtures require persistence-backed `TrackerCoreContainer` initialization,
+    swarm coordination, statistics infrastructure, both HTTP services, and registration state.
+
+  Configuration selection and `ConfigurationInstanceId` creation are the only meaningful overlap.
+  Extracting only those lines would add a shared test-support dependency without a behavior-focused
+  capability or material duplication reduction. Extracting more would force the handlers to create
+  server-only dependencies or turn the helper into the generic bootstrap this draft forbids. Keep
+  the bootstraps local; their construction remains useful documentation of each unit's coupling.
+
+- **Done when:** the completed reassessment records why the third consumer does not justify a
+  cross-file abstraction.
 
 ### B3 — Retain local mode and behavior fixtures unless separately justified
 
@@ -144,12 +142,12 @@ that handler tests can still stop early and skip what they do not use.
 
 - [x] Draft created from comparison of announce and scrape handler test bootstraps.
 - [x] B1 assessment completed.
-- [x] B2 deferred with a concrete reassessment trigger.
+- [x] B2 reassessed after the third-consumer trigger.
 - [x] B3 assessment completed.
 - [x] Maintainer reviewed the assessment decisions.
 - [x] B4 recorded `server.rs` as the third consumer and documented why tests avoid the production
       bootstrap.
-- [ ] Maintainer approved or rejected the layered-helper shape proposed under B2.
+- [x] Maintainer approved rejecting extraction and closing the draft.
 
 ### Progress Log
 
@@ -164,6 +162,13 @@ that handler tests can still stop early and skip what they do not use.
 - 2026-09-03 - GitHub Copilot - Recorded `server.rs::initialize_container` as the third bootstrap
   consumer (B4) and documented the maintainer's rationale for not reusing the production container
   factories. Proposed a layered-helper shape under B2 for later approval; nothing implemented.
+- 2026-09-03 - GitHub Copilot - Reassessed B2 after the completed server scenarios. The three
+  consumers share configuration-selection detail but not a cohesive infrastructure capability:
+  announce is metrics-specific, scrape intentionally omits statistics, and server requires
+  persistence, coordination, statistics, both services, and registration state. Proposed closing
+  the draft without an extraction; local bootstraps remain explicit dependency documentation.
+- 2026-09-03 - User/maintainer - Approved the B2 decision to retain local bootstraps and close this
+  cross-file draft without extraction.
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
@@ -25,9 +25,8 @@ This is not a plan to create a generic service factory.
 ### B1 — Similar infrastructure is initialized in both handler modules
 
 Both test modules select an HTTP tracker configuration and instance ID, then create in-memory
-whitelist, key, and torrent repositories; authentication; HTTP statistics event infrastructure; and
-an optional listener. These common concerns appear inside two independently maintained
-`initialize_core_tracker_services` functions.
+whitelist, key, and torrent repositories plus authentication. These common concerns appear inside
+two independently maintained `initialize_core_tracker_services` functions.
 
 **Effect.** Changes to shared infrastructure can require parallel edits, while the large setup
 functions make their common boundary hard to recognize.
@@ -41,31 +40,37 @@ used to instantiate `ScrapeService` in individual tests.
 **Effect.** A generic bootstrap that returns every possible component would make dependencies
 implicit, create optional fields, and weaken test expressiveness.
 
-### B3 — Background statistics lifecycle needs explicit ownership
+### B3 — Statistics infrastructure is no longer a shared bootstrap concern
 
-Both setups can start an event listener but do not retain its task handle. The listener is currently
-not part of the focused handler assertions.
+The focused scrape setup now passes no event sender because its tests do not assert statistics.
+The announce setup still creates statistics infrastructure because its service setup currently
+retains it.
 
-**Effect.** This is not a demonstrated flaky-test defect, but any shared context must make a
-listener's necessity and lifecycle explicit rather than spreading detached background work.
+**Effect.** Statistics initialization is not a cohesive cross-file responsibility. Any future shared
+context must not reintroduce listener work into scrape tests that do not assert it.
 
 ## Phase 2 — Proposed Refactorings
 
 ### B1 — Map exact common infrastructure and lifecycle needs
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / low effort
 - **Change:** List each setup dependency as common, announce-specific, scrape-specific, or
   configuration-dependent. Verify whether the event listener is needed for the current focused
   handler contracts.
 - **Guardrail:** Do not modify production code or introduce a common abstraction during this
   assessment.
-- **Done when:** the plan records a minimal candidate responsibility and an explicit lifecycle
-  decision.
+- **Decision:** The remaining common setup is configuration selection, in-memory repositories, and
+  authentication. However, it does not form a useful standalone test fixture: announce needs
+  whitelist authorization, persistence metrics, and `AnnounceHandler`; scrape needs
+  `ScrapeHandler` and now deliberately has no statistics sender. Extracting the common objects
+  would require a bundle that exposes construction ingredients rather than a behavior-focused
+  capability.
+- **Done when:** the remaining shared setup and explicit no-extraction rationale are recorded.
 
 ### B2 — Prototype a narrow test-only context only if B1 supports it
 
-- **Status:** TODO
+- **Status:** DEFERRED
 - **Priority:** Medium impact / medium effort
 - **Change:** If a cohesive boundary exists, introduce a private test-only context that owns only
   common infrastructure: core configuration, selected HTTP tracker configuration and instance ID,
@@ -73,31 +78,43 @@ listener's necessity and lifecycle explicit rather than spreading detached backg
 - **Guardrail:** Each handler module must still visibly construct its own handler and service with
   service-specific dependencies. The context must not expose a generic `build_service` API or
   optional fields for unrelated behavior.
-- **Done when:** both modules become simpler, dependencies remain readable at service construction,
-  and focused tests retain fresh isolated state.
+- **Decision:** Deferred. B1 found no cohesive shared responsibility that would make both modules
+  clearer today. Revisit only if a third consumer needs the same test infrastructure or if a
+  concrete shared capability emerges without optional fields.
+- **Done when:** a future concrete trigger justifies reassessment.
 
 ### B3 — Retain local mode and behavior fixtures unless separately justified
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / low effort
 - **Change:** Decide whether mode-specific wrappers and common HTTP bindings remain local or have a
   broader, established test-support home.
 - **Guardrail:** Do not move a fixture merely because it is duplicated twice. Shared ownership must
   be clearer than local ownership and must not broaden test coupling.
-- **Done when:** the plan records a keep-local or shared-home decision with rationale.
+- **Decision:** Keep fixtures local. `sample_http_service_binding()` appears in both files but has
+  only two consumers with different neighboring fixtures and test contexts. The mode wrappers also
+  directly express each handler's supported service configuration. A shared fixture module would
+  increase coupling without a clearer owner.
+- **Done when:** the keep-local decision is recorded.
 
 ## Progress Tracking
 
 - [x] Draft created from comparison of announce and scrape handler test bootstraps.
-- [ ] B1 assessment approved and completed.
-- [ ] B2 approved, implemented, reviewed, and validated, or no-change decision recorded.
-- [ ] B3 assessment completed and decision recorded.
-- [ ] Maintainer reviewed all completed work.
+- [x] B1 assessment completed.
+- [x] B2 deferred with a concrete reassessment trigger.
+- [x] B3 assessment completed.
+- [x] Maintainer reviewed the assessment decisions.
 
 ### Progress Log
 
 - 2026-09-02 - GitHub Copilot - Created this draft after identifying similar test infrastructure in
   announce and scrape handler modules. No implementation has been approved or performed.
+- 2026-09-02 - GitHub Copilot - Reassessed after completing the scrape-file plan. No cross-file
+  extraction is currently justified: the remaining overlap is construction detail, while handler
+  dependencies and statistics requirements differ. The draft remains deferred for a future concrete
+  trigger.
+- 2026-09-02 - User/maintainer - Reviewed and approved the deferred assessment. Revisit only when
+  a concrete shared test capability or a third consumer justifies it.
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/drafts/shared-handler-test-bootstrap.md
@@ -1,0 +1,107 @@
+---
+doc-type: test-bootstrap-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-files:
+  - packages/axum-http-server/src/v1/handlers/announce.rs
+  - packages/axum-http-server/src/v1/handlers/scrape.rs
+status: draft
+---
+
+# Draft Plan — Shared Handler Test Bootstrap
+
+Follow the shared [test-refactor-plan guidance](../README.md). This is a cross-file draft that must
+be reviewed and explicitly approved before implementation. It is intentionally separate from the
+file-local announce and scrape test plans.
+
+## Purpose
+
+Assess whether the duplicated **test infrastructure** in the announce and scrape handler modules
+can be reduced without hiding the distinct dependencies of `AnnounceService` and `ScrapeService`.
+This is not a plan to create a generic service factory.
+
+## Phase 1 — Identify Problems
+
+### B1 — Similar infrastructure is initialized in both handler modules
+
+Both test modules select an HTTP tracker configuration and instance ID, then create in-memory
+whitelist, key, and torrent repositories; authentication; HTTP statistics event infrastructure; and
+an optional listener. These common concerns appear inside two independently maintained
+`initialize_core_tracker_services` functions.
+
+**Effect.** Changes to shared infrastructure can require parallel edits, while the large setup
+functions make their common boundary hard to recognize.
+
+### B2 — Service-specific dependencies legitimately differ
+
+`announce.rs` additionally initializes database-backed download metrics, `AnnounceHandler`, and
+whitelist authorization. `scrape.rs` creates `ScrapeHandler` and returns construction ingredients
+used to instantiate `ScrapeService` in individual tests.
+
+**Effect.** A generic bootstrap that returns every possible component would make dependencies
+implicit, create optional fields, and weaken test expressiveness.
+
+### B3 — Background statistics lifecycle needs explicit ownership
+
+Both setups can start an event listener but do not retain its task handle. The listener is currently
+not part of the focused handler assertions.
+
+**Effect.** This is not a demonstrated flaky-test defect, but any shared context must make a
+listener's necessity and lifecycle explicit rather than spreading detached background work.
+
+## Phase 2 — Proposed Refactorings
+
+### B1 — Map exact common infrastructure and lifecycle needs
+
+- **Status:** TODO
+- **Priority:** High impact / low effort
+- **Change:** List each setup dependency as common, announce-specific, scrape-specific, or
+  configuration-dependent. Verify whether the event listener is needed for the current focused
+  handler contracts.
+- **Guardrail:** Do not modify production code or introduce a common abstraction during this
+  assessment.
+- **Done when:** the plan records a minimal candidate responsibility and an explicit lifecycle
+  decision.
+
+### B2 — Prototype a narrow test-only context only if B1 supports it
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Change:** If a cohesive boundary exists, introduce a private test-only context that owns only
+  common infrastructure: core configuration, selected HTTP tracker configuration and instance ID,
+  in-memory repositories, authentication, and necessary statistics sender/lifecycle.
+- **Guardrail:** Each handler module must still visibly construct its own handler and service with
+  service-specific dependencies. The context must not expose a generic `build_service` API or
+  optional fields for unrelated behavior.
+- **Done when:** both modules become simpler, dependencies remain readable at service construction,
+  and focused tests retain fresh isolated state.
+
+### B3 — Retain local mode and behavior fixtures unless separately justified
+
+- **Status:** TODO
+- **Priority:** Low impact / low effort
+- **Change:** Decide whether mode-specific wrappers and common HTTP bindings remain local or have a
+  broader, established test-support home.
+- **Guardrail:** Do not move a fixture merely because it is duplicated twice. Shared ownership must
+  be clearer than local ownership and must not broaden test coupling.
+- **Done when:** the plan records a keep-local or shared-home decision with rationale.
+
+## Progress Tracking
+
+- [x] Draft created from comparison of announce and scrape handler test bootstraps.
+- [ ] B1 assessment approved and completed.
+- [ ] B2 approved, implemented, reviewed, and validated, or no-change decision recorded.
+- [ ] B3 assessment completed and decision recorded.
+- [ ] Maintainer reviewed all completed work.
+
+### Progress Log
+
+- 2026-09-02 - GitHub Copilot - Created this draft after identifying similar test infrastructure in
+  announce and scrape handler modules. No implementation has been approved or performed.
+
+## Non-Goals
+
+- Do not create a universal handler or service factory.
+- Do not move production bootstrap code merely to make tests shorter.
+- Do not introduce shared mutable state, listeners without lifecycle ownership, retries, or sleeps.
+- Do not merge this draft into a file-local plan without maintainer approval.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
@@ -70,14 +70,19 @@ regression or versioned observability requirement.
 
 ### R2 — Assess the minimal router helper name
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / trivial effort
 - **Addresses:** P2
 - **Change:** Decide whether renaming `test_router()` to `router_with_request_layers()` materially
   improves intent.
 - **Guardrails:** Do not add routes, tracker services, listeners, or production setup. Retain the
   minimal successful endpoint and direct `oneshot` call.
-- **Done when:** a rename or no-change decision is recorded.
+- **Decision:** No change. The helper is scoped to the test module, and its implementation visibly
+  applies `with_request_layers` to a minimal successful route. Renaming it would make every Act
+  line longer without adding meaningful context; the test names and direct helper implementation
+  already establish that the tests exercise request layers rather than a representative tracker
+  router.
+- **Done when:** the no-change decision is recorded.
 
 ### R3 — Assess residual middleware coverage by contract value
 
@@ -98,7 +103,7 @@ regression or versioned observability requirement.
 - [x] Phase 2 refactorings ordered by impact and effort
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
-- [ ] R2 assessment completed and decision recorded
+- [x] R2 assessment completed and decision recorded
 - [ ] R3 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
@@ -113,6 +118,9 @@ regression or versioned observability requirement.
 - 2026-09-02 - GitHub Copilot - Completed R1. Both request-ID tests now use the same
   `REQUEST_ID_HEADER` constant while retaining their distinct propagation and generated-ID
   contracts.
+- 2026-09-02 - GitHub Copilot - Completed R2 assessment. Retained `test_router()` because its
+  test-module scope and direct `with_request_layers` implementation already make its narrow purpose
+  clear; a longer call-site name would not improve readability.
 
 ### Validation Evidence
 
@@ -120,7 +128,7 @@ regression or versioned observability requirement.
 | ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
 | R1                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
-| R2                 | TODO   | Not started.                                                                                                                                         |
+| R2                 | DONE   | Inspected the helper and its two call sites; no rename improves the local test contract.                                                             |
 | R3                 | TODO   | Not started.                                                                                                                                         |
 
 ## Non-Goals

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
@@ -59,7 +59,7 @@ regression or versioned observability requirement.
 
 ### R1 — Standardize the request-ID header name
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / trivial effort
 - **Addresses:** P1
 - **Change:** Introduce a private `REQUEST_ID_HEADER` constant and use it in both tests.
@@ -96,8 +96,8 @@ regression or versioned observability requirement.
 
 - [x] Phase 1 findings reviewed against the current file and package coverage evidence
 - [x] Phase 2 refactorings ordered by impact and effort
-- [ ] Maintainer approved implementation of R1
-- [ ] R1 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R1
+- [x] R1 implemented, reviewed, and validated
 - [ ] R2 assessment completed and decision recorded
 - [ ] R3 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
@@ -108,15 +108,20 @@ regression or versioned observability requirement.
 - 2026-09-02 - GitHub Copilot - Created the proposed plan from the current request-layer tests,
   package coverage evidence, and existing real-server contract coverage. No refactoring has been
   implemented.
+- 2026-09-02 - User/maintainer - Approved R1 after reviewing the test-local request-ID header
+  constant.
+- 2026-09-02 - GitHub Copilot - Completed R1. Both request-ID tests now use the same
+  `REQUEST_ID_HEADER` constant while retaining their distinct propagation and generated-ID
+  contracts.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                     |
-| ------------------ | ------ | ---------------------------- |
-| Plan documentation | TODO   | Not run after plan creation. |
-| R1                 | TODO   | Not started.                 |
-| R2                 | TODO   | Not started.                 |
-| R3                 | TODO   | Not started.                 |
+| Increment          | Status | Evidence                                                                                                                                             |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
+| R1                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
+| R2                 | TODO   | Not started.                                                                                                                                         |
+| R3                 | TODO   | Not started.                                                                                                                                         |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
@@ -86,14 +86,21 @@ regression or versioned observability requirement.
 
 ### R3 — Assess residual middleware coverage by contract value
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / medium effort
 - **Addresses:** P3
 - **Change:** Compare potentially uncovered compression, timeout, and trace branches with existing
   package tests and public requirements. Add a test only for a stable unobserved HTTP contract.
 - **Guardrails:** Do not wait for the default five-second timeout; test logs, closure execution,
   framework defaults, layer order, UUID uniqueness, or compression merely to improve coverage.
-- **Done when:** the plan records a behavior-justified test or a concrete no-change/defer rationale.
+- **Decision:** No change. The remaining branches are compression negotiation, the fixed
+  five-second timeout mapping, and request/response trace classification. No package requirement
+  identifies compression as a tracker contract, and a timeout test would require wall-clock waiting
+  or production-only configurability. Trace events and their fields are not a versioned public
+  observability contract. Existing real-server tests cover tracker route registration, protocol
+  responses, health checks, reverse-proxy behavior, and request-ID propagation. No stable,
+  unobserved HTTP-level behavior justifies expanding this focused test module.
+- **Done when:** the no-change rationale and existing coverage boundaries are recorded.
 
 ## Progress Tracking
 
@@ -104,9 +111,9 @@ regression or versioned observability requirement.
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
 - [x] R2 assessment completed and decision recorded
-- [ ] R3 assessment completed and decision recorded
-- [ ] Maintainer reviewed all approved changes
-- [ ] Plan completed and ready for commit
+- [x] R3 assessment completed and decision recorded
+- [x] Maintainer reviewed all approved changes
+- [x] Plan completed and ready for commit
 
 ### Progress Log
 
@@ -121,6 +128,11 @@ regression or versioned observability requirement.
 - 2026-09-02 - GitHub Copilot - Completed R2 assessment. Retained `test_router()` because its
   test-module scope and direct `with_request_layers` implementation already make its narrow purpose
   clear; a longer call-site name would not improve readability.
+- 2026-09-02 - GitHub Copilot - Completed R3 assessment. Deferred compression, timeout, and trace
+  coverage because no stable missing HTTP contract was identified; existing real-server tests cover
+  tracker route and protocol behavior.
+- 2026-09-02 - User/maintainer - Reviewed and approved R3's no-change decision and completion of
+  the routes test refactor plan.
 
 ### Validation Evidence
 
@@ -129,7 +141,7 @@ regression or versioned observability requirement.
 | Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
 | R1                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
 | R2                 | DONE   | Inspected the helper and its two call sites; no rename improves the local test contract.                                                             |
-| R3                 | TODO   | Not started.                                                                                                                                         |
+| R3                 | DONE   | Inspected middleware configuration, package documentation, and existing real-server contracts; no stable missing HTTP contract was found.            |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/routes-tests.md
@@ -1,0 +1,136 @@
+---
+doc-type: test-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-file: packages/axum-http-server/src/v1/routes.rs
+status: proposed
+---
+
+# Routes Test Refactor Plan
+
+Follow the shared [purpose, quality goals, and plan structure](README.md). This plan applies them
+only to `packages/axum-http-server/src/v1/routes.rs`.
+
+## Phase 1 — Identify Problems
+
+### Strengths to preserve
+
+1. The request-ID tests use an in-process Axum router, exercising real request layers without a
+   listener, external I/O, background task, or time dependency.
+2. Each test has concise Arrange–Act–Assert structure and a distinct contract: supplied request IDs
+   are propagated; generated request IDs are valid UUIDs.
+3. The generated-ID test correctly checks a deterministic property rather than an exact random UUID.
+4. Existing real-server tests cover `router()` registrations and protocol behavior for announce,
+   scrape, health-check, configuration modes, and reverse-proxy client-IP handling.
+
+### P1 — Request-ID header access is inconsistent
+
+**Problem.** One test uses the literal `"x-request-id"`; the other constructs
+`HeaderName::from_static("x-request-id")`.
+
+**Why it matters.** The same protocol name appears through two forms, which adds small but needless
+visual variation in a compact test module.
+
+**Opportunity.** Use one private `REQUEST_ID_HEADER` constant for request construction and response
+lookup. Keep client-provided ID values visible in the test.
+
+### P2 — Minimal router helper has a generic name
+
+**Problem.** `test_router()` does not state that its purpose is to expose request-layer behavior.
+
+**Why it matters.** A reader can mistake it for a representative tracker router.
+
+**Opportunity.** Assess whether `router_with_request_layers()` is clearer, while keeping its minimal
+successful endpoint and in-process `oneshot` boundary.
+
+### P3 — Remaining coverage is middleware composition, not a known missing contract
+
+**Problem.** Current coverage evidence records 93.43% line coverage and 82.35% function coverage
+for `v1/routes.rs`, with uncovered locations near request-layer composition and instrumentation.
+
+**Why it matters.** Compression, timeout, and tracing branches may be uncovered, but adding tests
+only to raise aggregate coverage would create framework-coupled or timing-sensitive tests.
+
+**Opportunity.** Assess each candidate only for an explicit stable HTTP contract. In particular,
+avoid a five-second timeout test, log-text assertions, and layer-order tests without a documented
+regression or versioned observability requirement.
+
+## Phase 2 — Proposed Refactorings
+
+### R1 — Standardize the request-ID header name
+
+- **Status:** TODO
+- **Priority:** Medium impact / trivial effort
+- **Addresses:** P1
+- **Change:** Introduce a private `REQUEST_ID_HEADER` constant and use it in both tests.
+- **Guardrails:** Keep `client_request_id` visible. Do not add a one-use assertion helper or assert a
+  generated UUID value.
+- **Done when:** the header name has one local representation and both existing contracts remain
+  explicit.
+
+### R2 — Assess the minimal router helper name
+
+- **Status:** TODO
+- **Priority:** Low impact / trivial effort
+- **Addresses:** P2
+- **Change:** Decide whether renaming `test_router()` to `router_with_request_layers()` materially
+  improves intent.
+- **Guardrails:** Do not add routes, tracker services, listeners, or production setup. Retain the
+  minimal successful endpoint and direct `oneshot` call.
+- **Done when:** a rename or no-change decision is recorded.
+
+### R3 — Assess residual middleware coverage by contract value
+
+- **Status:** TODO
+- **Priority:** Low impact / medium effort
+- **Addresses:** P3
+- **Change:** Compare potentially uncovered compression, timeout, and trace branches with existing
+  package tests and public requirements. Add a test only for a stable unobserved HTTP contract.
+- **Guardrails:** Do not wait for the default five-second timeout; test logs, closure execution,
+  framework defaults, layer order, UUID uniqueness, or compression merely to improve coverage.
+- **Done when:** the plan records a behavior-justified test or a concrete no-change/defer rationale.
+
+## Progress Tracking
+
+### Plan Checklist
+
+- [x] Phase 1 findings reviewed against the current file and package coverage evidence
+- [x] Phase 2 refactorings ordered by impact and effort
+- [ ] Maintainer approved implementation of R1
+- [ ] R1 implemented, reviewed, and validated
+- [ ] R2 assessment completed and decision recorded
+- [ ] R3 assessment completed and decision recorded
+- [ ] Maintainer reviewed all approved changes
+- [ ] Plan completed and ready for commit
+
+### Progress Log
+
+- 2026-09-02 - GitHub Copilot - Created the proposed plan from the current request-layer tests,
+  package coverage evidence, and existing real-server contract coverage. No refactoring has been
+  implemented.
+
+### Validation Evidence
+
+| Increment          | Status | Evidence                     |
+| ------------------ | ------ | ---------------------------- |
+| Plan documentation | TODO   | Not run after plan creation. |
+| R1                 | TODO   | Not started.                 |
+| R2                 | TODO   | Not started.                 |
+| R3                 | TODO   | Not started.                 |
+
+## Non-Goals
+
+- Do not add direct `router()` tests for tracker routes already covered by real-server contracts.
+- Do not duplicate reverse-proxy client-IP or health-check composition coverage.
+- Do not test generated UUID uniqueness, exact random values, trace-log text, layer order, or Axum
+  framework defaults.
+- Do not trigger a timeout by sleeping or add production configurability solely for this plan.
+- Do not move these small fixtures to a shared module.
+
+## Validation Per Approved Increment
+
+- `cargo fmt --all -- --check`
+- `cargo test -p torrust-tracker-axum-http-server --lib`
+- `git diff --check`
+- `linter markdown` when this plan changes
+- Refresh `coverage-evidence.md` only after an approved behavior-adding test.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -137,7 +137,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R5 — Add a concrete two-file response-mapping contract
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / low effort
 - **Addresses:** P4
 - **Change:** Add one `build_response` test with two fixed info hashes and distinct metadata,
@@ -180,8 +180,8 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] R3 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R4
 - [x] R4 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R5
-- [ ] R5 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R5
+- [x] R5 implemented, reviewed, and validated
 - [ ] R6 assessment completed and decision recorded
 - [ ] R7 draft assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
@@ -208,6 +208,10 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
   fixture.
 - 2026-09-02 - GitHub Copilot - Completed R4. Local setup now returns a configuration-aware
   `Arc<ScrapeService>`, removing repeated constructor wiring while keeping test inputs explicit.
+- 2026-09-02 - User/maintainer - Approved R5 after reviewing the two-file response-mapping
+  contract.
+- 2026-09-02 - GitHub Copilot - Completed R5. Added a fixed two-file `build_response` contract
+  with independently specified metadata and decoded protocol output.
 
 ### Validation Evidence
 
@@ -218,7 +222,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 | R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed.             |
 | R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
 | R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
-| R5                 | TODO   | Not started.                                                                                                                                         |
+| R5                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
 | R6                 | TODO   | Not started.                                                                                                                                         |
 | R7                 | TODO   | Not started.                                                                                                                                         |
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -126,7 +126,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R4 — Return a ready-to-call service from local setup
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P2
 - **Change:** Make the file-local setup return an `Arc<ScrapeService>` configured with the selected
@@ -178,8 +178,8 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] R2 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R3
 - [x] R3 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R4
-- [ ] R4 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R4
+- [x] R4 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R5
 - [ ] R5 implemented, reviewed, and validated
 - [ ] R6 assessment completed and decision recorded
@@ -204,19 +204,23 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - 2026-09-02 - GitHub Copilot - Completed R3. Extracted the `handle_scrape` service-delegation
   seam and added a focused contract proving an unresolved reverse-proxy client IP becomes a
   bencoded BitTorrent failure response with HTTP `200 OK`.
+- 2026-09-02 - User/maintainer - Approved R4 after reviewing the local ready-to-call service
+  fixture.
+- 2026-09-02 - GitHub Copilot - Completed R4. Local setup now returns a configuration-aware
+  `Arc<ScrapeService>`, removing repeated constructor wiring while keeping test inputs explicit.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                                                                                 |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                   |
-| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
-| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed. |
+| Increment          | Status | Evidence                                                                                                                                             |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                              |
+| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed.             |
 | R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
-| R4                 | TODO   | Not started.                                                                                                                             |
-| R5                 | TODO   | Not started.                                                                                                                             |
-| R6                 | TODO   | Not started.                                                                                                                             |
-| R7                 | TODO   | Not started.                                                                                                                             |
+| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
+| R5                 | TODO   | Not started.                                                                                                                                         |
+| R6                 | TODO   | Not started.                                                                                                                                         |
+| R7                 | TODO   | Not started.                                                                                                                                         |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -148,13 +148,21 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R6 — Assess statistics-listener necessity and lifecycle
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P5
 - **Change:** Verify configuration and sender/receiver requirements. Record either a no-change
   lifecycle rationale or an approved focused cleanup.
 - **Guardrail:** Do not remove required event wiring or add sleeps, retries, polling, or shared state.
-- **Done when:** listener necessity and ownership are explicit.
+- **Decision:** Removed the listener from this focused handler setup. `ScrapeService::send_event`
+  performs no event work when its optional sender is `None`, so an active listener is not required
+  for response-adaptation, authentication, whitelist, or client-IP contracts. Event publication is
+  directly tested in `packages/http-core/src/services/scrape.rs`; composed scrape metrics are
+  verified by the TCP4 and TCP6 assertions in
+  `packages/axum-http-server/tests/server/v1/contract/for_all_config_modes/receiving_an_scrape_request.rs`.
+  The resulting split keeps event publication and consumption coverage while removing background
+  work that this file's focused tests do not assert.
+- **Done when:** listener necessity, lifecycle decision, and coverage boundaries are recorded.
 
 ### R7 — Reassess the cross-file bootstrap draft after local changes
 
@@ -182,7 +190,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] R4 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R5
 - [x] R5 implemented, reviewed, and validated
-- [ ] R6 assessment completed and decision recorded
+- [x] R6 assessment completed and decision recorded
 - [ ] R7 draft assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
@@ -212,19 +220,24 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
   contract.
 - 2026-09-02 - GitHub Copilot - Completed R5. Added a fixed two-file `build_response` contract
   with independently specified metadata and decoded protocol output.
+- 2026-09-02 - User/maintainer - Confirmed that event coverage belongs in HTTP-core service tests
+  and composed package integration tests, not as listener work in focused handler tests without an assertion.
+- 2026-09-02 - GitHub Copilot - Completed R6. Removed optional statistics-listener infrastructure
+  from the focused scrape handler setup. `ScrapeService` receives no event sender; HTTP-core tests
+  cover `TcpScrape` publication and HTTP-server integration tests cover consumed TCP4/TCP6 metrics.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                                                                                             |
-| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
-| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                              |
-| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed.             |
-| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
-| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
-| R5                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed. |
-| R6                 | TODO   | Not started.                                                                                                                                         |
-| R7                 | TODO   | Not started.                                                                                                                                         |
+| Increment          | Status | Evidence                                                                                                                                                                                                                                           |
+| ------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                                                                                                                             |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                                                                                                                            |
+| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed.                                                                                                           |
+| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed.                                                                                               |
+| R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed.                                                                                               |
+| R5                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed.                                                                                               |
+| R6                 | DONE   | Inspected `ScrapeService::send_event`, HTTP-core service event tests, and HTTP-server TCP4/TCP6 metric integration assertions; editor diagnostics, `cargo fmt --all -- --check`, package library tests (32 passed), and `git diff --check` passed. |
+| R7                 | TODO   | Not started.                                                                                                                                                                                                                                       |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -1,0 +1,224 @@
+---
+doc-type: test-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-file: packages/axum-http-server/src/v1/handlers/scrape.rs
+status: proposed
+---
+
+# Scrape Handler Test Refactor Plan
+
+Follow the shared [purpose, quality goals, and plan structure](README.md). This plan applies them
+only to `packages/axum-http-server/src/v1/handlers/scrape.rs`. The separate
+[draft shared-bootstrap plan](drafts/shared-handler-test-bootstrap.md) owns cross-file setup
+questions and must not be implemented through this plan.
+
+## Phase 1 — Identify Problems
+
+### Strengths to preserve
+
+1. The response-mapping test decodes the bencoded body and compares complete, downloaded, and
+   incomplete values against an independently specified protocol response.
+2. Authentication, whitelist, and client-IP scenarios use fresh in-memory dependencies and fixed
+   inputs.
+3. Existing real-server tests cover multiple info hashes, private/whitelisted behavior, and TCP4/
+   TCP6 statistics separately from focused handler tests.
+
+### P1 — Handler module tests mainly exercise the service directly
+
+**Problem.** Six mode and client-IP tests call `ScrapeService::handle_scrape` directly. They live
+beside the Axum handler but do not exercise the handler's service-result-to-HTTP-response mapping.
+
+**Why it matters.** The local test boundary is unclear, and `handle`'s error-response conversion is
+not directly verified.
+
+**Opportunity.** Extract a narrow `handle_scrape` service-delegation seam, as in `announce.rs`, and
+add a focused test for the handler's observable bencoded failure response.
+
+### P2 — Service construction is repeated at test call sites
+
+**Problem.** Tests receive two dependency bundles and repeatedly construct `ScrapeService`, using
+two constructor variants.
+
+**Why it matters.** Each test must know constructor argument order, obscuring the key, IP, and
+configuration variation that actually defines its behavior.
+
+**Opportunity.** Make local setup return a ready-to-call `Arc<ScrapeService>` configured from the
+selected HTTP tracker configuration. Keep the cross-file bootstrap question out of this plan.
+
+### P3 — Common fixtures and error-test flow are inconsistent
+
+**Problem.** Five tests reconstruct the same loopback `ServiceBinding`; error tests use generic
+`response` and `error_response` names and lack AAA boundaries.
+
+**Why it matters.** Repeated mechanics and unclear value roles reduce scanning speed and create
+unnecessary update sites.
+
+**Opportunity.** Add local deterministic `sample_http_service_binding()` and
+`missing_client_ip_sources()` fixtures; rename error values to `actual_error` and
+`actual_error_response`; rename `assert_error_response` to `assert_failure_reason_contains`; and
+add concise AAA boundaries.
+
+### P4 — The response mapper has only a single-file focused example
+
+**Problem.** The local `build_response` test covers one info hash, while
+`to_protocol_scrape_data` loops over all requested files.
+
+**Why it matters.** Endpoint tests cover multiple info hashes, but a focused two-file mapping
+example would protect the local adapter loop directly.
+
+**Opportunity.** Add one concrete two-file response-mapping test with independently specified
+protocol output. Do not add a generic scenario type or parameterized matrix.
+
+### P5 — Statistics-listener ownership is unclear
+
+**Problem.** Setup may start a statistics listener and discards its task and cancellation handle;
+the local tests do not assert statistics.
+
+**Why it matters.** Detached background work weakens lifecycle clarity and may become a source of
+cost or flakiness.
+
+**Opportunity.** First verify whether the selected configurations require the listener for these
+contracts. Remove it only if it is unnecessary, or retain explicit ownership if required.
+
+### P6 — Module documentation names the wrong protocol request
+
+**Problem.** The module documentation describes `announce` requests.
+
+**Why it matters.** It misleads readers navigating the scrape handler and its tests.
+
+**Opportunity.** Correct it to `scrape` as a separate documentation-only change.
+
+## Phase 2 — Proposed Refactorings
+
+### R1 — Correct the scrape module documentation
+
+- **Status:** TODO
+- **Priority:** High impact / trivial effort
+- **Addresses:** P6
+- **Change:** Replace the module-documentation reference to `announce` with `scrape`.
+- **Guardrail:** Documentation only; do not combine with handler behavior changes.
+- **Done when:** the module-level description correctly identifies scrape requests.
+
+### R2 — Clarify local test setup and error contracts
+
+- **Status:** TODO
+- **Priority:** High impact / low effort
+- **Addresses:** P3
+- **Change:** Add the two narrow fixtures; use explicit actual-error names; rename the
+  failure-reason assertion helper; and add concise AAA boundaries.
+- **Guardrail:** Keep keys, configuration modes, client-IP sources, and expected contracts visible in
+  each test. Do not introduce a broad scenario fixture.
+- **Done when:** repeated mechanics are local helpers and each error test visibly expresses its
+  behavior-specific contract.
+
+### R3 — Re-establish the handler error-mapping boundary
+
+- **Status:** TODO
+- **Priority:** High impact / medium effort
+- **Addresses:** P1
+- **Change:** Extract `handle_scrape` as the service-delegation seam and add a focused test that an
+  `HttpScrapeError` becomes HTTP `200 OK` plus the expected bencoded failure response.
+- **Guardrail:** Preserve scrape's zeroed-data behavior for unauthenticated/private and
+  non-whitelisted cases. Assert protocol-visible output, not incidental error internals.
+- **Done when:** direct local coverage proves the handler's error-response conversion separately
+  from `ScrapeService` outcomes.
+
+### R4 — Return a ready-to-call service from local setup
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P2
+- **Change:** Make the file-local setup return an `Arc<ScrapeService>` configured with the selected
+  HTTP tracker configuration, then remove repeated constructor calls.
+- **Guardrail:** Keep this helper local. Do not generalize common bootstrap infrastructure or claim
+  coverage for the alternate `ScrapeService::new` constructor.
+- **Done when:** mode tests vary request, key, and client IP without repeating service construction.
+
+### R5 — Add a concrete two-file response-mapping contract
+
+- **Status:** TODO
+- **Priority:** Medium impact / low effort
+- **Addresses:** P4
+- **Change:** Add one `build_response` test with two fixed info hashes and distinct metadata,
+  decoding the response and comparing it with independently specified expected protocol data.
+- **Guardrail:** Do not derive the expected value through production mapping/serialization and do
+  not parameterize without new meaningful behavior variants.
+- **Done when:** the local mapper loop has one behavior-focused multi-file contract.
+
+### R6 — Assess statistics-listener necessity and lifecycle
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P5
+- **Change:** Verify configuration and sender/receiver requirements. Record either a no-change
+  lifecycle rationale or an approved focused cleanup.
+- **Guardrail:** Do not remove required event wiring or add sleeps, retries, polling, or shared state.
+- **Done when:** listener necessity and ownership are explicit.
+
+### R7 — Reassess the cross-file bootstrap draft after local changes
+
+- **Status:** TODO
+- **Priority:** Low impact / low effort
+- **Addresses:** Cross-file bootstrap duplication
+- **Change:** Revisit `drafts/shared-handler-test-bootstrap.md` after R2–R6. Promote it only when a
+  cohesive shared responsibility remains.
+- **Guardrail:** Do not implement cross-file extraction as part of this file-local plan.
+- **Done when:** the draft is retained, revised, promoted, or closed with rationale.
+
+## Progress Tracking
+
+### Plan Checklist
+
+- [x] Phase 1 findings reviewed against the current file
+- [x] Phase 2 refactorings ordered by impact and effort
+- [ ] Maintainer approved implementation of R1
+- [ ] R1 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R2
+- [ ] R2 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R3
+- [ ] R3 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R4
+- [ ] R4 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R5
+- [ ] R5 implemented, reviewed, and validated
+- [ ] R6 assessment completed and decision recorded
+- [ ] R7 draft assessment completed and decision recorded
+- [ ] Maintainer reviewed all approved changes
+- [ ] Plan completed and ready for commit
+
+### Progress Log
+
+- 2026-09-02 - GitHub Copilot - Created the proposed plan from the current `scrape.rs` tests,
+  existing integration coverage, and the completed announce-handler test plan. No refactoring has
+  been implemented.
+
+### Validation Evidence
+
+| Increment | Status | Evidence |
+| --- | --- | --- |
+| Plan documentation | TODO | Not run after plan creation. |
+| R1 | TODO | Not started. |
+| R2 | TODO | Not started. |
+| R3 | TODO | Not started. |
+| R4 | TODO | Not started. |
+| R5 | TODO | Not started. |
+| R6 | TODO | Not started. |
+| R7 | TODO | Not started. |
+
+## Non-Goals
+
+- Do not implement the shared-bootstrap draft through this plan.
+- Do not replace scrape's zeroed-data contracts with announce-style error contracts.
+- Do not introduce a generic response scenario where one inline expected response is clearer.
+- Do not add tests merely to raise an aggregate coverage percentage.
+- Do not add retries, sleeps, broad timeouts, or shared state.
+- Do not change production behavior except the explicitly isolated documentation correction.
+
+## Validation Per Approved Increment
+
+- `cargo fmt --all -- --check`
+- `cargo test -p torrust-tracker-axum-http-server --lib`
+- `git diff --check`
+- `linter markdown` when this plan changes
+- Refresh `coverage-evidence.md` only after an approved behavior-adding test.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -166,13 +166,17 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R7 — Reassess the cross-file bootstrap draft after local changes
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / low effort
 - **Addresses:** Cross-file bootstrap duplication
 - **Change:** Revisit `drafts/shared-handler-test-bootstrap.md` after R2–R6. Promote it only when a
   cohesive shared responsibility remains.
 - **Guardrail:** Do not implement cross-file extraction as part of this file-local plan.
-- **Done when:** the draft is retained, revised, promoted, or closed with rationale.
+- **Decision:** Retained the draft in deferred status. After R4 and R6, the remaining overlap is
+  configuration selection, in-memory repositories, and authentication. The handler-specific service
+  graphs still differ, and scrape deliberately excludes statistics infrastructure. A shared context
+  would expose construction ingredients rather than a cohesive behavior-focused capability.
+- **Done when:** the revised deferred draft and no-extraction rationale are recorded.
 
 ## Progress Tracking
 
@@ -191,9 +195,9 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] Maintainer approved implementation of R5
 - [x] R5 implemented, reviewed, and validated
 - [x] R6 assessment completed and decision recorded
-- [ ] R7 draft assessment completed and decision recorded
-- [ ] Maintainer reviewed all approved changes
-- [ ] Plan completed and ready for commit
+- [x] R7 draft assessment completed and decision recorded
+- [x] Maintainer reviewed all approved changes
+- [x] Plan completed and ready for commit
 
 ### Progress Log
 
@@ -225,6 +229,10 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - 2026-09-02 - GitHub Copilot - Completed R6. Removed optional statistics-listener infrastructure
   from the focused scrape handler setup. `ScrapeService` receives no event sender; HTTP-core tests
   cover `TcpScrape` publication and HTTP-server integration tests cover consumed TCP4/TCP6 metrics.
+- 2026-09-02 - GitHub Copilot - Completed R7. Retained the cross-file bootstrap draft as deferred:
+  no cohesive shared test capability remains after the scrape setup simplifications.
+- 2026-09-02 - User/maintainer - Reviewed and approved the R7 deferred cross-file bootstrap
+  decision and completion of the scrape-handler test refactor plan.
 
 ### Validation Evidence
 
@@ -237,7 +245,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 | R4                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed.                                                                                               |
 | R5                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (32 passed), and `git diff --check` passed.                                                                                               |
 | R6                 | DONE   | Inspected `ScrapeService::send_event`, HTTP-core service event tests, and HTTP-server TCP4/TCP6 metric integration assertions; editor diagnostics, `cargo fmt --all -- --check`, package library tests (32 passed), and `git diff --check` passed. |
-| R7                 | TODO   | Not started.                                                                                                                                                                                                                                       |
+| R7                 | DONE   | Reassessed the shared bootstrap draft after R2–R6; no cross-file extraction is justified without an opaque construction bundle.                                                                                                                    |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -114,7 +114,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R3 — Re-establish the handler error-mapping boundary
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / medium effort
 - **Addresses:** P1
 - **Change:** Extract `handle_scrape` as the service-delegation seam and add a focused test that an
@@ -176,8 +176,8 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] R1 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R2
 - [x] R2 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R3
-- [ ] R3 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R3
+- [x] R3 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R4
 - [ ] R4 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R5
@@ -200,19 +200,23 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
   clearer error-value names, explicit failure-reason assertion, and AAA structure.
 - 2026-09-02 - GitHub Copilot - Completed R2. Replaced repeated binding and missing-client-IP
   setup with narrow local fixtures, made actual values explicit, and added concise AAA boundaries.
+- 2026-09-02 - User/maintainer - Approved implementation of R3.
+- 2026-09-02 - GitHub Copilot - Completed R3. Extracted the `handle_scrape` service-delegation
+  seam and added a focused contract proving an unresolved reverse-proxy client IP becomes a
+  bencoded BitTorrent failure response with HTTP `200 OK`.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                                                                                                                |
-| ------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                  |
-| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed. |
+| Increment          | Status | Evidence                                                                                                                                 |
+| ------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                   |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                  |
 | R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed. |
-| R3                 | TODO   | Not started.                                                                                                            |
-| R4                 | TODO   | Not started.                                                                                                            |
-| R5                 | TODO   | Not started.                                                                                                            |
-| R6                 | TODO   | Not started.                                                                                                            |
-| R7                 | TODO   | Not started.                                                                                                            |
+| R3                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (31 passed), and `git diff --check` passed. |
+| R4                 | TODO   | Not started.                                                                                                                             |
+| R5                 | TODO   | Not started.                                                                                                                             |
+| R6                 | TODO   | Not started.                                                                                                                             |
+| R7                 | TODO   | Not started.                                                                                                                             |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -93,7 +93,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R1 — Correct the scrape module documentation
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / trivial effort
 - **Addresses:** P6
 - **Change:** Replace the module-documentation reference to `announce` with `scrape`.
@@ -172,8 +172,8 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 - [x] Phase 1 findings reviewed against the current file
 - [x] Phase 2 refactorings ordered by impact and effort
-- [ ] Maintainer approved implementation of R1
-- [ ] R1 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R1
+- [x] R1 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R2
 - [ ] R2 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R3
@@ -192,19 +192,23 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - 2026-09-02 - GitHub Copilot - Created the proposed plan from the current `scrape.rs` tests,
   existing integration coverage, and the completed announce-handler test plan. No refactoring has
   been implemented.
+- 2026-09-02 - User/maintainer - Approved R1 after reviewing the isolated module-documentation
+  correction.
+- 2026-09-02 - GitHub Copilot - Completed R1 by correcting the module documentation to identify
+  scrape requests.
 
 ### Validation Evidence
 
-| Increment | Status | Evidence |
-| --- | --- | --- |
-| Plan documentation | TODO | Not run after plan creation. |
-| R1 | TODO | Not started. |
-| R2 | TODO | Not started. |
-| R3 | TODO | Not started. |
-| R4 | TODO | Not started. |
-| R5 | TODO | Not started. |
-| R6 | TODO | Not started. |
-| R7 | TODO | Not started. |
+| Increment          | Status | Evidence                     |
+| ------------------ | ------ | ---------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
+| R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed. |
+| R2                 | TODO   | Not started.                 |
+| R3                 | TODO   | Not started.                 |
+| R4                 | TODO   | Not started.                 |
+| R5                 | TODO   | Not started.                 |
+| R6                 | TODO   | Not started.                 |
+| R7                 | TODO   | Not started.                 |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/scrape-tests.md
@@ -102,7 +102,7 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 
 ### R2 — Clarify local test setup and error contracts
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / low effort
 - **Addresses:** P3
 - **Change:** Add the two narrow fixtures; use explicit actual-error names; rename the
@@ -174,8 +174,8 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
 - [x] Phase 2 refactorings ordered by impact and effort
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R2
-- [ ] R2 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R2
+- [x] R2 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R3
 - [ ] R3 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R4
@@ -196,19 +196,23 @@ contracts. Remove it only if it is unnecessary, or retain explicit ownership if 
   correction.
 - 2026-09-02 - GitHub Copilot - Completed R1 by correcting the module documentation to identify
   scrape requests.
+- 2026-09-02 - User/maintainer - Approved R2 after reviewing the deterministic local fixtures,
+  clearer error-value names, explicit failure-reason assertion, and AAA structure.
+- 2026-09-02 - GitHub Copilot - Completed R2. Replaced repeated binding and missing-client-IP
+  setup with narrow local fixtures, made actual values explicit, and added concise AAA boundaries.
 
 ### Validation Evidence
 
-| Increment          | Status | Evidence                     |
-| ------------------ | ------ | ---------------------------- |
-| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
+| Increment          | Status | Evidence                                                                                                                |
+| ------------------ | ------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE   | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                  |
 | R1                 | DONE   | `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed. |
-| R2                 | TODO   | Not started.                 |
-| R3                 | TODO   | Not started.                 |
-| R4                 | TODO   | Not started.                 |
-| R5                 | TODO   | Not started.                 |
-| R6                 | TODO   | Not started.                 |
-| R7                 | TODO   | Not started.                 |
+| R2                 | DONE   | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib`, and `git diff --check` passed. |
+| R3                 | TODO   | Not started.                                                                                                            |
+| R4                 | TODO   | Not started.                                                                                                            |
+| R5                 | TODO   | Not started.                                                                                                            |
+| R6                 | TODO   | Not started.                                                                                                            |
+| R7                 | TODO   | Not started.                                                                                                            |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -119,6 +119,21 @@ vary tracker configuration or registry state without making every test explain t
 `initialize_container` duplication and shared bootstrap work remain separately tracked in
 `drafts/shared-handler-test-bootstrap.md` (B4).
 
+### P7 — The successful lifecycle Arrange also hides its defining scenario
+
+**Problem.** `it_should_preserve_the_launcher_bind_address_after_starting_and_stopping` directly
+assembles public configuration, container, optional TLS, empty registry, metadata, and launcher.
+The reader must infer that this is the normal counterpart to the duplicate-registration scenario:
+the configured HTTP binding is available to both the OS and the registry.
+
+**Why it matters.** The test's protected contract is launcher configuration preservation through a
+successful lifecycle, not configuration extraction or TLS selection. The scenario catalog is less
+useful if only failure states receive names.
+
+**Opportunity.** Add a paired file-local normal-start scenario fixture, tentatively named
+`ServerStartWithAvailableHttpBinding`, that owns the ordinary valid startup infrastructure and
+exposes the inputs needed for the visible start/stop lifecycle Act.
+
 ## Phase 2 — Proposed Refactorings
 
 ### R1 — Clarify lifecycle test names and AAA boundaries
@@ -189,7 +204,7 @@ vary tracker configuration or registry state without making every test explain t
 
 ### R6 — Name the duplicate-registration startup scenario
 
-- **Status:** APPROVED
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P6
 - **Change:** Replace the narrow plumbing helpers with a file-local test scenario, for example
@@ -208,6 +223,23 @@ vary tracker configuration or registry state without making every test explain t
   scenario fixture, and a reader can inspect that fixture for the detailed tracker bootstrap. The
   library tests still pass unchanged (34 passed).
 
+### R7 — Name the normal server-start scenario
+
+- **Status:** PROPOSED
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P2, P7
+- **Change:** Introduce a file-local `ServerStartWithAvailableHttpBinding` scenario fixture as the
+  successful counterpart to `ServerStartWithDuplicateRegistration`. It owns public configuration,
+  global setup, container construction, an empty `Registar`, launcher settings, and metadata. The
+  test Arrange names the scenario, while the Act visibly starts then stops the server.
+- **Guardrails:** Do not imply that the `HttpTrackerCoreContainer` internals are the behavior under
+  test. The scenario's documented invariant must state that its binding is available to both the OS
+  and the registry. Keep `HttpServer::new(...).start(...)`, `.stop()`, and the launcher bind-address
+  assertion in the test body. Do not add a generic fixture with unrelated configuration options;
+  use a builder only if a future variation reads more clearly as a small chain of named choices.
+- **Done when:** the normal lifecycle test's Arrange is a named scenario and its relationship to
+  the duplicate-registration scenario is clear without changing the 34-test behavior.
+
 ## Progress Tracking
 
 ### Plan Checklist
@@ -221,7 +253,9 @@ vary tracker configuration or registry state without making every test explain t
 - [x] R3 assessment completed and decision recorded
 - [ ] R4 assessment completed and decision recorded
 - [x] Maintainer approved implementation of R6
-- [ ] R6 implemented, reviewed, and validated
+- [x] R6 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R7
+- [ ] R7 implemented, reviewed, and validated
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
 
@@ -251,6 +285,12 @@ vary tracker configuration or registry state without making every test explain t
   Arrange section should name the complete duplicate-registration scenario, not individual plumbing
   steps. Approved a file-local scenario fixture as a navigable catalog entry for future
   configuration and registration-state scenarios.
+- 2026-09-03 - GitHub Copilot - Completed R6 with `ServerStartWithDuplicateRegistration`. The
+  scenario owns the address handoff, HTTP configuration, duplicate-registration state, global setup,
+  and container construction; the test keeps the server start and error/cleanup contract visible.
+- 2026-09-03 - User/maintainer - Requested a paired named scenario for the successful lifecycle
+  test, so the scenario catalog documents both an available HTTP binding and a duplicate
+  registration. R7 is proposed; no implementation was approved.
 
 ### Validation Evidence
 
@@ -262,7 +302,8 @@ vary tracker configuration or registry state without making every test explain t
 | R3                 | DONE     | Inspected `check_fn_with_client`, existing test helpers, package health contracts, and health-check API contracts; no deterministic non-listener seam exists. |
 | R4                 | TODO     | Not started.                                                                                                                                                  |
 | R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
-| R6                 | APPROVED | Scenario-fixture design approved; implementation not started.                                                                                                 |
+| R6                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                   |
+| R7                 | PROPOSED | Not started.                                                                                                                                                  |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -115,7 +115,7 @@ server-local test unless it proves a missing observable contract.
 
 ### R2 — Document the registration-test port-handoff limitation
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / trivial effort
 - **Addresses:** P3
 - **Change:** Add a concise comment beside the reservation/drop setup explaining why it is needed and
@@ -170,8 +170,8 @@ server-local test unless it proves a missing observable contract.
 - [x] Phase 2 refactorings ordered by impact and effort
 - [x] Maintainer approved implementation of R1
 - [x] R1 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R2
-- [ ] R2 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R2
+- [x] R2 implemented, reviewed, and validated
 - [ ] R3 assessment completed and decision recorded
 - [ ] R4 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
@@ -187,17 +187,21 @@ server-local test unless it proves a missing observable contract.
 - 2026-09-03 - GitHub Copilot - Completed R1. Renamed the lifecycle tests for launcher
   configuration preservation and duplicate-registration listener cleanup without changing their
   behavior.
+- 2026-09-03 - User/maintainer - Approved R2 after reviewing the documented port-handoff
+  limitation.
+- 2026-09-03 - GitHub Copilot - Completed R2. Documented why duplicate registration must occur
+  after listener binding and why retries or waiting would conceal the OS-level handoff risk.
 
 ### Validation Evidence
 
-| Increment          | Status   | Evidence                                               |
-| ------------------ | -------- | ------------------------------------------------------ |
-| Plan documentation | DONE     | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
+| Increment          | Status   | Evidence                                                                                                                                             |
+| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE     | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
 | R1                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed. |
-| R2                 | TODO     | Not started.                                           |
-| R3                 | TODO     | Not started.                                           |
-| R4                 | TODO     | Not started.                                           |
-| R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger. |
+| R2                 | DONE     | `cargo fmt --all -- --check`, package library tests (34 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed. |
+| R3                 | TODO     | Not started.                                                                                                                                         |
+| R4                 | TODO     | Not started.                                                                                                                                         |
+| R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                               |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -103,7 +103,7 @@ server-local test unless it proves a missing observable contract.
 
 ### R1 — Clarify lifecycle test names and AAA boundaries
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** High impact / low effort
 - **Addresses:** P1, P2
 - **Change:** Rename both lifecycle tests for their explicit controller/cleanup contracts and add
@@ -168,8 +168,8 @@ server-local test unless it proves a missing observable contract.
 
 - [x] Phase 1 findings reviewed against current code, coverage evidence, and external boundaries
 - [x] Phase 2 refactorings ordered by impact and effort
-- [ ] Maintainer approved implementation of R1
-- [ ] R1 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R1
+- [x] R1 implemented, reviewed, and validated
 - [ ] Maintainer approved implementation of R2
 - [ ] R2 implemented, reviewed, and validated
 - [ ] R3 assessment completed and decision recorded
@@ -182,13 +182,18 @@ server-local test unless it proves a missing observable contract.
 - 2026-09-03 - GitHub Copilot - Created the proposed plan from `server.rs`, current package coverage
   evidence, package integration contracts, cross-package health-check integration contracts, root
   integration scope, and E2E tooling. No refactoring has been implemented.
+- 2026-09-03 - User/maintainer - Approved R1 after reviewing the explicit lifecycle contract names
+  and start/stop AAA structure.
+- 2026-09-03 - GitHub Copilot - Completed R1. Renamed the lifecycle tests for launcher
+  configuration preservation and duplicate-registration listener cleanup without changing their
+  behavior.
 
 ### Validation Evidence
 
 | Increment          | Status   | Evidence                                               |
 | ------------------ | -------- | ------------------------------------------------------ |
-| Plan documentation | TODO     | Not run after plan creation.                           |
-| R1                 | TODO     | Not started.                                           |
+| Plan documentation | DONE     | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation. |
+| R1                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed. |
 | R2                 | TODO     | Not started.                                           |
 | R3                 | TODO     | Not started.                                           |
 | R4                 | TODO     | Not started.                                           |

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -99,6 +99,20 @@ platform-, or implementation-coupled.
 application integration, or E2E tests according to the narrowest stable boundary. Do not add a
 server-local test unless it proves a missing observable contract.
 
+### P6 — The registration-failure Arrange mixes five concerns
+
+**Problem.** The Arrange section of
+`it_should_release_the_listener_and_preserve_the_duplicate_binding_error_when_registration_fails`
+interleaves address reservation and release, configuration mutation, duplicate-registration seeding,
+global service setup, and container composition in one flat block.
+
+**Why it matters.** A reader must reconstruct the scenario ("start on an address whose registration
+is already taken") from low-level steps, which hides the one condition the test depends on.
+
+**Opportunity.** Extract small, intent-revealing, file-local helpers that hide mechanics but keep
+the scenario choice visible in the test body. `initialize_container` duplication is tracked
+separately in `drafts/shared-handler-test-bootstrap.md` (B4) and is out of scope here.
+
 ## Phase 2 — Proposed Refactorings
 
 ### R1 — Clarify lifecycle test names and AAA boundaries
@@ -167,6 +181,23 @@ server-local test unless it proves a missing observable contract.
   not a test-only task-scheduling hook.
 - **Done when:** a concrete flake or lifecycle change justifies separate design review.
 
+### R6 — Extract intent-revealing Arrange helpers for the registration-failure test
+
+- **Status:** APPROVED
+- **Priority:** Medium impact / low effort
+- **Addresses:** P6
+- **Change:** Introduce file-local test helpers such as `reserve_released_ephemeral_address()`,
+  `ephemeral_public_bound_to(bind_to)`, and
+  `registar_with_registered_http_binding(bind_to, configuration_instance_id)`, so the Arrange
+  section reads as: reserve an address, bind the configuration to it, pre-register that binding,
+  build the container, then start the server.
+- **Guardrails:** Keep the `HttpServer::start` call, the typed
+  `Error::Registration { DuplicateBinding }` match, and the `TcpListener::bind` release assertion
+  visible in the test body. Keep the R2 port-handoff comment beside the reservation logic. Do not
+  change production code, touch `initialize_container`, or introduce a generic server-test builder.
+- **Done when:** the test body states the scenario in a few named steps and the library tests still
+  pass unchanged (34 passed).
+
 ## Progress Tracking
 
 ### Plan Checklist
@@ -179,6 +210,8 @@ server-local test unless it proves a missing observable contract.
 - [x] R2 implemented, reviewed, and validated
 - [x] R3 assessment completed and decision recorded
 - [ ] R4 assessment completed and decision recorded
+- [x] Maintainer approved implementation of R6
+- [ ] R6 implemented, reviewed, and validated
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
 
@@ -199,6 +232,11 @@ server-local test unless it proves a missing observable contract.
 - 2026-09-03 - GitHub Copilot - Completed R3 assessment. Deferred a direct health-job result test:
   the injected client has no existing deterministic transport seam, while package and health-check
   API integration tests already cover HTTP, trusted HTTPS, and post-stop health outcomes.
+- 2026-09-03 - User/maintainer - Raised two readability concerns: `initialize_container` duplicates
+  bootstrap composition, and the registration-failure Arrange is hard to follow. Approved tracking
+  the bootstrap duplication in `drafts/shared-handler-test-bootstrap.md` (B4) and adding R6 for
+  file-local Arrange helpers. Clarified that tests intentionally avoid the production container
+  factories to keep dependencies minimal, explicit, and fast.
 
 ### Validation Evidence
 
@@ -210,6 +248,7 @@ server-local test unless it proves a missing observable contract.
 | R3                 | DONE     | Inspected `check_fn_with_client`, existing test helpers, package health contracts, and health-check API contracts; no deterministic non-listener seam exists. |
 | R4                 | TODO     | Not started.                                                                                                                                                  |
 | R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
+| R6                 | APPROVED | Not started.                                                                                                                                                  |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -3,7 +3,7 @@ doc-type: test-refactor-plan
 issue: 1348
 package: torrust-tracker-axum-http-server
 target-file: packages/axum-http-server/src/server.rs
-status: proposed
+status: completed
 semantic-links:
   related-artifacts:
     - packages/axum-http-server/src/server.rs
@@ -278,8 +278,8 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 - [x] R6 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R7
 - [x] R7 implemented, reviewed, and validated
-- [ ] Maintainer reviewed all approved changes
-- [ ] Plan completed and ready for commit
+- [x] Maintainer reviewed all approved changes
+- [x] Plan completed and ready for commit
 
 ### Progress Log
 
@@ -321,6 +321,8 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
   health at the health-check API integration boundary; reserved root and E2E coverage for their
   application-composition and container-interoperability responsibilities; deferred private launch,
   task/shutdown, logging, and TLS construction mechanics without an observable regression.
+- 2026-09-03 - User/maintainer - Reviewed the completed R4 assessment and approved closure of this
+  file-local server test-refactor plan. R5 remains deferred pending the documented trigger.
 
 ### Validation Evidence
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -225,7 +225,7 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 
 ### R7 — Name the normal server-start scenario
 
-- **Status:** PROPOSED
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P2, P7
 - **Change:** Introduce a file-local `ServerStartWithAvailableHttpBinding` scenario fixture as the
@@ -254,8 +254,8 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 - [ ] R4 assessment completed and decision recorded
 - [x] Maintainer approved implementation of R6
 - [x] R6 implemented, reviewed, and validated
-- [ ] Maintainer approved implementation of R7
-- [ ] R7 implemented, reviewed, and validated
+- [x] Maintainer approved implementation of R7
+- [x] R7 implemented, reviewed, and validated
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
 
@@ -291,6 +291,9 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 - 2026-09-03 - User/maintainer - Requested a paired named scenario for the successful lifecycle
   test, so the scenario catalog documents both an available HTTP binding and a duplicate
   registration. R7 is proposed; no implementation was approved.
+- 2026-09-03 - GitHub Copilot - Completed R7 with `ServerStartWithAvailableHttpBinding`. The
+  normal-start scenario owns configuration, global setup, container construction, registry, TLS
+  selection, and metadata; the test retains the visible start/stop lifecycle contract.
 
 ### Validation Evidence
 
@@ -303,7 +306,7 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 | R4                 | TODO     | Not started.                                                                                                                                                  |
 | R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
 | R6                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                   |
-| R7                 | PROPOSED | Not started.                                                                                                                                                  |
+| R7                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                   |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -180,7 +180,7 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 
 ### R4 — Assess external lifecycle coverage boundaries
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Low impact / low effort
 - **Addresses:** P5
 - **Change:** Record why remaining server behavior belongs to one of these existing boundaries:
@@ -189,6 +189,28 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
   `packages/e2e-tools/` for containerized interoperability.
 - **Guardrails:** Link only high-signal external test artifacts under this plan's semantic links; do
   not add markers to external source files just to describe coverage overlap.
+- **Decision:**
+  - **Listener, router, and protocol behavior:** retain package integration coverage in
+    `tests/server/v1/contract/`. `environment_should_be_started_and_stopped` proves its lifecycle
+    fixture can bind and stop an HTTP server; the all-modes contract proves the live health endpoint;
+    the announce and scrape contract modules prove routes and protocol handling; and
+    `using_ipv6_v6only.rs` proves the IPv6-only binding behavior. Server-local unit tests should not
+    repeat those live-listener contracts.
+  - **Registered HTTP and HTTPS health:** retain cross-package composition coverage in
+    `packages/axum-health-check-api-server/tests/server/contract.rs`. It verifies the health API's
+    observable report for running HTTP, trusted-certificate HTTPS, and a service stopped after
+    registration. This is the correct boundary for the `check_fn` callback plus registry plus
+    health API, rather than a scheduler-coupled `server.rs` test.
+  - **Application composition:** retain root `tests/` for configuration-driven multi-service startup,
+    discovery through runtime-registry snapshots, and application shutdown. These tests prove the
+    tracker application's composition rather than `HttpServer` controller internals; add an HTTP
+    case there only when an application-level configuration interaction needs coverage.
+  - **Containerized interoperability:** reserve `packages/e2e-tools/` for an externally observed,
+    multi-process tracker/client contract. It is an E2E runner, not evidence for a currently missing
+    `server.rs` unit-test branch; add coverage there only for a reproducible containerized defect.
+  - **Private launch, task/shutdown, logging, and TLS construction mechanics:** defer. They are
+    implementation mechanics or already exercised incidentally by the boundaries above. Test a
+    future observable lifecycle contract only when a regression demonstrates a stable seam.
 - **Done when:** the plan states the retained or deferred boundary for each relevant behavior class.
 
 ### R5 — Consider a deterministic listener-cleanup seam only on evidence
@@ -251,7 +273,7 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 - [x] Maintainer approved implementation of R2
 - [x] R2 implemented, reviewed, and validated
 - [x] R3 assessment completed and decision recorded
-- [ ] R4 assessment completed and decision recorded
+- [x] R4 assessment completed and decision recorded
 - [x] Maintainer approved implementation of R6
 - [x] R6 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R7
@@ -294,6 +316,11 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 - 2026-09-03 - GitHub Copilot - Completed R7 with `ServerStartWithAvailableHttpBinding`. The
   normal-start scenario owns configuration, global setup, container construction, registry, TLS
   selection, and metadata; the test retains the visible start/stop lifecycle contract.
+- 2026-09-03 - GitHub Copilot - Completed R4 assessment. Retained live listener, endpoint, route,
+  protocol, and IPv6 behavior at package integration boundaries; retained registered HTTP/HTTPS
+  health at the health-check API integration boundary; reserved root and E2E coverage for their
+  application-composition and container-interoperability responsibilities; deferred private launch,
+  task/shutdown, logging, and TLS construction mechanics without an observable regression.
 
 ### Validation Evidence
 
@@ -303,7 +330,7 @@ exposes the inputs needed for the visible start/stop lifecycle Act.
 | R1                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed.          |
 | R2                 | DONE     | `cargo fmt --all -- --check`, package library tests (34 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                           |
 | R3                 | DONE     | Inspected `check_fn_with_client`, existing test helpers, package health contracts, and health-check API contracts; no deterministic non-listener seam exists. |
-| R4                 | TODO     | Not started.                                                                                                                                                  |
+| R4                 | DONE     | Inspected package integration, cross-package health API integration, root application integration, and E2E runner boundaries; decision recorded.              |
 | R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
 | R6                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                   |
 | R7                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, package library tests, `linter markdown`, `linter cspell`, and `git diff --check` passed.                   |

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -126,7 +126,7 @@ server-local test unless it proves a missing observable contract.
 
 ### R3 — Assess a deterministic `check_fn_with_client` result contract
 
-- **Status:** TODO
+- **Status:** DONE
 - **Priority:** Medium impact / medium effort
 - **Addresses:** P4
 - **Change:** Identify an existing deterministic controlled HTTP-client boundary. If one can execute
@@ -135,8 +135,13 @@ server-local test unless it proves a missing observable contract.
 - **Guardrails:** Test one behavior-focused result path; do not duplicate URL-only, HTTP endpoint,
   trusted TLS, or health API registration tests. Do not use external networking, a port handoff,
   sleeps, retries, or log assertions.
-- **Done when:** the plan records a behavior-justified focused test or a concrete no-change/defer
-  rationale.
+- **Decision:** Deferred. `check_fn_with_client` accepts a concrete `reqwest::Client`, and no
+  existing deterministic in-process client transport or mock server seam can execute its spawned
+  request without a listener. The package and cross-package integration tests already cover HTTP
+  health success, trusted HTTPS health success, and post-stop request failure. Adding another
+  listener-based test here would duplicate those contracts and create the port/timing concerns that
+  this focused plan excludes.
+- **Done when:** the deferred rationale and existing coverage boundaries are recorded.
 
 ### R4 — Assess external lifecycle coverage boundaries
 
@@ -172,7 +177,7 @@ server-local test unless it proves a missing observable contract.
 - [x] R1 implemented, reviewed, and validated
 - [x] Maintainer approved implementation of R2
 - [x] R2 implemented, reviewed, and validated
-- [ ] R3 assessment completed and decision recorded
+- [x] R3 assessment completed and decision recorded
 - [ ] R4 assessment completed and decision recorded
 - [ ] Maintainer reviewed all approved changes
 - [ ] Plan completed and ready for commit
@@ -191,17 +196,20 @@ server-local test unless it proves a missing observable contract.
   limitation.
 - 2026-09-03 - GitHub Copilot - Completed R2. Documented why duplicate registration must occur
   after listener binding and why retries or waiting would conceal the OS-level handoff risk.
+- 2026-09-03 - GitHub Copilot - Completed R3 assessment. Deferred a direct health-job result test:
+  the injected client has no existing deterministic transport seam, while package and health-check
+  API integration tests already cover HTTP, trusted HTTPS, and post-stop health outcomes.
 
 ### Validation Evidence
 
-| Increment          | Status   | Evidence                                                                                                                                             |
-| ------------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Plan documentation | DONE     | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                               |
-| R1                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed. |
-| R2                 | DONE     | `cargo fmt --all -- --check`, package library tests (34 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed. |
-| R3                 | TODO     | Not started.                                                                                                                                         |
-| R4                 | TODO     | Not started.                                                                                                                                         |
-| R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                               |
+| Increment          | Status   | Evidence                                                                                                                                                      |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Plan documentation | DONE     | `linter markdown`, `linter cspell`, and `git diff --check` passed after plan creation.                                                                        |
+| R1                 | DONE     | Editor diagnostics, `cargo fmt --all -- --check`, `cargo test -p torrust-tracker-axum-http-server --lib` (34 passed), and `git diff --check` passed.          |
+| R2                 | DONE     | `cargo fmt --all -- --check`, package library tests (34 passed), `linter markdown`, `linter cspell`, and `git diff --check` passed.                           |
+| R3                 | DONE     | Inspected `check_fn_with_client`, existing test helpers, package health contracts, and health-check API contracts; no deterministic non-listener seam exists. |
+| R4                 | TODO     | Not started.                                                                                                                                                  |
+| R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
 
 ## Non-Goals
 

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -1,0 +1,214 @@
+---
+doc-type: test-refactor-plan
+issue: 1348
+package: torrust-tracker-axum-http-server
+target-file: packages/axum-http-server/src/server.rs
+status: proposed
+semantic-links:
+  related-artifacts:
+    - packages/axum-http-server/src/server.rs
+    - packages/axum-http-server/src/testing/environment.rs
+    - packages/axum-http-server/tests/server/v1/contract/mod.rs
+    - packages/axum-http-server/tests/server/v1/contract/for_all_config_modes/mod.rs
+    - packages/axum-http-server/tests/server/v1/contract/using_ipv6_v6only.rs
+    - packages/axum-health-check-api-server/tests/server/contract.rs
+    - docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md
+---
+
+# HTTP Server Test Refactor Plan
+
+Follow the shared [purpose, quality goals, and plan structure](README.md). This plan applies only
+to `packages/axum-http-server/src/server.rs`.
+
+## Phase 1 — Identify Problems
+
+### Strengths to preserve
+
+1. Health-check URL formation is fast, deterministic, and verifies both HTTP and HTTPS schemes.
+2. Listener bind failure is asserted through the package-owned `Error::Bind` type, not
+   platform-specific error text.
+3. The direct lifecycle test covers the `Stopped → Running → Stopped` state transition.
+4. The registration-failure test verifies one coupled cleanup contract: duplicate registration keeps
+   its typed cause **and** the listener is released.
+5. Package integration tests cover live HTTP listeners, health-check endpoint availability, route and
+   protocol behavior, and IPv6-only listener behavior.
+6. Cross-package health-check API tests cover registered HTTP/HTTPS service health and a stopped
+   service; they are linked above because they cover a composed behavior outside this package.
+
+### P1 — Lifecycle test names do not state their protected invariant
+
+**Problem.** `it_should_be_able_to_start_and_stop` does not state that the test protects retention
+of the launcher's original bind configuration after the full state transition. The registration test
+similarly buries its cleanup purpose in a long name.
+
+**Why it matters.** Lifecycle setup is substantial, so test names must tell a reader why that setup
+exists and what a failure means.
+
+**Opportunity.** Rename the tests to state the start/stop configuration-preservation contract and the
+failed-registration listener-cleanup contract. Keep each test's current behavior scope intact.
+
+### P2 — Direct lifecycle setup is dense
+
+**Problem.** `it_should_be_able_to_start_and_stop` mixes configuration selection, global setup,
+container composition, optional TLS configuration, registration setup, state transition, and its
+final assertion.
+
+**Why it matters.** A reader must navigate setup details before finding the controller contract.
+
+**Opportunity.** Assess concise AAA boundaries and small local naming improvements. Do not replace
+the direct `HttpServer` test with `testing::environment`, because that fixture panics on lifecycle
+errors and returns a different abstraction.
+
+### P3 — Registration cleanup uses an unavoidable but non-zero port-handoff risk
+
+**Problem.** The registration-failure test reserves an ephemeral address, releases the listener, then
+starts the server on the same address so registration can fail after binding. Another process could
+claim the address in the handoff window.
+
+**Why it matters.** This is a potential OS-level flake, even though the test asserts valuable cleanup
+behavior.
+
+**Opportunity.** Record the limitation and avoid duplicating the reservation/drop pattern. Do not add
+sleeps, retries, or polling. Consider a deterministic observation seam only if this test actually
+flakes or lifecycle design changes for another reason.
+
+### P4 — The health-check job result seam lacks direct focused coverage
+
+**Problem.** `check_fn_with_client` creates a `ServiceHealthCheckJob` that returns an HTTP status
+string or a request error string. URL construction is unit-tested, and composed HTTP/HTTPS health
+behavior is covered elsewhere, but this injected-client result propagation is not directly asserted
+in `server.rs`.
+
+**Why it matters.** This is a package-owned, injectable boundary that could prevent a regression in
+the health job without duplicating TLS or health-check API integration coverage.
+
+**Opportunity.** Assess one deterministic direct job-result test using an existing controlled client
+or server capability. Defer if such a boundary requires an external listener, port handoff, waiting,
+or new test infrastructure.
+
+### P5 — Uncovered server paths are not all behavior gaps
+
+**Problem.** Coverage is 85.62% for lines, 81.68% for regions, and 65.71% for functions. The
+uncovered queue includes private launch mechanics, task/shutdown handling, logging, TLS setup, and
+health-check helpers.
+
+**Why it matters.** Tests written only to increase those totals would become scheduler-,
+platform-, or implementation-coupled.
+
+**Opportunity.** Defer or use existing package integration, cross-package health integration, root
+application integration, or E2E tests according to the narrowest stable boundary. Do not add a
+server-local test unless it proves a missing observable contract.
+
+## Phase 2 — Proposed Refactorings
+
+### R1 — Clarify lifecycle test names and AAA boundaries
+
+- **Status:** TODO
+- **Priority:** High impact / low effort
+- **Addresses:** P1, P2
+- **Change:** Rename both lifecycle tests for their explicit controller/cleanup contracts and add
+  concise Arrange–Act–Assert boundaries where they improve scanning.
+- **Guardrails:** Do not add assertions for routes, logs, tasks, metrics, registry internals, or TLS
+  state. Preserve the registration failure's two coupled cleanup assertions as one contract.
+- **Done when:** a reader can identify each lifecycle contract from its name and phases without
+  changing behavior.
+
+### R2 — Document the registration-test port-handoff limitation
+
+- **Status:** TODO
+- **Priority:** Medium impact / trivial effort
+- **Addresses:** P3
+- **Change:** Add a concise comment beside the reservation/drop setup explaining why it is needed and
+  why the test deliberately does not use retries or waiting.
+- **Guardrails:** Do not change production code, add another port handoff, or mask flakes with
+  sleeps, polling, or retries.
+- **Done when:** the risk and intentional trade-off are clear to future maintainers.
+
+### R3 — Assess a deterministic `check_fn_with_client` result contract
+
+- **Status:** TODO
+- **Priority:** Medium impact / medium effort
+- **Addresses:** P4
+- **Change:** Identify an existing deterministic controlled HTTP-client boundary. If one can execute
+  the returned health job without listener timing or new infrastructure, add one focused assertion
+  for status-string or request-error propagation.
+- **Guardrails:** Test one behavior-focused result path; do not duplicate URL-only, HTTP endpoint,
+  trusted TLS, or health API registration tests. Do not use external networking, a port handoff,
+  sleeps, retries, or log assertions.
+- **Done when:** the plan records a behavior-justified focused test or a concrete no-change/defer
+  rationale.
+
+### R4 — Assess external lifecycle coverage boundaries
+
+- **Status:** TODO
+- **Priority:** Low impact / low effort
+- **Addresses:** P5
+- **Change:** Record why remaining server behavior belongs to one of these existing boundaries:
+  package integration for listener/endpoint/IPv6 behavior, health-check API integration for
+  registered HTTP/HTTPS health behavior, root `tests/` for application composition, or
+  `packages/e2e-tools/` for containerized interoperability.
+- **Guardrails:** Link only high-signal external test artifacts under this plan's semantic links; do
+  not add markers to external source files just to describe coverage overlap.
+- **Done when:** the plan states the retained or deferred boundary for each relevant behavior class.
+
+### R5 — Consider a deterministic listener-cleanup seam only on evidence
+
+- **Status:** DEFERRED
+- **Priority:** Low impact / high effort
+- **Addresses:** P3, P5
+- **Change:** Revisit only if the registration-failure test flakes or a production lifecycle change
+  creates a meaningful deterministic cleanup-observation seam.
+- **Guardrails:** Any future design must preserve public behavior and expose a lifecycle capability,
+  not a test-only task-scheduling hook.
+- **Done when:** a concrete flake or lifecycle change justifies separate design review.
+
+## Progress Tracking
+
+### Plan Checklist
+
+- [x] Phase 1 findings reviewed against current code, coverage evidence, and external boundaries
+- [x] Phase 2 refactorings ordered by impact and effort
+- [ ] Maintainer approved implementation of R1
+- [ ] R1 implemented, reviewed, and validated
+- [ ] Maintainer approved implementation of R2
+- [ ] R2 implemented, reviewed, and validated
+- [ ] R3 assessment completed and decision recorded
+- [ ] R4 assessment completed and decision recorded
+- [ ] Maintainer reviewed all approved changes
+- [ ] Plan completed and ready for commit
+
+### Progress Log
+
+- 2026-09-03 - GitHub Copilot - Created the proposed plan from `server.rs`, current package coverage
+  evidence, package integration contracts, cross-package health-check integration contracts, root
+  integration scope, and E2E tooling. No refactoring has been implemented.
+
+### Validation Evidence
+
+| Increment          | Status   | Evidence                                               |
+| ------------------ | -------- | ------------------------------------------------------ |
+| Plan documentation | TODO     | Not run after plan creation.                           |
+| R1                 | TODO     | Not started.                                           |
+| R2                 | TODO     | Not started.                                           |
+| R3                 | TODO     | Not started.                                           |
+| R4                 | TODO     | Not started.                                           |
+| R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger. |
+
+## Non-Goals
+
+- Do not add tests for logs, `BoxFuture` construction, internal graceful-shutdown task mechanics,
+  synthetic `JoinHandle`/oneshot failures, or impossible normal-address `ServiceBinding` failures.
+- Do not add a TLS lifecycle test that duplicates package integration or trusted health-check API
+  coverage.
+- Do not add retries, sleeps, polling, or further port-handoff tests.
+- Do not move `initialize_container` or create a generic server-test builder solely for aesthetics.
+- Do not use root integration or E2E tests as a substitute for a missing deterministic package-local
+  lifecycle-controller contract.
+
+## Validation Per Approved Increment
+
+- `cargo fmt --all -- --check`
+- `cargo test -p torrust-tracker-axum-http-server --lib`
+- `git diff --check`
+- `linter markdown` when this plan changes
+- Refresh `coverage-evidence.md` only after an approved behavior-adding test.

--- a/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
+++ b/docs/issues/open/1348-1347-add-tests-axum-http-server/test-refactor-plans/server-tests.md
@@ -99,19 +99,25 @@ platform-, or implementation-coupled.
 application integration, or E2E tests according to the narrowest stable boundary. Do not add a
 server-local test unless it proves a missing observable contract.
 
-### P6 — The registration-failure Arrange mixes five concerns
+### P6 — The registration-failure Arrange hides its defining scenario
 
 **Problem.** The Arrange section of
 `it_should_release_the_listener_and_preserve_the_duplicate_binding_error_when_registration_fails`
 interleaves address reservation and release, configuration mutation, duplicate-registration seeding,
 global service setup, and container composition in one flat block.
 
-**Why it matters.** A reader must reconstruct the scenario ("start on an address whose registration
-is already taken") from low-level steps, which hides the one condition the test depends on.
+**Why it matters.** A reader must reconstruct the defining initial condition ("start a server whose
+binding is already registered") from low-level steps. The required concrete container is visible,
+but its construction detail competes with the scenario that makes the registration fail.
 
-**Opportunity.** Extract small, intent-revealing, file-local helpers that hide mechanics but keep
-the scenario choice visible in the test body. `initialize_container` duplication is tracked
-separately in `drafts/shared-handler-test-bootstrap.md` (B4) and is out of scope here.
+**Opportunity.** Represent the complete initial condition as a file-local scenario fixture. The
+test should arrange a named scenario, not a collection of plumbing helpers. Its construction may
+hide infrastructure, while the test keeps the `HttpServer::start` Act and its error/cleanup Assert
+visible. This establishes a discoverable catalog of server-start scenarios; future scenarios may
+vary tracker configuration or registry state without making every test explain their construction.
+
+`initialize_container` duplication and shared bootstrap work remain separately tracked in
+`drafts/shared-handler-test-bootstrap.md` (B4).
 
 ## Phase 2 — Proposed Refactorings
 
@@ -181,22 +187,26 @@ separately in `drafts/shared-handler-test-bootstrap.md` (B4) and is out of scope
   not a test-only task-scheduling hook.
 - **Done when:** a concrete flake or lifecycle change justifies separate design review.
 
-### R6 — Extract intent-revealing Arrange helpers for the registration-failure test
+### R6 — Name the duplicate-registration startup scenario
 
 - **Status:** APPROVED
-- **Priority:** Medium impact / low effort
+- **Priority:** Medium impact / medium effort
 - **Addresses:** P6
-- **Change:** Introduce file-local test helpers such as `reserve_released_ephemeral_address()`,
-  `ephemeral_public_bound_to(bind_to)`, and
-  `registar_with_registered_http_binding(bind_to, configuration_instance_id)`, so the Arrange
-  section reads as: reserve an address, bind the configuration to it, pre-register that binding,
-  build the container, then start the server.
-- **Guardrails:** Keep the `HttpServer::start` call, the typed
+- **Change:** Replace the narrow plumbing helpers with a file-local test scenario, for example
+  `ServerStartWithDuplicateRegistration`. Its constructor establishes an available ephemeral
+  address, configures the tracker to use it, and pre-registers its HTTP binding. It exposes the
+  concrete inputs the Act needs: the configured `HttpTrackerCoreContainer`, launcher settings,
+  registration form, and runtime metadata.
+- **Guardrails:** The scenario name must state the condition under test. A fixture is chosen here
+  over a builder because the condition spans an address handoff, configuration, and registry state
+  that no single readable chain expresses; do not let the fixture accumulate unrelated options.
+  Keep `HttpServer::new(...).start(...)`, the typed
   `Error::Registration { DuplicateBinding }` match, and the `TcpListener::bind` release assertion
-  visible in the test body. Keep the R2 port-handoff comment beside the reservation logic. Do not
-  change production code, touch `initialize_container`, or introduce a generic server-test builder.
-- **Done when:** the test body states the scenario in a few named steps and the library tests still
-  pass unchanged (34 passed).
+  visible in the test body. Keep the R2 port-handoff comment beside the reservation logic inside
+  the scenario. Do not change production code or touch `initialize_container`.
+- **Done when:** the Arrange section names the duplicate-registration initial condition in one
+  scenario fixture, and a reader can inspect that fixture for the detailed tracker bootstrap. The
+  library tests still pass unchanged (34 passed).
 
 ## Progress Tracking
 
@@ -237,6 +247,10 @@ separately in `drafts/shared-handler-test-bootstrap.md` (B4) and is out of scope
   the bootstrap duplication in `drafts/shared-handler-test-bootstrap.md` (B4) and adding R6 for
   file-local Arrange helpers. Clarified that tests intentionally avoid the production container
   factories to keep dependencies minimal, explicit, and fast.
+- 2026-09-03 - User/maintainer - Refined R6 before committing its initial helper extraction: the
+  Arrange section should name the complete duplicate-registration scenario, not individual plumbing
+  steps. Approved a file-local scenario fixture as a navigable catalog entry for future
+  configuration and registration-state scenarios.
 
 ### Validation Evidence
 
@@ -248,7 +262,7 @@ separately in `drafts/shared-handler-test-bootstrap.md` (B4) and is out of scope
 | R3                 | DONE     | Inspected `check_fn_with_client`, existing test helpers, package health contracts, and health-check API contracts; no deterministic non-listener seam exists. |
 | R4                 | TODO     | Not started.                                                                                                                                                  |
 | R5                 | DEFERRED | Awaiting a concrete flake or lifecycle-design trigger.                                                                                                        |
-| R6                 | APPROVED | Not started.                                                                                                                                                  |
+| R6                 | APPROVED | Scenario-fixture design approved; implementation not started.                                                                                                 |
 
 ## Non-Goals
 

--- a/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
+++ b/docs/issues/open/1349-1347-add-tests-axum-rest-api-server/ISSUE.md
@@ -34,7 +34,7 @@ Improve maintainable test coverage for `torrust-tracker-axum-rest-api-server`, b
 
 ### In Scope
 
-- Record the starting package coverage baseline and the coverage increase achieved while testing critical behavior.
+- Record the starting package coverage baseline and the coverage increase achieved while testing critical behavior in an issue-local `coverage-evidence.md` document. Include the reproducible command, measurement scope, aggregate comparison, per-file results, and prioritized uncovered functions or regions; do not commit raw tool reports unless they are made human-readable.
 - Prefer fast unit tests close to the implementation whenever they provide the appropriate regression boundary.
 - Review and improve tests for HTTP/HTTPS startup, registration failure cleanup, listener errors, and graceful shutdown.
 - Test public routing and middleware contracts: unauthenticated health checks, protected API routes, token sources and precedence, and transport headers.
@@ -57,12 +57,34 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 | ID  | Status | Task                                  | Notes / Expected Output                                                                                                                                                                  |
 | --- | ------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Establish the baseline                | Run package coverage and identify critical untested paths.                                                                                                                               |
-| T2  | TODO   | Plan coverage improvement             | Identify critical behavior and record the coverage increase achieved without pursuing an arbitrary percentage.                                                                           |
+| T1  | TODO   | Establish the baseline                | Run package coverage, create `coverage-evidence.md`, state the measurement scope, and identify critical low-coverage files and paths.                                                    |
+| T2  | TODO   | Plan coverage improvement             | Select behavior by risk and detailed file/path evidence; record the coverage increase without pursuing an arbitrary percentage.                                                          |
 | T3  | TODO   | Add routing and authentication tests  | Cover public health checks, protection, token semantics, and middleware gaps; prefer fast tests close to the code when appropriate.                                                      |
 | T4  | TODO   | Add configuration and lifecycle tests | Cover configuration-gated routes and meaningful server lifecycle gaps, including behavior otherwise covered only at higher levels when package-level coverage provides regression value. |
-| T5  | TODO   | Review transport boundaries           | Cover behavior at the level it is implemented; simplify setup only when justified and retain valuable package integration coverage.                                                      |
-| T6  | TODO   | Verify and record evidence            | Complete automated checks, manual scenarios, and the post-implementation AC review.                                                                                                      |
+| T5  | TODO   | Review transport boundaries           | Cover behavior at the level it is implemented; simplify setup only when justified and retain valuable package integration coverage. Review each test increment before continuing.        |
+| T6  | TODO   | Verify and record evidence            | After maintainer review of the final test increment, complete automated checks, manual scenarios, coverage evidence, and the post-implementation AC review.                              |
+
+### Test Development Loop
+
+Apply this loop to every implementation-plan task that adds or changes tests; it is not a separate
+sequential task.
+
+1. Add the smallest behavior-focused test increment.
+2. Review the changed tests before starting the next test-producing task. Remove duplication,
+   extract justified mechanical helpers, improve naming and Arrange/Act/Assert structure, and use
+   expressive assertions.
+3. Run the focused tests for that increment and correct failures.
+4. After the final test-producing task, stop and ask the user/maintainer to review the generated
+   tests before final verification, committing, or opening a pull request.
+5. Address requested refactorings, then complete the full verification and acceptance review.
+
+For a multi-input REST contract, use a small scenario fixture when it makes the complete behavioral
+example clearer. The scenario owns request selectors, domain or service input, and independently
+specified expected output; builders hide only irrelevant fields of individual artifacts. Do not
+derive expected output with production mapping or serialization code under test. Keep the SUT call,
+the expected response representation, and the final actual-versus-expected assertion visible.
+Helpers may encapsulate repeated mechanics, such as successful-response decoding, but not behavior
+selection or expected-value construction.
 
 ## Progress Tracking
 
@@ -86,7 +108,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
 ## Acceptance Criteria
 
-- [ ] A coverage baseline and the coverage increase achieved are recorded, with critical behavior prioritized over an arbitrary percentage.
+- [ ] A coverage baseline and the coverage increase achieved are recorded in `coverage-evidence.md`, with measurement scope, per-file gaps, and critical behavior prioritized over an arbitrary percentage.
 - [ ] Tests cover identified critical REST-server transport gaps, including behavior previously covered only at a higher level when package-level coverage provides regression value.
 - [ ] Authentication, public/protected routing, configuration-gated routes, and lifecycle behavior are tested or explicitly justified as already covered.
 - [ ] Tests reuse appropriate fixtures and remain readable and maintainable.
@@ -119,23 +141,25 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                          |
-| ----- | ---------------------- | ------------------------------------------------- |
-| AC1   | TODO                   | Coverage command output recorded in progress log. |
-| AC2   | TODO                   | Added test paths and test output.                 |
-| AC3   | TODO                   | Test output and review notes.                     |
-| AC4   | TODO                   | Code review of test fixtures and assertions.      |
-| AC5   | TODO                   | `linter all` output.                              |
-| AC6   | TODO                   | Package test output.                              |
-| AC7   | TODO                   | Manual-verification table and evidence.           |
-| AC8   | TODO                   | Post-implementation review entry.                 |
-| AC9   | TODO                   | Relevant documentation diff.                      |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                       |
+| ----- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| AC1   | TODO                   | `coverage-evidence.md` records the command, scope, baseline, current totals, per-file detail, and prioritized follow-up areas. |
+| AC2   | TODO                   | Added test paths and test output.                                                                                              |
+| AC3   | TODO                   | Test output and review notes.                                                                                                  |
+| AC4   | TODO                   | Code review of test fixtures and assertions.                                                                                   |
+| AC5   | TODO                   | `linter all` output.                                                                                                           |
+| AC6   | TODO                   | Package test output.                                                                                                           |
+| AC7   | TODO                   | Manual-verification table and evidence.                                                                                        |
+| AC8   | TODO                   | Post-implementation review entry.                                                                                              |
+| AC9   | TODO                   | Relevant documentation diff.                                                                                                   |
 
 ## Risks and Trade-offs
 
 - The existing REST server fixture composes multiple services and can make contract tests expensive; prefer direct router tests when they exercise the correct transport boundary, while keeping higher-level tests that provide distinct value.
 - Tests that reach into private authentication helpers may constrain refactoring; favor HTTP-level authentication contracts unless a narrow unit test has clear value.
 - Configuration matrices can multiply test time; cover meaningful route-composition distinctions without duplicating equivalent endpoint tests.
+- Aggregate coverage can conceal low-coverage, high-risk files; mitigate it by recording human-readable per-file and uncovered-area evidence in `coverage-evidence.md` and selecting behavior by risk.
+- Generated raw coverage reports can be too large and tool-oriented for review; mitigate it by committing the concise evidence document and reproducible command instead.
 
 ## References
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,33 @@
+---
+semantic-links:
+  skill-links:
+    - write-unit-test
+  related-artifacts:
+    - .github/skills/dev/testing/write-unit-test/SKILL.md
+    - docs/testing/refactoring-patterns/README.md
+    - tests/AGENTS.md
+---
+
+# Testing
+
+This directory contains durable testing guidance shared by all workspace packages and the main
+application. It is not an issue-spec archive: patterns recorded here remain useful after their
+originating issue is closed.
+
+## References
+
+| Resource                                                                     | Purpose                                                                                                         |
+| ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| [Test refactoring-pattern catalog](refactoring-patterns/README.md)           | Reviewed examples for improving generated or existing test code without changing the behavior under test.       |
+| [Unit-test skill](../../.github/skills/dev/testing/write-unit-test/SKILL.md) | Required workflow and baseline conventions for writing package-local unit tests.                                |
+| [Application integration-test guidance](../../tests/AGENTS.md)               | Boundary selection, process isolation, lifecycle, and scenario guidance for main-application integration tests. |
+
+## Adding Catalog Entries
+
+Add one lowercase-kebab-case Markdown file per reviewed refactor under
+`docs/testing/refactoring-patterns/`. Each entry must state the problem, the selected pattern,
+when to use it, when not to use it, and a representative repository example. Keep the entry about
+test design rather than an issue's delivery history.
+
+Link the entry from the catalog README. When the entry changes the test-writing workflow, update
+the `write-unit-test` skill in the same change.

--- a/docs/testing/refactoring-patterns/README.md
+++ b/docs/testing/refactoring-patterns/README.md
@@ -1,0 +1,30 @@
+---
+semantic-links:
+  skill-links:
+    - write-unit-test
+  related-artifacts:
+    - docs/testing/README.md
+    - .github/skills/dev/testing/write-unit-test/SKILL.md
+---
+
+# Test Refactoring-Pattern Catalog
+
+Use this catalog when generated or existing test code is correct but does not clearly communicate
+the behavior it protects. Entries describe reviewed, repository-native patterns; they complement
+the mandatory conventions in the [unit-test skill](../../../.github/skills/dev/testing/write-unit-test/SKILL.md).
+
+## Entries
+
+| Pattern                                                                                                | Use it when                                                                                        | Representative source                                   |
+| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| [Scenario fixture with independent expected outputs](scenario-fixture-independent-expected-outputs.md) | One domain input must be verified through multiple independently decoded response representations. | `packages/axum-http-server/src/v1/handlers/announce.rs` |
+
+## Entry Requirements
+
+Each entry must include:
+
+1. The readability or maintainability problem that triggered the refactor.
+2. The selected pattern and its essential constraints.
+3. Appropriate and inappropriate uses.
+4. A repository source example and its originating issue, when applicable.
+5. How the pattern preserves deterministic execution and one behavior-focused contract.

--- a/docs/testing/refactoring-patterns/README.md
+++ b/docs/testing/refactoring-patterns/README.md
@@ -18,6 +18,7 @@ the mandatory conventions in the [unit-test skill](../../../.github/skills/dev/t
 | Pattern                                                                                                | Use it when                                                                                        | Representative source                                   |
 | ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | [Scenario fixture with independent expected outputs](scenario-fixture-independent-expected-outputs.md) | One domain input must be verified through multiple independently decoded response representations. | `packages/axum-http-server/src/v1/handlers/announce.rs` |
+| [Scenario fixtures for causal initial state](scenario-fixtures-for-causal-initial-state.md)            | Several setup operations establish the one state that makes the Act behave differently.            | `packages/axum-http-server/src/server.rs`               |
 
 ## Entry Requirements
 

--- a/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
+++ b/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
@@ -1,0 +1,72 @@
+---
+semantic-links:
+  skill-links:
+    - write-unit-test
+  related-artifacts:
+    - packages/axum-http-server/src/v1/handlers/announce.rs
+    - docs/testing/refactoring-patterns/README.md
+---
+
+# Scenario Fixture with Independent Expected Outputs
+
+## Problem
+
+The announce-response tests repeated many field assertions for the same decoded response. Moving
+those assertions into separate `expected_*` helper functions reduced repetition but separated the
+domain input from the expected protocol contracts. Readers had to find and mentally synchronize
+multiple fixtures, which made the scenario less expressive and created hidden coupling.
+
+## Pattern
+
+Represent one meaningful domain situation with a small test-only scenario type. It owns the domain
+input and each independently specified expected representation.
+
+```rust
+struct AnnounceResponseScenario {
+    announce_data: AnnounceData,
+    expected_normal: DeserializedNormal,
+    expected_compact: DeserializedCompact,
+}
+```
+
+Give the scenario an associated factory with a behavior-oriented name, such as
+`AnnounceResponseScenario::one_ipv4_seeder()`. Construct every expected value explicitly, and
+visibly set every input value that the expected output asserts. Do not derive expected values by
+calling the production mapping or response-building functions being tested.
+
+Each test keeps its distinguishing request condition local, then decodes and compares the whole
+observable response directly:
+
+```rust
+assert_eq!(decoded, scenario.expected_compact);
+```
+
+## Why This Works
+
+- **Expressive:** the factory identifies the real scenario rather than an implementation detail.
+- **Readable:** all related input and expected normal/compact contracts are adjacent.
+- **Maintainable:** changing the scenario updates one intentional test fixture instead of several
+  disconnected helpers and field assertions.
+- **Deterministic and fast:** the fixture has no clock, I/O, randomness, network listener, or
+  shared mutable state.
+- **One behavior-focused contract:** each test varies only the request's compact mode, so a failure
+  identifies the selected representation or its domain-to-protocol contract.
+
+## Use When
+
+- A single domain input has two or more observable protocol representations.
+- Response types implement `Debug` and `PartialEq`, making direct whole-value comparison useful.
+- Multiple tests differ only in a small selector such as a request flag or negotiated format.
+
+## Do Not Use When
+
+- The expected value is only used once and an inline literal is clearer.
+- A scenario would accumulate unrelated optional variants; split it into focused named scenarios.
+- Constructing an expected value would call the production code under test. Specify the contract
+  independently instead.
+
+## Repository Example
+
+[`packages/axum-http-server/src/v1/handlers/announce.rs`](../../../packages/axum-http-server/src/v1/handlers/announce.rs)
+uses this pattern to verify normal and compact bencoded announce responses. It was introduced
+during package-testing EPIC issue #1347, subissue #1348.

--- a/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
+++ b/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
@@ -18,33 +18,37 @@ multiple fixtures, which made the scenario less expressive and created hidden co
 
 ## Pattern
 
-Represent one meaningful domain situation with a small test-only scenario type. It owns the domain
-input and each independently specified expected representation.
+Represent one complete behavioral example with a small test-only scenario type. It owns the
+request, domain input, and independently specified expected response.
 
 ```rust
-struct AnnounceResponseScenario {
+struct AnnounceResponseScenario<TExpectedResponse> {
+  announce_request: Announce,
     announce_data: AnnounceData,
-    expected_normal: DeserializedNormal,
-    expected_compact: DeserializedCompact,
+  expected_response: TExpectedResponse,
 }
 ```
 
 Give the scenario an associated factory with a behavior-oriented name, such as
-`AnnounceResponseScenario::one_ipv4_seeder()`. Construct every expected value explicitly, and
-visibly set every input value that the expected output asserts. Do not derive expected values by
-calling the production mapping or response-building functions being tested.
+`AnnounceResponseScenario::compact_response_for_one_ipv4_seeder_when_accepted()`. A builder may
+hide fields that are irrelevant to the behavior, but the scenario owns all artifacts that form the
+example. Construct every expected value explicitly, and visibly set every input value that the
+expected output asserts. Do not derive expected values by calling the production mapping or
+response-building functions being tested.
 
-Each test keeps its distinguishing request condition local, then decodes and compares the whole
-observable response directly:
+Each test executes the production boundary with the complete scenario, then decodes and compares
+the whole observable response directly:
 
 ```rust
-assert_eq!(decoded, scenario.expected_compact);
+let response = build_response(&scenario.announce_request, scenario.announce_data);
+assert_eq!(decoded, scenario.expected_response);
 ```
 
 ## Why This Works
 
 - **Expressive:** the factory identifies the real scenario rather than an implementation detail.
-- **Readable:** all related input and expected normal/compact contracts are adjacent.
+- **Readable:** all related request, domain input, and expected response contracts belong to one
+  scenario.
 - **Maintainable:** changing the scenario updates one intentional test fixture instead of several
   disconnected helpers and field assertions.
 - **Deterministic and fast:** the fixture has no clock, I/O, randomness, network listener, or
@@ -56,7 +60,7 @@ assert_eq!(decoded, scenario.expected_compact);
 
 - A single domain input has two or more observable protocol representations.
 - Response types implement `Debug` and `PartialEq`, making direct whole-value comparison useful.
-- Multiple tests differ only in a small selector such as a request flag or negotiated format.
+- Related test artifacts form one concrete example, including the request that selects the result.
 
 ## Do Not Use When
 

--- a/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
+++ b/docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
@@ -23,9 +23,9 @@ request, domain input, and independently specified expected response.
 
 ```rust
 struct AnnounceResponseScenario<TExpectedResponse> {
-  announce_request: Announce,
+    announce_request: Announce,
     announce_data: AnnounceData,
-  expected_response: TExpectedResponse,
+    expected_response: TExpectedResponse,
 }
 ```
 
@@ -41,8 +41,15 @@ the whole observable response directly:
 
 ```rust
 let response = build_response(&scenario.announce_request, scenario.announce_data);
-assert_eq!(decoded, scenario.expected_response);
+let actual_response: DeserializedCompact = decode_successful_bencoded_response(response).await;
+
+assert_eq!(actual_response, scenario.expected_response);
 ```
+
+`decode_successful_bencoded_response` is a narrow test helper for repeated transport mechanics: it
+asserts the successful HTTP status, reads the body, and deserializes bencode. Keep the production
+boundary call, the expected response type, and the final behavioral assertion visible in each test.
+Do not use the helper to derive expected values or select a response representation.
 
 ## Why This Works
 

--- a/docs/testing/refactoring-patterns/scenario-fixtures-for-causal-initial-state.md
+++ b/docs/testing/refactoring-patterns/scenario-fixtures-for-causal-initial-state.md
@@ -1,0 +1,104 @@
+---
+semantic-links:
+  skill-links:
+    - write-unit-test
+  related-artifacts:
+    - packages/axum-http-server/src/server.rs
+    - docs/testing/refactoring-patterns/scenario-fixture-independent-expected-outputs.md
+    - docs/testing/refactoring-patterns/README.md
+---
+
+# Scenario Fixtures for Causal Initial State
+
+## Problem
+
+An Arrange section can consist of individually readable setup helpers while still concealing the
+condition that makes the test behave differently. For example, address reservation, configuration
+mutation, and registry seeding can leave readers to infer that the actual scenario is: "start a
+server whose binding is already registered." The test is then correct but difficult to understand,
+review, and extend.
+
+## Pattern
+
+First ask:
+
+> What is the one difference in initial state that makes this Act behave differently?
+
+Represent that answer with one focused test-only scenario fixture. Name the fixture after the
+causal condition, not after construction operations. For example,
+`ServerStartWithDuplicateRegistration` expresses the condition that makes a server start return a
+duplicate-registration error.
+
+The fixture owns the incidental mechanics required to establish that state: configuration selection
+or mutation, concrete dependency construction, resource allocation, and registry/database seeding.
+The test itself retains the production call under test and the observable assertions:
+
+```rust
+// Arrange
+let scenario = ServerStartWithDuplicateRegistration::new().await;
+
+// Act
+let result = HttpServer::new(scenario.launcher())
+    .start(scenario.container().await, scenario.registration_form(), scenario.metadata())
+    .await;
+
+// Assert
+assert_duplicate_binding_error(result, scenario.bind_address());
+```
+
+A scenario fixture may expose the concrete values needed for the Act, but it must not perform the
+Act, interpret its result, or assert it. Put comments about unavoidable setup constraints next to
+the mechanism inside the fixture, where maintainers can find the reason without obscuring the test.
+
+## Why This Works
+
+- **Expressive:** the Arrange section names the state that causes the selected behavior.
+- **Readable:** readers can understand the test without reconstructing a scenario from plumbing.
+- **Specific:** failures identify a business-relevant scenario rather than an arbitrary setup step.
+- **Maintainable:** detailed bootstrap logic has one discoverable home for that scenario.
+- **Extensible:** several focused fixtures form a catalog of important configuration and state
+  combinations, without forcing every test to duplicate their construction.
+- **Behavioral:** the test keeps the production boundary call and observable contract visible.
+
+## Use When
+
+- Several setup operations collectively establish one meaningful precondition.
+- The same state will be useful to understand, reuse, or vary in nearby tests.
+- Concrete dependencies are structurally required but not individually relevant to the behavior
+  being asserted.
+- The scenario varies a configuration, authorization state, persisted state, registration state, or
+  other condition that causally changes the Act's outcome.
+
+## Do Not Use When
+
+- An inline value states the condition more clearly than a new type.
+- The setup has no meaningful causal condition beyond ordinary valid input.
+- A readable builder chain already states the causal condition in the test body (see below).
+- The fixture would accumulate unrelated options or optional components to serve many tests;
+  split it into focused scenarios instead.
+- The fixture would hide the production call, expected outcome, or assertions.
+- The fixture would derive expected values by invoking production code under test.
+
+## Scenario Fixtures and Test Builders
+
+Scenario fixtures and test builders both make Arrange sections expressive. They solve different
+problems and are often used together.
+
+| Tool             | Reveals the causal state by…                                                     | Fits when…                                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| Test builder     | A readable call chain in the test body, e.g. `.private().with_expired_key(...)`. | The condition is one or two named choices on one object, and each test varies a different choice.                             |
+| Scenario fixture | A single type named for the resulting state.                                     | The condition emerges from several coordinated steps across objects, resources, or registries, and no chain reads as clearly. |
+
+A builder is the right choice when reading its chain tells you the scenario. A scenario fixture is
+the right choice when the scenario is a coordinated combination that a chain would only narrate. A
+fixture may use builders internally, and a scenario type may expose a small builder for the few
+variations it legitimately supports. Choose whichever leaves the test body stating the causal
+condition most directly; do not adopt one as a rule against the other.
+
+## Repository Example
+
+The duplicate-registration HTTP server-start test in
+[`packages/axum-http-server/src/server.rs`](../../../packages/axum-http-server/src/server.rs) is
+being refactored under package-testing EPIC issue #1347, subissue #1348. Its scenario fixture
+captures a server binding that is available to bind but already registered, while the test visibly
+starts the server and verifies both the typed error and listener cleanup.

--- a/packages/axum-http-server/Cargo.toml
+++ b/packages/axum-http-server/Cargo.toml
@@ -35,7 +35,7 @@ torrust-tracker-configuration = { version = "3.0.0", path = "../configuration" }
 torrust-net-primitives = "0.1.0"
 torrust-tracker-primitives = { version = "3.0.0", path = "../primitives" }
 torrust-tracker-swarm-coordination-registry = { version = "0.1.0", path = "../swarm-coordination-registry" }
-tower = { version = "0", features = [ "timeout" ] }
+tower = { version = "0", features = [ "timeout", "util" ] }
 tower-http = { version = "0", features = [ "compression-full", "cors", "propagate-header", "request-id", "trace" ] }
 tracing = "0"
 socket2 = "0.6.4"

--- a/packages/axum-http-server/README.md
+++ b/packages/axum-http-server/README.md
@@ -6,6 +6,32 @@ The Torrust Bittorrent HTTP tracker.
 
 [Crate documentation](https://docs.rs/torrust-tracker-axum-http-server).
 
+## Testing and Coverage
+
+This crate belongs to the Torrust Tracker Cargo workspace. Run its tests from the repository root:
+
+```text
+cargo test -p torrust-tracker-axum-http-server
+```
+
+Install [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) to measure coverage. From
+the repository root, run:
+
+```text
+cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --summary-only
+```
+
+When working from this package directory, use its manifest explicitly:
+
+```text
+cargo llvm-cov --manifest-path Cargo.toml --all-features --summary-only
+```
+
+Use `--json` instead of `--summary-only` when you need per-file, function, and region detail.
+Aggregate percentages are only a navigation aid: prioritize behavior risk and per-file gaps when
+choosing tests. For Issue #1348's current measurement method and coverage interpretation, see
+[`coverage-evidence.md`](../../docs/issues/open/1348-1347-add-tests-axum-http-server/coverage-evidence.md).
+
 ## License
 
 The project is licensed under the terms of the [GNU AFFERO GENERAL PUBLIC LICENSE](./LICENSE).

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -376,12 +376,12 @@ fn health_check_url(service_binding: &ServiceBinding) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::net::{Ipv4Addr, SocketAddr};
+    use std::net::{Ipv4Addr, SocketAddr, TcpListener};
     use std::sync::Arc;
 
     use tokio_util::sync::CancellationToken;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
-    use torrust_server_lib::registar::Registar;
+    use torrust_server_lib::registar::{Registar, RegistrationError, ServiceRegistration};
     use torrust_tracker_axum_server::tls::make_rust_tls;
     use torrust_tracker_configuration::v3_0_0::{Configuration, logging};
     use torrust_tracker_core::container::TrackerCoreContainer;
@@ -549,5 +549,51 @@ mod tests {
         let stopped = started.stop().await.expect("it should stop the server");
 
         assert_eq!(stopped.state.launcher.bind_to, bind_to);
+    }
+
+    #[tokio::test]
+    async fn it_should_preserve_registration_error_and_release_listener_when_registration_fails() {
+        // Arrange
+        let mut configuration = ephemeral_public();
+        let reserved_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve HTTP listener address");
+        let bind_to = reserved_listener.local_addr().expect("read reserved listener address");
+        drop(reserved_listener);
+        configuration.http_trackers.as_mut().expect("test configuration enables HTTP")[0].bind_address = bind_to;
+        let configuration = Arc::new(configuration);
+        let configuration_instance_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
+        let service_binding = ServiceBinding::new(Protocol::HTTP, bind_to).expect("HTTP service binding should be valid");
+        let registar = Registar::default();
+        registar
+            .give_form()
+            .register(ServiceRegistration::new(
+                service_binding,
+                RuntimeServiceMetadata::new(configuration_instance_id),
+                None,
+            ))
+            .await
+            .expect("reserve the HTTP service registration");
+        initialize_global_services(&configuration);
+        let http_tracker_container = Arc::new(initialize_container(&configuration).await);
+        let http_tracker_config = configuration.http_trackers.as_ref().expect("test configuration enables HTTP")[0].clone();
+
+        // Act
+        let result = HttpServer::new(Launcher::new(bind_to, None, http_tracker_config.network.ipv6_v6only))
+            .start(
+                http_tracker_container,
+                registar.give_form(),
+                RuntimeServiceMetadata::new(configuration_instance_id),
+            )
+            .await;
+
+        // Assert
+        let binding = match result {
+            Err(Error::Registration {
+                source: RegistrationError::DuplicateBinding(binding),
+            }) => binding,
+            Err(error) => panic!("HTTP starter should retain the registration failure source: {error}"),
+            Ok(_) => panic!("duplicate registration should fail"),
+        };
+        assert_eq!(binding.bind_address(), bind_to);
+        TcpListener::bind(bind_to).expect("HTTP listener should be released after registration failure");
     }
 }

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -381,7 +381,7 @@ mod tests {
 
     use tokio_util::sync::CancellationToken;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
-    use torrust_server_lib::registar::{Registar, RegistrationError, ServiceRegistration};
+    use torrust_server_lib::registar::{Registar, RegistrationError, ServiceRegistration, ServiceRegistrationForm};
     use torrust_tracker_axum_server::tls::make_rust_tls;
     use torrust_tracker_configuration::v3_0_0::{Configuration, logging};
     use torrust_tracker_core::container::TrackerCoreContainer;
@@ -512,6 +512,91 @@ mod tests {
         torrust_clock::initialize_static();
     }
 
+    /// A server-start scenario whose HTTP binding is available to the OS but already registered.
+    struct ServerStartWithDuplicateRegistration {
+        bind_to: SocketAddr,
+        configuration: Arc<Configuration>,
+        configuration_instance_id: ConfigurationInstanceId,
+        registar: Registar<RuntimeServiceMetadata>,
+    }
+
+    impl ServerStartWithDuplicateRegistration {
+        async fn new() -> Self {
+            let bind_to = Self::available_http_bind_address();
+            let configuration = Self::configuration_bound_to(bind_to);
+            let configuration_instance_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
+            let registar = Registar::default();
+
+            Self::pre_register_http_binding(&registar, bind_to, configuration_instance_id).await;
+
+            Self {
+                bind_to,
+                configuration,
+                configuration_instance_id,
+                registar,
+            }
+        }
+
+        fn available_http_bind_address() -> SocketAddr {
+            // Registration must fail after the server has bound this address, so the reservation is
+            // released before start. Do not add retries or waits: they would hide this OS-level handoff
+            // risk instead of preserving the cleanup contract under test.
+            let reserved_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve HTTP listener address");
+            let bind_to = reserved_listener.local_addr().expect("read reserved listener address");
+            drop(reserved_listener);
+
+            bind_to
+        }
+
+        fn configuration_bound_to(bind_to: SocketAddr) -> Arc<Configuration> {
+            let mut configuration = ephemeral_public();
+            configuration.http_trackers.as_mut().expect("test configuration enables HTTP")[0].bind_address = bind_to;
+
+            Arc::new(configuration)
+        }
+
+        async fn pre_register_http_binding(
+            registar: &Registar<RuntimeServiceMetadata>,
+            bind_to: SocketAddr,
+            configuration_instance_id: ConfigurationInstanceId,
+        ) {
+            let service_binding = ServiceBinding::new(Protocol::HTTP, bind_to).expect("HTTP service binding should be valid");
+
+            registar
+                .give_form()
+                .register(ServiceRegistration::new(
+                    service_binding,
+                    RuntimeServiceMetadata::new(configuration_instance_id),
+                    None,
+                ))
+                .await
+                .expect("reserve the HTTP service registration");
+        }
+
+        async fn container(&self) -> Arc<HttpTrackerCoreContainer> {
+            initialize_global_services(&self.configuration);
+            Arc::new(initialize_container(&self.configuration).await)
+        }
+
+        fn launcher(&self) -> Launcher {
+            let http_tracker_config = &self
+                .configuration
+                .http_trackers
+                .as_ref()
+                .expect("test configuration enables HTTP")[0];
+
+            Launcher::new(self.bind_to, None, http_tracker_config.network.ipv6_v6only)
+        }
+
+        fn registration_form(&self) -> ServiceRegistrationForm<RuntimeServiceMetadata> {
+            self.registar.give_form()
+        }
+
+        fn metadata(&self) -> RuntimeServiceMetadata {
+            RuntimeServiceMetadata::new(self.configuration_instance_id)
+        }
+    }
+
     #[tokio::test]
     async fn it_should_preserve_the_launcher_bind_address_after_starting_and_stopping() {
         // Arrange
@@ -554,38 +639,12 @@ mod tests {
     #[tokio::test]
     async fn it_should_release_the_listener_and_preserve_the_duplicate_binding_error_when_registration_fails() {
         // Arrange
-        let mut configuration = ephemeral_public();
-        // Registration must fail after the server has bound this address, so the reservation is
-        // released before start. Do not add retries or waits: they would hide this OS-level handoff
-        // risk instead of preserving the cleanup contract under test.
-        let reserved_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve HTTP listener address");
-        let bind_to = reserved_listener.local_addr().expect("read reserved listener address");
-        drop(reserved_listener);
-        configuration.http_trackers.as_mut().expect("test configuration enables HTTP")[0].bind_address = bind_to;
-        let configuration = Arc::new(configuration);
-        let configuration_instance_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
-        let service_binding = ServiceBinding::new(Protocol::HTTP, bind_to).expect("HTTP service binding should be valid");
-        let registar = Registar::default();
-        registar
-            .give_form()
-            .register(ServiceRegistration::new(
-                service_binding,
-                RuntimeServiceMetadata::new(configuration_instance_id),
-                None,
-            ))
-            .await
-            .expect("reserve the HTTP service registration");
-        initialize_global_services(&configuration);
-        let http_tracker_container = Arc::new(initialize_container(&configuration).await);
-        let http_tracker_config = configuration.http_trackers.as_ref().expect("test configuration enables HTTP")[0].clone();
+        let scenario = ServerStartWithDuplicateRegistration::new().await;
+        let http_tracker_container = scenario.container().await;
 
         // Act
-        let result = HttpServer::new(Launcher::new(bind_to, None, http_tracker_config.network.ipv6_v6only))
-            .start(
-                http_tracker_container,
-                registar.give_form(),
-                RuntimeServiceMetadata::new(configuration_instance_id),
-            )
+        let result = HttpServer::new(scenario.launcher())
+            .start(http_tracker_container, scenario.registration_form(), scenario.metadata())
             .await;
 
         // Assert
@@ -596,7 +655,7 @@ mod tests {
             Err(error) => panic!("HTTP starter should retain the registration failure source: {error}"),
             Ok(_) => panic!("duplicate registration should fail"),
         };
-        assert_eq!(binding.bind_address(), bind_to);
-        TcpListener::bind(bind_to).expect("HTTP listener should be released after registration failure");
+        assert_eq!(binding.bind_address(), scenario.bind_to);
+        TcpListener::bind(scenario.bind_to).expect("HTTP listener should be released after registration failure");
     }
 }

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -513,7 +513,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_be_able_to_start_and_stop() {
+    async fn it_should_preserve_the_launcher_bind_address_after_starting_and_stopping() {
+        // Arrange
         let configuration = Arc::new(ephemeral_public());
 
         let http_trackers = configuration
@@ -523,21 +524,19 @@ mod tests {
 
         let http_tracker_config = &http_trackers[0];
 
-        initialize_global_services(&configuration);
-
         let http_tracker_container = Arc::new(initialize_container(&configuration).await);
-
         let bind_to = http_tracker_config.bind_address;
-
         let tls = if let Some(tls_config) = &http_tracker_config.tls_config {
             Some(make_rust_tls(tls_config).await.expect("tls config failed"))
         } else {
             None
         };
-
         let register = &Registar::default();
         let stopped = HttpServer::new(Launcher::new(bind_to, tls, http_tracker_config.network.ipv6_v6only));
 
+        initialize_global_services(&configuration);
+
+        // Act
         let started = stopped
             .start(
                 http_tracker_container,
@@ -548,11 +547,12 @@ mod tests {
             .expect("it should start the server");
         let stopped = started.stop().await.expect("it should stop the server");
 
+        // Assert
         assert_eq!(stopped.state.launcher.bind_to, bind_to);
     }
 
     #[tokio::test]
-    async fn it_should_preserve_registration_error_and_release_listener_when_registration_fails() {
+    async fn it_should_release_the_listener_and_preserve_the_duplicate_binding_error_when_registration_fails() {
         // Arrange
         let mut configuration = ephemeral_public();
         let reserved_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve HTTP listener address");

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -555,6 +555,9 @@ mod tests {
     async fn it_should_release_the_listener_and_preserve_the_duplicate_binding_error_when_registration_fails() {
         // Arrange
         let mut configuration = ephemeral_public();
+        // Registration must fail after the server has bound this address, so the reservation is
+        // released before start. Do not add retries or waits: they would hide this OS-level handoff
+        // risk instead of preserving the cleanup contract under test.
         let reserved_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("reserve HTTP listener address");
         let bind_to = reserved_listener.local_addr().expect("read reserved listener address");
         drop(reserved_listener);

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -597,43 +597,75 @@ mod tests {
         }
     }
 
+    /// A server-start scenario whose HTTP binding is available to both the OS and the registry.
+    struct ServerStartWithAvailableHttpBinding {
+        bind_to: SocketAddr,
+        configuration: Arc<Configuration>,
+        configuration_instance_id: ConfigurationInstanceId,
+        registar: Registar<RuntimeServiceMetadata>,
+    }
+
+    impl ServerStartWithAvailableHttpBinding {
+        fn new() -> Self {
+            let configuration = Arc::new(ephemeral_public());
+            let bind_to = configuration
+                .http_trackers
+                .as_ref()
+                .expect("missing HTTP trackers configuration")[0]
+                .bind_address;
+
+            Self {
+                bind_to,
+                configuration,
+                configuration_instance_id: ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0),
+                registar: Registar::default(),
+            }
+        }
+
+        async fn container(&self) -> Arc<HttpTrackerCoreContainer> {
+            initialize_global_services(&self.configuration);
+            Arc::new(initialize_container(&self.configuration).await)
+        }
+
+        async fn launcher(&self) -> Launcher {
+            let http_tracker_config = &self
+                .configuration
+                .http_trackers
+                .as_ref()
+                .expect("missing HTTP trackers configuration")[0];
+            let tls = if let Some(tls_config) = &http_tracker_config.tls_config {
+                Some(make_rust_tls(tls_config).await.expect("tls config failed"))
+            } else {
+                None
+            };
+
+            Launcher::new(self.bind_to, tls, http_tracker_config.network.ipv6_v6only)
+        }
+
+        fn registration_form(&self) -> ServiceRegistrationForm<RuntimeServiceMetadata> {
+            self.registar.give_form()
+        }
+
+        fn metadata(&self) -> RuntimeServiceMetadata {
+            RuntimeServiceMetadata::new(self.configuration_instance_id)
+        }
+    }
+
     #[tokio::test]
     async fn it_should_preserve_the_launcher_bind_address_after_starting_and_stopping() {
         // Arrange
-        let configuration = Arc::new(ephemeral_public());
-
-        let http_trackers = configuration
-            .http_trackers
-            .clone()
-            .expect("missing HTTP trackers configuration");
-
-        let http_tracker_config = &http_trackers[0];
-
-        let http_tracker_container = Arc::new(initialize_container(&configuration).await);
-        let bind_to = http_tracker_config.bind_address;
-        let tls = if let Some(tls_config) = &http_tracker_config.tls_config {
-            Some(make_rust_tls(tls_config).await.expect("tls config failed"))
-        } else {
-            None
-        };
-        let register = &Registar::default();
-        let stopped = HttpServer::new(Launcher::new(bind_to, tls, http_tracker_config.network.ipv6_v6only));
-
-        initialize_global_services(&configuration);
+        let scenario = ServerStartWithAvailableHttpBinding::new();
+        let http_tracker_container = scenario.container().await;
 
         // Act
-        let started = stopped
-            .start(
-                http_tracker_container,
-                register.give_form(),
-                RuntimeServiceMetadata::new(ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0)),
-            )
+        let started = HttpServer::new(scenario.launcher().await)
+            .start(http_tracker_container, scenario.registration_form(), scenario.metadata())
             .await
             .expect("it should start the server");
         let stopped = started.stop().await.expect("it should stop the server");
 
         // Assert
-        assert_eq!(stopped.state.launcher.bind_to, bind_to);
+        assert_eq!(stopped.state.launcher.bind_to, scenario.bind_to);
     }
 
     #[tokio::test]

--- a/packages/axum-http-server/src/v1/extractors/authentication_key.rs
+++ b/packages/axum-http-server/src/v1/extractors/authentication_key.rs
@@ -128,7 +128,7 @@ mod tests {
 
     use super::parse_key;
 
-    fn assert_error_response(error: &Error, error_message: &str) {
+    fn assert_failure_reason_contains(error: &Error, error_message: &str) {
         assert!(
             error.failure_reason.contains(error_message),
             "Error response does not contain message: '{error_message}'. Error: {error:?}"
@@ -136,13 +136,16 @@ mod tests {
     }
 
     #[test]
-    fn it_should_return_an_authentication_error_if_the_key_cannot_be_parsed() {
+    fn it_should_map_an_invalid_path_key_to_an_invalid_key_format_authentication_failure() {
+        // Arrange
         let invalid_key = "invalid_key";
 
-        let response = parse_key(invalid_key).unwrap_err();
+        // Act
+        let actual_error_response = parse_key(invalid_key).unwrap_err();
 
-        assert_error_response(
-            &response,
+        // Assert
+        assert_failure_reason_contains(
+            &actual_error_response,
             "Tracker authentication error: Invalid format for authentication key param",
         );
     }

--- a/packages/axum-http-server/src/v1/extractors/authentication_key.rs
+++ b/packages/axum-http-server/src/v1/extractors/authentication_key.rs
@@ -124,9 +124,34 @@ fn custom_error(rejection: &PathRejection) -> responses::error::Error {
 #[cfg(test)]
 mod tests {
 
+    use axum::body::Body;
+    use axum::body::to_bytes;
+    use axum::http::StatusCode;
+    use axum::response::Response;
+    use axum::routing::get;
+    use axum::{Router, response::IntoResponse};
     use torrust_tracker_http_protocol::v1::responses::error::Error;
+    use tower::ServiceExt;
 
-    use super::{Key, parse_key};
+    use super::{Extract, Key, parse_key};
+
+    async fn protected_handler(Extract(_key): Extract) -> impl IntoResponse {
+        StatusCode::NO_CONTENT
+    }
+
+    async fn decode_bencoded_failure_response(response: Response) -> Error {
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a BitTorrent authentication failure response should use HTTP 200"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("the failure response body should be readable");
+
+        serde_bencode::from_bytes(&body).expect("the failure response should be valid bencode")
+    }
 
     fn assert_failure_reason_contains(error: &Error, error_message: &str) {
         assert!(
@@ -163,5 +188,25 @@ mod tests {
 
         // Assert
         assert_eq!(actual_key, expected_key);
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_an_invalid_key_format_failure_response_for_an_invalid_path_key() {
+        // Arrange
+        let router = Router::new().route("/{key}", get(protected_handler));
+        let request = axum::http::Request::builder()
+            .uri("/invalid_key")
+            .body(Body::empty())
+            .expect("the test request should be valid");
+
+        // Act
+        let response = router.oneshot(request).await.expect("the router should handle the request");
+        let actual_error_response = decode_bencoded_failure_response(response).await;
+
+        // Assert
+        assert_failure_reason_contains(
+            &actual_error_response,
+            "Tracker authentication error: Invalid format for authentication key param",
+        );
     }
 }

--- a/packages/axum-http-server/src/v1/extractors/authentication_key.rs
+++ b/packages/axum-http-server/src/v1/extractors/authentication_key.rs
@@ -10,7 +10,7 @@
 //! authentication errors.
 //!
 //! It returns a bencoded [`Error`](torrust_tracker_http_protocol::v1::responses::error)
-//! response (`500`) if the `key` parameter are missing or invalid.
+//! response with HTTP status `200 OK` if the `key` parameter is missing or invalid.
 //!
 //! **Sample authentication error responses**
 //!

--- a/packages/axum-http-server/src/v1/extractors/authentication_key.rs
+++ b/packages/axum-http-server/src/v1/extractors/authentication_key.rs
@@ -126,7 +126,7 @@ mod tests {
 
     use torrust_tracker_http_protocol::v1::responses::error::Error;
 
-    use super::parse_key;
+    use super::{Key, parse_key};
 
     fn assert_failure_reason_contains(error: &Error, error_message: &str) {
         assert!(
@@ -148,5 +148,20 @@ mod tests {
             &actual_error_response,
             "Tracker authentication error: Invalid format for authentication key param",
         );
+    }
+
+    #[test]
+    fn it_should_parse_a_valid_path_key() {
+        // Arrange
+        let valid_key = "YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ";
+        let expected_key = valid_key
+            .parse::<Key>()
+            .expect("the fixture should be a valid authentication key");
+
+        // Act
+        let actual_key = parse_key(valid_key).expect("a valid path key should be accepted");
+
+        // Assert
+        assert_eq!(actual_key, expected_key);
     }
 }

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -130,6 +130,9 @@ mod tests {
     use std::sync::Arc;
 
     use axum::body::to_bytes;
+    use axum::response::Response;
+    use hyper::StatusCode;
+    use serde::de::DeserializeOwned;
     use tokio_util::sync::CancellationToken;
     use torrust_tracker_configuration::v3_0_0::Configuration;
     use torrust_tracker_core::announce_handler::AnnounceHandler;
@@ -350,6 +353,23 @@ mod tests {
         }
     }
 
+    async fn decode_successful_bencoded_response<TExpectedResponse>(response: Response) -> TExpectedResponse
+    where
+        TExpectedResponse: DeserializeOwned,
+    {
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a successful announce response should use HTTP 200"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("announce response body should be readable");
+
+        serde_bencode::from_bytes(&body).expect("announce response should be valid bencode")
+    }
+
     fn sample_client_ip_sources() -> ClientIpSources {
         ClientIpSources {
             right_most_x_forwarded_for: None,
@@ -371,16 +391,10 @@ mod tests {
 
         // Act
         let response = super::build_response(&scenario.announce_request, scenario.announce_data);
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("announce response body should be readable");
-        let decoded: DeserializedNormal =
-            serde_bencode::from_bytes(&body).expect("response should be a non-compact bencoded announce response");
+        let actual_response: DeserializedNormal = decode_successful_bencoded_response(response).await;
 
         // Assert
-        assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_response);
+        assert_eq!(actual_response, scenario.expected_response);
     }
 
     #[tokio::test]
@@ -390,15 +404,10 @@ mod tests {
 
         // Act
         let response = super::build_response(&scenario.announce_request, scenario.announce_data);
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("announce response body should be readable");
-        let decoded = DeserializedCompact::from_bytes(&body).expect("response should be a compact bencoded announce response");
+        let actual_response: DeserializedCompact = decode_successful_bencoded_response(response).await;
 
         // Assert
-        assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_response);
+        assert_eq!(actual_response, scenario.expected_response);
     }
 
     #[tokio::test]
@@ -408,15 +417,10 @@ mod tests {
 
         // Act
         let response = super::build_response(&scenario.announce_request, scenario.announce_data);
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("announce response body should be readable");
-        let decoded = DeserializedCompact::from_bytes(&body).expect("response should be a compact bencoded announce response");
+        let actual_response: DeserializedCompact = decode_successful_bencoded_response(response).await;
 
         // Assert
-        assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_response);
+        assert_eq!(actual_response, scenario.expected_response);
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -126,8 +126,10 @@ fn to_protocol_announce_data(domain_data: DomainAnnounceData) -> responses::anno
 #[cfg(test)]
 mod tests {
 
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
 
+    use axum::body::to_bytes;
     use tokio_util::sync::CancellationToken;
     use torrust_tracker_configuration::v3_0_0::Configuration;
     use torrust_tracker_core::announce_handler::AnnounceHandler;
@@ -146,7 +148,9 @@ mod tests {
     use torrust_tracker_http_protocol::v1::requests::announce::{Announce, PeerIp};
     use torrust_tracker_http_protocol::v1::responses;
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
-    use torrust_tracker_primitives::{ConfigurationInstanceId, PeerId, ServiceRole};
+    use torrust_tracker_primitives::peer::fixture::PeerBuilder;
+    use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+    use torrust_tracker_primitives::{AnnounceData, AnnouncePolicy, ConfigurationInstanceId, PeerId, ServiceRole};
     use torrust_tracker_test_helpers::configuration;
 
     use crate::tests::helpers::sample_info_hash;
@@ -270,6 +274,102 @@ mod tests {
             error.failure_reason.contains(error_message),
             "Error response does not contain message: '{error_message}'. Error: {error:?}"
         );
+    }
+
+    fn sample_announce_data() -> AnnounceData {
+        AnnounceData {
+            peers: vec![Arc::new(
+                PeerBuilder::seeder()
+                    .with_peer_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+                    .build(),
+            )],
+            stats: SwarmMetadata {
+                complete: 3,
+                downloaded: 2,
+                incomplete: 4,
+            },
+            policy: AnnouncePolicy {
+                interval: 60,
+                interval_min: 30,
+                max_peers_per_announce: 74,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_a_non_compact_bencoded_response_when_compact_is_not_accepted() {
+        // Arrange
+        let announce_request = Announce {
+            compact: Some(torrust_tracker_http_protocol::v1::requests::announce::Compact::NotAccepted),
+            ..sample_announce_request()
+        };
+
+        // Act
+        let response = super::build_response(&announce_request, sample_announce_data());
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("announce response body should be readable");
+        let decoded: responses::announce::deserialization::DeserializedNormal =
+            serde_bencode::from_bytes(&body).expect("response should be a non-compact bencoded announce response");
+
+        // Assert
+        assert_eq!(status, hyper::StatusCode::OK);
+        assert_eq!(decoded.complete, 3);
+        assert_eq!(decoded.incomplete, 4);
+        assert_eq!(decoded.interval, 60);
+        assert_eq!(decoded.min_interval, 30);
+        assert_eq!(decoded.peers.len(), 1);
+        assert_eq!(decoded.peers[0].ip, "127.0.0.1");
+        assert_eq!(decoded.peers[0].peer_id, b"-qB00000000000000001");
+        assert_eq!(decoded.peers[0].port, 8080);
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_a_compact_bencoded_response_when_compact_is_omitted() {
+        // Arrange
+        let announce_request = sample_announce_request();
+
+        // Act
+        let response = super::build_response(&announce_request, sample_announce_data());
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("announce response body should be readable");
+        let decoded = responses::announce::deserialization::DeserializedCompact::from_bytes(&body)
+            .expect("response should be a compact bencoded announce response");
+
+        // Assert
+        assert_eq!(status, hyper::StatusCode::OK);
+        assert_eq!(decoded.complete, 3);
+        assert_eq!(decoded.incomplete, 4);
+        assert_eq!(decoded.interval, 60);
+        assert_eq!(decoded.min_interval, 30);
+        assert_eq!(decoded.peers, [127, 0, 0, 1, 0x1f, 0x90]);
+        assert!(decoded.peers6.is_empty());
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_a_compact_bencoded_response_when_compact_is_accepted() {
+        // Arrange
+        let announce_request = Announce {
+            compact: Some(torrust_tracker_http_protocol::v1::requests::announce::Compact::Accepted),
+            ..sample_announce_request()
+        };
+
+        // Act
+        let response = super::build_response(&announce_request, sample_announce_data());
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("announce response body should be readable");
+        let decoded = responses::announce::deserialization::DeserializedCompact::from_bytes(&body)
+            .expect("response should be a compact bencoded announce response");
+
+        // Assert
+        assert_eq!(status, hyper::StatusCode::OK);
+        assert_eq!(decoded.peers, [127, 0, 0, 1, 0x1f, 0x90]);
+        assert!(decoded.peers6.is_empty());
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -134,6 +134,7 @@ mod tests {
     use hyper::StatusCode;
     use serde::de::DeserializeOwned;
     use tokio_util::sync::CancellationToken;
+    use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_configuration::v3_0_0::Configuration;
     use torrust_tracker_core::announce_handler::AnnounceHandler;
     use torrust_tracker_core::authentication::key::repository::in_memory::InMemoryKeyRepository;
@@ -332,6 +333,12 @@ mod tests {
         }
     }
 
+    fn sample_http_service_binding() -> ServiceBinding {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
+
+        ServiceBinding::new(Protocol::HTTP, address).expect("the sample HTTP service binding should be valid")
+    }
+
     fn one_ipv4_seeder_announce_data() -> AnnounceData {
         AnnounceData {
             peers: vec![Arc::new(
@@ -377,7 +384,7 @@ mod tests {
         }
     }
 
-    fn assert_error_response(error: &responses::error::Error, error_message: &str) {
+    fn assert_failure_reason_contains(error: &responses::error::Error, error_message: &str) {
         assert!(
             error.failure_reason.contains(error_message),
             "Error response does not contain message: '{error_message}'. Error: {error:?}"
@@ -425,66 +432,66 @@ mod tests {
 
     mod with_tracker_in_private_mode {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_core::authentication;
         use torrust_tracker_http_protocol::v1::responses;
 
-        use super::{initialize_private_tracker, sample_announce_request, sample_client_ip_sources};
+        use super::{
+            assert_failure_reason_contains, initialize_private_tracker, sample_announce_request, sample_client_ip_sources,
+            sample_http_service_binding,
+        };
         use crate::v1::handlers::announce::handle_announce;
-        use crate::v1::handlers::announce::tests::assert_error_response;
 
         #[tokio::test]
         async fn it_should_fail_when_the_authentication_key_is_missing() {
+            // Arrange
             let http_core_tracker_services = initialize_private_tracker().await;
-
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
             let maybe_key = None;
 
-            let response = handle_announce(
+            // Act
+            let actual_error = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &sample_client_ip_sources(),
-                &server_service_binding,
+                &sample_http_service_binding(),
                 maybe_key,
             )
             .await
             .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(&error_response, "Tracker authentication error: Missing authentication key");
+            assert_failure_reason_contains(
+                &actual_error_response,
+                "Tracker authentication error: Missing authentication key",
+            );
         }
 
         #[tokio::test]
         async fn it_should_fail_when_the_authentication_key_is_invalid() {
+            // Arrange
             let http_core_tracker_services = initialize_private_tracker().await;
-
             let unregistered_key = authentication::Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
-
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
             let maybe_key = Some(unregistered_key);
 
-            let response = handle_announce(
+            // Act
+            let actual_error = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &sample_client_ip_sources(),
-                &server_service_binding,
+                &sample_http_service_binding(),
                 maybe_key,
             )
             .await
             .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 "Tracker authentication error: Failed to read key: YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ",
             );
         }
@@ -492,38 +499,36 @@ mod tests {
 
     mod with_tracker_in_listed_mode {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_protocol::v1::responses;
 
-        use super::{initialize_listed_tracker, sample_announce_request, sample_client_ip_sources};
+        use super::{
+            assert_failure_reason_contains, initialize_listed_tracker, sample_announce_request, sample_client_ip_sources,
+            sample_http_service_binding,
+        };
         use crate::v1::handlers::announce::handle_announce;
-        use crate::v1::handlers::announce::tests::assert_error_response;
 
         #[tokio::test]
         async fn it_should_fail_when_the_announced_torrent_is_not_whitelisted() {
+            // Arrange
             let http_core_tracker_services = initialize_listed_tracker().await;
-
             let announce_request = sample_announce_request();
 
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
-            let response = handle_announce(
+            // Act
+            let actual_error = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &announce_request,
                 &sample_client_ip_sources(),
-                &server_service_binding,
+                &sample_http_service_binding(),
                 None,
             )
             .await
             .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 &format!(
                     "Tracker whitelist error: The torrent: {}, is not whitelisted",
                     announce_request.info_hash
@@ -534,42 +539,40 @@ mod tests {
 
     mod with_tracker_on_reverse_proxy {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_protocol::v1::responses;
         use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
-        use super::{initialize_tracker_on_reverse_proxy, sample_announce_request};
+        use super::{
+            assert_failure_reason_contains, initialize_tracker_on_reverse_proxy, sample_announce_request,
+            sample_http_service_binding,
+        };
         use crate::v1::handlers::announce::handle_announce;
-        use crate::v1::handlers::announce::tests::assert_error_response;
 
         #[tokio::test]
         async fn it_should_fail_when_the_right_most_x_forwarded_for_header_ip_is_not_available() {
+            // Arrange
             let http_core_tracker_services = initialize_tracker_on_reverse_proxy().await;
-
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
                 connection_info_socket_address: None,
             };
 
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
-            let response = handle_announce(
+            // Act
+            let actual_error = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &client_ip_sources,
-                &server_service_binding,
+                &sample_http_service_binding(),
                 None,
             )
             .await
             .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 "Error resolving peer IP: missing or invalid the right most X-Forwarded-For IP",
             );
         }
@@ -577,42 +580,40 @@ mod tests {
 
     mod with_tracker_not_on_reverse_proxy {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_protocol::v1::responses;
         use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
-        use super::{initialize_tracker_not_on_reverse_proxy, sample_announce_request};
+        use super::{
+            assert_failure_reason_contains, initialize_tracker_not_on_reverse_proxy, sample_announce_request,
+            sample_http_service_binding,
+        };
         use crate::v1::handlers::announce::handle_announce;
-        use crate::v1::handlers::announce::tests::assert_error_response;
 
         #[tokio::test]
         async fn it_should_fail_when_the_client_ip_from_the_connection_info_is_not_available() {
+            // Arrange
             let http_core_tracker_services = initialize_tracker_not_on_reverse_proxy().await;
-
             let client_ip_sources = ClientIpSources {
                 right_most_x_forwarded_for: None,
                 connection_info_socket_address: None,
             };
 
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
-            let response = handle_announce(
+            // Act
+            let actual_error = handle_announce(
                 &http_core_tracker_services.announce_service,
                 &sample_announce_request(),
                 &client_ip_sources,
-                &server_service_binding,
+                &sample_http_service_binding(),
                 None,
             )
             .await
             .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 "Error resolving peer IP: cannot get the client IP from the connection info",
             );
         }

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -162,34 +162,21 @@ mod tests {
         pub announce_service: Arc<AnnounceService>,
     }
 
-    struct AnnounceResponseScenario {
+    struct AnnounceResponseScenario<TExpectedResponse> {
+        announce_request: Announce,
         announce_data: AnnounceData,
-        expected_normal: DeserializedNormal,
-        expected_compact: DeserializedCompact,
+        expected_response: TExpectedResponse,
     }
 
-    impl AnnounceResponseScenario {
-        fn one_ipv4_seeder() -> Self {
+    impl AnnounceResponseScenario<DeserializedNormal> {
+        fn non_compact_response_for_one_ipv4_seeder() -> Self {
             Self {
-                announce_data: AnnounceData {
-                    peers: vec![Arc::new(
-                        PeerBuilder::seeder()
-                            .with_peer_id(&PeerId(*b"-qB00000000000000001"))
-                            .with_peer_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
-                            .build(),
-                    )],
-                    stats: SwarmMetadata {
-                        complete: 3,
-                        downloaded: 2, // Not represented in the announce response.
-                        incomplete: 4,
-                    },
-                    policy: AnnouncePolicy {
-                        interval: 60,
-                        interval_min: 30,
-                        max_peers_per_announce: 74, // Not represented in the announce response.
-                    },
+                announce_request: Announce {
+                    compact: Some(Compact::NotAccepted),
+                    ..sample_announce_request()
                 },
-                expected_normal: DeserializedNormal {
+                announce_data: one_ipv4_seeder_announce_data(),
+                expected_response: DeserializedNormal {
                     complete: 3,
                     incomplete: 4,
                     interval: 60,
@@ -200,7 +187,34 @@ mod tests {
                         port: 8080,
                     }],
                 },
-                expected_compact: DeserializedCompact {
+            }
+        }
+    }
+
+    impl AnnounceResponseScenario<DeserializedCompact> {
+        fn compact_response_for_one_ipv4_seeder_when_omitted() -> Self {
+            Self {
+                announce_request: sample_announce_request(),
+                announce_data: one_ipv4_seeder_announce_data(),
+                expected_response: DeserializedCompact {
+                    complete: 3,
+                    incomplete: 4,
+                    interval: 60,
+                    min_interval: 30,
+                    peers: vec![127, 0, 0, 1, 0x1f, 0x90],
+                    peers6: Vec::new(),
+                },
+            }
+        }
+
+        fn compact_response_for_one_ipv4_seeder_when_accepted() -> Self {
+            Self {
+                announce_request: Announce {
+                    compact: Some(Compact::Accepted),
+                    ..sample_announce_request()
+                },
+                announce_data: one_ipv4_seeder_announce_data(),
+                expected_response: DeserializedCompact {
                     complete: 3,
                     incomplete: 4,
                     interval: 60,
@@ -315,6 +329,27 @@ mod tests {
         }
     }
 
+    fn one_ipv4_seeder_announce_data() -> AnnounceData {
+        AnnounceData {
+            peers: vec![Arc::new(
+                PeerBuilder::seeder()
+                    .with_peer_id(&PeerId(*b"-qB00000000000000001"))
+                    .with_peer_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+                    .build(),
+            )],
+            stats: SwarmMetadata {
+                complete: 3,
+                downloaded: 2, // Not represented in the announce response.
+                incomplete: 4,
+            },
+            policy: AnnouncePolicy {
+                interval: 60,
+                interval_min: 30,
+                max_peers_per_announce: 74, // Not represented in the announce response.
+            },
+        }
+    }
+
     fn sample_client_ip_sources() -> ClientIpSources {
         ClientIpSources {
             right_most_x_forwarded_for: None,
@@ -332,14 +367,10 @@ mod tests {
     #[tokio::test]
     async fn it_should_encode_a_non_compact_bencoded_response_when_compact_is_not_accepted() {
         // Arrange
-        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
-        let announce_request = Announce {
-            compact: Some(Compact::NotAccepted),
-            ..sample_announce_request()
-        };
+        let scenario = AnnounceResponseScenario::non_compact_response_for_one_ipv4_seeder();
 
         // Act
-        let response = super::build_response(&announce_request, scenario.announce_data);
+        let response = super::build_response(&scenario.announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
@@ -349,17 +380,16 @@ mod tests {
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_normal);
+        assert_eq!(decoded, scenario.expected_response);
     }
 
     #[tokio::test]
     async fn it_should_encode_a_compact_bencoded_response_when_compact_is_omitted() {
         // Arrange
-        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
-        let announce_request = sample_announce_request();
+        let scenario = AnnounceResponseScenario::compact_response_for_one_ipv4_seeder_when_omitted();
 
         // Act
-        let response = super::build_response(&announce_request, scenario.announce_data);
+        let response = super::build_response(&scenario.announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
@@ -368,20 +398,16 @@ mod tests {
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_compact);
+        assert_eq!(decoded, scenario.expected_response);
     }
 
     #[tokio::test]
     async fn it_should_encode_a_compact_bencoded_response_when_compact_is_accepted() {
         // Arrange
-        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
-        let announce_request = Announce {
-            compact: Some(Compact::Accepted),
-            ..sample_announce_request()
-        };
+        let scenario = AnnounceResponseScenario::compact_response_for_one_ipv4_seeder_when_accepted();
 
         // Act
-        let response = super::build_response(&announce_request, scenario.announce_data);
+        let response = super::build_response(&scenario.announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
@@ -390,7 +416,7 @@ mod tests {
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded, scenario.expected_compact);
+        assert_eq!(decoded, scenario.expected_response);
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -145,8 +145,11 @@ mod tests {
     use torrust_tracker_http_core::services::announce::AnnounceService;
     use torrust_tracker_http_core::statistics::event::listener::run_event_listener;
     use torrust_tracker_http_core::statistics::repository::Repository;
-    use torrust_tracker_http_protocol::v1::requests::announce::{Announce, PeerIp};
+    use torrust_tracker_http_protocol::v1::requests::announce::{Announce, Compact, PeerIp};
     use torrust_tracker_http_protocol::v1::responses;
+    use torrust_tracker_http_protocol::v1::responses::announce::deserialization::{
+        DeserializedCompact, DeserializedNormal, DictionaryPeer,
+    };
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
     use torrust_tracker_primitives::peer::fixture::PeerBuilder;
     use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
@@ -157,6 +160,56 @@ mod tests {
 
     struct CoreHttpTrackerServices {
         pub announce_service: Arc<AnnounceService>,
+    }
+
+    struct AnnounceResponseScenario {
+        announce_data: AnnounceData,
+        expected_normal: DeserializedNormal,
+        expected_compact: DeserializedCompact,
+    }
+
+    impl AnnounceResponseScenario {
+        fn one_ipv4_seeder() -> Self {
+            Self {
+                announce_data: AnnounceData {
+                    peers: vec![Arc::new(
+                        PeerBuilder::seeder()
+                            .with_peer_id(&PeerId(*b"-qB00000000000000001"))
+                            .with_peer_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
+                            .build(),
+                    )],
+                    stats: SwarmMetadata {
+                        complete: 3,
+                        downloaded: 2, // Not represented in the announce response.
+                        incomplete: 4,
+                    },
+                    policy: AnnouncePolicy {
+                        interval: 60,
+                        interval_min: 30,
+                        max_peers_per_announce: 74, // Not represented in the announce response.
+                    },
+                },
+                expected_normal: DeserializedNormal {
+                    complete: 3,
+                    incomplete: 4,
+                    interval: 60,
+                    min_interval: 30,
+                    peers: vec![DictionaryPeer {
+                        ip: "127.0.0.1".to_string(),
+                        peer_id: b"-qB00000000000000001".to_vec(),
+                        port: 8080,
+                    }],
+                },
+                expected_compact: DeserializedCompact {
+                    complete: 3,
+                    incomplete: 4,
+                    interval: 60,
+                    min_interval: 30,
+                    peers: vec![127, 0, 0, 1, 0x1f, 0x90],
+                    peers6: Vec::new(),
+                },
+            }
+        }
     }
 
     async fn initialize_private_tracker() -> CoreHttpTrackerServices {
@@ -276,100 +329,68 @@ mod tests {
         );
     }
 
-    fn sample_announce_data() -> AnnounceData {
-        AnnounceData {
-            peers: vec![Arc::new(
-                PeerBuilder::seeder()
-                    .with_peer_address(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080))
-                    .build(),
-            )],
-            stats: SwarmMetadata {
-                complete: 3,
-                downloaded: 2,
-                incomplete: 4,
-            },
-            policy: AnnouncePolicy {
-                interval: 60,
-                interval_min: 30,
-                max_peers_per_announce: 74,
-            },
-        }
-    }
-
     #[tokio::test]
     async fn it_should_encode_a_non_compact_bencoded_response_when_compact_is_not_accepted() {
         // Arrange
+        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
         let announce_request = Announce {
-            compact: Some(torrust_tracker_http_protocol::v1::requests::announce::Compact::NotAccepted),
+            compact: Some(Compact::NotAccepted),
             ..sample_announce_request()
         };
 
         // Act
-        let response = super::build_response(&announce_request, sample_announce_data());
+        let response = super::build_response(&announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("announce response body should be readable");
-        let decoded: responses::announce::deserialization::DeserializedNormal =
+        let decoded: DeserializedNormal =
             serde_bencode::from_bytes(&body).expect("response should be a non-compact bencoded announce response");
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded.complete, 3);
-        assert_eq!(decoded.incomplete, 4);
-        assert_eq!(decoded.interval, 60);
-        assert_eq!(decoded.min_interval, 30);
-        assert_eq!(decoded.peers.len(), 1);
-        assert_eq!(decoded.peers[0].ip, "127.0.0.1");
-        assert_eq!(decoded.peers[0].peer_id, b"-qB00000000000000001");
-        assert_eq!(decoded.peers[0].port, 8080);
+        assert_eq!(decoded, scenario.expected_normal);
     }
 
     #[tokio::test]
     async fn it_should_encode_a_compact_bencoded_response_when_compact_is_omitted() {
         // Arrange
+        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
         let announce_request = sample_announce_request();
 
         // Act
-        let response = super::build_response(&announce_request, sample_announce_data());
+        let response = super::build_response(&announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("announce response body should be readable");
-        let decoded = responses::announce::deserialization::DeserializedCompact::from_bytes(&body)
-            .expect("response should be a compact bencoded announce response");
+        let decoded = DeserializedCompact::from_bytes(&body).expect("response should be a compact bencoded announce response");
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded.complete, 3);
-        assert_eq!(decoded.incomplete, 4);
-        assert_eq!(decoded.interval, 60);
-        assert_eq!(decoded.min_interval, 30);
-        assert_eq!(decoded.peers, [127, 0, 0, 1, 0x1f, 0x90]);
-        assert!(decoded.peers6.is_empty());
+        assert_eq!(decoded, scenario.expected_compact);
     }
 
     #[tokio::test]
     async fn it_should_encode_a_compact_bencoded_response_when_compact_is_accepted() {
         // Arrange
+        let scenario = AnnounceResponseScenario::one_ipv4_seeder();
         let announce_request = Announce {
-            compact: Some(torrust_tracker_http_protocol::v1::requests::announce::Compact::Accepted),
+            compact: Some(Compact::Accepted),
             ..sample_announce_request()
         };
 
         // Act
-        let response = super::build_response(&announce_request, sample_announce_data());
+        let response = super::build_response(&announce_request, scenario.announce_data);
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX)
             .await
             .expect("announce response body should be readable");
-        let decoded = responses::announce::deserialization::DeserializedCompact::from_bytes(&body)
-            .expect("response should be a compact bencoded announce response");
+        let decoded = DeserializedCompact::from_bytes(&body).expect("response should be a compact bencoded announce response");
 
         // Assert
         assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(decoded.peers, [127, 0, 0, 1, 0x1f, 0x90]);
-        assert!(decoded.peers6.is_empty());
+        assert_eq!(decoded, scenario.expected_compact);
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -118,7 +118,6 @@ mod tests {
     use std::str::FromStr;
     use std::sync::Arc;
 
-    use tokio_util::sync::CancellationToken;
     use torrust_info_hash::InfoHash;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_configuration::v3_0_0::Configuration;
@@ -128,11 +127,7 @@ mod tests {
     use torrust_tracker_core::torrent::repository::in_memory::InMemoryTorrentRepository;
     use torrust_tracker_core::whitelist::authorization::WhitelistAuthorization;
     use torrust_tracker_core::whitelist::repository::in_memory::InMemoryWhitelist;
-    use torrust_tracker_http_core::event::bus::EventBus;
-    use torrust_tracker_http_core::event::sender::Broadcaster;
     use torrust_tracker_http_core::services::scrape::ScrapeService;
-    use torrust_tracker_http_core::statistics::event::listener::run_event_listener;
-    use torrust_tracker_http_core::statistics::repository::Repository;
     use torrust_tracker_http_protocol::v1::requests::scrape::Scrape;
     use torrust_tracker_http_protocol::v1::responses;
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
@@ -161,7 +156,6 @@ mod tests {
     }
 
     fn initialize_core_tracker_services(config: &Configuration) -> TestServices {
-        let cancellation_token = CancellationToken::new();
         let configuration_instance_id = config
             .http_trackers
             .as_deref()
@@ -185,30 +179,11 @@ mod tests {
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
-        // HTTP core stats
-        let http_core_broadcaster = Broadcaster::default();
-        let http_stats_repository = Arc::new(Repository::new());
-        let http_stats_event_bus = Arc::new(EventBus::new(
-            config.core.tracker_usage_statistics.into(),
-            http_core_broadcaster.clone(),
-        ));
-
-        let http_stats_event_sender = http_stats_event_bus.sender();
-
-        if config.core.tracker_usage_statistics {
-            let _unused = run_event_listener(
-                http_stats_event_bus.receiver(),
-                cancellation_token,
-                &http_stats_repository,
-                [(configuration_instance_id, true)].into(),
-            );
-        }
-
         let scrape_service = Arc::new(ScrapeService::new_with_http_tracker_config(
             core_config,
             scrape_handler,
             authentication_service,
-            http_stats_event_sender,
+            None,
             &http_tracker_config,
             configuration_instance_id,
         ));

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -1,4 +1,4 @@
-//! Axum [`handlers`](axum#handlers) for the `announce` requests.
+//! Axum [`handlers`](axum#handlers) for the `scrape` requests.
 //!
 //! The handlers perform the authentication and authorization of the request,
 //! and resolve the client IP address.

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -122,7 +122,6 @@ mod tests {
     use torrust_info_hash::InfoHash;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_configuration::v3_0_0::Configuration;
-    use torrust_tracker_configuration::v3_0_0::core::Core;
     use torrust_tracker_core::authentication::key::repository::in_memory::InMemoryKeyRepository;
     use torrust_tracker_core::authentication::service::AuthenticationService;
     use torrust_tracker_core::scrape_handler::ScrapeHandler;
@@ -141,35 +140,27 @@ mod tests {
     use torrust_tracker_primitives::{ConfigurationInstanceId, ScrapeData, ServiceRole};
     use torrust_tracker_test_helpers::configuration;
 
-    struct CoreTrackerServices {
-        pub core_config: Arc<Core>,
-        pub scrape_handler: Arc<ScrapeHandler>,
-        pub authentication_service: Arc<AuthenticationService>,
+    struct TestServices {
+        pub scrape_service: Arc<ScrapeService>,
     }
 
-    struct CoreHttpTrackerServices {
-        pub http_stats_event_sender: torrust_tracker_http_core::event::sender::Sender,
-        pub http_tracker_config: Arc<torrust_tracker_configuration::v3_0_0::http_tracker::HttpTracker>,
-        pub configuration_instance_id: ConfigurationInstanceId,
-    }
-
-    fn initialize_private_tracker() -> (CoreTrackerServices, CoreHttpTrackerServices) {
+    fn initialize_private_tracker() -> TestServices {
         initialize_core_tracker_services(&configuration::ephemeral_private())
     }
 
-    fn initialize_listed_tracker() -> (CoreTrackerServices, CoreHttpTrackerServices) {
+    fn initialize_listed_tracker() -> TestServices {
         initialize_core_tracker_services(&configuration::ephemeral_listed())
     }
 
-    fn initialize_tracker_on_reverse_proxy() -> (CoreTrackerServices, CoreHttpTrackerServices) {
+    fn initialize_tracker_on_reverse_proxy() -> TestServices {
         initialize_core_tracker_services(&configuration::ephemeral_with_reverse_proxy())
     }
 
-    fn initialize_tracker_not_on_reverse_proxy() -> (CoreTrackerServices, CoreHttpTrackerServices) {
+    fn initialize_tracker_not_on_reverse_proxy() -> TestServices {
         initialize_core_tracker_services(&configuration::ephemeral_without_reverse_proxy())
     }
 
-    fn initialize_core_tracker_services(config: &Configuration) -> (CoreTrackerServices, CoreHttpTrackerServices) {
+    fn initialize_core_tracker_services(config: &Configuration) -> TestServices {
         let cancellation_token = CancellationToken::new();
         let configuration_instance_id = config
             .http_trackers
@@ -180,13 +171,11 @@ mod tests {
             .next()
             .map(|(index, _)| ConfigurationInstanceId::new(ServiceRole::HttpTracker, index))
             .expect("the test configuration should contain an HTTP tracker");
-        let http_tracker_config = Arc::new(
-            config
-                .http_trackers
-                .as_ref()
-                .expect("the test configuration should contain an HTTP tracker")[0]
-                .clone(),
-        );
+        let http_tracker_config = config
+            .http_trackers
+            .as_ref()
+            .expect("the test configuration should contain an HTTP tracker")[0]
+            .clone();
 
         let core_config = Arc::new(config.core.clone());
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
@@ -215,18 +204,16 @@ mod tests {
             );
         }
 
-        (
-            CoreTrackerServices {
-                core_config,
-                scrape_handler,
-                authentication_service,
-            },
-            CoreHttpTrackerServices {
-                http_stats_event_sender,
-                http_tracker_config,
-                configuration_instance_id,
-            },
-        )
+        let scrape_service = Arc::new(ScrapeService::new_with_http_tracker_config(
+            core_config,
+            scrape_handler,
+            authentication_service,
+            http_stats_event_sender,
+            &http_tracker_config,
+            configuration_instance_id,
+        ));
+
+        TestServices { scrape_service }
     }
 
     fn sample_scrape_request() -> Scrape {
@@ -324,19 +311,11 @@ mod tests {
     #[tokio::test]
     async fn it_should_encode_a_bencoded_failure_response_when_the_client_ip_cannot_be_resolved() {
         // Arrange
-        let (core_tracker_services, core_http_tracker_services) = initialize_tracker_on_reverse_proxy();
-        let scrape_service = Arc::new(ScrapeService::new_with_http_tracker_config(
-            core_tracker_services.core_config,
-            core_tracker_services.scrape_handler,
-            core_tracker_services.authentication_service,
-            core_http_tracker_services.http_stats_event_sender,
-            &core_http_tracker_services.http_tracker_config,
-            core_http_tracker_services.configuration_instance_id,
-        ));
+        let test_services = initialize_tracker_on_reverse_proxy();
 
         // Act
         let response = super::handle(
-            &scrape_service,
+            &test_services.scrape_service,
             &sample_scrape_request(),
             &missing_client_ip_sources(),
             &sample_http_service_binding(),
@@ -356,7 +335,6 @@ mod tests {
         use std::str::FromStr;
 
         use torrust_tracker_core::authentication;
-        use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_primitives::ScrapeData;
 
         use super::{initialize_private_tracker, sample_client_ip_sources, sample_http_service_binding, sample_scrape_request};
@@ -364,19 +342,13 @@ mod tests {
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_missing() {
             // Arrange
-            let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
+            let test_services = initialize_private_tracker();
             let scrape_request = sample_scrape_request();
             let maybe_key = None;
-            let scrape_service = ScrapeService::new(
-                core_tracker_services.core_config.clone(),
-                core_tracker_services.scrape_handler.clone(),
-                core_tracker_services.authentication_service.clone(),
-                core_http_tracker_services.http_stats_event_sender.clone(),
-                core_http_tracker_services.configuration_instance_id,
-            );
 
             // Act
-            let actual_scrape_data = scrape_service
+            let actual_scrape_data = test_services
+                .scrape_service
                 .handle_scrape(
                     &scrape_request,
                     &sample_client_ip_sources(),
@@ -395,21 +367,14 @@ mod tests {
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_invalid() {
             // Arrange
-            let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
+            let test_services = initialize_private_tracker();
             let scrape_request = sample_scrape_request();
             let unregistered_key = authentication::Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
             let maybe_key = Some(unregistered_key);
 
-            let scrape_service = ScrapeService::new(
-                core_tracker_services.core_config.clone(),
-                core_tracker_services.scrape_handler.clone(),
-                core_tracker_services.authentication_service.clone(),
-                core_http_tracker_services.http_stats_event_sender.clone(),
-                core_http_tracker_services.configuration_instance_id,
-            );
-
             // Act
-            let actual_scrape_data = scrape_service
+            let actual_scrape_data = test_services
+                .scrape_service
                 .handle_scrape(
                     &scrape_request,
                     &sample_client_ip_sources(),
@@ -428,7 +393,6 @@ mod tests {
 
     mod with_tracker_in_listed_mode {
 
-        use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_primitives::ScrapeData;
 
         use super::{initialize_listed_tracker, sample_client_ip_sources, sample_http_service_binding, sample_scrape_request};
@@ -436,18 +400,12 @@ mod tests {
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_torrent_is_not_whitelisted() {
             // Arrange
-            let (core_tracker_services, core_http_tracker_services) = initialize_listed_tracker();
+            let test_services = initialize_listed_tracker();
             let scrape_request = sample_scrape_request();
-            let scrape_service = ScrapeService::new(
-                core_tracker_services.core_config.clone(),
-                core_tracker_services.scrape_handler.clone(),
-                core_tracker_services.authentication_service.clone(),
-                core_http_tracker_services.http_stats_event_sender.clone(),
-                core_http_tracker_services.configuration_instance_id,
-            );
 
             // Act
-            let actual_scrape_data = scrape_service
+            let actual_scrape_data = test_services
+                .scrape_service
                 .handle_scrape(
                     &scrape_request,
                     &sample_client_ip_sources(),
@@ -466,7 +424,6 @@ mod tests {
 
     mod with_tracker_on_reverse_proxy {
 
-        use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_http_protocol::v1::responses;
 
         use super::{
@@ -477,18 +434,11 @@ mod tests {
         #[tokio::test]
         async fn it_should_fail_when_the_right_most_x_forwarded_for_header_ip_is_not_available() {
             // Arrange
-            let (core_tracker_services, core_http_tracker_services) = initialize_tracker_on_reverse_proxy();
-            let scrape_service = ScrapeService::new_with_http_tracker_config(
-                core_tracker_services.core_config.clone(),
-                core_tracker_services.scrape_handler.clone(),
-                core_tracker_services.authentication_service.clone(),
-                core_http_tracker_services.http_stats_event_sender.clone(),
-                &core_http_tracker_services.http_tracker_config,
-                core_http_tracker_services.configuration_instance_id,
-            );
+            let test_services = initialize_tracker_on_reverse_proxy();
 
             // Act
-            let actual_error = scrape_service
+            let actual_error = test_services
+                .scrape_service
                 .handle_scrape(
                     &sample_scrape_request(),
                     &missing_client_ip_sources(),
@@ -510,7 +460,6 @@ mod tests {
 
     mod with_tracker_not_on_reverse_proxy {
 
-        use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_http_protocol::v1::responses;
 
         use super::{
@@ -521,17 +470,11 @@ mod tests {
         #[tokio::test]
         async fn it_should_fail_when_the_client_ip_from_the_connection_info_is_not_available() {
             // Arrange
-            let (core_tracker_services, core_http_tracker_services) = initialize_tracker_not_on_reverse_proxy();
-            let scrape_service = ScrapeService::new(
-                core_tracker_services.core_config.clone(),
-                core_tracker_services.scrape_handler.clone(),
-                core_tracker_services.authentication_service.clone(),
-                core_http_tracker_services.http_stats_event_sender.clone(),
-                core_http_tracker_services.configuration_instance_id,
-            );
+            let test_services = initialize_tracker_not_on_reverse_proxy();
 
             // Act
-            let actual_error = scrape_service
+            let actual_error = test_services
+                .scrape_service
                 .handle_scrape(
                     &sample_scrape_request(),
                     &missing_client_ip_sources(),

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -309,6 +309,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn it_should_encode_each_file_when_scrape_data_contains_multiple_files() {
+        // Arrange
+        let first_info_hash = sample_scrape_request().info_hashes[0];
+        let second_info_hash = InfoHash::from([2; 20]);
+        let mut scrape_data = ScrapeData::empty();
+        scrape_data.add_file(
+            &first_info_hash,
+            SwarmMetadata {
+                complete: 3,
+                downloaded: 2,
+                incomplete: 4,
+            },
+        );
+        scrape_data.add_file(
+            &second_info_hash,
+            SwarmMetadata {
+                complete: 7,
+                downloaded: 11,
+                incomplete: 13,
+            },
+        );
+
+        // Act
+        let response = super::build_response(scrape_data);
+        let actual_response = decode_successful_bencoded_response(response).await;
+
+        // Assert
+        let expected_response = responses::scrape::deserialization::ResponseBuilder::default()
+            .add_file(
+                first_info_hash,
+                responses::scrape::deserialization::File {
+                    complete: 3,
+                    downloaded: 2,
+                    incomplete: 4,
+                },
+            )
+            .add_file(
+                second_info_hash,
+                responses::scrape::deserialization::File {
+                    complete: 7,
+                    downloaded: 11,
+                    incomplete: 13,
+                },
+            )
+            .build();
+
+        assert_eq!(actual_response, expected_response);
+    }
+
+    #[tokio::test]
     async fn it_should_encode_a_bencoded_failure_response_when_the_client_ip_cannot_be_resolved() {
         // Arrange
         let test_services = initialize_tracker_on_reverse_proxy();

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -103,6 +103,7 @@ mod tests {
 
     use tokio_util::sync::CancellationToken;
     use torrust_info_hash::InfoHash;
+    use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_configuration::v3_0_0::Configuration;
     use torrust_tracker_configuration::v3_0_0::core::Core;
     use torrust_tracker_core::authentication::key::repository::in_memory::InMemoryKeyRepository;
@@ -223,7 +224,20 @@ mod tests {
         }
     }
 
-    fn assert_error_response(error: &responses::error::Error, error_message: &str) {
+    fn missing_client_ip_sources() -> ClientIpSources {
+        ClientIpSources {
+            right_most_x_forwarded_for: None,
+            connection_info_socket_address: None,
+        }
+    }
+
+    fn sample_http_service_binding() -> ServiceBinding {
+        let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
+
+        ServiceBinding::new(Protocol::HTTP, address).expect("the sample HTTP service binding should be valid")
+    }
+
+    fn assert_failure_reason_contains(error: &responses::error::Error, error_message: &str) {
         assert!(
             error.failure_reason.contains(error_message),
             "Error response does not contain message: '{error_message}'. Error: {error:?}"
@@ -276,26 +290,20 @@ mod tests {
     }
 
     mod with_tracker_in_private_mode {
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
         use std::str::FromStr;
 
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_core::authentication;
         use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_primitives::ScrapeData;
 
-        use super::{initialize_private_tracker, sample_client_ip_sources, sample_scrape_request};
+        use super::{initialize_private_tracker, sample_client_ip_sources, sample_http_service_binding, sample_scrape_request};
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_missing() {
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
+            // Arrange
             let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
-
             let scrape_request = sample_scrape_request();
             let maybe_key = None;
-
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -304,28 +312,27 @@ mod tests {
                 core_http_tracker_services.configuration_instance_id,
             );
 
-            let scrape_data = scrape_service
+            // Act
+            let actual_scrape_data = scrape_service
                 .handle_scrape(
                     &scrape_request,
                     &sample_client_ip_sources(),
-                    &server_service_binding,
+                    &sample_http_service_binding(),
                     maybe_key,
                 )
                 .await
                 .unwrap();
 
+            // Assert
             let expected_scrape_data = ScrapeData::zeroed(&scrape_request.info_hashes);
 
-            assert_eq!(scrape_data, expected_scrape_data);
+            assert_eq!(actual_scrape_data, expected_scrape_data);
         }
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_authentication_key_is_invalid() {
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
+            // Arrange
             let (core_tracker_services, core_http_tracker_services) = initialize_private_tracker();
-
             let scrape_request = sample_scrape_request();
             let unregistered_key = authentication::Key::from_str("YZSl4lMZupRuOpSRC3krIKR5BPB14nrJ").unwrap();
             let maybe_key = Some(unregistered_key);
@@ -338,41 +345,36 @@ mod tests {
                 core_http_tracker_services.configuration_instance_id,
             );
 
-            let scrape_data = scrape_service
+            // Act
+            let actual_scrape_data = scrape_service
                 .handle_scrape(
                     &scrape_request,
                     &sample_client_ip_sources(),
-                    &server_service_binding,
+                    &sample_http_service_binding(),
                     maybe_key,
                 )
                 .await
                 .unwrap();
 
+            // Assert
             let expected_scrape_data = ScrapeData::zeroed(&scrape_request.info_hashes);
 
-            assert_eq!(scrape_data, expected_scrape_data);
+            assert_eq!(actual_scrape_data, expected_scrape_data);
         }
     }
 
     mod with_tracker_in_listed_mode {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_primitives::ScrapeData;
 
-        use super::{initialize_listed_tracker, sample_client_ip_sources, sample_scrape_request};
+        use super::{initialize_listed_tracker, sample_client_ip_sources, sample_http_service_binding, sample_scrape_request};
 
         #[tokio::test]
         async fn it_should_return_zeroed_swarm_metadata_when_the_torrent_is_not_whitelisted() {
+            // Arrange
             let (core_tracker_services, core_http_tracker_services) = initialize_listed_tracker();
-
             let scrape_request = sample_scrape_request();
-
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -381,41 +383,38 @@ mod tests {
                 core_http_tracker_services.configuration_instance_id,
             );
 
-            let scrape_data = scrape_service
-                .handle_scrape(&scrape_request, &sample_client_ip_sources(), &server_service_binding, None)
+            // Act
+            let actual_scrape_data = scrape_service
+                .handle_scrape(
+                    &scrape_request,
+                    &sample_client_ip_sources(),
+                    &sample_http_service_binding(),
+                    None,
+                )
                 .await
                 .unwrap();
 
+            // Assert
             let expected_scrape_data = ScrapeData::zeroed(&scrape_request.info_hashes);
 
-            assert_eq!(scrape_data, expected_scrape_data);
+            assert_eq!(actual_scrape_data, expected_scrape_data);
         }
     }
 
     mod with_tracker_on_reverse_proxy {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_http_protocol::v1::responses;
-        use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
-        use super::{initialize_tracker_on_reverse_proxy, sample_scrape_request};
-        use crate::v1::handlers::scrape::tests::assert_error_response;
+        use super::{
+            assert_failure_reason_contains, initialize_tracker_on_reverse_proxy, missing_client_ip_sources,
+            sample_http_service_binding, sample_scrape_request,
+        };
 
         #[tokio::test]
         async fn it_should_fail_when_the_right_most_x_forwarded_for_header_ip_is_not_available() {
+            // Arrange
             let (core_tracker_services, core_http_tracker_services) = initialize_tracker_on_reverse_proxy();
-
-            let client_ip_sources = ClientIpSources {
-                right_most_x_forwarded_for: None,
-                connection_info_socket_address: None,
-            };
-
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
             let scrape_service = ScrapeService::new_with_http_tracker_config(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -425,15 +424,22 @@ mod tests {
                 core_http_tracker_services.configuration_instance_id,
             );
 
-            let response = scrape_service
-                .handle_scrape(&sample_scrape_request(), &client_ip_sources, &server_service_binding, None)
+            // Act
+            let actual_error = scrape_service
+                .handle_scrape(
+                    &sample_scrape_request(),
+                    &missing_client_ip_sources(),
+                    &sample_http_service_binding(),
+                    None,
+                )
                 .await
                 .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 "Error resolving peer IP: missing or invalid the right most X-Forwarded-For IP",
             );
         }
@@ -441,28 +447,18 @@ mod tests {
 
     mod with_tracker_not_on_reverse_proxy {
 
-        use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-        use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
         use torrust_tracker_http_core::services::scrape::ScrapeService;
         use torrust_tracker_http_protocol::v1::responses;
-        use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
 
-        use super::{initialize_tracker_not_on_reverse_proxy, sample_scrape_request};
-        use crate::v1::handlers::scrape::tests::assert_error_response;
+        use super::{
+            assert_failure_reason_contains, initialize_tracker_not_on_reverse_proxy, missing_client_ip_sources,
+            sample_http_service_binding, sample_scrape_request,
+        };
 
         #[tokio::test]
         async fn it_should_fail_when_the_client_ip_from_the_connection_info_is_not_available() {
+            // Arrange
             let (core_tracker_services, core_http_tracker_services) = initialize_tracker_not_on_reverse_proxy();
-
-            let client_ip_sources = ClientIpSources {
-                right_most_x_forwarded_for: None,
-                connection_info_socket_address: None,
-            };
-
-            let server_socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 7070);
-            let server_service_binding = ServiceBinding::new(Protocol::HTTP, server_socket_addr).unwrap();
-
             let scrape_service = ScrapeService::new(
                 core_tracker_services.core_config.clone(),
                 core_tracker_services.scrape_handler.clone(),
@@ -471,15 +467,22 @@ mod tests {
                 core_http_tracker_services.configuration_instance_id,
             );
 
-            let response = scrape_service
-                .handle_scrape(&sample_scrape_request(), &client_ip_sources, &server_service_binding, None)
+            // Act
+            let actual_error = scrape_service
+                .handle_scrape(
+                    &sample_scrape_request(),
+                    &missing_client_ip_sources(),
+                    &sample_http_service_binding(),
+                    None,
+                )
                 .await
                 .unwrap_err();
 
-            let error_response = responses::error::Error::from(response);
+            // Assert
+            let actual_error_response = responses::error::Error::from(actual_error);
 
-            assert_error_response(
-                &error_response,
+            assert_failure_reason_contains(
+                &actual_error_response,
                 "Error resolving peer IP: cannot get the client IP from the connection info",
             );
         }

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -9,7 +9,7 @@ use axum::response::{IntoResponse, Response};
 use hyper::StatusCode;
 use torrust_net_primitives::service_binding::ServiceBinding;
 use torrust_tracker_core::authentication::Key;
-use torrust_tracker_http_core::services::scrape::ScrapeService;
+use torrust_tracker_http_core::services::scrape::{HttpScrapeError, ScrapeService};
 use torrust_tracker_http_protocol::v1::requests::scrape::Scrape;
 use torrust_tracker_http_protocol::v1::responses;
 use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
@@ -55,9 +55,14 @@ async fn handle(
     server_service_binding: &ServiceBinding,
     maybe_key: Option<Key>,
 ) -> Response {
-    let scrape_data = match scrape_service
-        .handle_scrape(scrape_request, client_ip_sources, server_service_binding, maybe_key)
-        .await
+    let scrape_data = match handle_scrape(
+        scrape_service,
+        scrape_request,
+        client_ip_sources,
+        server_service_binding,
+        maybe_key,
+    )
+    .await
     {
         Ok(scrape_data) => scrape_data,
         Err(error) => {
@@ -67,6 +72,18 @@ async fn handle(
     };
 
     build_response(scrape_data)
+}
+
+async fn handle_scrape(
+    scrape_service: &Arc<ScrapeService>,
+    scrape_request: &Scrape,
+    client_ip_sources: &ClientIpSources,
+    server_service_binding: &ServiceBinding,
+    maybe_key: Option<Key>,
+) -> Result<DomainScrapeData, HttpScrapeError> {
+    scrape_service
+        .handle_scrape(scrape_request, client_ip_sources, server_service_binding, maybe_key)
+        .await
 }
 
 fn build_response(scrape_data: DomainScrapeData) -> Response {
@@ -114,6 +131,7 @@ mod tests {
     use torrust_tracker_core::whitelist::repository::in_memory::InMemoryWhitelist;
     use torrust_tracker_http_core::event::bus::EventBus;
     use torrust_tracker_http_core::event::sender::Broadcaster;
+    use torrust_tracker_http_core::services::scrape::ScrapeService;
     use torrust_tracker_http_core::statistics::event::listener::run_event_listener;
     use torrust_tracker_http_core::statistics::repository::Repository;
     use torrust_tracker_http_protocol::v1::requests::scrape::Scrape;
@@ -258,6 +276,20 @@ mod tests {
         responses::scrape::deserialization::Response::try_from_bencoded(&body).expect("scrape response should be valid bencode")
     }
 
+    async fn decode_bencoded_error_response(response: Response) -> responses::error::Error {
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a BitTorrent scrape failure response should use HTTP 200"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("scrape failure response body should be readable");
+
+        serde_bencode::from_bytes(&body).expect("scrape failure response should be valid bencode")
+    }
+
     #[tokio::test]
     async fn it_should_encode_domain_scrape_data_as_a_bencoded_response() {
         // Arrange
@@ -287,6 +319,37 @@ mod tests {
         );
 
         assert_eq!(actual_response, expected_response);
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_a_bencoded_failure_response_when_the_client_ip_cannot_be_resolved() {
+        // Arrange
+        let (core_tracker_services, core_http_tracker_services) = initialize_tracker_on_reverse_proxy();
+        let scrape_service = Arc::new(ScrapeService::new_with_http_tracker_config(
+            core_tracker_services.core_config,
+            core_tracker_services.scrape_handler,
+            core_tracker_services.authentication_service,
+            core_http_tracker_services.http_stats_event_sender,
+            &core_http_tracker_services.http_tracker_config,
+            core_http_tracker_services.configuration_instance_id,
+        ));
+
+        // Act
+        let response = super::handle(
+            &scrape_service,
+            &sample_scrape_request(),
+            &missing_client_ip_sources(),
+            &sample_http_service_binding(),
+            None,
+        )
+        .await;
+        let actual_error_response = decode_bencoded_error_response(response).await;
+
+        // Assert
+        assert_failure_reason_contains(
+            &actual_error_response,
+            "Error resolving peer IP: missing or invalid the right most X-Forwarded-For IP",
+        );
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -94,6 +94,7 @@ fn to_protocol_scrape_data(domain_data: DomainScrapeData) -> responses::scrape::
 
 #[cfg(test)]
 mod tests {
+    use axum::body::to_bytes;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
     use std::sync::Arc;
@@ -115,7 +116,8 @@ mod tests {
     use torrust_tracker_http_protocol::v1::requests::scrape::Scrape;
     use torrust_tracker_http_protocol::v1::responses;
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::ClientIpSources;
-    use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
+    use torrust_tracker_primitives::swarm_metadata::SwarmMetadata;
+    use torrust_tracker_primitives::{ConfigurationInstanceId, ScrapeData, ServiceRole};
     use torrust_tracker_test_helpers::configuration;
 
     struct CoreTrackerServices {
@@ -223,6 +225,44 @@ mod tests {
         assert!(
             error.failure_reason.contains(error_message),
             "Error response does not contain message: '{error_message}'. Error: {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_should_encode_domain_scrape_data_as_a_bencoded_response() {
+        // Arrange
+        let info_hash = sample_scrape_request().info_hashes[0];
+        let mut scrape_data = ScrapeData::empty();
+        scrape_data.add_file(
+            &info_hash,
+            SwarmMetadata {
+                complete: 3,
+                downloaded: 2,
+                incomplete: 4,
+            },
+        );
+
+        // Act
+        let response = super::build_response(scrape_data);
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("scrape response body should be readable");
+        let decoded = responses::scrape::deserialization::Response::try_from_bencoded(&body)
+            .expect("response should be a bencoded scrape response");
+
+        // Assert
+        assert_eq!(status, hyper::StatusCode::OK);
+        assert_eq!(
+            decoded,
+            responses::scrape::deserialization::Response::with_one_file(
+                info_hash,
+                responses::scrape::deserialization::File {
+                    complete: 3,
+                    downloaded: 2,
+                    incomplete: 4,
+                },
+            )
         );
     }
 

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -95,6 +95,8 @@ fn to_protocol_scrape_data(domain_data: DomainScrapeData) -> responses::scrape::
 #[cfg(test)]
 mod tests {
     use axum::body::to_bytes;
+    use axum::response::Response;
+    use hyper::StatusCode;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::str::FromStr;
     use std::sync::Arc;
@@ -228,6 +230,20 @@ mod tests {
         );
     }
 
+    async fn decode_successful_bencoded_response(response: Response) -> responses::scrape::deserialization::Response {
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "a successful scrape response should use HTTP 200"
+        );
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("scrape response body should be readable");
+
+        responses::scrape::deserialization::Response::try_from_bencoded(&body).expect("scrape response should be valid bencode")
+    }
+
     #[tokio::test]
     async fn it_should_encode_domain_scrape_data_as_a_bencoded_response() {
         // Arrange
@@ -244,26 +260,19 @@ mod tests {
 
         // Act
         let response = super::build_response(scrape_data);
-        let status = response.status();
-        let body = to_bytes(response.into_body(), usize::MAX)
-            .await
-            .expect("scrape response body should be readable");
-        let decoded = responses::scrape::deserialization::Response::try_from_bencoded(&body)
-            .expect("response should be a bencoded scrape response");
+        let actual_response = decode_successful_bencoded_response(response).await;
 
         // Assert
-        assert_eq!(status, hyper::StatusCode::OK);
-        assert_eq!(
-            decoded,
-            responses::scrape::deserialization::Response::with_one_file(
-                info_hash,
-                responses::scrape::deserialization::File {
-                    complete: 3,
-                    downloaded: 2,
-                    incomplete: 4,
-                },
-            )
+        let expected_response = responses::scrape::deserialization::Response::with_one_file(
+            info_hash,
+            responses::scrape::deserialization::File {
+                complete: 3,
+                downloaded: 2,
+                incomplete: 4,
+            },
         );
+
+        assert_eq!(actual_response, expected_response);
     }
 
     mod with_tracker_in_private_mode {

--- a/packages/axum-http-server/src/v1/routes.rs
+++ b/packages/axum-http-server/src/v1/routes.rs
@@ -174,6 +174,8 @@ mod tests {
 
     use super::with_request_layers;
 
+    const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
+
     fn service_binding() -> ServiceBinding {
         ServiceBinding::new(Protocol::HTTP, "127.0.0.1:7070".parse().expect("valid socket address"))
             .expect("valid HTTP service binding")
@@ -189,7 +191,7 @@ mod tests {
         let client_request_id = "test-request-id";
         let request = http::Request::builder()
             .uri("/")
-            .header("x-request-id", client_request_id)
+            .header(REQUEST_ID_HEADER, client_request_id)
             .body(Body::empty())
             .expect("valid request");
 
@@ -201,7 +203,7 @@ mod tests {
         assert_eq!(
             response
                 .headers()
-                .get("x-request-id")
+                .get(REQUEST_ID_HEADER)
                 .expect("request ID header")
                 .to_str()
                 .expect("request ID header should be valid text"),
@@ -221,7 +223,7 @@ mod tests {
         assert_eq!(response.status(), http::StatusCode::OK);
         let actual_request_id = response
             .headers()
-            .get(HeaderName::from_static("x-request-id"))
+            .get(REQUEST_ID_HEADER)
             .expect("request ID header")
             .to_str()
             .expect("request ID header should be valid text");

--- a/packages/axum-http-server/src/v1/routes.rs
+++ b/packages/axum-http-server/src/v1/routes.rs
@@ -161,3 +161,73 @@ fn with_request_layers(router: Router, server_service_binding: &ServiceBinding) 
                 .layer(TimeoutLayer::new(DEFAULT_REQUEST_TIMEOUT)),
         )
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::body::Body;
+    use axum::http::header::HeaderName;
+    use axum::routing::get;
+    use axum::{Router, http};
+    use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::with_request_layers;
+
+    fn service_binding() -> ServiceBinding {
+        ServiceBinding::new(Protocol::HTTP, "127.0.0.1:7070".parse().expect("valid socket address"))
+            .expect("valid HTTP service binding")
+    }
+
+    fn test_router() -> Router {
+        with_request_layers(Router::new().route("/", get(|| async {})), &service_binding())
+    }
+
+    #[tokio::test]
+    async fn it_should_propagate_a_client_supplied_request_id() {
+        // Arrange
+        let request_id = "test-request-id";
+        let request = http::Request::builder()
+            .uri("/")
+            .header("x-request-id", request_id)
+            .body(Body::empty())
+            .expect("valid request");
+
+        // Act
+        let response = test_router().oneshot(request).await.expect("router should handle request");
+
+        // Assert
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("x-request-id")
+                .expect("request ID header")
+                .to_str()
+                .expect("request ID header should be valid text"),
+            request_id
+        );
+    }
+
+    #[tokio::test]
+    async fn it_should_add_a_uuid_request_id_when_the_client_does_not_supply_one() {
+        // Arrange
+        let request = http::Request::builder().uri("/").body(Body::empty()).expect("valid request");
+
+        // Act
+        let response = test_router().oneshot(request).await.expect("router should handle request");
+
+        // Assert
+        assert_eq!(response.status(), http::StatusCode::OK);
+        let request_id = response
+            .headers()
+            .get(HeaderName::from_static("x-request-id"))
+            .expect("request ID header")
+            .to_str()
+            .expect("request ID header should be valid text");
+        assert!(
+            Uuid::parse_str(request_id).is_ok(),
+            "request ID should be a UUID: {request_id}"
+        );
+    }
+}

--- a/packages/axum-http-server/src/v1/routes.rs
+++ b/packages/axum-http-server/src/v1/routes.rs
@@ -186,10 +186,10 @@ mod tests {
     #[tokio::test]
     async fn it_should_propagate_a_client_supplied_request_id() {
         // Arrange
-        let request_id = "test-request-id";
+        let client_request_id = "test-request-id";
         let request = http::Request::builder()
             .uri("/")
-            .header("x-request-id", request_id)
+            .header("x-request-id", client_request_id)
             .body(Body::empty())
             .expect("valid request");
 
@@ -205,7 +205,7 @@ mod tests {
                 .expect("request ID header")
                 .to_str()
                 .expect("request ID header should be valid text"),
-            request_id
+            client_request_id
         );
     }
 
@@ -219,15 +219,15 @@ mod tests {
 
         // Assert
         assert_eq!(response.status(), http::StatusCode::OK);
-        let request_id = response
+        let actual_request_id = response
             .headers()
             .get(HeaderName::from_static("x-request-id"))
             .expect("request ID header")
             .to_str()
             .expect("request ID header should be valid text");
         assert!(
-            Uuid::parse_str(request_id).is_ok(),
-            "request ID should be a UUID: {request_id}"
+            Uuid::parse_str(actual_request_id).is_ok(),
+            "request ID should be a UUID: {actual_request_id}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Adds and refines the package-local Axum HTTP server test safety net for bencoded announce/scrape response mapping, authentication-key extraction, request-ID middleware, listener lifecycle, and readable server-start scenarios.

The accompanying coverage evidence records an increase from 93.82% to 95.07% lines, 91.66% to 92.99% regions, and 89.54% to 90.86% functions (test-inclusive package-source measurement).

## Tracking correction

Closes #2136.

Supersedes #2129, which was opened against #1348 before historical package-name changes were reconciled. Issue #1348 remains the separate `udp-core` testing subissue; #1349 remains the separate `http-core` testing subissue.

## Validation

- `cargo test -p torrust-tracker-axum-http-server` (34 unit tests, 55 integration tests)
- `linter all`
- mandatory pre-commit gate
