### PR TITLE
chore(lints): [#2134] enforce cognitive complexity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5189,7 +5189,6 @@ dependencies = [
  "mockall",
  "rstest",
  "serde",
- "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "torrust-clock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,10 +140,11 @@ warnings = { level = "deny", priority = -1 }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }
+cognitive_complexity = { level = "deny", priority = -1 }
 complexity = { level = "deny", priority = -1 }
 correctness = { level = "deny", priority = -1 }
 exit = { level = "deny", priority = 0 }
-nursery = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -2 }
 pedantic = { level = "deny", priority = -1 }
 perf = { level = "deny", priority = -1 }
 print_stderr = { level = "deny", priority = 0 }

--- a/docs/copilot-pr-reviews/pr-2147-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2147-copilot-suggestions.md
@@ -1,0 +1,54 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2147 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2147
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-05: Started processing three Copilot review threads.
+- 2026-09-05: Completed all threads; one action and two documented no-action decisions.
+
+## Suggestions
+
+| #   | Thread ID             | Path                                   | URL                                                                         | Suggestion Summary                                          | Decision                                                                                                                        | Reply URL                                                                   | Status | Thread State |
+| --- | --------------------- | -------------------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | PRRT_kwDOGp2yqc6fiht1 | `packages/configuration/src/lib.rs`    | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940351533 | Inline TOML environment configuration is logged verbatim.   | action: log only the byte length, not potentially secret configuration content.                                                 | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940808030 | DONE   | RESOLVED     |
+| 2   | PRRT_kwDOGp2yqc6fiht6 | `packages/test-helpers/src/logging.rs` | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940351543 | `write_all` appears to require an imported `Write` trait.   | no-action: `LogCapturer` implements `io::Write`, so the method is available; adding the import is unused and Clippy rejects it. | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940808854 | DONE   | RESOLVED     |
+| 3   | PRRT_kwDOGp2yqc6fihuA | `src/console/profiling.rs`             | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940351550 | Change “successfully shutdown” to “successfully shut down”. | no-action: the thread is outdated and the message is outside the cognitive-complexity scope; preserve established CLI output.   | https://github.com/torrust/torrust-tracker/pull/2147#discussion_r3940808941 | DONE | RESOLVED |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -154,17 +154,17 @@ On 2026-09-03, all 20 remaining package manifests were temporarily updated to in
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                            | Notes / Expected Output                                                                                                                                                         |
-| --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
-| T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
-| T3  | IN_PROGRESS | Refactor event-processing functions          | All event handlers/listeners and the UDP-server error logger are complete. Refactor the profiling runner while preserving its asymmetric shutdown behavior.                  |
-| T4  | IN_PROGRESS | Refactor event listener loops                 | Swarm, tracker-core, HTTP core, and UDP core are complete. Apply the receive-result extraction to both UDP-server dispatchers.                                                  |
-| T5  | IN_PROGRESS | Add focused regression tests                  | Event-processing coverage is complete. Add proportionate profiling CLI coverage where a deterministic executable fixture is practical.                                         |
-| T6  | TODO   | Complete Cargo lint policy                      | Add `[lints] workspace = true` to every package manifest and add `cognitive_complexity = { level = "deny", priority = -1 }` only after T2 through T5 leave the workspace clean. |
-| T7  | TODO   | Verify CI enforcement                           | Confirm `linter all` (as run in `testing.yaml`) fails on a cognitive-complexity violation and passes after the complete remediation; no workflow change expected.               |
-| T8  | TODO   | Update affected documentation                   | Align lint-policy documentation with the final `Cargo.toml` and CI ownership.                                                                                                   |
-| T9  | TODO   | Run verification and review acceptance criteria | Record automated and mandatory manual evidence, then re-review every acceptance criterion.                                                                                      |
+| ID  | Status      | Task                                            | Notes / Expected Output                                                                                                                                                                                                                                      |
+| --- | ----------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | DONE        | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.                                                                                       |
+| T2  | DONE        | Remediate workspace lint baseline               | All 87 diagnostics exposed by full workspace-lint inheritance were fixed; flag-free workspace Clippy passes.                                                                                                                                                 |
+| T3  | DONE        | Refactor event-processing functions             | All fourteen identified functions were structurally refactored without cognitive-complexity allowances or threshold changes.                                                                                                                                 |
+| T4  | DONE        | Refactor event listener loops                   | All affected listeners retain `biased` cancellation priority, receiver-close termination, and lag continuation.                                                                                                                                              |
+| T5  | DONE        | Add focused regression tests                    | Deterministic listener, policy-routing, metric, persistence-failure, banning, and UDP error-event tests were added. Profiling extraction is behavior-preserving; process-level tests are disproportionate without a deterministic signal-readiness boundary. |
+| T6  | DONE        | Complete Cargo lint policy                      | Every workspace package inherits lint policy; root `Cargo.toml` denies `cognitive_complexity` and gives it precedence over `nursery`.                                                                                                                        |
+| T7  | DONE        | Verify CI enforcement                           | `linter all`, invoked by both pre-commit and `testing.yaml`, failed on an intentional 27/25 profiling violation and passed after restoration.                                                                                                                |
+| T8  | DONE        | Update affected documentation                   | This issue specification records the final Cargo policy, CI ownership, implementation scope, and evidence.                                                                                                                                                   |
+| T9  | IN_PROGRESS | Run verification and review acceptance criteria | Final full-suite verification and independent task review remain.                                                                                                                                                                                            |
 
 ## Progress Tracking
 
@@ -174,10 +174,10 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue #2134 created and specification moved to `docs/issues/open/`
 - [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
+- [x] Implementation completed
 - [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded (status + evidence)
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Manual verification scenarios executed and recorded (status + evidence)
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
 - [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
@@ -199,20 +199,23 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-05 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed three additional UDP-server violations (29/25, 32/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 - 2026-09-05 UTC - GitHub Copilot - Refactored both UDP-server event listeners and the UDP error logger, adding deterministic listener and error-event regression coverage in `33387541`. - Local commit workflow
 - 2026-09-05 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed the root profiling runner violation (27/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
+- 2026-09-05 UTC - GitHub Copilot - Refactored `profiling::run` by extracting its shutdown selection into `wait_for_shutdown` in `0278ae00`; root-library tests and explicit cognitive-complexity Clippy passed. - Local commit workflow
+- 2026-09-05 UTC - GitHub Copilot - Enabled `cognitive_complexity = { level = "deny", priority = -1 }` in root `Cargo.toml` in `b2733dac` and set `nursery` to priority `-2`, as Cargo requires to permit the individual lint override. - Local commit workflow
+- 2026-09-05 UTC - GitHub Copilot - Verified flag-free workspace Clippy and `linter all` pass with the root policy enabled. Temporarily restored the profiling runner's previous 27/25 shape; `linter all` failed with the expected cognitive-complexity diagnostic, then passed after the compliant helper was restored. Both pre-commit and `testing.yaml` invoke `linter all`. - Terminal output and workflow inspection in this session
 
 ## Acceptance Criteria
 
-- [ ] AC1: All fourteen identified handlers, listeners, error-log functions, and the profiling runner in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, `udp-server`, and the root crate comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
-- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, UDP error responses and event publication, profiling CLI/startup reporting, timer-versus-Ctrl+C behavior, and logging semantics are preserved.
-- [ ] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
-- [ ] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
-- [ ] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
-- [ ] AC6: Focused regression tests cover behavior affected by the baseline remediation, including listener receive outcomes where practicable.
-- [ ] `linter all` exits with code `0`.
+- [x] AC1: All fourteen identified handlers, listeners, error-log functions, and the profiling runner in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, `udp-server`, and the root crate comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
+- [x] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, UDP error responses and event publication, profiling CLI/startup reporting, timer-versus-Ctrl+C behavior, and logging semantics are preserved.
+- [x] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
+- [x] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
+- [x] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
+- [x] AC6: Focused regression tests cover behavior affected by the baseline remediation, including listener receive outcomes where practicable.
+- [x] `linter all` exits with code `0`.
 - [ ] Relevant tests pass.
-- [ ] Manual verification scenarios are executed and documented (status + evidence).
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
-- [ ] Documentation is updated when behavior/workflow changes.
+- [x] Manual verification scenarios are executed and documented (status + evidence).
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [x] Documentation is updated when behavior/workflow changes.
 
 ## Verification Plan
 
@@ -243,11 +246,11 @@ Define verification before implementation starts and execute it before closing t
 
 Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
-| ID  | Scenario                       | Command/Steps                                                                                                                                                                | Expected Result                                                                                                                                             | Status | Evidence                          |
-| --- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | --------------------------------- |
-| M1  | Validate workspace remediation | Run `cargo clippy --workspace --all-targets --all-features` after completing all baseline fixes and again after enabling cognitive complexity.                               | The command exits 0 both before and after the new lint is enabled.                                                                                          | TODO   | Pending workspace Clippy output   |
-| M2  | Validate CI enforcement        | Temporarily reintroduce one cognitive-complexity violation (or check out the pre-refactor commit) with the lint declared, run `linter all`, then restore the fix and re-run. | `linter all` fails on the violation and passes after the fix, proving the existing CI step enforces the lint.                                               | TODO   | Pending local `linter all` output |
-| M3  | Validate listener behavior     | Exercise cancellation, closed receiver, successful event delivery, and lagged receiver paths with focused tests or deterministic test harness steps.                         | Cancellation and closed receiver terminate; successful events are handled; lagged receivers continue; existing log and ordering semantics remain unchanged. | TODO   | Pending focused test output       |
+| ID  | Scenario                       | Command/Steps                                                                                                                                                                | Expected Result                                                                                                                                             | Status | Evidence                    |
+| --- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | --------------------------- |
+| M1  | Validate workspace remediation | Run `cargo clippy --workspace --all-targets --all-features` after completing all baseline fixes and again after enabling cognitive complexity.                               | The command exits 0 both before and after the new lint is enabled.                                                                                          | DONE   | 2026-09-05 terminal output  |
+| M2  | Validate CI enforcement        | Temporarily reintroduce one cognitive-complexity violation (or check out the pre-refactor commit) with the lint declared, run `linter all`, then restore the fix and re-run. | `linter all` fails on the violation and passes after the fix, proving the existing CI step enforces the lint.                                               | DONE   | 2026-09-05 terminal output  |
+| M3  | Validate listener behavior     | Exercise cancellation, closed receiver, successful event delivery, and lagged receiver paths with focused tests or deterministic test harness steps.                         | Cancellation and closed receiver terminate; successful events are handled; lagged receivers continue; existing log and ordering semantics remain unchanged. | DONE   | Focused package test output |
 
 Notes:
 
@@ -256,14 +259,14 @@ Notes:
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                                              |
-| ----- | ---------------------- | --------------------------------------------------------------------- |
-| AC1   | TODO                   | Pending focused and workspace Clippy output                           |
-| AC2   | TODO                   | Pending regression-test and manual-scenario evidence                  |
-| AC3   | TODO                   | Pending Cargo lint-inheritance inspection and workspace Clippy output |
-| AC4   | TODO                   | Pending `linter all` fail/pass evidence and CI run                    |
-| AC5   | TODO                   | Pending clean workspace Clippy output                                 |
-| AC6   | TODO                   | Pending focused test output                                           |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                    |
+| ----- | ---------------------- | --------------------------------------------------------------------------- |
+| AC1   | DONE                   | Focused cognitive-complexity Clippy and root policy workspace Clippy output |
+| AC2   | DONE                   | Refactor review plus focused regression test output                         |
+| AC3   | DONE                   | Root `Cargo.toml` inspection and inherited workspace lint validation        |
+| AC4   | DONE                   | Intentional 27/25 `linter all` failure and restored pass output             |
+| AC5   | DONE                   | Flag-free workspace Clippy output                                           |
+| AC6   | DONE                   | Focused deterministic listener and behavior test output                     |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -96,6 +96,14 @@ root-policy enforcement check on 2026-09-04 found four additional violations:
 - `handle_event` in `packages/udp-core/src/statistics/event/handler.rs` has complexity 38.
 - `dispatch_events` in `packages/udp-core/src/statistics/event/listener.rs` has complexity 37.
 
+After the HTTP and UDP core refactors exposed subsequent workspace compilation, a further
+temporary root-policy enforcement check on 2026-09-05 found three additional violations in
+`packages/udp-server`:
+
+- `dispatch_events` in `src/banning/event/listener.rs` has complexity 29.
+- `log_error` in `src/handlers/error.rs` has complexity 32.
+- `dispatch_events` in `src/statistics/event/listener.rs` has complexity 37.
+
 `Cargo.toml` defines the workspace Clippy policy, but `cognitive_complexity` is not included. Workspace lint settings are only inherited by manifests that opt into `[lints] workspace = true`; the affected package does not currently opt in. CI enforces Clippy through `linter all` (which runs `cargo clippy` for the workspace), so once the lint is declared in `Cargo.toml` and inherited by every package, the existing CI step enforces it without extra workflow changes.
 
 Implementation baseline verified on 2026-09-03:
@@ -112,9 +120,9 @@ On 2026-09-03, all 20 remaining package manifests were temporarily updated to in
 
 ### In Scope
 
-- Refactor all ten identified handler and listener functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, and `udp-core` until none exceeds the default `clippy::cognitive_complexity` threshold.
-- Preserve event-to-metric and persistence updates, labels, timestamps, metrics-policy routing, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, and logging behavior.
-- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling, metrics-policy routing, and persistence failure handling.
+- Refactor all thirteen identified handlers, listeners, and error-log functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, and `udp-server` until none exceeds the default `clippy::cognitive_complexity` threshold.
+- Preserve event-to-metric and persistence updates, labels, timestamps, metrics-policy routing, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, UDP error-response construction, and logging behavior.
+- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling, metrics-policy routing, persistence failure handling, and UDP error-event publication.
 - Add `[lints] workspace = true` to every workspace package manifest that does not yet inherit the workspace lint policy, so the lint applies to all 26 packages.
 - Fix every diagnostic exposed by the newly inherited workspace lint policy, preserving behavior and adding or adjusting focused regression coverage where a fix changes executable code.
 - Add `cognitive_complexity` with level `deny` to `[workspace.lints.clippy]` in the root `Cargo.toml` only after the workspace is clean under the inherited existing policy.
@@ -142,9 +150,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
 | T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
-| T3  | IN_PROGRESS | Refactor event metrics handlers              | `swarm-coordination-registry` and `tracker-core` are complete. Refactor the HTTP and UDP core handlers while preserving metrics, labels, and policy behavior.                   |
-| T4  | IN_PROGRESS | Refactor event listener loops                 | `swarm-coordination-registry` and `tracker-core` are complete. Apply the receive-result extraction to HTTP and UDP core dispatchers.                                            |
-| T5  | IN_PROGRESS | Add focused regression tests                  | Swarm and tracker-core coverage is complete; add HTTP/UDP core label-propagation, metrics-policy, and lifecycle coverage.                                                      |
+| T3  | IN_PROGRESS | Refactor event metrics handlers              | Swarm, tracker-core, HTTP core, and UDP core are complete. Refactor the UDP-server error logger while preserving response and event behavior.                                 |
+| T4  | IN_PROGRESS | Refactor event listener loops                 | Swarm, tracker-core, HTTP core, and UDP core are complete. Apply the receive-result extraction to both UDP-server dispatchers.                                                  |
+| T5  | IN_PROGRESS | Add focused regression tests                  | Add UDP-server error-event publication, metrics-policy, banning, and lifecycle coverage.                                                                                        |
 | T6  | TODO   | Complete Cargo lint policy                      | Add `[lints] workspace = true` to every package manifest and add `cognitive_complexity = { level = "deny", priority = -1 }` only after T2 through T5 leave the workspace clean. |
 | T7  | TODO   | Verify CI enforcement                           | Confirm `linter all` (as run in `testing.yaml`) fails on a cognitive-complexity violation and passes after the complete remediation; no workflow change expected.               |
 | T8  | TODO   | Update affected documentation                   | Align lint-policy documentation with the final `Cargo.toml` and CI ownership.                                                                                                   |
@@ -179,11 +187,13 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-04 UTC - GitHub Copilot - A temporary root cognitive-complexity policy check exposed four additional tracker-core violations (46/25, 35/25, 29/25, and 29/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 - 2026-09-04 UTC - GitHub Copilot - Refactored the tracker-core event handlers and listeners, adding deterministic lifecycle and persistence-failure regression coverage in `abc0c54e`. - Local commit workflow
 - 2026-09-04 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed four additional HTTP and UDP core violations (43/25, 37/25, 38/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
+- 2026-09-04 UTC - GitHub Copilot - Refactored the HTTP and UDP core event handlers and listeners, adding deterministic lifecycle, policy-routing, and label-propagation coverage in `d635566e` and `7c6c609d`. - Local commit workflow
+- 2026-09-05 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed three additional UDP-server violations (29/25, 32/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 
 ## Acceptance Criteria
 
-- [ ] AC1: All ten identified handler and listener functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, and `udp-core` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
-- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, and logging semantics are preserved.
+- [ ] AC1: All thirteen identified handlers, listeners, and error-log functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, and `udp-server` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
+- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, UDP error responses and event publication, and logging semantics are preserved.
 - [ ] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
 - [ ] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
 - [ ] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
@@ -209,6 +219,8 @@ Define verification before implementation starts and execute it before closing t
 - `cargo clippy -p torrust-tracker-http-core --all-targets --all-features`
 - `cargo test -p torrust-tracker-udp-core --all-features`
 - `cargo clippy -p torrust-tracker-udp-core --all-targets --all-features`
+- `cargo test -p torrust-tracker-udp-server --all-features`
+- `cargo clippy -p torrust-tracker-udp-server --all-targets --all-features`
 - `cargo clippy --workspace --all-targets --all-features` (must fail before the refactor once the lint is declared, and pass after)
 - `linter all`
 - `cargo test --doc --workspace`
@@ -262,5 +274,8 @@ Notes:
 - `packages/http-core/src/statistics/event/listener.rs`
 - `packages/udp-core/src/statistics/event/handler.rs`
 - `packages/udp-core/src/statistics/event/listener.rs`
+- `packages/udp-server/src/banning/event/listener.rs`
+- `packages/udp-server/src/handlers/error.rs`
+- `packages/udp-server/src/statistics/event/listener.rs`
 - `docs/adrs/20260727000000_events_are_objective_facts.md`
 - `docs/issues/closed/1786-tighten-lint-config.md`

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -88,6 +88,14 @@ temporary root-policy enforcement check on 2026-09-04 found four additional viol
 - `dispatch_in_memory_events` in `src/statistics/event/listener.rs` has complexity 29.
 - `dispatch_persistent_completed_statistics_events` in `src/statistics/event/listener.rs` has complexity 29.
 
+After the tracker-core refactor exposed subsequent workspace compilation, a further temporary
+root-policy enforcement check on 2026-09-04 found four additional violations:
+
+- `handle_event` in `packages/http-core/src/statistics/event/handler.rs` has complexity 43.
+- `dispatch_events` in `packages/http-core/src/statistics/event/listener.rs` has complexity 37.
+- `handle_event` in `packages/udp-core/src/statistics/event/handler.rs` has complexity 38.
+- `dispatch_events` in `packages/udp-core/src/statistics/event/listener.rs` has complexity 37.
+
 `Cargo.toml` defines the workspace Clippy policy, but `cognitive_complexity` is not included. Workspace lint settings are only inherited by manifests that opt into `[lints] workspace = true`; the affected package does not currently opt in. CI enforces Clippy through `linter all` (which runs `cargo clippy` for the workspace), so once the lint is declared in `Cargo.toml` and inherited by every package, the existing CI step enforces it without extra workflow changes.
 
 Implementation baseline verified on 2026-09-03:
@@ -104,9 +112,9 @@ On 2026-09-03, all 20 remaining package manifests were temporarily updated to in
 
 ### In Scope
 
-- Refactor all six identified handler and listener functions in `swarm-coordination-registry` and `tracker-core` until none exceeds the default `clippy::cognitive_complexity` threshold.
-- Preserve event-to-metric and persistence updates, labels, timestamps, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, and logging behavior.
-- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling and persistence failure handling.
+- Refactor all ten identified handler and listener functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, and `udp-core` until none exceeds the default `clippy::cognitive_complexity` threshold.
+- Preserve event-to-metric and persistence updates, labels, timestamps, metrics-policy routing, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, and logging behavior.
+- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling, metrics-policy routing, and persistence failure handling.
 - Add `[lints] workspace = true` to every workspace package manifest that does not yet inherit the workspace lint policy, so the lint applies to all 26 packages.
 - Fix every diagnostic exposed by the newly inherited workspace lint policy, preserving behavior and adding or adjusting focused regression coverage where a fix changes executable code.
 - Add `cognitive_complexity` with level `deny` to `[workspace.lints.clippy]` in the root `Cargo.toml` only after the workspace is clean under the inherited existing policy.
@@ -134,9 +142,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
 | T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
-| T3  | IN_PROGRESS | Refactor event metrics handlers              | `swarm-coordination-registry` is complete; split its `handle_event` into helpers. Refactor the two tracker-core handlers while preserving metrics and persistence behavior.      |
-| T4  | IN_PROGRESS | Refactor event listener loops                 | `swarm-coordination-registry` is complete; split receive-result handling from its dispatcher. Apply the same approach to both tracker-core listeners.                            |
-| T5  | IN_PROGRESS | Add focused regression tests                  | `swarm-coordination-registry` coverage is complete; add tracker-core handler, persistence-failure, and listener lifecycle coverage.                                             |
+| T3  | IN_PROGRESS | Refactor event metrics handlers              | `swarm-coordination-registry` and `tracker-core` are complete. Refactor the HTTP and UDP core handlers while preserving metrics, labels, and policy behavior.                   |
+| T4  | IN_PROGRESS | Refactor event listener loops                 | `swarm-coordination-registry` and `tracker-core` are complete. Apply the receive-result extraction to HTTP and UDP core dispatchers.                                            |
+| T5  | IN_PROGRESS | Add focused regression tests                  | Swarm and tracker-core coverage is complete; add HTTP/UDP core label-propagation, metrics-policy, and lifecycle coverage.                                                      |
 | T6  | TODO   | Complete Cargo lint policy                      | Add `[lints] workspace = true` to every package manifest and add `cognitive_complexity = { level = "deny", priority = -1 }` only after T2 through T5 leave the workspace clean. |
 | T7  | TODO   | Verify CI enforcement                           | Confirm `linter all` (as run in `testing.yaml`) fails on a cognitive-complexity violation and passes after the complete remediation; no workflow change expected.               |
 | T8  | TODO   | Update affected documentation                   | Align lint-policy documentation with the final `Cargo.toml` and CI ownership.                                                                                                   |
@@ -169,11 +177,13 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-04 UTC - GitHub Copilot - Completed workspace lint inheritance and all baseline remediation. Flag-free workspace Clippy passed. - Local commit workflow
 - 2026-09-04 UTC - GitHub Copilot - Refactored the swarm-coordination-registry event handler and listener, adding deterministic lifecycle and metric regression coverage in `7e347911`. - Local commit workflow
 - 2026-09-04 UTC - GitHub Copilot - A temporary root cognitive-complexity policy check exposed four additional tracker-core violations (46/25, 35/25, 29/25, and 29/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
+- 2026-09-04 UTC - GitHub Copilot - Refactored the tracker-core event handlers and listeners, adding deterministic lifecycle and persistence-failure regression coverage in `abc0c54e`. - Local commit workflow
+- 2026-09-04 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed four additional HTTP and UDP core violations (43/25, 37/25, 38/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 
 ## Acceptance Criteria
 
-- [ ] AC1: All six identified handler and listener functions in `swarm-coordination-registry` and `tracker-core` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
-- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, listener ordering, termination behavior, and logging semantics are preserved.
+- [ ] AC1: All ten identified handler and listener functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, and `udp-core` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
+- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, and logging semantics are preserved.
 - [ ] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
 - [ ] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
 - [ ] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
@@ -195,6 +205,10 @@ Define verification before implementation starts and execute it before closing t
 - `cargo clippy -p torrust-tracker-swarm-coordination-registry --all-targets --all-features`
 - `cargo test -p torrust-tracker-core --all-features`
 - `cargo clippy -p torrust-tracker-core --all-targets --all-features`
+- `cargo test -p torrust-tracker-http-core --all-features`
+- `cargo clippy -p torrust-tracker-http-core --all-targets --all-features`
+- `cargo test -p torrust-tracker-udp-core --all-features`
+- `cargo clippy -p torrust-tracker-udp-core --all-targets --all-features`
 - `cargo clippy --workspace --all-targets --all-features` (must fail before the refactor once the lint is declared, and pass after)
 - `linter all`
 - `cargo test --doc --workspace`
@@ -244,5 +258,9 @@ Notes:
 - `packages/swarm-coordination-registry/src/statistics/event/listener.rs`
 - `packages/tracker-core/src/statistics/event/handler.rs`
 - `packages/tracker-core/src/statistics/event/listener.rs`
+- `packages/http-core/src/statistics/event/handler.rs`
+- `packages/http-core/src/statistics/event/listener.rs`
+- `packages/udp-core/src/statistics/event/handler.rs`
+- `packages/udp-core/src/statistics/event/listener.rs`
 - `docs/adrs/20260727000000_events_are_objective_facts.md`
 - `docs/issues/closed/1786-tighten-lint-config.md`

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -164,7 +164,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T6  | DONE        | Complete Cargo lint policy                      | Every workspace package inherits lint policy; root `Cargo.toml` denies `cognitive_complexity` and gives it precedence over `nursery`.                                                                                                                        |
 | T7  | DONE        | Verify CI enforcement                           | `linter all`, invoked by both pre-commit and `testing.yaml`, failed on an intentional 27/25 profiling violation and passed after restoration.                                                                                                                |
 | T8  | DONE        | Update affected documentation                   | This issue specification records the final Cargo policy, CI ownership, implementation scope, and evidence.                                                                                                                                                   |
-| T9  | IN_PROGRESS | Run verification and review acceptance criteria | Final full-suite verification and independent task review remain.                                                                                                                                                                                            |
+| T9  | IN_PROGRESS | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; independent final task review remains.                                                                            |
 
 ## Progress Tracking
 
@@ -175,7 +175,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] GitHub issue #2134 created and specification moved to `docs/issues/open/`
 - [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
 - [x] Implementation completed
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [x] Manual verification scenarios executed and recorded (status + evidence)
 - [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [ ] Reviewer validated acceptance criteria and updated checkboxes
@@ -202,6 +202,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-05 UTC - GitHub Copilot - Refactored `profiling::run` by extracting its shutdown selection into `wait_for_shutdown` in `0278ae00`; root-library tests and explicit cognitive-complexity Clippy passed. - Local commit workflow
 - 2026-09-05 UTC - GitHub Copilot - Enabled `cognitive_complexity = { level = "deny", priority = -1 }` in root `Cargo.toml` in `b2733dac` and set `nursery` to priority `-2`, as Cargo requires to permit the individual lint override. - Local commit workflow
 - 2026-09-05 UTC - GitHub Copilot - Verified flag-free workspace Clippy and `linter all` pass with the root policy enabled. Temporarily restored the profiling runner's previous 27/25 shape; `linter all` failed with the expected cognitive-complexity diagnostic, then passed after the compliant helper was restored. Both pre-commit and `testing.yaml` invoke `linter all`. - Terminal output and workflow inspection in this session
+- 2026-09-05 UTC - GitHub Copilot - Final pre-push verification passed: nightly formatting, nightly workspace checks, nightly documentation build, and the complete stable test suite. Corrected twelve pre-existing broken rustdoc links in `7b75d393` so the mandatory documentation build could complete. - Pre-push JSON output and local commit workflow
 
 ## Acceptance Criteria
 
@@ -212,7 +213,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
 - [x] AC6: Focused regression tests cover behavior affected by the baseline remediation, including listener receive outcomes where practicable.
 - [x] `linter all` exits with code `0`.
-- [ ] Relevant tests pass.
+- [x] Relevant tests pass.
 - [x] Manual verification scenarios are executed and documented (status + evidence).
 - [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
 - [x] Documentation is updated when behavior/workflow changes.

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -8,7 +8,7 @@ github-issue: 2134
 spec-path: docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
 branch: "2134-fix-cognitive-complexity-lint-enforcement"
 related-pr: null
-last-updated-utc: 2026-09-03 00:15
+last-updated-utc: 2026-09-05 00:00
 semantic-links:
   skill-links:
     - create-issue
@@ -18,6 +18,8 @@ semantic-links:
     - .github/workflows/testing.yaml
     - packages/swarm-coordination-registry/src/statistics/event/handler.rs
     - packages/swarm-coordination-registry/src/statistics/event/listener.rs
+    - src/console/profiling.rs
+    - packages/e2e-tools/src/bin/profiling.rs
     - .github/skills/dev/planning/create-issue/SKILL.md
 ---
 
@@ -104,6 +106,12 @@ temporary root-policy enforcement check on 2026-09-05 found three additional vio
 - `log_error` in `src/handlers/error.rs` has complexity 32.
 - `dispatch_events` in `src/statistics/event/listener.rs` has complexity 37.
 
+After the UDP-server refactor exposed subsequent workspace compilation, a further temporary
+root-policy enforcement check on 2026-09-05 found one additional violation in the root
+`torrust-tracker` crate:
+
+- `run` in `src/console/profiling.rs` has complexity 27.
+
 `Cargo.toml` defines the workspace Clippy policy, but `cognitive_complexity` is not included. Workspace lint settings are only inherited by manifests that opt into `[lints] workspace = true`; the affected package does not currently opt in. CI enforces Clippy through `linter all` (which runs `cargo clippy` for the workspace), so once the lint is declared in `Cargo.toml` and inherited by every package, the existing CI step enforces it without extra workflow changes.
 
 Implementation baseline verified on 2026-09-03:
@@ -120,9 +128,9 @@ On 2026-09-03, all 20 remaining package manifests were temporarily updated to in
 
 ### In Scope
 
-- Refactor all thirteen identified handlers, listeners, and error-log functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, and `udp-server` until none exceeds the default `clippy::cognitive_complexity` threshold.
-- Preserve event-to-metric and persistence updates, labels, timestamps, metrics-policy routing, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, UDP error-response construction, and logging behavior.
-- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling, metrics-policy routing, persistence failure handling, and UDP error-event publication.
+- Refactor all fourteen identified handlers, listeners, error-log functions, and the profiling runner in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, `udp-server`, and the root crate until none exceeds the default `clippy::cognitive_complexity` threshold.
+- Preserve event-to-metric and persistence updates, labels, timestamps, metrics-policy routing, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, UDP error-response construction, profiling CLI/startup reporting, timer-versus-Ctrl+C behavior, and logging behavior.
+- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling, metrics-policy routing, persistence failure handling, UDP error-event publication, and profiling CLI behavior.
 - Add `[lints] workspace = true` to every workspace package manifest that does not yet inherit the workspace lint policy, so the lint applies to all 26 packages.
 - Fix every diagnostic exposed by the newly inherited workspace lint policy, preserving behavior and adding or adjusting focused regression coverage where a fix changes executable code.
 - Add `cognitive_complexity` with level `deny` to `[workspace.lints.clippy]` in the root `Cargo.toml` only after the workspace is clean under the inherited existing policy.
@@ -150,9 +158,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
 | T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
-| T3  | IN_PROGRESS | Refactor event metrics handlers              | Swarm, tracker-core, HTTP core, and UDP core are complete. Refactor the UDP-server error logger while preserving response and event behavior.                                 |
+| T3  | IN_PROGRESS | Refactor event-processing functions          | All event handlers/listeners and the UDP-server error logger are complete. Refactor the profiling runner while preserving its asymmetric shutdown behavior.                  |
 | T4  | IN_PROGRESS | Refactor event listener loops                 | Swarm, tracker-core, HTTP core, and UDP core are complete. Apply the receive-result extraction to both UDP-server dispatchers.                                                  |
-| T5  | IN_PROGRESS | Add focused regression tests                  | Add UDP-server error-event publication, metrics-policy, banning, and lifecycle coverage.                                                                                        |
+| T5  | IN_PROGRESS | Add focused regression tests                  | Event-processing coverage is complete. Add proportionate profiling CLI coverage where a deterministic executable fixture is practical.                                         |
 | T6  | TODO   | Complete Cargo lint policy                      | Add `[lints] workspace = true` to every package manifest and add `cognitive_complexity = { level = "deny", priority = -1 }` only after T2 through T5 leave the workspace clean. |
 | T7  | TODO   | Verify CI enforcement                           | Confirm `linter all` (as run in `testing.yaml`) fails on a cognitive-complexity violation and passes after the complete remediation; no workflow change expected.               |
 | T8  | TODO   | Update affected documentation                   | Align lint-policy documentation with the final `Cargo.toml` and CI ownership.                                                                                                   |
@@ -189,11 +197,13 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-04 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed four additional HTTP and UDP core violations (43/25, 37/25, 38/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 - 2026-09-04 UTC - GitHub Copilot - Refactored the HTTP and UDP core event handlers and listeners, adding deterministic lifecycle, policy-routing, and label-propagation coverage in `d635566e` and `7c6c609d`. - Local commit workflow
 - 2026-09-05 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed three additional UDP-server violations (29/25, 32/25, and 37/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
+- 2026-09-05 UTC - GitHub Copilot - Refactored both UDP-server event listeners and the UDP error logger, adding deterministic listener and error-event regression coverage in `33387541`. - Local commit workflow
+- 2026-09-05 UTC - GitHub Copilot - A subsequent temporary root cognitive-complexity policy check exposed the root profiling runner violation (27/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 
 ## Acceptance Criteria
 
-- [ ] AC1: All thirteen identified handlers, listeners, and error-log functions in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, and `udp-server` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
-- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, UDP error responses and event publication, and logging semantics are preserved.
+- [ ] AC1: All fourteen identified handlers, listeners, error-log functions, and the profiling runner in `swarm-coordination-registry`, `tracker-core`, `http-core`, `udp-core`, `udp-server`, and the root crate comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
+- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, metrics-policy routing, listener ordering, termination behavior, UDP error responses and event publication, profiling CLI/startup reporting, timer-versus-Ctrl+C behavior, and logging semantics are preserved.
 - [ ] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
 - [ ] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
 - [ ] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
@@ -221,6 +231,7 @@ Define verification before implementation starts and execute it before closing t
 - `cargo clippy -p torrust-tracker-udp-core --all-targets --all-features`
 - `cargo test -p torrust-tracker-udp-server --all-features`
 - `cargo clippy -p torrust-tracker-udp-server --all-targets --all-features`
+- `cargo clippy -p torrust-tracker --lib -- -D clippy::cognitive_complexity -D warnings`
 - `cargo clippy --workspace --all-targets --all-features` (must fail before the refactor once the lint is declared, and pass after)
 - `linter all`
 - `cargo test --doc --workspace`
@@ -277,5 +288,7 @@ Notes:
 - `packages/udp-server/src/banning/event/listener.rs`
 - `packages/udp-server/src/handlers/error.rs`
 - `packages/udp-server/src/statistics/event/listener.rs`
+- `src/console/profiling.rs`
+- `packages/e2e-tools/src/bin/profiling.rs`
 - `docs/adrs/20260727000000_events_are_objective_facts.md`
 - `docs/issues/closed/1786-tighten-lint-config.md`

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -79,6 +79,15 @@ error: could not compile `torrust-tracker-swarm-coordination-registry` (lib test
 - `handle_event` in `packages/swarm-coordination-registry/src/statistics/event/handler.rs` has complexity 59.
 - `dispatch_events` in `packages/swarm-coordination-registry/src/statistics/event/listener.rs` has complexity 29.
 
+After the swarm-coordination-registry refactor exposed subsequent workspace compilation, a
+temporary root-policy enforcement check on 2026-09-04 found four additional violations in
+`packages/tracker-core`:
+
+- `handle_in_memory_event` in `src/statistics/event/handler.rs` has complexity 46.
+- `handle_persistent_completed_statistics_event` in `src/statistics/event/handler.rs` has complexity 35.
+- `dispatch_in_memory_events` in `src/statistics/event/listener.rs` has complexity 29.
+- `dispatch_persistent_completed_statistics_events` in `src/statistics/event/listener.rs` has complexity 29.
+
 `Cargo.toml` defines the workspace Clippy policy, but `cognitive_complexity` is not included. Workspace lint settings are only inherited by manifests that opt into `[lints] workspace = true`; the affected package does not currently opt in. CI enforces Clippy through `linter all` (which runs `cargo clippy` for the workspace), so once the lint is declared in `Cargo.toml` and inherited by every package, the existing CI step enforces it without extra workflow changes.
 
 Implementation baseline verified on 2026-09-03:
@@ -95,9 +104,9 @@ On 2026-09-03, all 20 remaining package manifests were temporarily updated to in
 
 ### In Scope
 
-- Refactor `handle_event` and `dispatch_events` until neither exceeds the default `clippy::cognitive_complexity` threshold.
-- Preserve event-to-metric updates, labels, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, and logging behavior.
-- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling.
+- Refactor all six identified handler and listener functions in `swarm-coordination-registry` and `tracker-core` until none exceeds the default `clippy::cognitive_complexity` threshold.
+- Preserve event-to-metric and persistence updates, labels, timestamps, listener cancellation priority, receiver-closed termination, lagged-receiver continuation, and logging behavior.
+- Retain and extend focused automated coverage where needed to protect the refactored behavior, especially listener receive-result handling and persistence failure handling.
 - Add `[lints] workspace = true` to every workspace package manifest that does not yet inherit the workspace lint policy, so the lint applies to all 26 packages.
 - Fix every diagnostic exposed by the newly inherited workspace lint policy, preserving behavior and adding or adjusting focused regression coverage where a fix changes executable code.
 - Add `cognitive_complexity` with level `deny` to `[workspace.lints.clippy]` in the root `Cargo.toml` only after the workspace is clean under the inherited existing policy.
@@ -125,9 +134,9 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
 | T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
-| T3  | TODO   | Refactor event metrics handler                  | Split `handle_event` into intention-revealing helpers while preserving all existing metric effects and labels.                                                                  |
-| T4  | TODO   | Refactor event listener loop                    | Split receive-result handling from `dispatch_events` while retaining `biased` cancellation priority and all shutdown/lag behavior.                                              |
-| T5  | TODO   | Add focused regression tests                    | Preserve handler coverage and add listener behavior coverage where practical.                                                                                                   |
+| T3  | IN_PROGRESS | Refactor event metrics handlers              | `swarm-coordination-registry` is complete; split its `handle_event` into helpers. Refactor the two tracker-core handlers while preserving metrics and persistence behavior.      |
+| T4  | IN_PROGRESS | Refactor event listener loops                 | `swarm-coordination-registry` is complete; split receive-result handling from its dispatcher. Apply the same approach to both tracker-core listeners.                            |
+| T5  | IN_PROGRESS | Add focused regression tests                  | `swarm-coordination-registry` coverage is complete; add tracker-core handler, persistence-failure, and listener lifecycle coverage.                                             |
 | T6  | TODO   | Complete Cargo lint policy                      | Add `[lints] workspace = true` to every package manifest and add `cognitive_complexity = { level = "deny", priority = -1 }` only after T2 through T5 leave the workspace clean. |
 | T7  | TODO   | Verify CI enforcement                           | Confirm `linter all` (as run in `testing.yaml`) fails on a cognitive-complexity violation and passes after the complete remediation; no workflow change expected.               |
 | T8  | TODO   | Update affected documentation                   | Align lint-policy documentation with the final `Cargo.toml` and CI ownership.                                                                                                   |
@@ -157,11 +166,14 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-03 00:00 UTC - GitHub Copilot - Created GitHub issue #2134. - https://github.com/torrust/torrust-tracker/issues/2134
 - 2026-09-03 00:00 UTC - Committer - Verified the specification progress and staged scope before the specification commit. - Local commit workflow
 - 2026-09-03 00:15 UTC - GitHub Copilot - Created the implementation branch from merged `develop`. Began package-scoped workspace lint inheritance and baseline remediation; `udp-protocol` is complete in commit `df3bab7a`. - Local commit workflow
+- 2026-09-04 UTC - GitHub Copilot - Completed workspace lint inheritance and all baseline remediation. Flag-free workspace Clippy passed. - Local commit workflow
+- 2026-09-04 UTC - GitHub Copilot - Refactored the swarm-coordination-registry event handler and listener, adding deterministic lifecycle and metric regression coverage in `7e347911`. - Local commit workflow
+- 2026-09-04 UTC - GitHub Copilot - A temporary root cognitive-complexity policy check exposed four additional tracker-core violations (46/25, 35/25, 29/25, and 29/25). Reverted the temporary policy and expanded this specification before implementation. - Terminal output and source inspection in this session
 
 ## Acceptance Criteria
 
-- [ ] AC1: `handle_event` and `dispatch_events` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
-- [ ] AC2: Existing observable event-metric behavior, metric labels, listener ordering, termination behavior, and logging semantics are preserved.
+- [ ] AC1: All six identified handler and listener functions in `swarm-coordination-registry` and `tracker-core` comply with Clippy's default cognitive-complexity threshold without a `clippy::cognitive_complexity` allowance.
+- [ ] AC2: Existing observable event-metric and persistence behavior, metric labels, timestamps, listener ordering, termination behavior, and logging semantics are preserved.
 - [ ] AC3: Root `Cargo.toml` declares `clippy::cognitive_complexity` as a denied workspace lint, and every workspace package manifest inherits workspace lints via `[lints] workspace = true`.
 - [ ] AC4: `cargo clippy --workspace --all-targets --all-features` (with no extra `-D` flags) fails on a cognitive-complexity violation, so the existing `linter all` CI step enforces it.
 - [ ] AC5: Every diagnostic exposed by enabling workspace lint inheritance, including the 87-diagnostic baseline, is fixed without lint allowances that weaken the workspace policy.
@@ -181,6 +193,8 @@ Define verification before implementation starts and execute it before closing t
 - `cargo fmt --check`
 - `cargo test -p torrust-tracker-swarm-coordination-registry`
 - `cargo clippy -p torrust-tracker-swarm-coordination-registry --all-targets --all-features`
+- `cargo test -p torrust-tracker-core --all-features`
+- `cargo clippy -p torrust-tracker-core --all-targets --all-features`
 - `cargo clippy --workspace --all-targets --all-features` (must fail before the refactor once the lint is declared, and pass after)
 - `linter all`
 - `cargo test --doc --workspace`
@@ -228,5 +242,7 @@ Notes:
 - `.github/workflows/testing.yaml`
 - `packages/swarm-coordination-registry/src/statistics/event/handler.rs`
 - `packages/swarm-coordination-registry/src/statistics/event/listener.rs`
+- `packages/tracker-core/src/statistics/event/handler.rs`
+- `packages/tracker-core/src/statistics/event/listener.rs`
 - `docs/adrs/20260727000000_events_are_objective_facts.md`
 - `docs/issues/closed/1786-tighten-lint-config.md`

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
@@ -1,14 +1,14 @@
 ---
 doc-type: issue
 issue-type: task
-status: planned
+status: in-progress
 priority: p1
 epic: null
 github-issue: 2134
 spec-path: docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
-branch: "2134-fix-cognitive-complexity-lint-enforcement-spec"
+branch: "2134-fix-cognitive-complexity-lint-enforcement"
 related-pr: null
-last-updated-utc: 2026-09-03 00:00
+last-updated-utc: 2026-09-03 00:15
 semantic-links:
   skill-links:
     - create-issue
@@ -124,7 +124,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | ID  | Status | Task                                            | Notes / Expected Output                                                                                                                                                         |
 | --- | ------ | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE   | Establish enforcement baseline                  | Verified 26 workspace packages, temporarily enabled lint inheritance in all 20 remaining manifests, recorded the 87-diagnostic baseline, then reverted the experiment.          |
-| T2  | TODO   | Remediate workspace lint baseline               | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
+| T2  | IN_PROGRESS | Remediate workspace lint baseline           | Fix all 87 diagnostics exposed by full workspace-lint inheritance, retaining behavior and adding focused regression tests where needed.                                         |
 | T3  | TODO   | Refactor event metrics handler                  | Split `handle_event` into intention-revealing helpers while preserving all existing metric effects and labels.                                                                  |
 | T4  | TODO   | Refactor event listener loop                    | Split receive-result handling from `dispatch_events` while retaining `biased` cancellation priority and all shutdown/lag behavior.                                              |
 | T5  | TODO   | Add focused regression tests                    | Preserve handler coverage and add listener behavior coverage where practical.                                                                                                   |
@@ -140,7 +140,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Spec drafted in `docs/issues/drafts/`
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue #2134 created and specification moved to `docs/issues/open/`
-- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
 - [ ] Implementation completed
 - [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [ ] Manual verification scenarios executed and recorded (status + evidence)
@@ -156,6 +156,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-03 00:00 UTC - GitHub Copilot - Temporarily enabled workspace lint inheritance in all 20 remaining package manifests and recorded a flag-free full-workspace baseline of 87 diagnostics, chiefly `use_self`, `missing_const_for_fn`, and `derive_partial_eq_without_eq`. The experiment was reverted; user expanded this issue to remediate every diagnostic before enabling the cognitive-complexity lint. - Terminal output and user direction in this session
 - 2026-09-03 00:00 UTC - GitHub Copilot - Created GitHub issue #2134. - https://github.com/torrust/torrust-tracker/issues/2134
 - 2026-09-03 00:00 UTC - Committer - Verified the specification progress and staged scope before the specification commit. - Local commit workflow
+- 2026-09-03 00:15 UTC - GitHub Copilot - Created the implementation branch from merged `develop`. Began package-scoped workspace lint inheritance and baseline remediation; `udp-protocol` is complete in commit `df3bab7a`. - Local commit workflow
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
@@ -5,7 +5,7 @@ status: in-progress
 priority: p1
 epic: null
 github-issue: 2134
-spec-path: docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement.md
+spec-path: docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
 branch: "2134-fix-cognitive-complexity-lint-enforcement"
 related-pr: null
 last-updated-utc: 2026-09-05 00:00
@@ -21,6 +21,7 @@ semantic-links:
     - src/console/profiling.rs
     - packages/e2e-tools/src/bin/profiling.rs
     - .github/skills/dev/planning/create-issue/SKILL.md
+    - docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/implementation-retrospective.md
 ---
 
 # Issue #2134 - Fix cognitive-complexity violations and enforce the Clippy lint
@@ -164,7 +165,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T6  | DONE        | Complete Cargo lint policy                      | Every workspace package inherits lint policy; root `Cargo.toml` denies `cognitive_complexity` and gives it precedence over `nursery`.                                                                                                                        |
 | T7  | DONE        | Verify CI enforcement                           | `linter all`, invoked by both pre-commit and `testing.yaml`, failed on an intentional 27/25 profiling violation and passed after restoration.                                                                                                                |
 | T8  | DONE        | Update affected documentation                   | This issue specification records the final Cargo policy, CI ownership, implementation scope, and evidence.                                                                                                                                                   |
-| T9  | IN_PROGRESS | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; independent final task review remains.                                                                            |
+| T9  | IN_PROGRESS | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; independent final task review remains.                                                                                                                                                         |
 
 ## Progress Tracking
 
@@ -178,7 +179,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [x] Manual verification scenarios executed and recorded (status + evidence)
 - [x] Acceptance criteria reviewed after implementation and updated with evidence
-- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [x] Reviewer validated acceptance criteria and updated checkboxes
 - [x] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
@@ -203,6 +204,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-05 UTC - GitHub Copilot - Enabled `cognitive_complexity = { level = "deny", priority = -1 }` in root `Cargo.toml` in `b2733dac` and set `nursery` to priority `-2`, as Cargo requires to permit the individual lint override. - Local commit workflow
 - 2026-09-05 UTC - GitHub Copilot - Verified flag-free workspace Clippy and `linter all` pass with the root policy enabled. Temporarily restored the profiling runner's previous 27/25 shape; `linter all` failed with the expected cognitive-complexity diagnostic, then passed after the compliant helper was restored. Both pre-commit and `testing.yaml` invoke `linter all`. - Terminal output and workflow inspection in this session
 - 2026-09-05 UTC - GitHub Copilot - Final pre-push verification passed: nightly formatting, nightly workspace checks, nightly documentation build, and the complete stable test suite. Corrected twelve pre-existing broken rustdoc links in `7b75d393` so the mandatory documentation build could complete. - Pre-push JSON output and local commit workflow
+- 2026-09-05 UTC - Task Reviewer - Independently reviewed the full branch against this specification. All acceptance criteria passed; this material scope expansion required an issue-local implementation retrospective. - Final task review
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
@@ -165,7 +165,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T6  | DONE        | Complete Cargo lint policy                      | Every workspace package inherits lint policy; root `Cargo.toml` denies `cognitive_complexity` and gives it precedence over `nursery`.                                                                                                                        |
 | T7  | DONE        | Verify CI enforcement                           | `linter all`, invoked by both pre-commit and `testing.yaml`, failed on an intentional 27/25 profiling violation and passed after restoration.                                                                                                                |
 | T8  | DONE        | Update affected documentation                   | This issue specification records the final Cargo policy, CI ownership, implementation scope, and evidence.                                                                                                                                                   |
-| T9  | IN_PROGRESS | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; independent final task review remains.                                                                                                                                                         |
+| T9  | DONE        | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; the independent final task review passed.                                                                                                                                                      |
 
 ## Progress Tracking
 
@@ -205,6 +205,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-05 UTC - GitHub Copilot - Verified flag-free workspace Clippy and `linter all` pass with the root policy enabled. Temporarily restored the profiling runner's previous 27/25 shape; `linter all` failed with the expected cognitive-complexity diagnostic, then passed after the compliant helper was restored. Both pre-commit and `testing.yaml` invoke `linter all`. - Terminal output and workflow inspection in this session
 - 2026-09-05 UTC - GitHub Copilot - Final pre-push verification passed: nightly formatting, nightly workspace checks, nightly documentation build, and the complete stable test suite. Corrected twelve pre-existing broken rustdoc links in `7b75d393` so the mandatory documentation build could complete. - Pre-push JSON output and local commit workflow
 - 2026-09-05 UTC - Task Reviewer - Independently reviewed the full branch against this specification. All acceptance criteria passed; this material scope expansion required an issue-local implementation retrospective. - Final task review
+- 2026-09-05 UTC - Task Reviewer - Re-reviewed the full branch after the folder-layout migration and retrospective. All acceptance criteria, validation evidence, and completion-review requirements passed. - Final task review
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/ISSUE.md
@@ -165,7 +165,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T6  | DONE        | Complete Cargo lint policy                      | Every workspace package inherits lint policy; root `Cargo.toml` denies `cognitive_complexity` and gives it precedence over `nursery`.                                                                                                                        |
 | T7  | DONE        | Verify CI enforcement                           | `linter all`, invoked by both pre-commit and `testing.yaml`, failed on an intentional 27/25 profiling violation and passed after restoration.                                                                                                                |
 | T8  | DONE        | Update affected documentation                   | This issue specification records the final Cargo policy, CI ownership, implementation scope, and evidence.                                                                                                                                                   |
-| T9  | DONE        | Run verification and review acceptance criteria | The full stable suite and pre-push gate passed on 2026-09-05; the independent final task review passed.                                                                                                                                                      |
+| T9  | IN_PROGRESS | Run verification and review acceptance criteria | Nightly CI exposed a zerocopy macro-generated `empty_enums` false positive; validate the documented compatibility fix and repeat final review.                                                                                                             |
 
 ## Progress Tracking
 
@@ -176,7 +176,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - [x] GitHub issue #2134 created and specification moved to `docs/issues/open/`
 - [x] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
 - [x] Implementation completed
-- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
 - [x] Manual verification scenarios executed and recorded (status + evidence)
 - [x] Acceptance criteria reviewed after implementation and updated with evidence
 - [x] Reviewer validated acceptance criteria and updated checkboxes
@@ -206,6 +206,7 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 - 2026-09-05 UTC - GitHub Copilot - Final pre-push verification passed: nightly formatting, nightly workspace checks, nightly documentation build, and the complete stable test suite. Corrected twelve pre-existing broken rustdoc links in `7b75d393` so the mandatory documentation build could complete. - Pre-push JSON output and local commit workflow
 - 2026-09-05 UTC - Task Reviewer - Independently reviewed the full branch against this specification. All acceptance criteria passed; this material scope expansion required an issue-local implementation retrospective. - Final task review
 - 2026-09-05 UTC - Task Reviewer - Re-reviewed the full branch after the folder-layout migration and retrospective. All acceptance criteria, validation evidence, and completion-review requirements passed. - Final task review
+- 2026-09-05 UTC - GitHub Copilot - The nightly PR `linter all` job reported `clippy::empty_enums` from zerocopy-generated `FromBytes` helper enums in `udp-protocol`, plus an explicit uninhabited registry error enum. Replaced the explicit enum with `Infallible`, removed its unused `thiserror` dependency, and added a documented crate-level exception for the macro-generated false positive. Nightly and stable `linter all` now pass locally. - GitHub Actions job 101292805541 and local validation
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/implementation-retrospective.md
+++ b/docs/issues/open/2134-fix-cognitive-complexity-lint-enforcement/implementation-retrospective.md
@@ -1,0 +1,74 @@
+---
+semantic-links:
+  related-artifacts:
+    - ISSUE.md
+    - Cargo.toml
+    - .github/workflows/testing.yaml
+    - contrib/dev-tools/git/hooks/pre-commit.sh
+---
+
+# Implementation Retrospective — Issue #2134 cognitive-complexity enforcement
+
+## Purpose
+
+Record reusable lessons from enabling `clippy::cognitive_complexity` for the complete Torrust
+Tracker Cargo workspace.
+
+## Outcome
+
+All workspace packages now inherit the workspace lint policy. The root `Cargo.toml` denies
+`clippy::cognitive_complexity`, and the existing `linter all` invocation in pre-commit and CI
+enforces it. Fourteen functions were structurally simplified without cognitive-complexity
+allowances or a threshold change. Focused regression tests cover the refactored event-processing
+paths.
+
+## What Went Well
+
+1. Enabling lint inheritance before the new gate exposed the pre-existing baseline explicitly and
+   allowed each diagnostic to be fixed without weakening the policy.
+2. Repeated policy trials revealed violations incrementally; focused refactors and deterministic
+   receiver tests preserved cancellation, closed-channel, lagged-channel, and metrics-policy
+   behavior.
+3. The existing `linter all` integration made the final CI and hook enforcement path available
+   without a redundant workflow step.
+
+## What Changed During Implementation
+
+The approved initial scope covered two violations in `swarm-coordination-registry`. As compilation
+proceeded after each remediation, policy trials exposed twelve additional violations in
+`tracker-core`, `http-core`, `udp-core`, `udp-server`, and the root profiling runner. The work also
+found that Cargo requires the `nursery` lint group to have lower priority than an individual
+overriding lint; its priority changed from `-1` to `-2`.
+
+The final pre-push documentation build exposed twelve stale intra-doc links in unrelated existing
+documentation. They were corrected in `7b75d393` to restore the required validation gate.
+
+## Root Cause
+
+The original investigation stopped as soon as the compiler encountered the first
+cognitive-complexity failures. It therefore could not enumerate later violations that compilation
+would only reach after earlier failures were fixed. The original specification also predated the
+repository's folder-style issue layout and did not reserve an issue-local retrospective artifact.
+
+## Improvements for Future Work
+
+1. When adding a denied workspace lint, run it with `cargo clippy --workspace --all-targets
+--all-features` repeatedly until the complete workspace reaches a fixed point before treating
+   the violation inventory as final.
+2. Start complex issue specifications in folder-style layout so validation evidence and
+   retrospectives can be recorded locally without a mid-implementation migration.
+
+## Avoiding Overcorrection
+
+Do not add a separate CI Clippy workflow step for each new Cargo lint: `testing.yaml` and the
+pre-commit hook already run `linter all`, which invokes Clippy. Do not create cross-package event
+listener abstractions solely to reduce local complexity; package-local helpers retained clear
+protocol and domain boundaries.
+
+## Evidence
+
+- [Issue specification](ISSUE.md)
+- `b2733dac` — denied root cognitive-complexity policy
+- `9e2a692b`, `e289ab60`, `2f6be923`, `477bd377`, `33387541`, and `0278ae00` — structural refactors
+- `7b75d393` — nightly rustdoc link corrections
+- 2026-09-05 pre-push JSON output — nightly formatting/check/docs and full stable tests passed

--- a/packages/axum-health-check-api-server/Cargo.toml
+++ b/packages/axum-health-check-api-server/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { version = "0", features = [ "macros" ] }
 axum-server = { version = "0", features = [ "tls-rustls-no-provider" ] }

--- a/packages/axum-health-check-api-server/src/handlers.rs
+++ b/packages/axum-health-check-api-server/src/handlers.rs
@@ -13,7 +13,7 @@ use super::responses;
 ///
 #[instrument(skip(registar), ret(level = Level::DEBUG))]
 pub(crate) async fn health_check_handler(State(registar): State<Registar<RuntimeServiceMetadata>>) -> Json<Report> {
-    let mut checks: Vec<_> = registar
+    let checks: Vec<_> = registar
         .services()
         .await
         .into_iter()
@@ -35,7 +35,7 @@ pub(crate) async fn health_check_handler(State(registar): State<Registar<Runtime
     }
 
     let jobs = checks
-        .drain(..)
+        .into_iter()
         .map(|(service_binding, service_type, public_url, health_check)| {
             tokio::spawn(async move {
                 CheckReport {
@@ -54,7 +54,7 @@ pub(crate) async fn health_check_handler(State(registar): State<Registar<Runtime
 
     let results: Vec<CheckReport> = futures::future::join_all(jobs)
         .await
-        .drain(..)
+        .into_iter()
         .map(|r| r.expect("it should be able to connect to the job"))
         .collect();
 

--- a/packages/axum-health-check-api-server/src/resources.rs
+++ b/packages/axum-health-check-api-server/src/resources.rs
@@ -22,11 +22,11 @@ pub struct CheckReport {
 
 impl CheckReport {
     #[must_use]
-    pub fn pass(&self) -> bool {
+    pub const fn pass(&self) -> bool {
         self.result.is_ok()
     }
     #[must_use]
-    pub fn fail(&self) -> bool {
+    pub const fn fail(&self) -> bool {
         self.result.is_err()
     }
 }
@@ -40,7 +40,7 @@ pub struct Report {
 
 impl Report {
     #[must_use]
-    pub fn none() -> Report {
+    pub fn none() -> Self {
         Self {
             status: Status::None,
             message: String::new(),
@@ -49,7 +49,7 @@ impl Report {
     }
 
     #[must_use]
-    pub fn ok(details: Vec<CheckReport>) -> Report {
+    pub const fn ok(details: Vec<CheckReport>) -> Self {
         Self {
             status: Status::Ok,
             message: String::new(),
@@ -58,7 +58,7 @@ impl Report {
     }
 
     #[must_use]
-    pub fn error(message: String, details: Vec<CheckReport>) -> Report {
+    pub const fn error(message: String, details: Vec<CheckReport>) -> Self {
         Self {
             status: Status::Error,
             message,

--- a/packages/axum-health-check-api-server/src/responses.rs
+++ b/packages/axum-health-check-api-server/src/responses.rs
@@ -2,11 +2,11 @@ use axum::Json;
 
 use super::resources::{CheckReport, Report};
 
-pub fn ok(details: Vec<CheckReport>) -> Json<Report> {
+pub const fn ok(details: Vec<CheckReport>) -> Json<Report> {
     Json(Report::ok(details))
 }
 
-pub fn error(message: String, details: Vec<CheckReport>) -> Json<Report> {
+pub const fn error(message: String, details: Vec<CheckReport>) -> Json<Report> {
     Json(Report::error(message, details))
 }
 

--- a/packages/axum-health-check-api-server/src/server.rs
+++ b/packages/axum-health-check-api-server/src/server.rs
@@ -106,7 +106,7 @@ pub fn start(
     socket.set_nonblocking(true)?;
     let address = socket.local_addr()?;
     let protocol = Protocol::HTTP; // The health check API only supports HTTP directly now. Use a reverse proxy for HTTPS.
-    let service_binding = ServiceBinding::new(protocol.clone(), address).map_err(std::io::Error::other)?;
+    let service_binding = ServiceBinding::new(protocol, address).map_err(std::io::Error::other)?;
 
     let handle = Handle::new();
 

--- a/packages/axum-health-check-api-server/tests/server/contract.rs
+++ b/packages/axum-health-check-api-server/tests/server/contract.rs
@@ -41,7 +41,7 @@ mod api {
     use crate::server::client::get;
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_good_health_for_api_service() {
+    async fn it_should_return_good_health_for_api_service() {
         logging::setup();
 
         let mut configuration = configuration::ephemeral();
@@ -107,7 +107,7 @@ mod api {
     }
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_error_when_api_service_was_stopped_after_registration() {
+    async fn it_should_return_error_when_api_service_was_stopped_after_registration() {
         logging::setup();
 
         let configuration = Arc::new(configuration::ephemeral());
@@ -183,7 +183,7 @@ mod http {
     }
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_good_health_for_http_service() {
+    async fn it_should_return_good_health_for_http_service() {
         logging::setup();
 
         let configuration = configuration::ephemeral();
@@ -237,7 +237,7 @@ mod http {
     }
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_good_health_for_https_service_with_a_trusted_test_certificate() {
+    async fn it_should_return_good_health_for_https_service_with_a_trusted_test_certificate() {
         logging::setup();
         install_rustls_crypto_provider();
 
@@ -296,7 +296,7 @@ mod http {
     }
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_error_when_http_service_was_stopped_after_registration() {
+    async fn it_should_return_error_when_http_service_was_stopped_after_registration() {
         logging::setup();
 
         let configuration = configuration::ephemeral();
@@ -363,7 +363,7 @@ mod udp {
     use crate::server::client::get;
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_good_health_for_udp_service() {
+    async fn it_should_return_good_health_for_udp_service() {
         logging::setup();
 
         let configuration = configuration::ephemeral();
@@ -413,7 +413,7 @@ mod udp {
     }
 
     #[tokio::test]
-    pub(crate) async fn it_should_return_error_when_udp_service_was_stopped_after_registration() {
+    async fn it_should_return_error_when_udp_service_was_stopped_after_registration() {
         logging::setup();
 
         let configuration = configuration::ephemeral();

--- a/packages/axum-http-server/Cargo.toml
+++ b/packages/axum-http-server/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { version = "0", features = [ "macros" ] }
 axum-client-ip = "0"

--- a/packages/axum-http-server/examples/http_only_public_tracker.rs
+++ b/packages/axum-http-server/examples/http_only_public_tracker.rs
@@ -41,6 +41,7 @@
 //! cargo tree -p torrust-tracker-axum-http-server --example http_only_public_tracker
 //! ```
 
+use std::io::Write as _;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
@@ -76,27 +77,29 @@ async fn main() {
         network: Network::default(),
     };
 
-    println!("Types from torrust-tracker-configuration used by this binary:");
-    println!("  Core        — tracker domain settings");
-    println!("  HttpTracker — bind address, TLS config");
-    println!("  (Configuration aggregate and idle types are NOT compiled in)");
-    println!();
+    let stdout = std::io::stdout();
+    let mut output = stdout.lock();
+    writeln!(output, "Types from torrust-tracker-configuration used by this binary:").expect("stdout should be writable");
+    writeln!(output, "  Core        — tracker domain settings").expect("stdout should be writable");
+    writeln!(output, "  HttpTracker — bind address, TLS config").expect("stdout should be writable");
+    writeln!(output, "  (Configuration aggregate and idle types are NOT compiled in)").expect("stdout should be writable");
+    writeln!(output).expect("stdout should be writable");
 
     // Start the tracker using the narrowed API; `Started` is a type alias for `Environment<Running>`.
     let core_config = Arc::new(core);
     let http_tracker_config = Arc::new(http_tracker);
     let env = Started::new(&core_config, &http_tracker_config).await;
 
-    println!("Listening on {}", env.bind_address());
-    println!("Press Ctrl-C to stop.");
+    writeln!(output, "Listening on {}", env.bind_address()).expect("stdout should be writable");
+    writeln!(output, "Press Ctrl-C to stop.").expect("stdout should be writable");
 
     tokio::signal::ctrl_c().await.expect("failed to install Ctrl-C handler");
-    println!("\nShutting down...");
+    writeln!(output, "\nShutting down...").expect("stdout should be writable");
 
     env.stop().await;
 
     // Best-effort cleanup of the temporary database file.
     std::fs::remove_file(&db_path).ok();
 
-    println!("Stopped.");
+    writeln!(output, "Stopped.").expect("stdout should be writable");
 }

--- a/packages/axum-http-server/src/lib.rs
+++ b/packages/axum-http-server/src/lib.rs
@@ -316,7 +316,7 @@ pub enum Version {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    pub(crate) mod helpers {
+    pub mod helpers {
         use torrust_info_hash::InfoHash;
 
         /// # Panics

--- a/packages/axum-http-server/src/lib.rs
+++ b/packages/axum-http-server/src/lib.rs
@@ -7,7 +7,7 @@
 //! - `Announce`: used to announce the presence of a peer to the tracker.
 //! - `Scrape`: used to get information about a torrent.
 //!
-//! Refer to the [`bit_torrent`](crate::shared::bit_torrent) module for more
+//! Refer to the `bit_torrent` module for more
 //! information about the `BitTorrent` protocol.
 //!
 //! ## Table of Contents
@@ -78,13 +78,13 @@
 //! > **NOTICE**: the `info_hash` parameter is NOT a `URL` encoded string param.
 //! > It is percent encode of the raw `info_hash` bytes (40 bytes). URL `GET` params
 //! > can contain any bytes, not only well-formed UTF-8. The `info_hash` is a
-//! > 20-byte SHA1. Check the [`percent_encoding`]
+//! > 20-byte SHA1. Check the `percent_encoding`
 //! > module to know more about the encoding.
 //!
 //! > **NOTICE**: the `peer_id` parameter is NOT a `URL` encoded string param.
 //! > It is percent encode of the raw peer ID bytes (20 bytes). URL `GET` params
 //! > can contain any bytes, not only well-formed UTF-8. The `info_hash` is a
-//! > 20-byte SHA1. Check the [`percent_encoding`]
+//! > 20-byte SHA1. Check the `percent_encoding`
 //! > module to know more about the encoding.
 //!
 
@@ -233,7 +233,7 @@
 //! `info_hash` parameters: `info_hash=%81%00%0...00%00%00&info_hash=%82%00%0...00%00%00`
 //!
 //! > **NOTICE**: the maximum number of torrents you can scrape at the same time
-//! > is `74`. Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](torrust_tracker_udp_server::MAX_SCRAPE_TORRENTS).
+//! > is `74`. Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](torrust_tracker_core::MAX_SCRAPE_TORRENTS).
 //!
 //! **Sample response**
 //!

--- a/packages/axum-http-server/src/server.rs
+++ b/packages/axum-http-server/src/server.rs
@@ -224,7 +224,7 @@ pub struct Running {
 impl HttpServer<Stopped> {
     /// It creates a new `HttpServer` controller in `stopped` state.
     #[must_use]
-    pub fn new(launcher: Launcher) -> Self {
+    pub const fn new(launcher: Launcher) -> Self {
         Self {
             state: Stopped { launcher },
         }
@@ -299,7 +299,7 @@ impl HttpServer<Stopped> {
             .await
         {
             let _ = tx_halt.send(Halted::Normal);
-            let _ = task.await;
+            drop(task.await);
             return Err(Error::Registration { source });
         }
 

--- a/packages/axum-http-server/src/testing/environment.rs
+++ b/packages/axum-http-server/src/testing/environment.rs
@@ -25,7 +25,7 @@ pub struct Environment<S> {
     pub cancellation_token: CancellationToken,
 }
 
-impl<S> Environment<S> {
+impl<S: Sync> Environment<S> {
     /// Add a torrent to the tracker
     pub async fn add_torrent_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
         self.container
@@ -151,7 +151,7 @@ impl Environment<Running> {
     }
 
     #[must_use]
-    pub fn bind_address(&self) -> &std::net::SocketAddr {
+    pub const fn bind_address(&self) -> &std::net::SocketAddr {
         &self.server.state.binding
     }
 

--- a/packages/axum-http-server/src/v1/extractors/announce_request.rs
+++ b/packages/axum-http-server/src/v1/extractors/announce_request.rs
@@ -52,7 +52,7 @@ where
     fn from_request_parts(parts: &mut Parts, _state: &S) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         async {
             match extract_announce_from(parts.uri.query()) {
-                Ok(announce_request) => Ok(ExtractRequest(announce_request)),
+                Ok(announce_request) => Ok(Self(announce_request)),
                 Err(error) => Err((StatusCode::OK, error.write()).into_response()),
             }
         }

--- a/packages/axum-http-server/src/v1/extractors/authentication_key.rs
+++ b/packages/axum-http-server/src/v1/extractors/authentication_key.rs
@@ -80,7 +80,7 @@ where
             let maybe_path_with_key = Path::<KeyParam>::from_request_parts(parts, state).await;
 
             match extract_key(maybe_path_with_key) {
-                Ok(key) => Ok(Extract(key)),
+                Ok(key) => Ok(Self(key)),
                 Err(error) => Err((StatusCode::OK, error.write()).into_response()),
             }
         }

--- a/packages/axum-http-server/src/v1/extractors/client_ip_sources.rs
+++ b/packages/axum-http-server/src/v1/extractors/client_ip_sources.rs
@@ -57,17 +57,17 @@ where
     #[allow(clippy::manual_async_fn)]
     fn from_request_parts(parts: &mut Parts, state: &S) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         async move {
-            let right_most_x_forwarded_for = match RightmostXForwardedFor::from_request_parts(parts, state).await {
-                Ok(right_most_x_forwarded_for) => Some(right_most_x_forwarded_for.0),
-                Err(_) => None,
-            };
+            let right_most_x_forwarded_for = RightmostXForwardedFor::from_request_parts(parts, state)
+                .await
+                .ok()
+                .map(|right_most_x_forwarded_for| right_most_x_forwarded_for.0);
 
-            let connection_info_ip = match ConnectInfo::<SocketAddr>::from_request_parts(parts, state).await {
-                Ok(connection_info_socket_addr) => Some(connection_info_socket_addr.0),
-                Err(_) => None,
-            };
+            let connection_info_ip = ConnectInfo::<SocketAddr>::from_request_parts(parts, state)
+                .await
+                .ok()
+                .map(|connection_info_socket_addr| connection_info_socket_addr.0);
 
-            Ok(Extract(ClientIpSources {
+            Ok(Self(ClientIpSources {
                 right_most_x_forwarded_for,
                 connection_info_socket_address: connection_info_ip,
             }))

--- a/packages/axum-http-server/src/v1/extractors/scrape_request.rs
+++ b/packages/axum-http-server/src/v1/extractors/scrape_request.rs
@@ -52,7 +52,7 @@ where
     fn from_request_parts(parts: &mut Parts, _state: &S) -> impl Future<Output = Result<Self, Self::Rejection>> + Send {
         async {
             match extract_scrape_from(parts.uri.query()) {
-                Ok(scrape_request) => Ok(ExtractRequest(scrape_request)),
+                Ok(scrape_request) => Ok(Self(scrape_request)),
                 Err(error) => Err((StatusCode::OK, error.write()).into_response()),
             }
         }

--- a/packages/axum-http-server/src/v1/handlers/announce.rs
+++ b/packages/axum-http-server/src/v1/handlers/announce.rs
@@ -264,7 +264,7 @@ mod tests {
         let core_config = Arc::new(config.core.clone());
         let database = initialize_database(&config.core).await;
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
         let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
         let authentication_service = Arc::new(AuthenticationService::new(&config.core, &in_memory_key_repository));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
@@ -289,7 +289,7 @@ mod tests {
         let http_stats_repository = Arc::new(Repository::new());
         let http_stats_event_bus = Arc::new(EventBus::new(
             config.core.tracker_usage_statistics.into(),
-            http_core_broadcaster.clone(),
+            http_core_broadcaster,
         ));
 
         let http_stats_event_sender = http_stats_event_bus.sender();
@@ -309,10 +309,10 @@ mod tests {
             .expect("the test configuration should contain an HTTP tracker")[0];
         let announce_service = Arc::new(AnnounceService::new_with_http_tracker_config(
             core_config.clone(),
-            announce_handler.clone(),
-            authentication_service.clone(),
-            whitelist_authorization.clone(),
-            http_stats_event_sender.clone(),
+            announce_handler,
+            authentication_service,
+            whitelist_authorization,
+            http_stats_event_sender,
             http_tracker_config,
             configuration_instance_id,
         ));

--- a/packages/axum-http-server/src/v1/handlers/scrape.rs
+++ b/packages/axum-http-server/src/v1/handlers/scrape.rs
@@ -175,7 +175,7 @@ mod tests {
 
         let core_config = Arc::new(config.core.clone());
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
         let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
         let authentication_service = Arc::new(AuthenticationService::new(&config.core, &in_memory_key_repository));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());

--- a/packages/axum-http-server/tests/common/http.rs
+++ b/packages/axum-http-server/tests/common/http.rs
@@ -8,11 +8,11 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self { params: vec![] }
     }
 
-    pub fn params(params: Vec<QueryParam>) -> Self {
+    pub const fn params(params: Vec<QueryParam>) -> Self {
         Self { params }
     }
 

--- a/packages/axum-rest-api-server/Cargo.toml
+++ b/packages/axum-rest-api-server/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum = { version = "0", features = [ "macros" ] }
 axum-extra = { version = "0", features = [ "query" ] }

--- a/packages/axum-rest-api-server/src/server.rs
+++ b/packages/axum-rest-api-server/src/server.rs
@@ -111,7 +111,7 @@ pub struct Running {
 
 impl Running {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         local_addr: SocketAddr,
         halt_task: tokio::sync::oneshot::Sender<Halted>,
         task: tokio::task::JoinHandle<Launcher>,
@@ -126,7 +126,7 @@ impl Running {
 
 impl ApiServer<Stopped> {
     #[must_use]
-    pub fn new(launcher: Launcher) -> Self {
+    pub const fn new(launcher: Launcher) -> Self {
         Self {
             state: Stopped { launcher },
         }
@@ -177,7 +177,7 @@ impl ApiServer<Stopped> {
             .await
         {
             let _ = tx_halt.send(Halted::Normal);
-            let _ = task.await;
+            drop(task.await);
             return Err(Error::Registration { source });
         }
 
@@ -371,7 +371,7 @@ mod tests {
         let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
         let udp_tracker_server_config = cfg.udp_tracker_server.clone();
         let udp_tracker_configuration_instance_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
-        let http_api_config = Arc::new(cfg.http_api.clone().expect("missing HTTP API configuration").clone());
+        let http_api_config = Arc::new(cfg.http_api.clone().expect("missing HTTP API configuration"));
 
         initialize_global_services(&cfg);
 

--- a/packages/axum-rest-api-server/src/testing/environment.rs
+++ b/packages/axum-rest-api-server/src/testing/environment.rs
@@ -21,7 +21,7 @@ pub type Started = Environment<Running>;
 
 pub struct Environment<S>
 where
-    S: std::fmt::Debug + std::fmt::Display,
+    S: std::fmt::Debug + std::fmt::Display + Sync,
 {
     pub container: Arc<EnvContainer>,
     pub registar: Registar<RuntimeServiceMetadata>,
@@ -30,7 +30,7 @@ where
 
 impl<S> Environment<S>
 where
-    S: std::fmt::Debug + std::fmt::Display,
+    S: std::fmt::Debug + std::fmt::Display + Sync,
 {
     /// Add a torrent to the tracker
     pub async fn add_torrent_peer(&self, info_hash: &InfoHash, peer: &peer::Peer) {
@@ -143,7 +143,7 @@ impl Environment<Running> {
     }
 
     #[must_use]
-    pub fn bind_address(&self) -> SocketAddr {
+    pub const fn bind_address(&self) -> SocketAddr {
         self.server.state.local_addr
     }
 }
@@ -175,13 +175,7 @@ impl EnvContainer {
         let udp_tracker_config = Arc::new(udp_tracker_configurations[0].clone());
         let udp_tracker_server_config = configuration.udp_tracker_server.clone();
 
-        let http_api_config = Arc::new(
-            configuration
-                .http_api
-                .clone()
-                .expect("missing HTTP API configuration")
-                .clone(),
-        );
+        let http_api_config = Arc::new(configuration.http_api.clone().expect("missing HTTP API configuration"));
 
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),

--- a/packages/axum-rest-api-server/src/v1/context/auth_key/routes.rs
+++ b/packages/axum-rest-api-server/src/v1/context/auth_key/routes.rs
@@ -34,6 +34,6 @@ pub fn add(prefix: &str, router: Router, auth_key_service: Option<&Arc<AuthKeyAp
         )
         .route(
             &format!("{prefix}/keys"),
-            post(add_auth_key_handler).with_state(auth_key_service.clone()),
+            post(add_auth_key_handler).with_state(auth_key_service),
         )
 }

--- a/packages/axum-rest-api-server/src/v1/context/stats/handlers.rs
+++ b/packages/axum-rest-api-server/src/v1/context/stats/handlers.rs
@@ -28,24 +28,24 @@ pub struct QueryParams {
 pub async fn get_stats_handler(State(stats_service): State<Arc<StatsApiService>>, params: Query<QueryParams>) -> Response {
     let stats = stats_service.get_stats().await;
 
-    match params.0.format {
-        Some(format) => match format {
+    params.0.format.map_or_else(
+        || stats_response(&stats),
+        |format| match format {
             Format::Json => stats_response(&stats),
             Format::Prometheus => metrics_response(&stats),
         },
-        None => stats_response(&stats),
-    }
+    )
 }
 
 /// It handles the request to get the tracker extendable metrics.
 pub async fn get_metrics_handler(State(stats_service): State<Arc<StatsApiService>>, params: Query<QueryParams>) -> Response {
     let labeled_stats = stats_service.get_labeled_stats().await;
 
-    match params.0.format {
-        Some(format) => match format {
+    params.0.format.map_or_else(
+        || labeled_stats_response(&labeled_stats),
+        |format| match format {
             Format::Json => labeled_stats_response(&labeled_stats),
             Format::Prometheus => labeled_metrics_response(&labeled_stats),
         },
-        None => labeled_stats_response(&labeled_stats),
-    }
+    )
 }

--- a/packages/axum-rest-api-server/src/v1/context/torrent/handlers.rs
+++ b/packages/axum-rest-api-server/src/v1/context/torrent/handlers.rs
@@ -32,10 +32,12 @@ pub async fn get_torrent_handler(
 ) -> Response {
     match InfoHash::from_str(&info_hash.0) {
         Err(_) => invalid_info_hash_param_response(&info_hash.0),
-        Ok(info_hash) => match service.get_torrent(&info_hash).await {
-            Some(torrent) => torrent_info_response(torrent).into_response(),
-            None => torrent_not_known_response(),
-        },
+        Ok(info_hash) => service
+            .get_torrent(&info_hash)
+            .await
+            .map_or_else(torrent_not_known_response, |torrent| {
+                torrent_info_response(torrent).into_response()
+            }),
     }
 }
 

--- a/packages/axum-rest-api-server/src/v1/context/torrent/responses.rs
+++ b/packages/axum-rest-api-server/src/v1/context/torrent/responses.rs
@@ -7,14 +7,14 @@ use torrust_tracker_rest_api_protocol::v1::context::torrent::resources::torrent:
 /// `200` response that contains an array of
 /// [`ListItem`](torrust_tracker_rest_api_protocol::v1::context::torrent::resources::torrent::ListItem)
 /// resources as json.
-pub fn torrent_list_response(items: Vec<ListItem>) -> Json<Vec<ListItem>> {
+pub const fn torrent_list_response(items: Vec<ListItem>) -> Json<Vec<ListItem>> {
     Json(items)
 }
 
 /// `200` response that contains a
 /// [`Torrent`](torrust_tracker_rest_api_protocol::v1::context::torrent::resources::torrent::Torrent)
 /// resources as json.
-pub fn torrent_info_response(torrent: Torrent) -> Json<Torrent> {
+pub const fn torrent_info_response(torrent: Torrent) -> Json<Torrent> {
     Json(torrent)
 }
 

--- a/packages/axum-rest-api-server/src/v1/context/whitelist/routes.rs
+++ b/packages/axum-rest-api-server/src/v1/context/whitelist/routes.rs
@@ -31,6 +31,6 @@ pub fn add(prefix: &str, router: Router, whitelist_service: Option<&Arc<Whitelis
         // Whitelist commands
         .route(
             &format!("{prefix}/reload"),
-            get(reload_whitelist_handler).with_state(whitelist_service.clone()),
+            get(reload_whitelist_handler).with_state(whitelist_service),
         )
 }

--- a/packages/axum-rest-api-server/src/v1/middlewares/auth.rs
+++ b/packages/axum-rest-api-server/src/v1/middlewares/auth.rs
@@ -114,13 +114,13 @@ fn extract_bearer_token_from_header(request: &Request<axum::body::Body>) -> Resu
                 return Ok(Some(String::new()));
             }
 
-            if !header_value.starts_with(&format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} ").to_string()) {
+            if !header_value.starts_with(&format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} ")) {
                 // Invalid token type. Missing "Bearer" prefix.
                 return Err(AuthError::UnknownTokenProvided);
             }
 
             Ok(header_value
-                .strip_prefix(&format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} ").to_string())
+                .strip_prefix(&format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} "))
                 .map(std::string::ToString::to_string))
         }
     }
@@ -140,9 +140,9 @@ enum AuthError {
 impl IntoResponse for AuthError {
     fn into_response(self) -> Response {
         match self {
-            AuthError::Unauthorized => unauthorized_response(),
-            AuthError::TokenNotValid => token_not_valid_response(),
-            AuthError::UnknownTokenProvided => unknown_auth_data_provided_response(),
+            Self::Unauthorized => unauthorized_response(),
+            Self::TokenNotValid => token_not_valid_response(),
+            Self::UnknownTokenProvided => unknown_auth_data_provided_response(),
         }
     }
 }

--- a/packages/axum-rest-api-server/tests/server/connection_info.rs
+++ b/packages/axum-rest-api-server/tests/server/connection_info.rs
@@ -4,6 +4,6 @@ pub fn connection_with_invalid_token(origin: Origin) -> ConnectionInfo {
     ConnectionInfo::authenticated(origin, "invalid token")
 }
 
-pub fn connection_with_no_token(origin: Origin) -> ConnectionInfo {
+pub const fn connection_with_no_token(origin: Origin) -> ConnectionInfo {
     ConnectionInfo::anonymous(origin)
 }

--- a/packages/axum-server/Cargo.toml
+++ b/packages/axum-server/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 axum-server = { version = "0", features = [ "tls-rustls-no-provider" ] }
 camino = { version = "1", features = [ "serde", "serde1" ] }

--- a/packages/axum-server/src/custom_axum_server.rs
+++ b/packages/axum-server/src/custom_axum_server.rs
@@ -100,7 +100,7 @@ pub struct TimeoutService<S> {
 }
 
 impl<S> TimeoutService<S> {
-    fn new(inner: S, sender: UnboundedSender<TimerSignal>) -> Self {
+    const fn new(inner: S, sender: UnboundedSender<TimerSignal>) -> Self {
         Self { inner, sender }
     }
 }
@@ -134,7 +134,7 @@ pin_project! {
 }
 
 impl<F> TimeoutServiceFuture<F> {
-    fn new(inner: F, sender: UnboundedSender<TimerSignal>) -> Self {
+    const fn new(inner: F, sender: UnboundedSender<TimerSignal>) -> Self {
         Self {
             inner,
             sender: Some(sender),
@@ -172,7 +172,7 @@ pin_project! {
 }
 
 impl<B> TimeoutBody<B> {
-    fn new(inner: B, sender: UnboundedSender<TimerSignal>) -> Self {
+    const fn new(inner: B, sender: UnboundedSender<TimerSignal>) -> Self {
         Self { inner, sender }
     }
 }
@@ -250,7 +250,7 @@ impl<IO: AsyncRead + Unpin> AsyncRead for TimeoutStream<IO> {
 
         if !self.waiting {
             // return error if timer is elapsed
-            if let Poll::Ready(()) = self.sleep.as_mut().poll(cx) {
+            if self.sleep.as_mut().poll(cx) == Poll::Ready(()) {
                 return Poll::Ready(Err(std::io::Error::new(ErrorKind::TimedOut, "request header read timed out")));
             }
         }

--- a/packages/configuration/Cargo.toml
+++ b/packages/configuration/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "3.0.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 camino = { version = "1", features = [ "serde", "serde1" ] }
 derive_more = { version = "2", features = [ "constructor", "display" ] }

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -156,7 +156,10 @@ impl Info {
         let env_var_config_toml_path = ENV_VAR_CONFIG_TOML_PATH.to_string();
 
         let config_toml = env::var(env_var_config_toml).map_or(None, |config_toml| {
-            info!("Loading extra configuration from environment variable:\n {config_toml}");
+            info!(
+                config_toml_bytes = config_toml.len(),
+                "Loading extra configuration from environment variable"
+            );
             Some(config_toml)
         });
 

--- a/packages/configuration/src/lib.rs
+++ b/packages/configuration/src/lib.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use thiserror::Error;
 use torrust_located_error::{DynError, LocatedError};
+use tracing::info;
 
 // Environment variables
 
@@ -68,7 +69,7 @@ impl Default for Metadata {
 impl Metadata {
     /// Creates a `Metadata` with a specific schema version, keeping other fields at their defaults.
     #[must_use]
-    pub fn with_schema_version(schema_version: Version) -> Self {
+    pub const fn with_schema_version(schema_version: Version) -> Self {
         Self {
             app: Self::default_app(),
             purpose: Self::default_purpose(),
@@ -76,11 +77,11 @@ impl Metadata {
         }
     }
 
-    fn default_app() -> App {
+    const fn default_app() -> App {
         App::TorrustTracker
     }
 
-    fn default_purpose() -> Purpose {
+    const fn default_purpose() -> Purpose {
         Purpose::Configuration
     }
 
@@ -154,20 +155,21 @@ impl Info {
         let env_var_config_toml = ENV_VAR_CONFIG_TOML.to_string();
         let env_var_config_toml_path = ENV_VAR_CONFIG_TOML_PATH.to_string();
 
-        let config_toml = if let Ok(config_toml) = env::var(env_var_config_toml) {
-            println!("Loading extra configuration from environment variable:\n {config_toml}");
+        let config_toml = env::var(env_var_config_toml).map_or(None, |config_toml| {
+            info!("Loading extra configuration from environment variable:\n {config_toml}");
             Some(config_toml)
-        } else {
-            None
-        };
+        });
 
-        let config_toml_path = if let Ok(config_toml_path) = env::var(env_var_config_toml_path) {
-            println!("Loading extra configuration from file: `{config_toml_path}` ...");
-            config_toml_path
-        } else {
-            println!("Loading extra configuration from default configuration file: `{default_config_toml_path}` ...");
-            default_config_toml_path
-        };
+        let config_toml_path = env::var(env_var_config_toml_path).map_or_else(
+            |_| {
+                info!("Loading extra configuration from default configuration file: `{default_config_toml_path}` ...");
+                default_config_toml_path
+            },
+            |config_toml_path| {
+                info!("Loading extra configuration from file: `{config_toml_path}` ...");
+                config_toml_path
+            },
+        );
 
         Ok(Self {
             config_toml,

--- a/packages/configuration/src/v2_0_0/core.rs
+++ b/packages/configuration/src/v2_0_0/core.rs
@@ -76,11 +76,11 @@ impl Core {
         Database::default()
     }
 
-    fn default_inactive_peer_cleanup_interval() -> u64 {
+    const fn default_inactive_peer_cleanup_interval() -> u64 {
         600
     }
 
-    fn default_listed() -> bool {
+    const fn default_listed() -> bool {
         false
     }
 
@@ -88,7 +88,7 @@ impl Core {
         Network::default()
     }
 
-    fn default_private() -> bool {
+    const fn default_private() -> bool {
         false
     }
 
@@ -104,7 +104,7 @@ impl Core {
         TrackerPolicy::default()
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         true
     }
 }

--- a/packages/configuration/src/v2_0_0/database.rs
+++ b/packages/configuration/src/v2_0_0/database.rs
@@ -33,7 +33,7 @@ impl Default for Database {
 }
 
 impl Database {
-    fn default_driver() -> Driver {
+    const fn default_driver() -> Driver {
         Driver::Sqlite3
     }
 

--- a/packages/configuration/src/v2_0_0/health_check_api.rs
+++ b/packages/configuration/src/v2_0_0/health_check_api.rs
@@ -24,7 +24,7 @@ impl Default for HealthCheckApi {
 }
 
 impl HealthCheckApi {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1313)
     }
 }

--- a/packages/configuration/src/v2_0_0/http_tracker.rs
+++ b/packages/configuration/src/v2_0_0/http_tracker.rs
@@ -49,19 +49,19 @@ impl Default for HttpTracker {
 }
 
 impl HttpTracker {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 7070)
     }
 
-    fn default_tsl_config() -> Option<TslConfig> {
+    const fn default_tsl_config() -> Option<TslConfig> {
         None
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         false
     }
 
-    fn default_ipv6_v6only() -> bool {
+    const fn default_ipv6_v6only() -> bool {
         false
     }
 }

--- a/packages/configuration/src/v2_0_0/logging.rs
+++ b/packages/configuration/src/v2_0_0/logging.rs
@@ -27,7 +27,7 @@ impl Default for Logging {
 }
 
 impl Logging {
-    fn default_threshold() -> Threshold {
+    const fn default_threshold() -> Threshold {
         Threshold::Info
     }
 }
@@ -62,7 +62,7 @@ pub fn setup(cfg: &Logging) {
     });
 }
 
-fn map_to_tracing_level_filter(threshold: &Threshold) -> LevelFilter {
+const fn map_to_tracing_level_filter(threshold: &Threshold) -> LevelFilter {
     match threshold {
         Threshold::Off => LevelFilter::OFF,
         Threshold::Error => LevelFilter::ERROR,
@@ -100,13 +100,13 @@ pub enum TraceStyle {
 impl std::fmt::Display for TraceStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let style = match self {
-            TraceStyle::Default => "Default Style",
-            TraceStyle::Pretty(path) => match path {
+            Self::Default => "Default Style",
+            Self::Pretty(path) => match path {
                 true => "Pretty Style with File Paths",
                 false => "Pretty Style without File Paths",
             },
-            TraceStyle::Compact => "Compact Style",
-            TraceStyle::Json => "Json Format",
+            Self::Compact => "Compact Style",
+            Self::Json => "Json Format",
         };
 
         f.write_str(style)

--- a/packages/configuration/src/v2_0_0/mod.rs
+++ b/packages/configuration/src/v2_0_0/mod.rs
@@ -320,8 +320,8 @@ impl Configuration {
     ///
     /// Will return `Err` if `path` is not a valid path or the configuration
     /// file cannot be created.
-    pub fn create_default_configuration_file(path: &str) -> Result<Configuration, Error> {
-        let config = Configuration::default();
+    pub fn create_default_configuration_file(path: &str) -> Result<Self, Error> {
+        let config = Self::default();
         config.save_to_file(path)?;
         Ok(config)
     }
@@ -335,23 +335,27 @@ impl Configuration {
     /// # Errors
     ///
     /// Will return `Err` if the environment variable does not exist or has a bad configuration.
-    pub fn load(info: &Info) -> Result<Configuration, Error> {
+    pub fn load(info: &Info) -> Result<Self, Error> {
         // Load configuration provided by the user, prioritizing env vars
-        let figment = if let Some(config_toml) = &info.config_toml {
-            Figment::from(Toml::string(config_toml)).merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
-        } else {
-            Figment::from(Toml::file(&info.config_toml_path))
-                .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
-        };
+        let figment = info.config_toml.as_ref().map_or_else(
+            || {
+                Figment::from(Toml::file(&info.config_toml_path))
+                    .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
+            },
+            |config_toml| {
+                Figment::from(Toml::string(config_toml))
+                    .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
+            },
+        );
 
         // Make sure user has provided the mandatory options.
         Self::check_mandatory_options(&figment)?;
 
         // Fill missing options with default values.
-        let figment = figment.join(Serialized::defaults(Configuration::default()));
+        let figment = figment.join(Serialized::defaults(Self::default()));
 
         // Build final configuration.
-        let config: Configuration = figment.extract()?;
+        let config: Self = figment.extract()?;
 
         // Make sure the provided schema version matches this version.
         if config.metadata.schema_version != Version::new(VERSION_2_0_0) {

--- a/packages/configuration/src/v2_0_0/network.rs
+++ b/packages/configuration/src/v2_0_0/network.rs
@@ -32,11 +32,11 @@ impl Default for Network {
 }
 
 impl Network {
-    fn default_external_ip() -> Option<ExternalIp> {
+    const fn default_external_ip() -> Option<ExternalIp> {
         None
     }
 
-    fn default_on_reverse_proxy() -> bool {
+    const fn default_on_reverse_proxy() -> bool {
         false
     }
 }
@@ -65,7 +65,7 @@ impl FromStr for ExternalIp {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ip: IpAddr = s.parse().map_err(|_| "invalid IP address format")?;
-        ExternalIp::try_from(ip)
+        Self::try_from(ip)
     }
 }
 
@@ -88,6 +88,6 @@ impl<'de> Deserialize<'de> for ExternalIp {
         D: serde::Deserializer<'de>,
     {
         let ip = IpAddr::deserialize(deserializer)?;
-        ExternalIp::try_from(ip).map_err(serde::de::Error::custom)
+        Self::try_from(ip).map_err(serde::de::Error::custom)
     }
 }

--- a/packages/configuration/src/v2_0_0/tracker_api.rs
+++ b/packages/configuration/src/v2_0_0/tracker_api.rs
@@ -44,17 +44,17 @@ impl Default for HttpApi {
 }
 
 impl HttpApi {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1212)
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    fn default_tsl_config() -> Option<TslConfig> {
+    const fn default_tsl_config() -> Option<TslConfig> {
         None
     }
 
     fn default_access_tokens() -> AccessTokens {
-        [].iter().cloned().collect()
+        std::iter::empty().collect()
     }
 
     pub fn add_token(&mut self, key: &str, token: &str) {

--- a/packages/configuration/src/v2_0_0/udp_tracker.rs
+++ b/packages/configuration/src/v2_0_0/udp_tracker.rs
@@ -51,23 +51,23 @@ impl Default for UdpTracker {
 }
 
 impl UdpTracker {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 6969)
     }
 
-    fn default_cookie_lifetime() -> Duration {
+    const fn default_cookie_lifetime() -> Duration {
         Duration::from_secs(120)
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         false
     }
 
-    fn default_ipv6_v6only() -> bool {
+    const fn default_ipv6_v6only() -> bool {
         false
     }
 
-    fn default_max_connection_id_errors_per_ip() -> u32 {
+    const fn default_max_connection_id_errors_per_ip() -> u32 {
         10
     }
 }

--- a/packages/configuration/src/v3_0_0/core.rs
+++ b/packages/configuration/src/v3_0_0/core.rs
@@ -74,15 +74,15 @@ impl Core {
         AnnouncePolicy::default()
     }
 
-    fn default_inactive_peer_cleanup_interval() -> u64 {
+    const fn default_inactive_peer_cleanup_interval() -> u64 {
         600
     }
 
-    fn default_listed() -> bool {
+    const fn default_listed() -> bool {
         false
     }
 
-    fn default_private() -> bool {
+    const fn default_private() -> bool {
         false
     }
 
@@ -98,7 +98,7 @@ impl Core {
         TrackerPolicy::default()
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         true
     }
 }

--- a/packages/configuration/src/v3_0_0/database.rs
+++ b/packages/configuration/src/v3_0_0/database.rs
@@ -191,7 +191,7 @@ impl<'de> Deserialize<'de> for Database {
     }
 }
 
-fn reject_network_fields(raw: &RawDatabase) -> Result<(), &'static str> {
+const fn reject_network_fields(raw: &RawDatabase) -> Result<(), &'static str> {
     if raw.host.is_some() || raw.port.is_some() || raw.user.is_some() || raw.password.is_some() || raw.database.is_some() {
         return Err("SQLite database configuration only accepts the `path` field");
     }

--- a/packages/configuration/src/v3_0_0/health_check_api.rs
+++ b/packages/configuration/src/v3_0_0/health_check_api.rs
@@ -29,7 +29,7 @@ impl Default for HealthCheckApi {
 }
 
 impl HealthCheckApi {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1313)
     }
 }

--- a/packages/configuration/src/v3_0_0/http_tracker.rs
+++ b/packages/configuration/src/v3_0_0/http_tracker.rs
@@ -63,23 +63,23 @@ impl Default for HttpTracker {
 }
 
 impl HttpTracker {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 7070)
     }
 
-    fn default_tls_config() -> Option<TlsConfig> {
+    const fn default_tls_config() -> Option<TlsConfig> {
         None
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         false
     }
 
-    fn default_use_ip_from_query_string() -> bool {
+    const fn default_use_ip_from_query_string() -> bool {
         false
     }
 
-    fn default_public_url() -> Option<HttpUrl> {
+    const fn default_public_url() -> Option<HttpUrl> {
         None
     }
 

--- a/packages/configuration/src/v3_0_0/logging.rs
+++ b/packages/configuration/src/v3_0_0/logging.rs
@@ -36,11 +36,11 @@ impl Default for Logging {
 }
 
 impl Logging {
-    fn default_trace_filter() -> Threshold {
+    const fn default_trace_filter() -> Threshold {
         Threshold::Info
     }
 
-    fn default_trace_style() -> TraceStyle {
+    const fn default_trace_style() -> TraceStyle {
         TraceStyle::Full
     }
 }
@@ -75,7 +75,7 @@ pub fn setup(cfg: &Logging) {
     });
 }
 
-fn map_to_tracing_level_filter(trace_filter: &Threshold) -> LevelFilter {
+const fn map_to_tracing_level_filter(trace_filter: &Threshold) -> LevelFilter {
     match trace_filter {
         Threshold::Off => LevelFilter::OFF,
         Threshold::Error => LevelFilter::ERROR,
@@ -118,10 +118,10 @@ pub enum TraceStyle {
 impl std::fmt::Display for TraceStyle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let style = match self {
-            TraceStyle::Full => "Full Style",
-            TraceStyle::Pretty => "Pretty Style",
-            TraceStyle::Compact => "Compact Style",
-            TraceStyle::Json => "Json Format",
+            Self::Full => "Full Style",
+            Self::Pretty => "Pretty Style",
+            Self::Compact => "Compact Style",
+            Self::Json => "Json Format",
         };
 
         f.write_str(style)

--- a/packages/configuration/src/v3_0_0/mod.rs
+++ b/packages/configuration/src/v3_0_0/mod.rs
@@ -351,8 +351,8 @@ impl Configuration {
     ///
     /// Will return `Err` if `path` is not a valid path or the configuration
     /// file cannot be created.
-    pub fn create_default_configuration_file(path: &str) -> Result<Configuration, Error> {
-        let config = Configuration::default();
+    pub fn create_default_configuration_file(path: &str) -> Result<Self, Error> {
+        let config = Self::default();
         config.save_to_file(path)?;
         Ok(config)
     }
@@ -366,14 +366,18 @@ impl Configuration {
     /// # Errors
     ///
     /// Will return `Err` if the environment variable does not exist or has a bad configuration.
-    pub fn load(info: &Info) -> Result<Configuration, Error> {
+    pub fn load(info: &Info) -> Result<Self, Error> {
         // Load configuration provided by the user, prioritizing env vars
-        let figment = if let Some(config_toml) = &info.config_toml {
-            Figment::from(Toml::string(config_toml)).merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
-        } else {
-            Figment::from(Toml::file(&info.config_toml_path))
-                .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
-        };
+        let figment = info.config_toml.as_ref().map_or_else(
+            || {
+                Figment::from(Toml::file(&info.config_toml_path))
+                    .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
+            },
+            |config_toml| {
+                Figment::from(Toml::string(config_toml))
+                    .merge(Env::prefixed(CONFIG_OVERRIDE_PREFIX).split(CONFIG_OVERRIDE_SEPARATOR))
+            },
+        );
 
         // Make sure user has provided the mandatory options.
         Self::check_mandatory_options(&figment)?;
@@ -385,7 +389,7 @@ impl Configuration {
         let figment = figment.join(Serialized::defaults(Self::defaults_for_loading()));
 
         // Build final configuration.
-        let config: Configuration = figment.extract()?;
+        let config: Self = figment.extract()?;
 
         // Make sure the provided schema version matches this version.
         if config.metadata.schema_version != Version::new(VERSION_3_0_0) {

--- a/packages/configuration/src/v3_0_0/network.rs
+++ b/packages/configuration/src/v3_0_0/network.rs
@@ -53,15 +53,15 @@ impl Default for Network {
 }
 
 impl Network {
-    fn default_external_ip() -> Option<ExternalIp> {
+    const fn default_external_ip() -> Option<ExternalIp> {
         None
     }
 
-    fn default_on_reverse_proxy() -> bool {
+    const fn default_on_reverse_proxy() -> bool {
         false
     }
 
-    fn default_ipv6_v6only() -> bool {
+    const fn default_ipv6_v6only() -> bool {
         false
     }
 }
@@ -90,7 +90,7 @@ impl FromStr for ExternalIp {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let ip: IpAddr = s.parse().map_err(|_| "invalid IP address format")?;
-        ExternalIp::try_from(ip)
+        Self::try_from(ip)
     }
 }
 
@@ -113,6 +113,6 @@ impl<'de> Deserialize<'de> for ExternalIp {
         D: serde::Deserializer<'de>,
     {
         let ip = IpAddr::deserialize(deserializer)?;
-        ExternalIp::try_from(ip).map_err(serde::de::Error::custom)
+        Self::try_from(ip).map_err(serde::de::Error::custom)
     }
 }

--- a/packages/configuration/src/v3_0_0/public_url.rs
+++ b/packages/configuration/src/v3_0_0/public_url.rs
@@ -60,7 +60,7 @@ impl HttpUrl {
 
     /// Returns a reference to the inner [`Url`].
     #[must_use]
-    pub fn as_url(&self) -> &Url {
+    pub const fn as_url(&self) -> &Url {
         &self.0
     }
 }
@@ -135,7 +135,7 @@ impl UdpUrl {
 
     /// Returns a reference to the inner [`Url`].
     #[must_use]
-    pub fn as_url(&self) -> &Url {
+    pub const fn as_url(&self) -> &Url {
         &self.0
     }
 }

--- a/packages/configuration/src/v3_0_0/tracker_api.rs
+++ b/packages/configuration/src/v3_0_0/tracker_api.rs
@@ -58,11 +58,11 @@ impl Default for HttpApi {
 }
 
 impl HttpApi {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1212)
     }
 
-    fn default_tls_config() -> Option<TlsConfig> {
+    const fn default_tls_config() -> Option<TlsConfig> {
         None
     }
 
@@ -70,7 +70,7 @@ impl HttpApi {
         AccessTokens::new()
     }
 
-    fn default_public_url() -> Option<HttpUrl> {
+    const fn default_public_url() -> Option<HttpUrl> {
         None
     }
 

--- a/packages/configuration/src/v3_0_0/types.rs
+++ b/packages/configuration/src/v3_0_0/types.rs
@@ -26,7 +26,7 @@ impl<const MINIMUM: u64> AtLeastU64<MINIMUM> {
     /// # Errors
     ///
     /// Returns [`ValueBelowMinimumError`] when `value` is less than `MINIMUM`.
-    pub fn new(value: u64) -> Result<Self, ValueBelowMinimumError> {
+    pub const fn new(value: u64) -> Result<Self, ValueBelowMinimumError> {
         if value < MINIMUM {
             return Err(ValueBelowMinimumError { minimum: MINIMUM });
         }

--- a/packages/configuration/src/v3_0_0/udp_tracker.rs
+++ b/packages/configuration/src/v3_0_0/udp_tracker.rs
@@ -52,19 +52,19 @@ impl Default for UdpTracker {
 }
 
 impl UdpTracker {
-    fn default_bind_address() -> SocketAddr {
+    const fn default_bind_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 6969)
     }
 
-    fn default_cookie_lifetime() -> Duration {
+    const fn default_cookie_lifetime() -> Duration {
         Duration::from_secs(120)
     }
 
-    fn default_tracker_usage_statistics() -> bool {
+    const fn default_tracker_usage_statistics() -> bool {
         false
     }
 
-    fn default_public_url() -> Option<UdpUrl> {
+    const fn default_public_url() -> Option<UdpUrl> {
         None
     }
 

--- a/packages/configuration/src/v3_0_0/udp_tracker_server.rs
+++ b/packages/configuration/src/v3_0_0/udp_tracker_server.rs
@@ -156,7 +156,7 @@ fn default_ip_bans_reset_interval_in_secs() -> IpBansResetIntervalInSecs {
         .expect("the default IP-ban reset interval must satisfy its minimum")
 }
 
-fn default_max_connection_id_errors_per_ip() -> u32 {
+const fn default_max_connection_id_errors_per_ip() -> u32 {
     10
 }
 

--- a/packages/events/Cargo.toml
+++ b/packages/events/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures = "0"
 tokio = { version = "1", features = [ "macros", "net", "rt-multi-thread", "signal", "sync", "time" ] }

--- a/packages/events/src/broadcaster.rs
+++ b/packages/events/src/broadcaster.rs
@@ -45,15 +45,15 @@ impl<Event: Sync + Send + Clone> Receiver for broadcast::Receiver<Event> {
 
 impl<Event> From<broadcast::error::SendError<Event>> for SendError<Event> {
     fn from(err: broadcast::error::SendError<Event>) -> Self {
-        SendError(err.0)
+        Self(err.0)
     }
 }
 
 impl From<broadcast::error::RecvError> for RecvError {
     fn from(err: broadcast::error::RecvError) -> Self {
         match err {
-            broadcast::error::RecvError::Lagged(amt) => RecvError::Lagged(amt),
-            broadcast::error::RecvError::Closed => RecvError::Closed,
+            broadcast::error::RecvError::Lagged(amt) => Self::Lagged(amt),
+            broadcast::error::RecvError::Closed => Self::Closed,
         }
     }
 }

--- a/packages/events/src/bus.rs
+++ b/packages/events/src/bus.rs
@@ -45,7 +45,7 @@ impl<Event: Sync + Send + Clone + 'static> Default for EventBus<Event> {
 
 impl<Event: Sync + Send + Clone + 'static> EventBus<Event> {
     #[must_use]
-    pub fn new(sender_status: SenderStatus, broadcaster: Broadcaster<Event>) -> Self {
+    pub const fn new(sender_status: SenderStatus, broadcaster: Broadcaster<Event>) -> Self {
         Self {
             sender_status,
             broadcaster,

--- a/packages/events/src/receiver.rs
+++ b/packages/events/src/receiver.rs
@@ -29,8 +29,8 @@ pub enum RecvError {
 impl fmt::Display for RecvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RecvError::Closed => write!(f, "channel closed"),
-            RecvError::Lagged(amt) => write!(f, "channel lagged by {amt}"),
+            Self::Closed => write!(f, "channel closed"),
+            Self::Lagged(amt) => write!(f, "channel lagged by {amt}"),
         }
     }
 }

--- a/packages/http-core/Cargo.toml
+++ b/packages/http-core/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-tracker-http-protocol = { version = "0.1.0", path = "../http-protocol" }
 torrust-info-hash = "=0.2.0"

--- a/packages/http-core/benches/helpers/util.rs
+++ b/packages/http-core/benches/helpers/util.rs
@@ -57,7 +57,7 @@ pub async fn initialize_core_tracker_services_with_config(
     let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
     let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&database.torrent_metrics_store));
     let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-    let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+    let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
     let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
     let authentication_service = Arc::new(AuthenticationService::new(&core_config, &in_memory_key_repository));
 
@@ -81,7 +81,7 @@ pub async fn initialize_core_tracker_services_with_config(
     let http_stats_repository = Arc::new(Repository::new());
     let http_stats_event_bus = Arc::new(EventBus::new(
         config.core.tracker_usage_statistics.into(),
-        http_core_broadcaster.clone(),
+        http_core_broadcaster,
     ));
 
     let http_stats_event_sender = http_stats_event_bus.sender();
@@ -121,7 +121,7 @@ fn first_http_tracker_configuration_instance_id(config: &Configuration) -> Confi
         .expect("the benchmark configuration should contain an HTTP tracker")
 }
 
-pub fn sample_peer() -> peer::Peer {
+pub const fn sample_peer() -> peer::Peer {
     peer::Peer {
         peer_id: PeerId(*b"-qB00000000000000000"),
         peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(126, 0, 0, 1)), 8080),

--- a/packages/http-core/src/container.rs
+++ b/packages/http-core/src/container.rs
@@ -124,7 +124,7 @@ impl HttpTrackerCoreServices {
         // the shared statistics listener, so it must not suppress publication.
         // A future consumer-demand optimization needs an inventory and benchmark
         // evidence before this can become conditional.
-        let http_stats_event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, http_core_broadcaster.clone()));
+        let http_stats_event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, http_core_broadcaster));
 
         let http_stats_event_sender = http_stats_event_bus.sender();
 

--- a/packages/http-core/src/event.rs
+++ b/packages/http-core/src/event.rs
@@ -50,7 +50,7 @@ pub struct ConnectionContext {
 
 impl ConnectionContext {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         configuration_instance_id: ConfigurationInstanceId,
         remote_client_addr: RemoteClientAddr,
         server_service_binding: ServiceBinding,
@@ -134,7 +134,7 @@ pub struct ServerConnectionContext {
 
 impl From<ConnectionContext> for LabelSet {
     fn from(connection_context: ConnectionContext) -> Self {
-        let mut label_set = LabelSet::from([
+        let mut label_set = Self::from([
             (
                 label_name!("server_binding_protocol"),
                 LabelValue::new(&connection_context.server.service_binding.protocol().to_string()),

--- a/packages/http-core/src/event.rs
+++ b/packages/http-core/src/event.rs
@@ -77,12 +77,12 @@ impl ConnectionContext {
     }
 
     #[must_use]
-    pub fn client_ip_addr(&self) -> IpAddr {
+    pub const fn client_ip_addr(&self) -> IpAddr {
         self.client.ip_addr()
     }
 
     #[must_use]
-    pub fn client_port(&self) -> Option<u16> {
+    pub const fn client_port(&self) -> Option<u16> {
         self.client.port()
     }
 
@@ -102,7 +102,7 @@ impl ConnectionContext {
     }
 
     #[must_use]
-    pub fn client_address_ip_type(&self) -> IpType {
+    pub const fn client_address_ip_type(&self) -> IpType {
         match self.client.ip_addr() {
             IpAddr::V6(v6) if v6.to_ipv4_mapped().is_some() => IpType::V4MappedV6,
             _ => IpType::Plain,
@@ -117,12 +117,12 @@ pub struct ClientConnectionContext {
 
 impl ClientConnectionContext {
     #[must_use]
-    pub fn ip_addr(&self) -> IpAddr {
+    pub const fn ip_addr(&self) -> IpAddr {
         self.remote_client_addr.ip()
     }
 
     #[must_use]
-    pub fn port(&self) -> Option<u16> {
+    pub const fn port(&self) -> Option<u16> {
         self.remote_client_addr.port()
     }
 }

--- a/packages/http-core/src/services/announce.rs
+++ b/packages/http-core/src/services/announce.rs
@@ -252,15 +252,15 @@ impl AnnounceService {
             uploaded: NumberOfBytes::new(uploaded.0),
             downloaded: NumberOfBytes::new(downloaded.0),
             left: NumberOfBytes::new(left.0),
-            event: match &announce_request.event {
-                Some(event) => match event {
+            event: announce_request
+                .event
+                .as_ref()
+                .map_or(AnnounceEvent::None, |event| match event {
                     ProtocolAnnounceEvent::Started => AnnounceEvent::Started,
                     ProtocolAnnounceEvent::Stopped => AnnounceEvent::Stopped,
                     ProtocolAnnounceEvent::Completed => AnnounceEvent::Completed,
                     ProtocolAnnounceEvent::Empty => AnnounceEvent::None,
-                },
-                None => AnnounceEvent::None,
-            },
+                }),
         }
     }
 
@@ -320,10 +320,9 @@ impl AnnounceService {
 
     /// Determines how many peers the client wants in the response
     fn peers_wanted(announce_request: &Announce) -> PeersWanted {
-        match announce_request.numwant {
-            Some(numwant) => PeersWanted::only(numwant),
-            None => PeersWanted::AsManyAsPossible,
-        }
+        announce_request
+            .numwant
+            .map_or(PeersWanted::AsManyAsPossible, PeersWanted::only)
     }
 
     async fn send_event(
@@ -479,7 +478,7 @@ mod tests {
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
         let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&database.torrent_metrics_store));
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
         let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
         let authentication_service = Arc::new(AuthenticationService::new(&core_config, &in_memory_key_repository));
 
@@ -503,7 +502,7 @@ mod tests {
         let http_stats_repository = Arc::new(Repository::new());
         let http_stats_event_bus = Arc::new(EventBus::new(
             config.core.tracker_usage_statistics.into(),
-            http_core_broadcaster.clone(),
+            http_core_broadcaster,
         ));
 
         let http_stats_event_sender = http_stats_event_bus.sender();

--- a/packages/http-core/src/services/error_mapping.rs
+++ b/packages/http-core/src/services/error_mapping.rs
@@ -1,7 +1,7 @@
 use torrust_tracker_core::error::TrackerCoreError;
 use torrust_tracker_http_protocol::v1::responses::error::Error as HttpProtocolErrorResponse;
 
-pub(crate) fn protocol_error_from_tracker_core_error(error: TrackerCoreError) -> HttpProtocolErrorResponse {
+pub fn protocol_error_from_tracker_core_error(error: TrackerCoreError) -> HttpProtocolErrorResponse {
     match error {
         TrackerCoreError::AnnounceError { source } => HttpProtocolErrorResponse {
             failure_reason: format!("Tracker announce error: {source}"),

--- a/packages/http-core/src/services/scrape.rs
+++ b/packages/http-core/src/services/scrape.rs
@@ -253,7 +253,7 @@ mod tests {
             .expect("the test configuration should contain an HTTP tracker");
         let database = initialize_database(&config.core).await;
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
         let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&database.torrent_metrics_store));
         let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());

--- a/packages/http-core/src/statistics/event/handler.rs
+++ b/packages/http-core/src/statistics/event/handler.rs
@@ -9,44 +9,57 @@ use crate::statistics::HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
 use crate::statistics::repository::Repository;
 
 pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now: DurationSinceUnixEpoch) {
-    match event {
-        Event::TcpAnnounce { connection, .. } => {
-            let mut label_set = LabelSet::from(connection);
-            label_set.upsert(label_name!("request_kind"), LabelValue::new("announce"));
+    let (mut label_set, request_kind) = labels_and_request_kind(event);
+    label_set.upsert(label_name!("request_kind"), LabelValue::new(request_kind.as_str()));
 
-            match stats_repository
-                .increase_counter(&metric_name!(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
-                .await
-            {
-                Ok(()) => {
-                    tracing::debug!(
-                        "Successfully increased the counter for HTTP announce requests received: {}",
-                        label_set
-                    );
-                }
-                Err(err) => tracing::error!("Failed to increase the counter: {}", err),
-            }
-        }
-        Event::TcpScrape { connection } => {
-            let mut label_set = LabelSet::from(connection);
-            label_set.upsert(label_name!("request_kind"), LabelValue::new("scrape"));
-
-            match stats_repository
-                .increase_counter(&metric_name!(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
-                .await
-            {
-                Ok(()) => {
-                    tracing::debug!(
-                        "Successfully increased the counter for HTTP scrape requests received: {}",
-                        label_set
-                    );
-                }
-                Err(err) => tracing::error!("Failed to increase the counter: {}", err),
-            }
-        }
+    match stats_repository
+        .increase_counter(&metric_name!(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
+        .await
+    {
+        Ok(()) => log_counter_increased(request_kind, &label_set),
+        Err(err) => tracing::error!("Failed to increase the counter: {}", err),
     }
 
     tracing::debug!("stats: {:?}", stats_repository.get_stats().await);
+}
+
+fn labels_and_request_kind(event: Event) -> (LabelSet, RequestKind) {
+    match event {
+        Event::TcpAnnounce { connection, .. } => (LabelSet::from(connection), RequestKind::Announce),
+        Event::TcpScrape { connection } => (LabelSet::from(connection), RequestKind::Scrape),
+    }
+}
+
+fn log_counter_increased(request_kind: RequestKind, label_set: &LabelSet) {
+    match request_kind {
+        RequestKind::Announce => {
+            tracing::debug!(
+                "Successfully increased the counter for HTTP announce requests received: {}",
+                label_set
+            );
+        }
+        RequestKind::Scrape => {
+            tracing::debug!(
+                "Successfully increased the counter for HTTP scrape requests received: {}",
+                label_set
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RequestKind {
+    Announce,
+    Scrape,
+}
+
+impl RequestKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Announce => "announce",
+            Self::Scrape => "scrape",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -55,12 +68,16 @@ mod tests {
     use std::sync::Arc;
 
     use torrust_clock::clock::Time;
+    use torrust_metrics::label::{LabelSet, LabelValue};
+    use torrust_metrics::metric_collection::aggregate::sum::Sum;
+    use torrust_metrics::{label_name, metric_name};
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::{RemoteClientAddr, ResolvedIp};
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
 
     use crate::CurrentClock;
     use crate::event::{ConnectionContext, Event};
+    use crate::statistics::HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
     use crate::tests::{sample_info_hash, sample_peer_using_ipv4, sample_peer_using_ipv6};
@@ -171,5 +188,49 @@ mod tests {
         let stats = stats_repository.get_stats().await;
 
         assert_eq!(stats.tcp6_scrapes_handled(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_propagate_all_connection_labels_and_request_kind() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new());
+        let event = Event::TcpScrape {
+            connection: ConnectionContext::new(
+                ConfigurationInstanceId::new(ServiceRole::HttpTracker, 7),
+                RemoteClientAddr::new(
+                    ResolvedIp::FromSocketAddr(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x0201))),
+                    Some(49152),
+                ),
+                ServiceBinding::new(Protocol::HTTP, SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 7443)).unwrap(),
+            )
+            .with_public_url(Some("https://tracker.example.test:7443/announce".to_string())),
+        };
+        let expected_labels = LabelSet::from([
+            (label_name!("server_binding_protocol"), LabelValue::new("http")),
+            (label_name!("server_binding_ip"), LabelValue::new("::1")),
+            (label_name!("server_binding_address_ip_type"), LabelValue::new("plain")),
+            (label_name!("server_binding_address_ip_family"), LabelValue::new("inet6")),
+            (label_name!("server_binding_port"), LabelValue::new("7443")),
+            (label_name!("client_address_ip_family"), LabelValue::new("inet6")),
+            (label_name!("client_address_ip_type"), LabelValue::new("v4_mapped_v6")),
+            (
+                label_name!("public_url"),
+                LabelValue::new("https://tracker.example.test:7443/announce"),
+            ),
+            (label_name!("request_kind"), LabelValue::new("scrape")),
+        ]);
+
+        // Act
+        handle_event(event, &stats_repository, CurrentClock::now()).await;
+
+        // Assert
+        let counter_value = {
+            let stats = stats_repository.get_stats().await;
+            stats
+                .metric_collection
+                .sum(&metric_name!(HTTP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &expected_labels)
+                .unwrap()
+        };
+        assert!((counter_value - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/packages/http-core/src/statistics/event/listener.rs
+++ b/packages/http-core/src/statistics/event/listener.rs
@@ -77,7 +77,7 @@ async fn dispatch_events(
     }
 }
 
-fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
+const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
     match event {
         crate::event::Event::TcpAnnounce { connection, .. } | crate::event::Event::TcpScrape { connection } => {
             connection.configuration_instance_id()

--- a/packages/http-core/src/statistics/event/listener.rs
+++ b/packages/http-core/src/statistics/event/listener.rs
@@ -49,31 +49,48 @@ async fn dispatch_events(
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) if metrics_policy.get(&event_connection_id(&event)).copied().unwrap_or(false) => {
-                        handle_event(event, &stats_repository, CurrentClock::now()).await;
-                    }
-                    Ok(event) => {
-                        tracing::warn!(
-                            target: HTTP_TRACKER_LOG_TARGET,
-                            configuration_instance_id = ?event_connection_id(&event),
-                            "Ignoring HTTP tracker event from an unknown or metrics-disabled listener"
-                        );
-                    }
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: HTTP_TRACKER_LOG_TARGET, "Http tracker core statistics receiver closed.");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: HTTP_TRACKER_LOG_TARGET, "Http tracker core statistics receiver lagged by {} events.", n);
-                            }
-                        }
-                    }
+                if should_stop_after_receiving_event(result, &stats_repository, &metrics_policy).await {
+                    break;
                 }
             }
         }
+    }
+}
+
+async fn should_stop_after_receiving_event(
+    result: Result<crate::event::Event, RecvError>,
+    stats_repository: &Arc<Repository>,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) -> bool {
+    match result {
+        Ok(event) => {
+            handle_received_event(event, stats_repository, metrics_policy).await;
+            false
+        }
+        Err(RecvError::Closed) => {
+            tracing::info!(target: HTTP_TRACKER_LOG_TARGET, "Http tracker core statistics receiver closed.");
+            true
+        }
+        Err(RecvError::Lagged(n)) => {
+            tracing::warn!(target: HTTP_TRACKER_LOG_TARGET, "Http tracker core statistics receiver lagged by {} events.", n);
+            false
+        }
+    }
+}
+
+async fn handle_received_event(
+    event: crate::event::Event,
+    stats_repository: &Arc<Repository>,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) {
+    if metrics_policy.get(&event_connection_id(&event)).copied().unwrap_or(false) {
+        handle_event(event, stats_repository, CurrentClock::now()).await;
+    } else {
+        tracing::warn!(
+            target: HTTP_TRACKER_LOG_TARGET,
+            configuration_instance_id = ?event_connection_id(&event),
+            "Ignoring HTTP tracker event from an unknown or metrics-disabled listener"
+        );
     }
 }
 
@@ -87,12 +104,14 @@ const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstan
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
 
+    use futures::future::BoxFuture;
+    use tokio_util::sync::CancellationToken;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
-    use torrust_tracker_events::broadcaster::Broadcaster;
-    use torrust_tracker_events::sender::Sender as _;
+    use torrust_tracker_events::receiver::RecvError;
     use torrust_tracker_http_protocol::v1::services::peer_ip_resolver::{RemoteClientAddr, ResolvedIp};
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
 
@@ -100,6 +119,26 @@ mod tests {
     use crate::event::receiver::Receiver;
     use crate::event::{ConnectionContext, Event};
     use crate::statistics::repository::Repository;
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> Self {
+            Self {
+                results: results.into_iter().collect(),
+            }
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> BoxFuture<'_, Result<Self::Event, RecvError>> {
+            Box::pin(std::future::ready(self.results.pop_front().unwrap_or(Err(RecvError::Closed))))
+        }
+    }
 
     fn scrape_event(configuration_instance_id: ConfigurationInstanceId) -> Event {
         Event::TcpScrape {
@@ -112,28 +151,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_update_metrics_only_for_an_enabled_configuration_instance() {
+    async fn it_should_stop_when_the_receiver_is_closed() {
         // Arrange
-        let enabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
-        let disabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 1);
-        let unknown_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 2);
-        let broadcaster = Broadcaster::default();
-        let receiver: Receiver = Box::new(broadcaster.subscribe());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Err(RecvError::Closed)]));
         let repository = Arc::new(Repository::new());
 
-        for configuration_instance_id in [enabled_id, disabled_id, unknown_id] {
-            let _unused = broadcaster
-                .send(scrape_event(configuration_instance_id))
-                .await
-                .unwrap()
-                .unwrap();
-        }
-        drop(broadcaster);
+        // Act
+        dispatch_events(receiver, CancellationToken::new(), repository.clone(), BTreeMap::new()).await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.tcp4_scrapes_handled(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_continue_after_lag_and_process_an_enabled_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(scrape_event(enabled_id)),
+            Err(RecvError::Closed),
+        ]));
+        let repository = Arc::new(Repository::new());
 
         // Act
         dispatch_events(
             receiver,
-            tokio_util::sync::CancellationToken::new(),
+            CancellationToken::new(),
+            repository.clone(),
+            [(enabled_id, true)].into(),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.tcp4_scrapes_handled(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_cancellation_over_a_ready_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Ok(scrape_event(enabled_id))]));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(receiver, cancellation_token, repository.clone(), [(enabled_id, true)].into()).await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.tcp4_scrapes_handled(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_ignore_disabled_and_unknown_events_before_processing_an_enabled_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 0);
+        let disabled_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 1);
+        let unknown_id = ConfigurationInstanceId::new(ServiceRole::HttpTracker, 2);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([
+            Ok(scrape_event(disabled_id)),
+            Ok(scrape_event(unknown_id)),
+            Ok(scrape_event(enabled_id)),
+            Err(RecvError::Closed),
+        ]));
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(
+            receiver,
+            CancellationToken::new(),
             repository.clone(),
             [(enabled_id, true), (disabled_id, false)].into(),
         )

--- a/packages/http-protocol/Cargo.toml
+++ b/packages/http-protocol/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-info-hash = "=0.2.0"
 torrust-peer-id = "0.1.0"

--- a/packages/http-protocol/src/v1/requests/announce.rs
+++ b/packages/http-protocol/src/v1/requests/announce.rs
@@ -130,7 +130,7 @@ fn percent_decode_ip_parameter(value: &str) -> Result<String, ParseAnnounceQuery
 /// This type is used both for server-side parsing and client-side construction.
 /// The `ip` field preserves its raw semantic state so service policy can make a
 /// client-visible decision without silently ignoring non-empty values.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Announce {
     // Mandatory params
     /// The `InfoHash` of the torrent.
@@ -225,7 +225,7 @@ pub enum ParseAnnounceQueryError {
 ///
 /// Refer to [BEP 03. The `BitTorrent Protocol` Specification](https://www.bittorrent.org/beps/bep_0003.html)
 /// for more information.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Event {
     /// Event sent when a download first begins.
     Started,
@@ -263,10 +263,10 @@ impl FromStr for Event {
 impl fmt::Display for Event {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Event::Started => write!(f, "started"),
-            Event::Stopped => write!(f, "stopped"),
-            Event::Completed => write!(f, "completed"),
-            Event::Empty => write!(f, "empty"),
+            Self::Started => write!(f, "started"),
+            Self::Stopped => write!(f, "stopped"),
+            Self::Completed => write!(f, "completed"),
+            Self::Empty => write!(f, "empty"),
         }
     }
 }
@@ -280,7 +280,7 @@ impl fmt::Display for Event {
 /// - [`Compact`](crate::v1::responses::announce::Compact) response.
 ///
 /// Refer to [BEP 23. Tracker Returns Compact Peer Lists](https://www.bittorrent.org/beps/bep_0023.html)
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Compact {
     /// The client advises the tracker that the client prefers compact format.
     Accepted = 1,
@@ -292,8 +292,8 @@ pub enum Compact {
 impl fmt::Display for Compact {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Compact::Accepted => write!(f, "1"),
-            Compact::NotAccepted => write!(f, "0"),
+            Self::Accepted => write!(f, "1"),
+            Self::NotAccepted => write!(f, "0"),
         }
     }
 }
@@ -316,7 +316,7 @@ impl FromStr for Compact {
 
 impl From<ParseQueryError> for responses::error::Error {
     fn from(err: ParseQueryError) -> Self {
-        responses::error::Error {
+        Self {
             failure_reason: format!("Bad request. Cannot parse query params: {err}"),
         }
     }
@@ -324,7 +324,7 @@ impl From<ParseQueryError> for responses::error::Error {
 
 impl From<ParseAnnounceQueryError> for responses::error::Error {
     fn from(err: ParseAnnounceQueryError) -> Self {
-        responses::error::Error {
+        Self {
             failure_reason: format!("Bad request. Cannot parse query params for announce request: {err}"),
         }
     }
@@ -426,7 +426,7 @@ impl AnnounceBuilder {
     ///
     /// Will panic if the default info-hash value is not a valid info-hash.
     #[must_use]
-    pub fn with_default_values() -> AnnounceBuilder {
+    pub fn with_default_values() -> Self {
         let default_announce = Announce {
             info_hash: InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(), // DevSkim: ignore DS173237
             peer_id: PeerId(*b"-qB00000000000000001"),
@@ -445,31 +445,31 @@ impl AnnounceBuilder {
     }
 
     #[must_use]
-    pub fn with_info_hash(mut self, info_hash: &InfoHash) -> Self {
+    pub const fn with_info_hash(mut self, info_hash: &InfoHash) -> Self {
         self.announce.info_hash = *info_hash;
         self
     }
 
     #[must_use]
-    pub fn with_peer_id(mut self, peer_id: &PeerId) -> Self {
+    pub const fn with_peer_id(mut self, peer_id: &PeerId) -> Self {
         self.announce.peer_id = *peer_id;
         self
     }
 
     #[must_use]
-    pub fn with_port(mut self, port: u16) -> Self {
+    pub const fn with_port(mut self, port: u16) -> Self {
         self.announce.port = port;
         self
     }
 
     #[must_use]
-    pub fn with_ip(mut self, ip: IpAddr) -> Self {
+    pub const fn with_ip(mut self, ip: IpAddr) -> Self {
         self.announce.ip = PeerIp::Literal(ip);
         self
     }
 
     #[must_use]
-    pub fn with_event(mut self, event: Event) -> Self {
+    pub const fn with_event(mut self, event: Event) -> Self {
         self.announce.event = Some(event);
         self
     }
@@ -506,26 +506,26 @@ impl AnnounceBuilder {
     }
 
     #[must_use]
-    pub fn with_compact(mut self, compact: Compact) -> Self {
+    pub const fn with_compact(mut self, compact: Compact) -> Self {
         self.announce.compact = Some(compact);
         self
     }
 
     #[must_use]
-    pub fn without_compact(mut self) -> Self {
+    pub const fn without_compact(mut self) -> Self {
         self.announce.compact = None;
         self
     }
 
     #[must_use]
-    pub fn with_numwant(mut self, numwant: u32) -> Self {
+    pub const fn with_numwant(mut self, numwant: u32) -> Self {
         self.announce.numwant = Some(numwant);
         self
     }
 
     /// Consumes the builder and returns the constructed [`Announce`].
     #[must_use]
-    pub fn query(self) -> Announce {
+    pub const fn query(self) -> Announce {
         self.announce
     }
 }
@@ -637,17 +637,18 @@ fn extract_compact(query: &Query) -> Result<Option<Compact>, ParseAnnounceQueryE
 }
 
 fn extract_numwant(query: &Query) -> Result<Option<u32>, ParseAnnounceQueryError> {
-    match query.get_param(NUMWANT) {
-        Some(raw_param) => match u32::from_str(&raw_param) {
-            Ok(numwant) => Ok(Some(numwant)),
-            Err(_) => Err(ParseAnnounceQueryError::InvalidParam {
-                param_name: NUMWANT.to_owned(),
-                param_value: raw_param.clone(),
-                location: Location::caller(),
-            }),
+    query.get_param(NUMWANT).map_or_else(
+        || Ok(None),
+        |raw_param| {
+            u32::from_str(&raw_param)
+                .map(Some)
+                .map_err(|_| ParseAnnounceQueryError::InvalidParam {
+                    param_name: NUMWANT.to_owned(),
+                    param_value: raw_param.clone(),
+                    location: Location::caller(),
+                })
         },
-        None => Ok(None),
-    }
+    )
 }
 
 #[cfg(test)]
@@ -831,7 +832,7 @@ mod tests {
 
             use crate::v1::query::Query;
             use crate::v1::requests::announce::{
-                Announce, COMPACT, DOWNLOADED, EVENT, INFO_HASH, LEFT, NUMWANT, PEER_ID, PORT, UPLOADED,
+                Announce, COMPACT, DOWNLOADED, EVENT, INFO_HASH, LEFT, NUMWANT, PEER_ID, PORT, ParseAnnounceQueryError, UPLOADED,
             };
 
             #[test]
@@ -961,7 +962,14 @@ mod tests {
                 ])
                 .to_string();
 
-                assert!(Announce::try_from(raw_query.parse::<Query>().unwrap()).is_err());
+                assert!(matches!(
+                    Announce::try_from(raw_query.parse::<Query>().unwrap()),
+                    Err(ParseAnnounceQueryError::InvalidParam {
+                        param_name,
+                        param_value,
+                        ..
+                    }) if param_name == NUMWANT && param_value == "-1"
+                ));
             }
         }
     }

--- a/packages/http-protocol/src/v1/requests/scrape.rs
+++ b/packages/http-protocol/src/v1/requests/scrape.rs
@@ -14,7 +14,7 @@ use crate::v1::responses;
 // Query param names
 const INFO_HASH: &str = "info_hash";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Scrape {
     pub info_hashes: Vec<InfoHash>,
 }
@@ -44,7 +44,7 @@ pub enum ParseScrapeQueryError {
 
 impl From<ParseScrapeQueryError> for responses::error::Error {
     fn from(err: ParseScrapeQueryError) -> Self {
-        responses::error::Error {
+        Self {
             failure_reason: format!("Bad request. Cannot parse query params for scrape request: {err}"),
         }
     }

--- a/packages/http-protocol/src/v1/responses/announce/data.rs
+++ b/packages/http-protocol/src/v1/responses/announce/data.rs
@@ -15,7 +15,7 @@ use torrust_peer_id::PeerId;
 // Nightly Clippy diagnoses that proc-macro expansion; remove this allowance once derive_more emits
 // field-init shorthand.
 #[allow(clippy::redundant_field_names)]
-#[derive(Clone, Debug, PartialEq, Constructor, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Constructor, Default)]
 pub struct AnnounceData {
     pub peers: Vec<Peer>,
     pub stats: SwarmMetadata,

--- a/packages/http-protocol/src/v1/responses/announce/deserialization.rs
+++ b/packages/http-protocol/src/v1/responses/announce/deserialization.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Non-compact announce response (BEP 3 dictionary format).
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct DeserializedNormal {
     pub complete: u32,
     pub incomplete: u32,
@@ -17,7 +17,7 @@ pub struct DeserializedNormal {
 }
 
 /// A peer in dictionary format (BEP 3).
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct DictionaryPeer {
     pub ip: String,
     #[serde(rename = "peer id")]
@@ -27,7 +27,7 @@ pub struct DictionaryPeer {
 }
 
 /// Raw compact announce response (BEP 23) from serde deserialization.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct DeserializedCompact {
     pub complete: u32,
     pub incomplete: u32,
@@ -47,12 +47,12 @@ impl DeserializedCompact {
     ///
     /// Will return an error if bytes can't be deserialized.
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, serde_bencode::Error> {
-        serde_bencode::from_bytes::<DeserializedCompact>(bytes)
+        serde_bencode::from_bytes::<Self>(bytes)
     }
 }
 
 /// Parsed compact announce response with peer entries extracted.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DeserializedCompactParsed {
     pub complete: u32,
     pub incomplete: u32,
@@ -64,14 +64,14 @@ pub struct DeserializedCompactParsed {
 pub use crate::v1::responses::announce::encoding::CompactPeer;
 
 /// A list of compact peer entries.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CompactPeerList {
     peers: Vec<CompactPeer>,
 }
 
 impl CompactPeerList {
     #[must_use]
-    pub fn new(peers: Vec<CompactPeer>) -> Self {
+    pub const fn new(peers: Vec<CompactPeer>) -> Self {
         Self { peers }
     }
 }

--- a/packages/http-protocol/src/v1/responses/announce/encoding.rs
+++ b/packages/http-protocol/src/v1/responses/announce/encoding.rs
@@ -30,7 +30,7 @@ use crate::v1::responses::announce::data::{AnnounceData, Peer};
 // Nightly Clippy diagnoses that proc-macro expansion; remove this allowance once derive_more emits
 // field-init shorthand.
 #[allow(clippy::redundant_field_names)]
-#[derive(Debug, AsRef, PartialEq, Constructor)]
+#[derive(Debug, AsRef, PartialEq, Eq, Constructor)]
 pub struct Announce<E>
 where
     E: From<AnnounceData> + Into<Vec<u8>>,
@@ -98,10 +98,8 @@ pub struct Compact {
 
 impl From<AnnounceData> for Compact {
     fn from(data: AnnounceData) -> Self {
-        let compact_peers: Vec<CompactPeer> = data.peers.into_iter().map(CompactPeer::from).collect();
-
         let (peers, peers6): (Vec<CompactPeerData<Ipv4Addr>>, Vec<CompactPeerData<Ipv6Addr>>) =
-            compact_peers.into_iter().collect();
+            data.peers.into_iter().map(CompactPeer::from).collect();
 
         let peers_encoded: CompactPeersEncoded = peers.into_iter().collect();
         let peers_encoded_6: CompactPeersEncoded = peers6.into_iter().collect();
@@ -145,7 +143,7 @@ impl Into<Vec<u8>> for Compact {
 /// };
 ///
 ///  ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct NormalPeer {
     /// The peer's ID.
     pub peer_id: [u8; 20],
@@ -157,7 +155,7 @@ pub struct NormalPeer {
 
 impl From<Peer> for NormalPeer {
     fn from(peer: Peer) -> Self {
-        NormalPeer {
+        Self {
             peer_id: peer.peer_id.0,
             ip: peer.peer_addr.ip(),
             port: peer.peer_addr.port(),
@@ -197,7 +195,7 @@ impl From<&NormalPeer> for BencodeMut<'_> {
 ///
 /// Refer to [BEP 23: Tracker Returns Compact Peer Lists](https://www.bittorrent.org/beps/bep_0023.html)
 /// for more information.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CompactPeer {
     /// The peer's IP address.
     V4(CompactPeerData<Ipv4Addr>),
@@ -208,7 +206,7 @@ pub enum CompactPeer {
 impl CompactPeer {
     /// Creates a compact peer from a socket address.
     #[must_use]
-    pub fn new(socket_addr: &SocketAddr) -> Self {
+    pub const fn new(socket_addr: &SocketAddr) -> Self {
         match socket_addr.ip() {
             IpAddr::V4(ip) => Self::V4(CompactPeerData {
                 ip,
@@ -223,7 +221,7 @@ impl CompactPeer {
 
     /// Creates a compact peer from 6 bytes (IPv4) or 18 bytes (IPv6).
     #[must_use]
-    pub fn new_from_bytes(bytes: &[u8]) -> Self {
+    pub const fn new_from_bytes(bytes: &[u8]) -> Self {
         if bytes.len() == 18 {
             // IPv6: 16 bytes IP + 2 bytes port
             let ip = Ipv6Addr::new(
@@ -258,7 +256,7 @@ impl From<Peer> for CompactPeer {
 
 /// The [`CompactPeerData`], that made with either a [`Ipv4Addr`], or [`Ipv6Addr`] along with a `port`.
 ///
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CompactPeerData<V> {
     /// The peer's IP address.
     pub ip: V,

--- a/packages/http-protocol/src/v1/responses/error.rs
+++ b/packages/http-protocol/src/v1/responses/error.rs
@@ -17,7 +17,7 @@ use crate::v1::auth;
 use crate::v1::services::peer_ip_resolver::PeerIpResolutionError;
 
 /// `Error` response for the HTTP tracker.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Error {
     /// Human readable string which explains why the request failed.
     #[serde(rename = "failure reason")]

--- a/packages/http-protocol/src/v1/responses/scrape/data.rs
+++ b/packages/http-protocol/src/v1/responses/scrape/data.rs
@@ -20,7 +20,7 @@ pub struct SwarmMetadata {
 // Intentional boundary duplication: this represents scrape response payload
 // semantics for the HTTP protocol crate, not tracker-domain semantics.
 // adr: docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct ScrapeData {
     pub files: BTreeMap<InfoHash, SwarmMetadata>,
 }

--- a/packages/http-protocol/src/v1/responses/scrape/deserialization.rs
+++ b/packages/http-protocol/src/v1/responses/scrape/deserialization.rs
@@ -10,7 +10,7 @@ use serde_bencode::value::Value;
 use thiserror::Error;
 use torrust_info_hash::InfoHash;
 
-#[derive(Debug, PartialEq, Default, Deserialize)]
+#[derive(Debug, PartialEq, Eq, Default, Deserialize)]
 pub struct Response {
     pub files: HashMap<InfoHash, File>,
 }
@@ -33,7 +33,7 @@ impl Response {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
 pub struct File {
     pub complete: i64,
     pub downloaded: i64,

--- a/packages/http-protocol/src/v1/responses/scrape/encoding.rs
+++ b/packages/http-protocol/src/v1/responses/scrape/encoding.rs
@@ -37,7 +37,7 @@ use crate::v1::responses::scrape::data::ScrapeData;
 ///     String::from_utf8(expected_bytes.to_vec()).unwrap()
 /// );
 /// ```
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct Bencoded {
     /// The scrape data to be bencoded.
     scrape_data: ScrapeData,

--- a/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
+++ b/packages/http-protocol/src/v1/services/peer_ip_resolver.rs
@@ -64,11 +64,7 @@ impl From<ReverseProxyMode> for bool {
 
 impl From<bool> for ReverseProxyMode {
     fn from(reverse_proxy_mode: bool) -> Self {
-        if reverse_proxy_mode {
-            ReverseProxyMode::Enabled
-        } else {
-            ReverseProxyMode::Disabled
-        }
+        if reverse_proxy_mode { Self::Enabled } else { Self::Disabled }
     }
 }
 /// This struct contains the sources from which the peer IP can be obtained.
@@ -82,7 +78,7 @@ pub struct ClientIpSources {
 }
 
 impl ClientIpSources {
-    fn try_client_ip_from_connection_info(&self) -> Result<IpAddr, PeerIpResolutionError> {
+    const fn try_client_ip_from_connection_info(&self) -> Result<IpAddr, PeerIpResolutionError> {
         if let Some(socket_addr) = self.connection_info_socket_address {
             Ok(socket_addr.ip())
         } else {
@@ -92,7 +88,7 @@ impl ClientIpSources {
         }
     }
 
-    fn try_client_ip_from_proxy_header(&self) -> Result<IpAddr, PeerIpResolutionError> {
+    const fn try_client_ip_from_proxy_header(&self) -> Result<IpAddr, PeerIpResolutionError> {
         if let Some(ip) = self.right_most_x_forwarded_for {
             Ok(ip)
         } else {
@@ -137,19 +133,19 @@ pub struct RemoteClientAddr {
 
 impl RemoteClientAddr {
     #[must_use]
-    pub fn new(ip: ResolvedIp, port: Option<u16>) -> Self {
+    pub const fn new(ip: ResolvedIp, port: Option<u16>) -> Self {
         Self { ip, port }
     }
 
     #[must_use]
-    pub fn ip(&self) -> IpAddr {
+    pub const fn ip(&self) -> IpAddr {
         match self.ip {
             ResolvedIp::FromSocketAddr(ip) | ResolvedIp::FromXForwardedFor(ip) => ip,
         }
     }
 
     #[must_use]
-    pub fn port(&self) -> Option<u16> {
+    pub const fn port(&self) -> Option<u16> {
         self.port
     }
 }

--- a/packages/primitives/Cargo.toml
+++ b/packages/primitives/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "3.0.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-peer-id = "0.1.0"
 binascii = "0"

--- a/packages/primitives/src/announce.rs
+++ b/packages/primitives/src/announce.rs
@@ -67,15 +67,15 @@ impl Default for AnnouncePolicy {
 }
 
 impl AnnouncePolicy {
-    fn default_interval() -> u32 {
+    const fn default_interval() -> u32 {
         120
     }
 
-    fn default_interval_min() -> u32 {
+    const fn default_interval_min() -> u32 {
         120
     }
 
-    fn default_max_peers_per_announce() -> usize {
+    const fn default_max_peers_per_announce() -> usize {
         74
     }
 }
@@ -85,7 +85,7 @@ impl AnnouncePolicy {
 // Nightly Clippy diagnoses that proc-macro expansion; remove this allowance once derive_more emits
 // field-init shorthand.
 #[allow(clippy::redundant_field_names)]
-#[derive(Clone, Debug, PartialEq, Constructor, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Constructor, Default)]
 pub struct AnnounceData {
     /// The list of peers that are downloading the same torrent.
     /// It excludes the peer that made the request.
@@ -95,7 +95,9 @@ pub struct AnnounceData {
     pub policy: AnnouncePolicy,
 }
 
-/// Intentional boundary duplication: this domain type mirrors
+/// Intentional boundary duplication.
+///
+/// This domain type mirrors
 /// protocol-level `AnnounceEvent` definitions in `udp-protocol` and
 /// `http-protocol`, but is kept here so domain logic does not depend on
 /// protocol wire formats.

--- a/packages/primitives/src/driver.rs
+++ b/packages/primitives/src/driver.rs
@@ -25,7 +25,7 @@ pub enum Driver {
 impl Driver {
     /// Returns the stable lowercase identifier used by CLI and reports.
     #[must_use]
-    pub fn as_str(&self) -> &'static str {
+    pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Sqlite3 => "sqlite3",
             Self::MySQL => "mysql",

--- a/packages/primitives/src/mode.rs
+++ b/packages/primitives/src/mode.rs
@@ -29,7 +29,7 @@ impl Default for PrivateMode {
 }
 
 impl PrivateMode {
-    fn default_check_keys_expiration() -> bool {
+    const fn default_check_keys_expiration() -> bool {
         true
     }
 }

--- a/packages/primitives/src/pagination.rs
+++ b/packages/primitives/src/pagination.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 // Nightly Clippy diagnoses that proc-macro expansion; remove this allowance once derive_more emits
 // field-init shorthand.
 #[allow(clippy::redundant_field_names)]
-#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Constructor)]
+#[derive(Deserialize, Copy, Clone, Debug, PartialEq, Eq, Constructor)]
 pub struct Pagination {
     /// The page number, starting at 0
     pub offset: u32,
@@ -16,26 +16,26 @@ pub struct Pagination {
 
 impl Pagination {
     #[must_use]
-    pub fn new_with_options(offset_option: Option<u32>, limit_option: Option<u32>) -> Self {
+    pub const fn new_with_options(offset_option: Option<u32>, limit_option: Option<u32>) -> Self {
         let offset = match offset_option {
             Some(offset) => offset,
-            None => Pagination::default_offset(),
+            None => Self::default_offset(),
         };
         let limit = match limit_option {
             Some(offset) => offset,
-            None => Pagination::default_limit(),
+            None => Self::default_limit(),
         };
 
         Self { offset, limit }
     }
 
     #[must_use]
-    pub fn default_offset() -> u32 {
+    pub const fn default_offset() -> u32 {
         0
     }
 
     #[must_use]
-    pub fn default_limit() -> u32 {
+    pub const fn default_limit() -> u32 {
         4000
     }
 }

--- a/packages/primitives/src/peer.rs
+++ b/packages/primitives/src/peer.rs
@@ -45,10 +45,10 @@ pub enum PeerRole {
 impl PeerRole {
     /// Returns the opposite role: Seeder becomes Leecher, and vice versa.
     #[must_use]
-    pub fn opposite(self) -> Self {
+    pub const fn opposite(self) -> Self {
         match self {
-            PeerRole::Seeder => PeerRole::Leecher,
-            PeerRole::Leecher => PeerRole::Seeder,
+            Self::Seeder => Self::Leecher,
+            Self::Leecher => Self::Seeder,
         }
     }
 }
@@ -56,8 +56,8 @@ impl PeerRole {
 impl fmt::Display for PeerRole {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PeerRole::Seeder => write!(f, "seeder"),
-            PeerRole::Leecher => write!(f, "leecher"),
+            Self::Seeder => write!(f, "seeder"),
+            Self::Leecher => write!(f, "leecher"),
         }
     }
 }
@@ -67,8 +67,8 @@ impl FromStr for PeerRole {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
-            "seeder" => Ok(PeerRole::Seeder),
-            "leecher" => Ok(PeerRole::Leecher),
+            "seeder" => Ok(Self::Seeder),
+            "leecher" => Ok(Self::Leecher),
             _ => Err(ParsePeerRoleError::InvalidPeerRole {
                 location: Location::caller(),
                 raw_param: s.to_string(),
@@ -283,20 +283,20 @@ impl Peer {
         }
     }
 
-    pub fn ip(&mut self) -> IpAddr {
+    pub const fn ip(&mut self) -> IpAddr {
         self.peer_addr.ip()
     }
 
-    pub fn change_ip(&mut self, new_ip: &IpAddr) {
+    pub const fn change_ip(&mut self, new_ip: &IpAddr) {
         self.peer_addr = SocketAddr::new(*new_ip, self.peer_addr.port());
     }
 
-    pub fn mark_as_completed(&mut self) {
+    pub const fn mark_as_completed(&mut self) {
         self.event = AnnounceEvent::Completed;
     }
 
     #[must_use]
-    pub fn into_completed(self) -> Self {
+    pub const fn into_completed(self) -> Self {
         Self {
             event: AnnounceEvent::Completed,
             ..self
@@ -304,7 +304,7 @@ impl Peer {
     }
 
     #[must_use]
-    pub fn into_seeder(self) -> Self {
+    pub const fn into_seeder(self) -> Self {
         Self {
             left: NumberOfBytes::new(0),
             ..self
@@ -371,7 +371,7 @@ impl Id {
         ];
 
         let data = PeerId(bytes);
-        Id { data }
+        Self { data }
     }
 }
 
@@ -444,10 +444,7 @@ impl Id {
 
         binascii::bin2hex(&self.0, &mut tmp).unwrap();
 
-        match std::str::from_utf8(&tmp) {
-            Ok(hex) => Some(format!("0x{hex}")),
-            Err(_) => None,
-        }
+        std::str::from_utf8(&tmp).ok().map(|hex| format!("0x{hex}"))
     }
 
     #[must_use]
@@ -481,7 +478,7 @@ pub trait Encoding: From<Peer> + PartialEq {}
 
 impl<P: Encoding> FromIterator<Peer> for Vec<P> {
     fn from_iter<T: IntoIterator<Item = Peer>>(iter: T) -> Self {
-        let mut peers: Vec<P> = vec![];
+        let mut peers: Self = vec![];
 
         for peer in iter {
             peers.push(peer.into());
@@ -499,7 +496,7 @@ pub mod fixture {
     use super::{Id, Peer, PeerId};
     use crate::{AnnounceEvent, NumberOfBytes};
 
-    #[derive(PartialEq, Debug)]
+    #[derive(PartialEq, Eq, Debug)]
 
     pub struct PeerBuilder {
         peer: Peer,
@@ -515,7 +512,7 @@ pub mod fixture {
     impl PeerBuilder {
         #[allow(dead_code)]
         #[must_use]
-        pub fn seeder() -> Self {
+        pub const fn seeder() -> Self {
             let peer = Peer {
                 peer_id: PeerId(*b"-qB00000000000000001"),
                 peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
@@ -531,7 +528,7 @@ pub mod fixture {
 
         #[allow(dead_code)]
         #[must_use]
-        pub fn leecher() -> Self {
+        pub const fn leecher() -> Self {
             let peer = Peer {
                 peer_id: PeerId(*b"-qB00000000000000002"),
                 peer_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2)), 8080),
@@ -547,73 +544,73 @@ pub mod fixture {
 
         #[allow(dead_code)]
         #[must_use]
-        pub fn with_peer_id(mut self, peer_id: &PeerId) -> Self {
+        pub const fn with_peer_id(mut self, peer_id: &PeerId) -> Self {
             self.peer.peer_id = *peer_id;
             self
         }
 
         #[allow(dead_code)]
         #[must_use]
-        pub fn with_peer_addr(mut self, peer_addr: &SocketAddr) -> Self {
+        pub const fn with_peer_addr(mut self, peer_addr: &SocketAddr) -> Self {
             self.peer.peer_addr = *peer_addr;
             self
         }
 
         #[must_use]
-        pub fn with_peer_address(mut self, peer_addr: SocketAddr) -> Self {
+        pub const fn with_peer_address(mut self, peer_addr: SocketAddr) -> Self {
             self.peer.peer_addr = peer_addr;
             self
         }
 
         #[must_use]
-        pub fn updated_on(mut self, updated: DurationSinceUnixEpoch) -> Self {
+        pub const fn updated_on(mut self, updated: DurationSinceUnixEpoch) -> Self {
             self.peer.updated = updated;
             self
         }
 
         #[must_use]
-        pub fn with_bytes_left_to_download(mut self, left: i64) -> Self {
+        pub const fn with_bytes_left_to_download(mut self, left: i64) -> Self {
             self.peer.left = NumberOfBytes::new(left);
             self
         }
 
         #[must_use]
-        pub fn with_no_bytes_left_to_download(mut self) -> Self {
+        pub const fn with_no_bytes_left_to_download(mut self) -> Self {
             self.peer.left = NumberOfBytes::new(0);
             self
         }
 
         #[must_use]
-        pub fn last_updated_on(mut self, updated: DurationSinceUnixEpoch) -> Self {
+        pub const fn last_updated_on(mut self, updated: DurationSinceUnixEpoch) -> Self {
             self.peer.updated = updated;
             self
         }
 
         #[must_use]
-        pub fn with_event(mut self, event: AnnounceEvent) -> Self {
+        pub const fn with_event(mut self, event: AnnounceEvent) -> Self {
             self.peer.event = event;
             self
         }
 
         #[must_use]
-        pub fn with_event_started(mut self) -> Self {
+        pub const fn with_event_started(mut self) -> Self {
             self.peer.event = AnnounceEvent::Started;
             self
         }
 
         #[must_use]
-        pub fn with_event_completed(mut self) -> Self {
+        pub const fn with_event_completed(mut self) -> Self {
             self.peer.event = AnnounceEvent::Completed;
             self
         }
 
         #[must_use]
-        pub fn build(self) -> Peer {
+        pub const fn build(self) -> Peer {
             self.into()
         }
 
         #[must_use]
-        pub fn into(self) -> Peer {
+        pub const fn into(self) -> Peer {
             self.peer
         }
     }

--- a/packages/primitives/src/policy.rs
+++ b/packages/primitives/src/policy.rs
@@ -44,15 +44,15 @@ impl Default for TrackerPolicy {
 }
 
 impl TrackerPolicy {
-    fn default_max_peer_timeout() -> u32 {
+    const fn default_max_peer_timeout() -> u32 {
         900
     }
 
-    fn default_persistent_torrent_completed_stat() -> bool {
+    const fn default_persistent_torrent_completed_stat() -> bool {
         false
     }
 
-    fn default_remove_peerless_torrents() -> bool {
+    const fn default_remove_peerless_torrents() -> bool {
         true
     }
 }

--- a/packages/primitives/src/runtime_service_metadata.rs
+++ b/packages/primitives/src/runtime_service_metadata.rs
@@ -49,7 +49,7 @@ impl RuntimeServiceMetadata {
 
     /// Returns the configured public URL for the listener, when present.
     #[must_use]
-    pub fn public_url(&self) -> Option<&Url> {
+    pub const fn public_url(&self) -> Option<&Url> {
         self.public_url.as_ref()
     }
 }

--- a/packages/primitives/src/scrape.rs
+++ b/packages/primitives/src/scrape.rs
@@ -7,7 +7,7 @@ use torrust_info_hash::InfoHash;
 use crate::swarm_metadata::SwarmMetadata;
 
 /// Structure that holds the data returned by the `scrape` request.
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct ScrapeData {
     /// A map of infohashes and swarm metadata for each torrent.
     pub files: HashMap<InfoHash, SwarmMetadata>,

--- a/packages/primitives/src/swarm_metadata.rs
+++ b/packages/primitives/src/swarm_metadata.rs
@@ -35,17 +35,17 @@ impl SwarmMetadata {
     }
 
     #[must_use]
-    pub fn downloads(&self) -> NumberOfDownloads {
+    pub const fn downloads(&self) -> NumberOfDownloads {
         self.downloaded
     }
 
     #[must_use]
-    pub fn seeders(&self) -> u32 {
+    pub const fn seeders(&self) -> u32 {
         self.complete
     }
 
     #[must_use]
-    pub fn leechers(&self) -> u32 {
+    pub const fn leechers(&self) -> u32 {
         self.incomplete
     }
 }
@@ -53,7 +53,7 @@ impl SwarmMetadata {
 /// Structure that holds aggregate swarm metadata.
 ///
 /// Metrics are aggregate values for all active torrents/swarms.
-#[derive(Copy, Clone, Debug, PartialEq, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub struct AggregateActiveSwarmMetadata {
     /// Total number of peers that have ever completed downloading.
     pub total_downloaded: u64,

--- a/packages/rest-api-application/Cargo.toml
+++ b/packages/rest-api-application/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-tracker-rest-api-protocol = { version = "0.1.0", path = "../rest-api-protocol" }
 torrust-info-hash = "=0.2.0"

--- a/packages/rest-api-client/Cargo.toml
+++ b/packages/rest-api-client/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 hyper = "1"
 reqwest = { version = "0", features = [ "json", "query" ] }

--- a/packages/rest-api-client/src/common/http.rs
+++ b/packages/rest-api-client/src/common/http.rs
@@ -9,12 +9,12 @@ pub struct Query {
 
 impl Query {
     #[must_use]
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Self { params: vec![] }
     }
 
     #[must_use]
-    pub fn params(params: Vec<QueryParam>) -> Self {
+    pub const fn params(params: Vec<QueryParam>) -> Self {
         Self { params }
     }
 

--- a/packages/rest-api-client/src/connection_info.rs
+++ b/packages/rest-api-client/src/connection_info.rs
@@ -19,7 +19,7 @@ impl ConnectionInfo {
     }
 
     #[must_use]
-    pub fn anonymous(origin: Origin) -> Self {
+    pub const fn anonymous(origin: Origin) -> Self {
         Self { origin, api_token: None }
     }
 }
@@ -66,7 +66,7 @@ impl FromStr for Origin {
         url.set_query(None);
         url.set_fragment(None);
 
-        Ok(Origin { url })
+        Ok(Self { url })
     }
 }
 
@@ -86,7 +86,7 @@ impl Origin {
     }
 
     #[must_use]
-    pub fn url(&self) -> &Url {
+    pub const fn url(&self) -> &Url {
         &self.url
     }
 }

--- a/packages/rest-api-client/src/v1/client.rs
+++ b/packages/rest-api-client/src/v1/client.rs
@@ -75,7 +75,7 @@ impl ApiClient {
 
     /// Returns a reference to the inner [`ApiHttpClient`] for low-level operations.
     #[must_use]
-    pub fn inner(&self) -> &ApiHttpClient {
+    pub const fn inner(&self) -> &ApiHttpClient {
         &self.inner
     }
 
@@ -381,7 +381,7 @@ impl ApiHttpClient {
     /// Prefer [`Self::post_empty`] for most use cases; use this when you need access
     /// to the raw token-injection logic.
     pub(crate) async fn post_empty_result(&self, path: &str, headers: Option<HeaderMap>) -> Result<Response, ClientError> {
-        let builder = self.http_client.post(self.base_url(path)?.clone());
+        let builder = self.http_client.post(self.base_url(path)?);
 
         let builder = match headers {
             Some(headers) => builder.headers(headers),
@@ -399,7 +399,7 @@ impl ApiHttpClient {
     /// # Errors
     ///
     /// Will return an error if the request can't be sent.
-    pub async fn post_form<T: Serialize + ?Sized>(
+    pub async fn post_form<T: Serialize + Sync + ?Sized>(
         &self,
         path: &str,
         form: &T,
@@ -412,13 +412,13 @@ impl ApiHttpClient {
     ///
     /// Prefer [`Self::post_form`] for most use cases; use this when you need access
     /// to the raw token-injection logic.
-    pub(crate) async fn post_form_result<T: Serialize + ?Sized>(
+    pub(crate) async fn post_form_result<T: Serialize + Sync + ?Sized>(
         &self,
         path: &str,
         form: &T,
         headers: Option<HeaderMap>,
     ) -> Result<Response, ClientError> {
-        let builder = self.http_client.post(self.base_url(path)?.clone()).json(&form);
+        let builder = self.http_client.post(self.base_url(path)?).json(&form);
 
         let builder = match headers {
             Some(headers) => builder.headers(headers),
@@ -435,7 +435,7 @@ impl ApiHttpClient {
 
     /// Fallible version of [`Self::delete`] that returns a `Result` instead of panicking.
     async fn delete_result(&self, path: &str, headers: Option<HeaderMap>) -> Result<Response, ClientError> {
-        let builder = self.http_client.delete(self.base_url(path)?.clone());
+        let builder = self.http_client.delete(self.base_url(path)?);
 
         let builder = match headers {
             Some(headers) => builder.headers(headers),
@@ -475,38 +475,28 @@ impl ApiHttpClient {
         let url = self.base_url(path)?;
         match &self.connection_info.api_token {
             Some(token) => {
-                let headers = if let Some(headers) = headers {
-                    // Headers provided -> add auth token if not already present
+                let headers = headers.map_or_else(
+                    || headers_with_auth_token(token),
+                    |headers| {
+                        // Headers provided -> add auth token if not already present
 
-                    if headers.get(header::AUTHORIZATION).is_some() {
-                        // Auth token already present -> use provided
-                        headers
-                    } else {
-                        let mut headers = headers;
+                        if headers.get(header::AUTHORIZATION).is_some() {
+                            // Auth token already present -> use provided
+                            headers
+                        } else {
+                            let mut headers = headers;
 
-                        headers.insert(
-                            header::AUTHORIZATION,
-                            format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} {token}")
-                                .parse()
-                                .expect("the auth token is not a valid header value"),
-                        );
+                            headers.insert(
+                                header::AUTHORIZATION,
+                                format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} {token}")
+                                    .parse()
+                                    .expect("the auth token is not a valid header value"),
+                            );
 
-                        headers
-                    }
-                } else {
-                    // No headers provided -> create headers with auth token
-
-                    let mut headers = HeaderMap::new();
-
-                    headers.insert(
-                        header::AUTHORIZATION,
-                        format!("{AUTH_BEARER_TOKEN_HEADER_PREFIX} {token}")
-                            .parse()
-                            .expect("the auth token is not a valid header value"),
-                    );
-
-                    headers
-                };
+                            headers
+                        }
+                    },
+                );
 
                 get_result(url, Some(params), Some(headers)).await
             }

--- a/packages/rest-api-protocol/Cargo.toml
+++ b/packages/rest-api-protocol/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1", features = [ "derive" ] }
 serde_with = { version = "3", features = [ "json" ] }

--- a/packages/rest-api-protocol/src/v1/context/auth_key/resources/auth_key.rs
+++ b/packages/rest-api-protocol/src/v1/context/auth_key/resources/auth_key.rs
@@ -37,16 +37,16 @@ pub enum AuthKeyError {
 impl fmt::Display for AuthKeyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            AuthKeyError::DurationOverflow { seconds_valid } => {
+            Self::DurationOverflow { seconds_valid } => {
                 write!(f, "duration overflow: {seconds_valid}")
             }
-            AuthKeyError::InvalidKey { key, reason } => {
+            Self::InvalidKey { key, reason } => {
                 write!(f, "invalid key: \"{key}\", {reason}")
             }
-            AuthKeyError::DisabledByConfiguration { capability } => {
+            Self::DisabledByConfiguration { capability } => {
                 write!(f, "{capability} capability is disabled by configuration")
             }
-            AuthKeyError::Database(msg) => write!(f, "{msg}"),
+            Self::Database(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/packages/rest-api-protocol/src/v1/context/whitelist/resources/whitelist.rs
+++ b/packages/rest-api-protocol/src/v1/context/whitelist/resources/whitelist.rs
@@ -21,13 +21,13 @@ pub enum WhitelistError {
 impl fmt::Display for WhitelistError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            WhitelistError::DisabledByConfiguration { capability } => {
+            Self::DisabledByConfiguration { capability } => {
                 write!(f, "{capability} capability is disabled by configuration")
             }
             // Forward the inner message as-is to preserve the original
             // error response format from the previous direct-to-WhitelistManager
             // wiring (the Axum handlers format via `{e}`).
-            WhitelistError::Database(msg) => write!(f, "{msg}"),
+            Self::Database(msg) => write!(f, "{msg}"),
         }
     }
 }

--- a/packages/rest-api-runtime-adapter/Cargo.toml
+++ b/packages/rest-api-runtime-adapter/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-tracker-configuration = { version = "3.0.0", path = "../configuration" }
 torrust-tracker-rest-api-application = { version = "0.1.0", path = "../rest-api-application" }

--- a/packages/rest-api-runtime-adapter/src/v1/adapters/stats.rs
+++ b/packages/rest-api-runtime-adapter/src/v1/adapters/stats.rs
@@ -117,28 +117,22 @@ impl StatsQueryPort for TrackerStatsAdapter {
     }
 
     async fn get_labeled_stats(&self) -> LabeledStats {
-        let swarms_stats = self.swarms_stats_repository.get_metrics().await;
-        let tracker_core_stats = self.tracker_core_stats_repository.get_metrics().await;
-        let http_stats = self.http_stats_repository.get_stats().await;
-        let udp_stats = self.udp_core_stats_repository.get_stats().await;
-        let udp_server_stats = self.udp_server_stats_repository.get_stats().await;
-
         let mut metrics = MetricCollection::default();
 
         metrics
-            .merge(&swarms_stats.metric_collection)
+            .merge(&self.swarms_stats_repository.get_metrics().await.metric_collection)
             .expect("failed to merge torrent repository metrics");
         metrics
-            .merge(&tracker_core_stats.metric_collection)
+            .merge(&self.tracker_core_stats_repository.get_metrics().await.metric_collection)
             .expect("failed to merge tracker core metrics");
         metrics
-            .merge(&http_stats.metric_collection)
+            .merge(&self.http_stats_repository.get_stats().await.metric_collection)
             .expect("failed to merge HTTP core metrics");
         metrics
-            .merge(&udp_stats.metric_collection)
+            .merge(&self.udp_core_stats_repository.get_stats().await.metric_collection)
             .expect("failed to merge UDP core metrics");
         metrics
-            .merge(&udp_server_stats.metric_collection)
+            .merge(&self.udp_server_stats_repository.get_stats().await.metric_collection)
             .expect("failed to merge UDP server metrics");
 
         LabeledStats { metrics }

--- a/packages/rest-api-runtime-adapter/src/v1/container.rs
+++ b/packages/rest-api-runtime-adapter/src/v1/container.rs
@@ -56,7 +56,7 @@ impl TrackerHttpApiCoreContainer {
         udp_tracker_server_config: &UdpTrackerServer,
         udp_tracker_configuration_instance_id: ConfigurationInstanceId,
         http_api_config: &Arc<HttpApi>,
-    ) -> Arc<TrackerHttpApiCoreContainer> {
+    ) -> Arc<Self> {
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
@@ -104,8 +104,8 @@ impl TrackerHttpApiCoreContainer {
         udp_tracker_core_container: &Arc<UdpTrackerCoreContainer>,
         udp_tracker_server_container: &Arc<UdpTrackerServerContainer>,
         http_api_config: &Arc<HttpApi>,
-    ) -> Arc<TrackerHttpApiCoreContainer> {
-        Arc::new(TrackerHttpApiCoreContainer {
+    ) -> Arc<Self> {
+        Arc::new(Self {
             http_api_config: http_api_config.clone(),
 
             // Swarm Coordination Registry Container

--- a/packages/swarm-coordination-registry/Cargo.toml
+++ b/packages/swarm-coordination-registry/Cargo.toml
@@ -15,6 +15,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-info-hash = "=0.2.0"
 chrono = { version = "0", default-features = false, features = [ "clock" ] }

--- a/packages/swarm-coordination-registry/Cargo.toml
+++ b/packages/swarm-coordination-registry/Cargo.toml
@@ -24,7 +24,6 @@ chrono = { version = "0", default-features = false, features = [ "clock" ] }
 crossbeam-skiplist = "0"
 futures = "0"
 serde = { version = "1.0.219", features = [ "derive" ] }
-thiserror = "2.0.12"
 tokio = { version = "1", features = [ "macros", "net", "rt-multi-thread", "signal", "sync" ] }
 tokio-util = "0.7.15"
 torrust-clock = "3.0.0"

--- a/packages/swarm-coordination-registry/examples/bench_peers.rs
+++ b/packages/swarm-coordination-registry/examples/bench_peers.rs
@@ -2,6 +2,7 @@
 //! Usage: cargo run --package torrust-tracker-swarm-coordination-registry --example `bench_peers` --release
 
 use std::hint::black_box;
+use std::io::Write;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Instant;
 
@@ -11,7 +12,7 @@ use torrust_tracker_primitives::{AnnounceEvent, NumberOfBytes, PeerId};
 use torrust_tracker_swarm_coordination_registry::event::sender::Sender;
 use torrust_tracker_swarm_coordination_registry::swarm::coordinator::Coordinator;
 
-fn make_peer(ip_last_octet: u8, port: u16, seed: u8) -> Peer {
+const fn make_peer(ip_last_octet: u8, port: u16, seed: u8) -> Peer {
     let mut id = [seed; 20];
     id[0] = ip_last_octet;
     Peer {
@@ -63,29 +64,41 @@ fn bench_peers_excluding(num_peers: usize, limit: usize, iterations: u64) -> f64
 
 fn main() {
     let iterations = 100_000;
+    let mut stdout = std::io::stdout().lock();
 
-    println!("=== Baseline: Coordinator::peers_excluding ===");
-    println!("iterations={iterations}");
+    writeln!(stdout, "=== Baseline: Coordinator::peers_excluding ===").expect("failed to write benchmark output");
+    writeln!(stdout, "iterations={iterations}").expect("failed to write benchmark output");
 
     for num_peers in [10, 74, 100, 500, 1000] {
         let ns = bench_peers_excluding(num_peers, 74, iterations);
         let per_peer = ns / f64::from(u32::try_from(num_peers).expect("num_peers fits in u32"));
-        println!("{num_peers:>4} peers: {ns:>10.2} ns/iter  ({per_peer:.2} ns/peer)");
+        writeln!(stdout, "{num_peers:>4} peers: {ns:>10.2} ns/iter  ({per_peer:.2} ns/peer)")
+            .expect("failed to write benchmark output");
     }
 
     // Memory estimate
-    println!();
-    println!("=== Memory per peer ===");
-    println!("Peer struct:        {} bytes", std::mem::size_of::<Peer>());
-    println!("Arc<Peer>:          {} bytes", std::mem::size_of::<std::sync::Arc<Peer>>());
-    println!("SocketAddr:         {} bytes", std::mem::size_of::<SocketAddr>());
-    println!("PeerId:             {} bytes", std::mem::size_of::<PeerId>());
-    println!(
+    writeln!(stdout).expect("failed to write benchmark output");
+    writeln!(stdout, "=== Memory per peer ===").expect("failed to write benchmark output");
+    writeln!(stdout, "Peer struct:        {} bytes", std::mem::size_of::<Peer>()).expect("failed to write benchmark output");
+    writeln!(
+        stdout,
+        "Arc<Peer>:          {} bytes",
+        std::mem::size_of::<std::sync::Arc<Peer>>()
+    )
+    .expect("failed to write benchmark output");
+    writeln!(stdout, "SocketAddr:         {} bytes", std::mem::size_of::<SocketAddr>())
+        .expect("failed to write benchmark output");
+    writeln!(stdout, "PeerId:             {} bytes", std::mem::size_of::<PeerId>()).expect("failed to write benchmark output");
+    writeln!(
+        stdout,
         "CompactPeer (est):  {} bytes (PeerId + SocketAddr)",
         std::mem::size_of::<PeerId>() + std::mem::size_of::<SocketAddr>()
-    );
-    println!(
+    )
+    .expect("failed to write benchmark output");
+    writeln!(
+        stdout,
         "Vec<Arc<Peer>>(74): {} bytes",
         std::mem::size_of::<Vec<std::sync::Arc<Peer>>>() + 74 * std::mem::size_of::<std::sync::Arc<Peer>>()
-    );
+    )
+    .expect("failed to write benchmark output");
 }

--- a/packages/swarm-coordination-registry/src/container.rs
+++ b/packages/swarm-coordination-registry/src/container.rs
@@ -22,7 +22,7 @@ impl SwarmCoordinationRegistryContainer {
         let broadcaster = Broadcaster::default();
         let stats_repository = Arc::new(Repository::new());
 
-        let event_bus = Arc::new(EventBus::new(sender_status, broadcaster.clone()));
+        let event_bus = Arc::new(EventBus::new(sender_status, broadcaster));
 
         let stats_event_sender = event_bus.sender();
 

--- a/packages/swarm-coordination-registry/src/statistics/event/handler.rs
+++ b/packages/swarm-coordination-registry/src/statistics/event/handler.rs
@@ -15,151 +15,187 @@ use crate::statistics::{
     SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL,
 };
 
-#[allow(clippy::too_many_lines)]
 pub async fn handle_event(event: Event, stats_repository: &Arc<Repository>, now: DurationSinceUnixEpoch) {
     match event {
-        // Torrent events
-        Event::TorrentAdded { info_hash, .. } => {
-            tracing::debug!(info_hash = ?info_hash, "Torrent added",);
-
-            let _unused = stats_repository
-                .increment_gauge(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
-
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
-        }
-        Event::TorrentRemoved { info_hash } => {
-            tracing::debug!(info_hash = ?info_hash, "Torrent removed",);
-
-            let _unused = stats_repository
-                .decrement_gauge(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
-
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
-        }
-
-        // Peer events
-        Event::PeerAdded { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer added", );
-
-            let label_set = label_set_for_peer(&peer);
-
-            let _unused = stats_repository
-                .increment_gauge(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
-                    &label_set,
-                    now,
-                )
-                .await;
-
-            let _unused = stats_repository
-                .increment_counter(&metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL), &label_set, now)
-                .await;
-        }
-        Event::PeerRemoved { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer removed", );
-
-            let label_set = label_set_for_peer(&peer);
-
-            let _unused = stats_repository
-                .decrement_gauge(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
-                    &label_set,
-                    now,
-                )
-                .await;
-
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL),
-                    &label_set,
-                    now,
-                )
-                .await;
-        }
+        Event::TorrentAdded { info_hash, .. } => handle_torrent_added(info_hash, stats_repository, now).await,
+        Event::TorrentRemoved { info_hash } => handle_torrent_removed(info_hash, stats_repository, now).await,
+        Event::PeerAdded { info_hash, peer } => handle_peer_added(info_hash, peer, stats_repository, now).await,
+        Event::PeerRemoved { info_hash, peer } => handle_peer_removed(info_hash, peer, stats_repository, now).await,
         Event::PeerUpdated {
             info_hash,
             old_peer,
             new_peer,
-        } => {
-            tracing::debug!(info_hash = ?info_hash, old_peer = ?old_peer, new_peer = ?new_peer, "Peer updated", );
-
-            // If the peer's role has changed, we need to adjust the number of
-            // connections
-            if old_peer.role() != new_peer.role() {
-                let _unused = stats_repository
-                    .increment_gauge(
-                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
-                        &label_set_for_peer(&new_peer),
-                        now,
-                    )
-                    .await;
-
-                let _unused = stats_repository
-                    .decrement_gauge(
-                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
-                        &label_set_for_peer(&old_peer),
-                        now,
-                    )
-                    .await;
-            }
-
-            // If the peer reverted from a completed state to any other state,
-            // we need to increment the counter for reverted completed.
-            if old_peer.is_completed() && !new_peer.is_completed() {
-                let _unused = stats_repository
-                    .increment_counter(
-                        &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL),
-                        &LabelSet::default(),
-                        now,
-                    )
-                    .await;
-            }
-
-            // Regardless of the role change, we still need to increment the
-            // counter for updated peers.
-            let label_set = label_set_for_peer(&new_peer);
-
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
-                    &label_set,
-                    now,
-                )
-                .await;
-        }
+        } => handle_peer_updated(info_hash, old_peer, new_peer, stats_repository, now).await,
         Event::PeerDownloadCompleted { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer download completed", );
-
-            let _unused: Result<(), torrust_metrics::metric_collection::Error> = stats_repository
-                .increment_counter(
-                    &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL),
-                    &label_set_for_peer(&peer),
-                    now,
-                )
-                .await;
+            handle_peer_download_completed(info_hash, peer, stats_repository, now).await;
         }
     }
+}
+
+async fn handle_torrent_added(
+    info_hash: torrust_info_hash::InfoHash,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, "Torrent added",);
+    let _unused = stats_repository
+        .increment_gauge(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_ADDED_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
+}
+
+async fn handle_torrent_removed(
+    info_hash: torrust_info_hash::InfoHash,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, "Torrent removed",);
+    let _unused = stats_repository
+        .decrement_gauge(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_REMOVED_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
+}
+
+async fn handle_peer_added(
+    info_hash: torrust_info_hash::InfoHash,
+    peer: Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer added", );
+    let label_set = label_set_for_peer(&peer);
+    let _unused = stats_repository
+        .increment_gauge(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+            &label_set,
+            now,
+        )
+        .await;
+    let _unused = stats_repository
+        .increment_counter(&metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL), &label_set, now)
+        .await;
+}
+
+async fn handle_peer_removed(
+    info_hash: torrust_info_hash::InfoHash,
+    peer: Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer removed", );
+    let label_set = label_set_for_peer(&peer);
+    let _unused = stats_repository
+        .decrement_gauge(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+            &label_set,
+            now,
+        )
+        .await;
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL),
+            &label_set,
+            now,
+        )
+        .await;
+}
+
+async fn handle_peer_updated(
+    info_hash: torrust_info_hash::InfoHash,
+    old_peer: Peer,
+    new_peer: Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, old_peer = ?old_peer, new_peer = ?new_peer, "Peer updated", );
+    update_peer_connection_gauges(&old_peer, &new_peer, stats_repository, now).await;
+    record_completed_state_reversion(&old_peer, &new_peer, stats_repository, now).await;
+
+    let label_set = label_set_for_peer(&new_peer);
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
+            &label_set,
+            now,
+        )
+        .await;
+}
+
+async fn update_peer_connection_gauges(
+    old_peer: &Peer,
+    new_peer: &Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    if old_peer.role() != new_peer.role() {
+        let _unused = stats_repository
+            .increment_gauge(
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+                &label_set_for_peer(new_peer),
+                now,
+            )
+            .await;
+        let _unused = stats_repository
+            .decrement_gauge(
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+                &label_set_for_peer(old_peer),
+                now,
+            )
+            .await;
+    }
+}
+
+async fn record_completed_state_reversion(
+    old_peer: &Peer,
+    new_peer: &Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    if old_peer.is_completed() && !new_peer.is_completed() {
+        let _unused = stats_repository
+            .increment_counter(
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL),
+                &LabelSet::default(),
+                now,
+            )
+            .await;
+    }
+}
+
+async fn handle_peer_download_completed(
+    info_hash: torrust_info_hash::InfoHash,
+    peer: Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer download completed", );
+    let _unused: Result<(), torrust_metrics::metric_collection::Error> = stats_repository
+        .increment_counter(
+            &metric_name!(SWARM_COORDINATION_REGISTRY_TORRENTS_DOWNLOADS_TOTAL),
+            &label_set_for_peer(&peer),
+            now,
+        )
+        .await;
 }
 
 /// Returns the label set to be included in the metrics for the given peer.
@@ -372,15 +408,18 @@ mod tests {
 
         use torrust_clock::clock::stopped::Stopped;
         use torrust_clock::clock::{self, Time};
+        use torrust_metrics::label::LabelSet;
         use torrust_metrics::metric_name;
+        use torrust_tracker_primitives::AnnounceEvent;
 
         use crate::CurrentClock;
         use crate::event::Event;
-        use crate::statistics::event::handler::tests::expect_counter_metric_to_be;
+        use crate::statistics::event::handler::tests::{expect_counter_metric_to_be, expect_gauge_metric_to_be};
         use crate::statistics::event::handler::{handle_event, label_set_for_peer};
         use crate::statistics::repository::Repository;
         use crate::statistics::{
-            SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL,
+            SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL,
+            SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL, SWARM_COORDINATION_REGISTRY_PEERS_REMOVED_TOTAL,
             SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL,
         };
         use crate::tests::{sample_info_hash, sample_peer};
@@ -600,6 +639,77 @@ mod tests {
                 &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_UPDATED_TOTAL),
                 &label_set_for_peer(&new_peer),
                 1,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn it_should_increment_completed_state_reverted_when_a_completed_peer_is_updated_to_not_completed() {
+            // Arrange
+            clock::Stopped::local_set_to_unix_epoch();
+            let stats_repository = Arc::new(Repository::new());
+            let old_peer = sample_peer();
+            let mut new_peer = old_peer;
+            new_peer.event = AnnounceEvent::Started;
+
+            // Act
+            handle_event(
+                Event::PeerUpdated {
+                    info_hash: sample_info_hash(),
+                    old_peer,
+                    new_peer,
+                },
+                &stats_repository,
+                CurrentClock::now(),
+            )
+            .await;
+
+            // Assert
+            expect_counter_metric_to_be(
+                &stats_repository,
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_COMPLETED_STATE_REVERTED_TOTAL),
+                &LabelSet::default(),
+                1,
+            )
+            .await;
+        }
+
+        #[tokio::test]
+        async fn it_should_not_change_peer_connection_gauge_when_an_updated_peer_role_is_unchanged() {
+            // Arrange
+            clock::Stopped::local_set_to_unix_epoch();
+            let stats_repository = Arc::new(Repository::new());
+            let peer = sample_peer();
+            let label_set = label_set_for_peer(&peer);
+
+            handle_event(
+                Event::PeerAdded {
+                    info_hash: sample_info_hash(),
+                    peer,
+                },
+                &stats_repository,
+                CurrentClock::now(),
+            )
+            .await;
+
+            // Act
+            handle_event(
+                Event::PeerUpdated {
+                    info_hash: sample_info_hash(),
+                    old_peer: peer,
+                    new_peer: peer,
+                },
+                &stats_repository,
+                CurrentClock::now(),
+            )
+            .await;
+
+            // Assert
+            expect_gauge_metric_to_be(
+                &stats_repository,
+                &metric_name!(SWARM_COORDINATION_REGISTRY_PEER_CONNECTIONS_TOTAL),
+                &label_set,
+                1.0,
             )
             .await;
         }

--- a/packages/swarm-coordination-registry/src/statistics/event/listener.rs
+++ b/packages/swarm-coordination-registry/src/statistics/event/listener.rs
@@ -38,21 +38,157 @@ async fn dispatch_events(mut receiver: Receiver, cancellation_token: Cancellatio
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) => handle_event(event, &stats_repository, CurrentClock::now()).await,
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Swarm coordination registry event receiver closed.");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Swarm coordination registry event receiver lagged by {} events.", n);
-                            }
-                        }
-                    }
+                if !handle_receive_result(result, &stats_repository).await {
+                    break;
                 }
             }
         }
+    }
+}
+
+async fn handle_receive_result(result: Result<crate::event::Event, RecvError>, stats_repository: &Arc<Repository>) -> bool {
+    match result {
+        Ok(event) => {
+            handle_event(event, stats_repository, CurrentClock::now()).await;
+            true
+        }
+        Err(error) => handle_receive_error(&error),
+    }
+}
+
+fn handle_receive_error(error: &RecvError) -> bool {
+    match error {
+        RecvError::Closed => {
+            tracing::info!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Swarm coordination registry event receiver closed.");
+            false
+        }
+        RecvError::Lagged(number_of_events) => {
+            tracing::warn!(target: SWARM_COORDINATION_REGISTRY_LOG_TARGET, "Swarm coordination registry event receiver lagged by {} events.", number_of_events);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use futures::future::{self, BoxFuture};
+    use tokio_util::sync::CancellationToken;
+    use torrust_clock::clock;
+    use torrust_clock::clock::stopped::Stopped;
+    use torrust_metrics::label::LabelSet;
+    use torrust_metrics::metric_name;
+    use torrust_tracker_events::receiver::RecvError;
+
+    use super::dispatch_events;
+    use crate::event::Event;
+    use crate::event::receiver::Receiver;
+    use crate::statistics::SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL;
+    use crate::statistics::repository::Repository;
+    use crate::tests::{sample_info_hash, sample_peer};
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> Self {
+            Self {
+                results: results.into_iter().collect(),
+            }
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> BoxFuture<'_, Result<Self::Event, RecvError>> {
+            Box::pin(future::ready(self.results.pop_front().unwrap_or(Err(RecvError::Closed))))
+        }
+    }
+
+    fn peer_added_event() -> Event {
+        Event::PeerAdded {
+            info_hash: sample_info_hash(),
+            peer: sample_peer(),
+        }
+    }
+
+    async fn expect_peer_added_metric_to_be(stats_repository: &Repository, expected_value: u64) {
+        let metric_name = metric_name!(SWARM_COORDINATION_REGISTRY_PEERS_ADDED_TOTAL);
+        let label_set = LabelSet::from((
+            torrust_metrics::label_name!("peer_role"),
+            torrust_metrics::label::LabelValue::new("seeder"),
+        ));
+        let value = stats_repository
+            .get_metrics()
+            .await
+            .metric_collection
+            .get_counter_value(&metric_name, &label_set)
+            .map_or(0, |counter| counter.value());
+
+        assert_eq!(value, expected_value);
+    }
+
+    #[tokio::test]
+    async fn it_should_handle_an_event_then_stop_when_the_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::new());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Ok(peer_added_event()), Err(RecvError::Closed)]));
+
+        // Act
+        dispatch_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_peer_added_metric_to_be(&stats_repository, 1).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_continue_after_lag_then_handle_an_event_then_stop_when_the_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::new());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(peer_added_event()),
+            Err(RecvError::Closed),
+        ]));
+
+        // Act
+        dispatch_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_peer_added_metric_to_be(&stats_repository, 1).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_stop_when_the_receiver_is_closed() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Err(RecvError::Closed)]));
+
+        // Act
+        dispatch_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_peer_added_metric_to_be(&stats_repository, 0).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_pre_cancelled_token_over_a_ready_event() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Ok(peer_added_event())]));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        // Act
+        dispatch_events(receiver, cancellation_token, stats_repository.clone()).await;
+
+        // Assert
+        expect_peer_added_metric_to_be(&stats_repository, 0).await;
     }
 }

--- a/packages/swarm-coordination-registry/src/swarm/coordinator.rs
+++ b/packages/swarm-coordination-registry/src/swarm/coordinator.rs
@@ -58,36 +58,38 @@ impl Coordinator {
 
     #[must_use]
     pub fn peers(&self, limit: Option<usize>) -> Vec<Arc<Peer>> {
-        match limit {
-            Some(limit) => self.peers.values().take(limit).cloned().collect(),
-            None => self.peers.values().cloned().collect(),
-        }
+        limit.map_or_else(
+            || self.peers.values().cloned().collect(),
+            |limit| self.peers.values().take(limit).cloned().collect(),
+        )
     }
 
     #[must_use]
     pub fn peers_excluding(&self, peer_addr: &SocketAddr, limit: Option<usize>) -> Vec<Arc<peer::Peer>> {
-        match limit {
-            Some(limit) => self
-                .peers
-                .values()
-                // Take peers which are not the client peer
-                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
-                // Limit the number of peers on the result
-                .take(limit)
-                .cloned()
-                .collect(),
-            None => self
-                .peers
-                .values()
-                // Take peers which are not the client peer
-                .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
-                .cloned()
-                .collect(),
-        }
+        limit.map_or_else(
+            || {
+                self.peers
+                    .values()
+                    // Take peers which are not the client peer
+                    .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
+                    .cloned()
+                    .collect()
+            },
+            |limit| {
+                self.peers
+                    .values()
+                    // Take peers which are not the client peer
+                    .filter(|peer| peer::ReadInfo::get_address(peer.as_ref()) != *peer_addr)
+                    // Limit the number of peers on the result
+                    .take(limit)
+                    .cloned()
+                    .collect()
+            },
+        )
     }
 
     #[must_use]
-    pub fn metadata(&self) -> SwarmMetadata {
+    pub const fn metadata(&self) -> SwarmMetadata {
         self.metadata
     }
 
@@ -305,7 +307,7 @@ pub struct ActivityMetadata {
 
 impl ActivityMetadata {
     #[must_use]
-    pub fn new(is_active: bool, active_peers_total: usize, inactive_peers_total: usize) -> Self {
+    pub const fn new(is_active: bool, active_peers_total: usize, inactive_peers_total: usize) -> Self {
         Self {
             is_active,
             active_peers_total,

--- a/packages/swarm-coordination-registry/src/swarm/registry.rs
+++ b/packages/swarm-coordination-registry/src/swarm/registry.rs
@@ -376,13 +376,13 @@ impl Registry {
 
     /// Calculates and returns overall torrent metrics.
     ///
-    /// The returned [`AggregateSwarmMetadata`] contains aggregate data such as
+    /// The returned [`AggregateActiveSwarmMetadata`] contains aggregate data such as
     /// the total number of torrents, total complete (seeders), incomplete
     /// (leechers), and downloaded counts.
     ///
     /// # Returns
     ///
-    /// A [`AggregateSwarmMetadata`] struct with the aggregated metrics.
+    /// An [`AggregateActiveSwarmMetadata`] struct with the aggregated metrics.
     ///
     /// # Errors
     ///

--- a/packages/swarm-coordination-registry/src/swarm/registry.rs
+++ b/packages/swarm-coordination-registry/src/swarm/registry.rs
@@ -78,9 +78,7 @@ impl Registry {
             Some(existing_swarm_handle) => existing_swarm_handle,
         };
 
-        let mut swarm = swarm_handle.value().lock().await;
-
-        swarm.handle_announcement(peer).await;
+        swarm_handle.value().lock().await.handle_announcement(peer).await;
 
         Ok(())
     }
@@ -139,20 +137,22 @@ impl Registry {
     /// A vector of `(InfoHash, TorrentEntry)` tuples.
     #[must_use]
     pub fn get_paginated(&self, pagination: Option<&Pagination>) -> Vec<(InfoHash, CoordinatorHandle)> {
-        match pagination {
-            Some(pagination) => self
-                .swarms
-                .iter()
-                .skip(pagination.offset as usize)
-                .take(pagination.limit as usize)
-                .map(|entry| (*entry.key(), entry.value().clone()))
-                .collect(),
-            None => self
-                .swarms
-                .iter()
-                .map(|entry| (*entry.key(), entry.value().clone()))
-                .collect(),
-        }
+        pagination.map_or_else(
+            || {
+                self.swarms
+                    .iter()
+                    .map(|entry| (*entry.key(), entry.value().clone()))
+                    .collect()
+            },
+            |pagination| {
+                self.swarms
+                    .iter()
+                    .skip(pagination.offset as usize)
+                    .take(pagination.limit as usize)
+                    .map(|entry| (*entry.key(), entry.value().clone()))
+                    .collect()
+            },
+        )
     }
 
     /// Retrieves swarm metadata for a given torrent.
@@ -253,9 +253,7 @@ impl Registry {
         let mut active_torrents_total = 0;
 
         for swarm_handle in &self.swarms {
-            let swarm = swarm_handle.value().lock().await;
-
-            let activity_metadata = swarm.get_activity_metadata(current_cutoff);
+            let activity_metadata = swarm_handle.value().lock().await.get_activity_metadata(current_cutoff);
 
             if activity_metadata.is_active {
                 active_torrents_total += 1;
@@ -303,8 +301,7 @@ impl Registry {
         let mut inactive_peers_removed = 0;
 
         for swarm_handle in &self.swarms {
-            let mut swarm = swarm_handle.value().lock().await;
-            let removed = swarm.remove_inactive(current_cutoff).await;
+            let removed = swarm_handle.value().lock().await.remove_inactive(current_cutoff).await;
             inactive_peers_removed += removed;
         }
 
@@ -328,9 +325,7 @@ impl Registry {
         let mut peerless_torrents_removed = 0;
 
         for swarm_handle in &self.swarms {
-            let swarm = swarm_handle.value().lock().await;
-
-            if swarm.meets_retaining_policy(policy) {
+            if swarm_handle.value().lock().await.meets_retaining_policy(policy) {
                 continue;
             }
 
@@ -397,9 +392,7 @@ impl Registry {
         let mut metrics = AggregateActiveSwarmMetadata::default();
 
         for swarm_handle in &self.swarms {
-            let swarm = swarm_handle.value().lock().await;
-
-            let stats = swarm.metadata();
+            let stats = swarm_handle.value().lock().await.metadata();
 
             metrics.total_complete += u64::from(stats.complete);
             metrics.total_downloaded += u64::from(stats.downloaded);
@@ -898,7 +891,7 @@ mod tests {
                             complete: 1,
                             incomplete: 0
                         },
-                        peers: vec!(peer),
+                        peers: vec![peer],
                         number_of_peers: 1
                     },
                     torrent_entry_info
@@ -937,7 +930,7 @@ mod tests {
                                 complete: 1,
                                 incomplete: 0
                             },
-                            peers: vec!(peer),
+                            peers: vec![peer],
                             number_of_peers: 1
                         },
                         torrent_entry
@@ -987,7 +980,7 @@ mod tests {
                                     complete: 1,
                                     incomplete: 0
                                 },
-                                peers: vec!(peer_one),
+                                peers: vec![peer_one],
                                 number_of_peers: 1
                             },
                             torrent_entry_info
@@ -1022,7 +1015,7 @@ mod tests {
                                     complete: 1,
                                     incomplete: 0
                                 },
-                                peers: vec!(peer_two),
+                                peers: vec![peer_two],
                                 number_of_peers: 1
                             },
                             torrent_entry_info

--- a/packages/swarm-coordination-registry/src/swarm/registry.rs
+++ b/packages/swarm-coordination-registry/src/swarm/registry.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use crossbeam_skiplist::SkipMap;
@@ -189,7 +190,6 @@ impl Registry {
         match self.get_swarm_metadata(info_hash).await {
             Ok(Some(swarm_metadata)) => Ok(swarm_metadata),
             Ok(None) => Ok(SwarmMetadata::zeroed()),
-            Err(err) => Err(err),
         }
     }
 
@@ -465,8 +465,8 @@ impl Registry {
     }
 }
 
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum Error {}
+/// The registry currently exposes no recoverable error cases.
+pub type Error = Infallible;
 
 #[derive(Clone, Debug, Default)]
 pub struct AggregateActivityMetadata {

--- a/packages/test-helpers/Cargo.toml
+++ b/packages/test-helpers/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "3.0.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 rand = "0"
 torrust-tracker-client-lib = { version = "0.1.0", path = "../tracker-client" }

--- a/packages/test-helpers/src/logging.rs
+++ b/packages/test-helpers/src/logging.rs
@@ -78,7 +78,7 @@ pub struct LogCapturer<'a> {
 }
 
 impl<'a> LogCapturer<'a> {
-    pub fn new(buf: &'a Mutex<CircularBuffer>) -> Self {
+    pub const fn new(buf: &'a Mutex<CircularBuffer>) -> Self {
         Self { logs: buf }
     }
 
@@ -89,7 +89,7 @@ impl<'a> LogCapturer<'a> {
 
 impl io::Write for LogCapturer<'_> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        print!("{}", String::from_utf8(buf.to_vec()).unwrap());
+        std::io::stdout().lock().write_all(buf)?;
 
         let mut target = self.buf()?;
 
@@ -145,7 +145,7 @@ impl CircularBuffer {
     /// Won't return any error.
     #[allow(clippy::unnecessary_wraps)]
     #[allow(clippy::unused_self)]
-    pub fn flush(&mut self) -> io::Result<()> {
+    pub const fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
 

--- a/packages/tracker-client/Cargo.toml
+++ b/packages/tracker-client/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [lib]
 name = "torrust_tracker_client"
 

--- a/packages/tracker-client/src/http/client/mod.rs
+++ b/packages/tracker-client/src/http/client/mod.rs
@@ -240,10 +240,9 @@ impl Client {
     }
 
     fn build_path(&self, path: &str) -> String {
-        match &self.key {
-            Some(key) => format!("{path}/{key}"),
-            None => path.to_string(),
-        }
+        self.key
+            .as_ref()
+            .map_or_else(|| path.to_string(), |key| format!("{path}/{key}"))
     }
 
     fn build_url(&self, path: &str) -> String {

--- a/packages/tracker-client/src/udp/client.rs
+++ b/packages/tracker-client/src/udp/client.rs
@@ -190,9 +190,9 @@ impl UdpTrackerClient {
     ///
     /// If unable to connect to the remote address.
     ///
-    pub async fn new(remote_addr: SocketAddr, timeout: Duration) -> Result<UdpTrackerClient, Error> {
+    pub async fn new(remote_addr: SocketAddr, timeout: Duration) -> Result<Self, Error> {
         let client = UdpClient::connected(remote_addr, timeout).await?;
-        Ok(UdpTrackerClient { client })
+        Ok(Self { client })
     }
 
     /// # Errors

--- a/packages/tracker-core/Cargo.toml
+++ b/packages/tracker-core/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [features]
 default = [  ]
 db-compatibility-tests = [  ]

--- a/packages/tracker-core/src/announce_handler.rs
+++ b/packages/tracker-core/src/announce_handler.rs
@@ -244,7 +244,7 @@ impl AnnounceHandler {
 }
 
 /// Specifies how many peers a client wants in the announce response.
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum PeersWanted {
     /// Request as many peers as possible (default behavior).
     #[default]
@@ -259,8 +259,8 @@ impl PeersWanted {
     ///
     /// The cap is applied when [`limit`](PeersWanted::limit) is called.
     #[must_use]
-    pub fn only(amount: u32) -> Self {
-        PeersWanted::Only { amount: amount as usize }
+    pub const fn only(amount: u32) -> Self {
+        Self::Only { amount: amount as usize }
     }
 
     /// Constructs a `PeersWanted` from a raw client-supplied value.
@@ -269,13 +269,13 @@ impl PeersWanted {
     /// any positive value is stored as-is and capped at the tracker limit
     /// when [`limit`](PeersWanted::limit) is called.
     #[must_use]
-    pub fn from_client_request(value: i32) -> Self {
+    pub const fn from_client_request(value: i32) -> Self {
         if value <= 0 {
-            PeersWanted::AsManyAsPossible
+            Self::AsManyAsPossible
         } else {
             // Safe: value > 0, so casting to usize is lossless on all supported platforms.
             #[allow(clippy::cast_sign_loss)]
-            PeersWanted::Only { amount: value as usize }
+            Self::Only { amount: value as usize }
         }
     }
 
@@ -285,8 +285,8 @@ impl PeersWanted {
     /// - `Only { amount }` resolves to `amount.min(max_peers)`.
     pub(crate) fn limit(&self, max_peers: usize) -> usize {
         match self {
-            PeersWanted::AsManyAsPossible => max_peers,
-            PeersWanted::Only { amount } => (*amount).min(max_peers),
+            Self::AsManyAsPossible => max_peers,
+            Self::Only { amount } => (*amount).min(max_peers),
         }
     }
 }

--- a/packages/tracker-core/src/authentication/key/mod.rs
+++ b/packages/tracker-core/src/authentication/key/mod.rs
@@ -150,8 +150,9 @@ pub fn generate_key(lifetime: Option<Duration>) -> PeerKey {
 pub fn verify_key_expiration(auth_key: &PeerKey) -> Result<(), Error> {
     let current_time: DurationSinceUnixEpoch = CurrentClock::now();
 
-    match auth_key.valid_until {
-        Some(valid_until) => {
+    auth_key.valid_until.map_or_else(
+        || Ok(()),
+        |valid_until| {
             if valid_until < current_time {
                 Err(Error::KeyExpired {
                     location: Location::caller(),
@@ -159,9 +160,8 @@ pub fn verify_key_expiration(auth_key: &PeerKey) -> Result<(), Error> {
             } else {
                 Ok(())
             }
-        }
-        None => Ok(()), // Permanent key
-    }
+        },
+    )
 }
 
 /// Verification error. Error returned when an [`PeerKey`] cannot be
@@ -193,7 +193,7 @@ pub enum Error {
 
 impl From<sqlx::Error> for Error {
     fn from(e: sqlx::Error) -> Self {
-        Error::KeyVerificationError {
+        Self::KeyVerificationError {
             source: (Arc::new(e) as DynError).into(),
         }
     }

--- a/packages/tracker-core/src/authentication/key/peer_key.rs
+++ b/packages/tracker-core/src/authentication/key/peer_key.rs
@@ -162,7 +162,7 @@ impl Key {
             .take(AUTH_KEY_LENGTH)
             .map(char::from)
             .collect();
-        random_id.parse::<Key>().expect("Failed to generate a valid random key")
+        random_id.parse::<Self>().expect("Failed to generate a valid random key")
     }
 
     #[must_use]
@@ -204,7 +204,7 @@ impl FromStr for Key {
     type Err = ParseKeyError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Key::new(s)?;
+        Self::new(s)?;
         Ok(Self(s.to_string()))
     }
 }

--- a/packages/tracker-core/src/authentication/key/repository/in_memory.rs
+++ b/packages/tracker-core/src/authentication/key/repository/in_memory.rs
@@ -79,7 +79,7 @@ impl InMemoryKeyRepository {
         keys_lock.clear();
 
         for key in peer_keys {
-            keys_lock.insert(key.key.clone(), key.clone());
+            keys_lock.insert(key.key.clone(), key);
         }
     }
 }

--- a/packages/tracker-core/src/authentication/key/repository/persisted.rs
+++ b/packages/tracker-core/src/authentication/key/repository/persisted.rs
@@ -116,7 +116,7 @@ mod tests {
             assert!(result.is_ok());
 
             let keys = repository.load_keys().await.unwrap();
-            assert_eq!(keys, vec!(peer_key));
+            assert_eq!(keys, vec![peer_key]);
         }
 
         #[tokio::test]
@@ -158,7 +158,7 @@ mod tests {
 
             let keys = repository.load_keys().await.unwrap();
 
-            assert_eq!(keys, vec!(peer_key));
+            assert_eq!(keys, vec![peer_key]);
         }
     }
 }

--- a/packages/tracker-core/src/authentication/mod.rs
+++ b/packages/tracker-core/src/authentication/mod.rs
@@ -68,10 +68,7 @@ mod tests {
             let db_key_repository = Arc::new(DatabaseKeyRepository::new(&stores.auth_key_store));
             let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
             let authentication_service = Arc::new(service::AuthenticationService::new(&config.core, &in_memory_key_repository));
-            let keys_handler = Arc::new(KeysHandler::new(
-                &db_key_repository.clone(),
-                &in_memory_key_repository.clone(),
-            ));
+            let keys_handler = Arc::new(KeysHandler::new(&db_key_repository, &in_memory_key_repository));
 
             (keys_handler, authentication_service)
         }

--- a/packages/tracker-core/src/authentication/service.rs
+++ b/packages/tracker-core/src/authentication/service.rs
@@ -69,7 +69,7 @@ impl AuthenticationService {
 
     /// Returns `true` is the tracker is in private mode.
     #[must_use]
-    fn tracker_is_private(&self) -> bool {
+    const fn tracker_is_private(&self) -> bool {
         self.config.private
     }
 
@@ -136,7 +136,7 @@ mod tests {
 
                 let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
 
-                AuthenticationService::new(&config, &in_memory_key_repository.clone())
+                AuthenticationService::new(&config, &in_memory_key_repository)
             }
 
             #[tokio::test]
@@ -172,7 +172,7 @@ mod tests {
 
                 let in_memory_key_repository = Arc::new(InMemoryKeyRepository::default());
 
-                AuthenticationService::new(&config, &in_memory_key_repository.clone())
+                AuthenticationService::new(&config, &in_memory_key_repository)
             }
 
             #[tokio::test]

--- a/packages/tracker-core/src/databases/driver/mysql/mod.rs
+++ b/packages/tracker-core/src/databases/driver/mysql/mod.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     impl RunningMysqlContainer {
-        fn new(container: ContainerAsync<GenericImage>, internal_port: u16) -> Self {
+        const fn new(container: ContainerAsync<GenericImage>, internal_port: u16) -> Self {
             Self {
                 container,
                 internal_port,
@@ -203,7 +203,7 @@ mod tests {
     #[tokio::test]
     async fn run_mysql_driver_tests() -> Result<(), Box<dyn std::error::Error + 'static>> {
         if std::env::var("TORRUST_TRACKER_CORE_RUN_MYSQL_DRIVER_TEST").is_err() {
-            println!("Skipping the MySQL driver tests.");
+            tracing::info!("Skipping the MySQL driver tests.");
             return Ok(());
         }
 

--- a/packages/tracker-core/src/databases/driver/postgres/mod.rs
+++ b/packages/tracker-core/src/databases/driver/postgres/mod.rs
@@ -119,7 +119,7 @@ mod tests {
     }
 
     impl RunningPostgresContainer {
-        fn new(container: ContainerAsync<GenericImage>, internal_port: u16) -> Self {
+        const fn new(container: ContainerAsync<GenericImage>, internal_port: u16) -> Self {
             Self {
                 container,
                 internal_port,
@@ -184,7 +184,7 @@ mod tests {
     #[tokio::test]
     async fn run_postgres_driver_tests() -> Result<(), Box<dyn std::error::Error + 'static>> {
         if std::env::var("TORRUST_TRACKER_CORE_RUN_POSTGRES_DRIVER_TEST").is_err() {
-            println!("Skipping the PostgreSQL driver tests.");
+            tracing::info!("Skipping the PostgreSQL driver tests.");
             return Ok(());
         }
 

--- a/packages/tracker-core/src/scrape_handler.rs
+++ b/packages/tracker-core/src/scrape_handler.rs
@@ -145,7 +145,7 @@ mod tests {
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
         let whitelist_authorization = Arc::new(whitelist::authorization::WhitelistAuthorization::new(
             &config.core,
-            &in_memory_whitelist.clone(),
+            &in_memory_whitelist,
         ));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
 

--- a/packages/tracker-core/src/statistics/event/handler.rs
+++ b/packages/tracker-core/src/statistics/event/handler.rs
@@ -16,47 +16,73 @@ use crate::statistics::{
 pub async fn handle_in_memory_event(event: Event, stats_repository: &Arc<Repository>, now: DurationSinceUnixEpoch) {
     match event {
         // Torrent events
-        Event::TorrentAdded { info_hash, .. } => {
-            tracing::debug!(info_hash = ?info_hash, "Torrent added",);
-        }
-        Event::TorrentRemoved { info_hash } => {
-            tracing::debug!(info_hash = ?info_hash, "Torrent removed",);
-        }
+        Event::TorrentAdded { info_hash, .. } => handle_torrent_added(info_hash),
+        Event::TorrentRemoved { info_hash } => handle_torrent_removed(info_hash),
 
         // Peer events
-        Event::PeerAdded { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer added", );
-        }
-        Event::PeerRemoved { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer removed", );
-        }
+        Event::PeerAdded { info_hash, peer } => handle_peer_added(info_hash, peer),
+        Event::PeerRemoved { info_hash, peer } => handle_peer_removed(info_hash, peer),
         Event::PeerUpdated {
             info_hash,
             old_peer,
             new_peer,
-        } => {
-            tracing::debug!(info_hash = ?info_hash, old_peer = ?old_peer, new_peer = ?new_peer, "Peer updated");
-        }
+        } => handle_peer_updated(info_hash, old_peer, new_peer),
         Event::PeerDownloadCompleted { info_hash, peer } => {
-            tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer download completed", );
-
-            // Increment the number of downloads for all the torrents in memory
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(TRACKER_CORE_PERSISTENT_TORRENTS_DOWNLOADS_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
-            let _unused = stats_repository
-                .increment_counter(
-                    &metric_name!(TRACKER_CORE_IN_SESSION_TORRENTS_DOWNLOADS_TOTAL),
-                    &LabelSet::default(),
-                    now,
-                )
-                .await;
+            handle_peer_download_completed(info_hash, peer, stats_repository, now).await;
         }
     }
+}
+
+fn handle_torrent_added(info_hash: torrust_info_hash::InfoHash) {
+    tracing::debug!(info_hash = ?info_hash, "Torrent added",);
+}
+
+fn handle_torrent_removed(info_hash: torrust_info_hash::InfoHash) {
+    tracing::debug!(info_hash = ?info_hash, "Torrent removed",);
+}
+
+fn handle_peer_added(info_hash: torrust_info_hash::InfoHash, peer: torrust_tracker_primitives::peer::Peer) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer added", );
+}
+
+fn handle_peer_removed(info_hash: torrust_info_hash::InfoHash, peer: torrust_tracker_primitives::peer::Peer) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer removed", );
+}
+
+fn handle_peer_updated(
+    info_hash: torrust_info_hash::InfoHash,
+    old_peer: torrust_tracker_primitives::peer::Peer,
+    new_peer: torrust_tracker_primitives::peer::Peer,
+) {
+    tracing::debug!(info_hash = ?info_hash, old_peer = ?old_peer, new_peer = ?new_peer, "Peer updated");
+}
+
+async fn handle_peer_download_completed(
+    info_hash: torrust_info_hash::InfoHash,
+    peer: torrust_tracker_primitives::peer::Peer,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    tracing::debug!(info_hash = ?info_hash, peer = ?peer, "Peer download completed", );
+
+    increment_in_memory_download_counters(stats_repository, now).await;
+}
+
+async fn increment_in_memory_download_counters(stats_repository: &Repository, now: DurationSinceUnixEpoch) {
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(TRACKER_CORE_PERSISTENT_TORRENTS_DOWNLOADS_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
+    let _unused = stats_repository
+        .increment_counter(
+            &metric_name!(TRACKER_CORE_IN_SESSION_TORRENTS_DOWNLOADS_TOTAL),
+            &LabelSet::default(),
+            now,
+        )
+        .await;
 }
 
 /// Handles a swarm coordination event and persists completed-download statistics.
@@ -67,32 +93,190 @@ pub async fn handle_persistent_completed_statistics_event(
     now: DurationSinceUnixEpoch,
 ) {
     if let Event::PeerDownloadCompleted { info_hash, .. } = event {
-        match db_downloads_metric_repository
-            .increase_downloads_for_torrent(&info_hash)
-            .await
-        {
-            Ok(()) => {
-                tracing::debug!(info_hash = ?info_hash, "Number of torrent downloads increased");
-            }
-            Err(err) => {
-                tracing::error!(info_hash = ?info_hash, error = ?err, "Failed to increase number of downloads for the torrent");
-            }
-        }
+        increase_torrent_downloads(db_downloads_metric_repository, &info_hash).await;
+        increase_global_downloads(db_downloads_metric_repository, stats_repository, now).await;
+    }
+}
 
-        match db_downloads_metric_repository.increase_global_downloads().await {
-            Ok(()) => {
-                tracing::debug!("Global number of downloads increased");
-                let _unused = stats_repository
-                    .increment_counter(
-                        &metric_name!(TRACKER_CORE_PERSISTED_TORRENTS_DOWNLOADS_TOTAL),
-                        &LabelSet::default(),
-                        now,
-                    )
-                    .await;
-            }
-            Err(err) => {
-                tracing::error!(error = ?err, "Failed to increase global number of downloads");
-            }
+async fn increase_torrent_downloads(
+    db_downloads_metric_repository: &DatabaseDownloadsMetricRepository,
+    info_hash: &torrust_info_hash::InfoHash,
+) {
+    match db_downloads_metric_repository.increase_downloads_for_torrent(info_hash).await {
+        Ok(()) => tracing::debug!(info_hash = ?info_hash, "Number of torrent downloads increased"),
+        Err(error) => {
+            tracing::error!(info_hash = ?info_hash, error = ?error, "Failed to increase number of downloads for the torrent");
         }
+    }
+}
+
+async fn increase_global_downloads(
+    db_downloads_metric_repository: &DatabaseDownloadsMetricRepository,
+    stats_repository: &Repository,
+    now: DurationSinceUnixEpoch,
+) {
+    match db_downloads_metric_repository.increase_global_downloads().await {
+        Ok(()) => {
+            tracing::debug!("Global number of downloads increased");
+            let _unused = stats_repository
+                .increment_counter(
+                    &metric_name!(TRACKER_CORE_PERSISTED_TORRENTS_DOWNLOADS_TOTAL),
+                    &LabelSet::default(),
+                    now,
+                )
+                .await;
+        }
+        Err(error) => tracing::error!(error = ?error, "Failed to increase global number of downloads"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::panic::Location;
+    use std::sync::Arc;
+
+    use torrust_clock::DurationSinceUnixEpoch;
+    use torrust_tracker_primitives::Driver;
+    use torrust_tracker_swarm_coordination_registry::event::Event;
+
+    use super::{handle_in_memory_event, handle_persistent_completed_statistics_event};
+    use crate::databases::error::Error;
+    use crate::databases::setup::initialize_database;
+    use crate::databases::{MockTorrentMetricsStore, TorrentMetricsStore};
+    use crate::statistics::persisted::downloads::DatabaseDownloadsMetricRepository;
+    use crate::statistics::repository::Repository;
+    use crate::test_helpers::tests::{ephemeral_configuration, sample_info_hash, sample_peer};
+
+    fn peer_added_event() -> Event {
+        Event::PeerAdded {
+            info_hash: sample_info_hash(),
+            peer: sample_peer(),
+        }
+    }
+
+    fn peer_download_completed_event() -> Event {
+        Event::PeerDownloadCompleted {
+            info_hash: sample_info_hash(),
+            peer: sample_peer(),
+        }
+    }
+
+    async fn database_downloads_repository() -> Arc<DatabaseDownloadsMetricRepository> {
+        let configuration = ephemeral_configuration();
+        let stores = initialize_database(&configuration).await;
+
+        Arc::new(DatabaseDownloadsMetricRepository::new(&stores.torrent_metrics_store))
+    }
+
+    #[tokio::test]
+    async fn it_should_increment_in_memory_completion_metrics_when_a_peer_download_is_completed() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::default());
+        let now = DurationSinceUnixEpoch::new(1, 0);
+
+        // Act
+        handle_in_memory_event(peer_download_completed_event(), &stats_repository, now).await;
+
+        // Assert
+        assert_eq!(stats_repository.get_torrents_downloads_total().await, 1);
+        assert_eq!(stats_repository.get_torrents_downloads_in_session_total().await, 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_not_increment_in_memory_completion_metrics_when_an_event_is_not_a_completion() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::default());
+        let now = DurationSinceUnixEpoch::new(1, 0);
+
+        // Act
+        handle_in_memory_event(peer_added_event(), &stats_repository, now).await;
+
+        // Assert
+        assert_eq!(stats_repository.get_torrents_downloads_total().await, 0);
+        assert_eq!(stats_repository.get_torrents_downloads_in_session_total().await, 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_persist_completion_statistics_when_a_peer_download_is_completed() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let now = DurationSinceUnixEpoch::new(1, 0);
+
+        // Act
+        handle_persistent_completed_statistics_event(
+            peer_download_completed_event(),
+            &downloads_repository,
+            &stats_repository,
+            now,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(
+            downloads_repository
+                .load_torrent_downloads(&sample_info_hash())
+                .await
+                .unwrap(),
+            Some(1)
+        );
+        assert_eq!(downloads_repository.load_global_downloads().await.unwrap(), Some(1));
+        assert_eq!(stats_repository.get_torrents_downloads_persisted_total().await, 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_not_persist_completion_statistics_when_an_event_is_not_a_completion() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let now = DurationSinceUnixEpoch::new(1, 0);
+
+        // Act
+        handle_persistent_completed_statistics_event(peer_added_event(), &downloads_repository, &stats_repository, now).await;
+
+        // Assert
+        assert_eq!(
+            downloads_repository
+                .load_torrent_downloads(&sample_info_hash())
+                .await
+                .unwrap(),
+            None
+        );
+        assert_eq!(downloads_repository.load_global_downloads().await.unwrap(), None);
+        assert_eq!(stats_repository.get_torrents_downloads_persisted_total().await, 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_persist_global_completion_statistics_when_torrent_persistence_fails() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let mut store = MockTorrentMetricsStore::new();
+        store.expect_load_torrent_downloads().returning(|_| {
+            Box::pin(std::future::ready(Err(Error::UpdateFailed {
+                location: Location::caller(),
+                driver: Driver::Sqlite3,
+            })))
+        });
+        store
+            .expect_load_global_downloads()
+            .returning(|| Box::pin(std::future::ready(Ok(None))));
+        store
+            .expect_save_global_downloads()
+            .returning(|_| Box::pin(std::future::ready(Ok(()))));
+        let store: Arc<dyn TorrentMetricsStore> = Arc::new(store);
+        let downloads_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&store));
+        let now = DurationSinceUnixEpoch::new(1, 0);
+
+        // Act
+        handle_persistent_completed_statistics_event(
+            peer_download_completed_event(),
+            &downloads_repository,
+            &stats_repository,
+            now,
+        )
+        .await;
+
+        // Assert
+        assert_eq!(stats_repository.get_torrents_downloads_persisted_total().await, 1);
     }
 }

--- a/packages/tracker-core/src/statistics/event/listener.rs
+++ b/packages/tracker-core/src/statistics/event/listener.rs
@@ -66,19 +66,8 @@ async fn dispatch_in_memory_events(
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) => handle_in_memory_event(event, &stats_repository, CurrentClock::now()).await,
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver closed");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver lagged by {} events", n);
-                            }
-                        }
-                    }
+                if !handle_in_memory_receive_result(result, &stats_repository).await {
+                    break;
                 }
             }
         }
@@ -101,21 +90,288 @@ async fn dispatch_persistent_completed_statistics_events(
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) => handle_persistent_completed_statistics_event(event, &db_downloads_metric_repository, &stats_repository, CurrentClock::now()).await,
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver closed");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver lagged by {} events", n);
-                            }
-                        }
-                    }
+                if !handle_persistent_completed_statistics_receive_result(
+                    result,
+                    &db_downloads_metric_repository,
+                    &stats_repository,
+                ).await {
+                    break;
                 }
             }
         }
+    }
+}
+
+async fn handle_in_memory_receive_result(
+    result: Result<torrust_tracker_swarm_coordination_registry::event::Event, RecvError>,
+    stats_repository: &Arc<Repository>,
+) -> bool {
+    match result {
+        Ok(event) => {
+            handle_in_memory_event(event, stats_repository, CurrentClock::now()).await;
+            true
+        }
+        Err(error) => handle_receive_error(&error),
+    }
+}
+
+async fn handle_persistent_completed_statistics_receive_result(
+    result: Result<torrust_tracker_swarm_coordination_registry::event::Event, RecvError>,
+    db_downloads_metric_repository: &Arc<DatabaseDownloadsMetricRepository>,
+    stats_repository: &Arc<Repository>,
+) -> bool {
+    match result {
+        Ok(event) => {
+            handle_persistent_completed_statistics_event(
+                event,
+                db_downloads_metric_repository,
+                stats_repository,
+                CurrentClock::now(),
+            )
+            .await;
+            true
+        }
+        Err(error) => handle_receive_error(&error),
+    }
+}
+
+fn handle_receive_error(error: &RecvError) -> bool {
+    match error {
+        RecvError::Closed => {
+            tracing::info!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver closed");
+            false
+        }
+        RecvError::Lagged(number_of_events) => {
+            tracing::warn!(target: TRACKER_CORE_LOG_TARGET, "Tracker core event receiver lagged by {} events", number_of_events);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::sync::Arc;
+
+    use tokio_util::sync::CancellationToken;
+    use torrust_clock::clock;
+    use torrust_clock::clock::stopped::Stopped as _;
+    use torrust_tracker_events::receiver::RecvError;
+    use torrust_tracker_swarm_coordination_registry::event::Event;
+
+    use super::{dispatch_in_memory_events, dispatch_persistent_completed_statistics_events};
+    use crate::databases::setup::initialize_database;
+    use crate::statistics::persisted::downloads::DatabaseDownloadsMetricRepository;
+    use crate::statistics::repository::Repository;
+    use crate::test_helpers::tests::{ephemeral_configuration, sample_info_hash, sample_peer};
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> Self {
+            Self {
+                results: results.into_iter().collect(),
+            }
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> Pin<Box<dyn Future<Output = Result<Self::Event, RecvError>> + Send + '_>> {
+            Box::pin(std::future::ready(self.results.pop_front().unwrap_or(Err(RecvError::Closed))))
+        }
+    }
+
+    fn peer_download_completed_event() -> Event {
+        Event::PeerDownloadCompleted {
+            info_hash: sample_info_hash(),
+            peer: sample_peer(),
+        }
+    }
+
+    async fn database_downloads_repository() -> Arc<DatabaseDownloadsMetricRepository> {
+        let configuration = ephemeral_configuration();
+        let stores = initialize_database(&configuration).await;
+
+        Arc::new(DatabaseDownloadsMetricRepository::new(&stores.torrent_metrics_store))
+    }
+
+    async fn expect_in_memory_download_metrics_to_be(stats_repository: &Repository, expected_value: u64) {
+        assert_eq!(stats_repository.get_torrents_downloads_total().await, expected_value);
+        assert_eq!(
+            stats_repository.get_torrents_downloads_in_session_total().await,
+            expected_value
+        );
+    }
+
+    async fn expect_persisted_download_metrics_to_be(
+        downloads_repository: &DatabaseDownloadsMetricRepository,
+        stats_repository: &Repository,
+        expected_value: Option<u32>,
+    ) {
+        assert_eq!(downloads_repository.load_global_downloads().await.unwrap(), expected_value);
+        assert_eq!(
+            stats_repository.get_torrents_downloads_persisted_total().await,
+            u64::from(expected_value.unwrap_or(0))
+        );
+    }
+
+    #[tokio::test]
+    async fn it_should_handle_an_event_then_stop_when_the_in_memory_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::default());
+        let receiver = Box::new(ScriptedReceiver::new([
+            Ok(peer_download_completed_event()),
+            Err(RecvError::Closed),
+        ]));
+
+        // Act
+        dispatch_in_memory_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_in_memory_download_metrics_to_be(&stats_repository, 1).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_continue_after_lag_then_handle_an_event_then_stop_when_the_in_memory_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::default());
+        let receiver = Box::new(ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(peer_download_completed_event()),
+            Err(RecvError::Closed),
+        ]));
+
+        // Act
+        dispatch_in_memory_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_in_memory_download_metrics_to_be(&stats_repository, 1).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_stop_when_the_in_memory_receiver_is_closed() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::default());
+        let receiver = Box::new(ScriptedReceiver::new([Err(RecvError::Closed)]));
+
+        // Act
+        dispatch_in_memory_events(receiver, CancellationToken::new(), stats_repository.clone()).await;
+
+        // Assert
+        expect_in_memory_download_metrics_to_be(&stats_repository, 0).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_a_pre_cancelled_token_over_a_ready_in_memory_event() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::default());
+        let receiver = Box::new(ScriptedReceiver::new([Ok(peer_download_completed_event())]));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        // Act
+        dispatch_in_memory_events(receiver, cancellation_token, stats_repository.clone()).await;
+
+        // Assert
+        expect_in_memory_download_metrics_to_be(&stats_repository, 0).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_handle_an_event_then_stop_when_the_persistent_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let receiver = Box::new(ScriptedReceiver::new([
+            Ok(peer_download_completed_event()),
+            Err(RecvError::Closed),
+        ]));
+
+        // Act
+        dispatch_persistent_completed_statistics_events(
+            receiver,
+            CancellationToken::new(),
+            downloads_repository.clone(),
+            stats_repository.clone(),
+        )
+        .await;
+
+        // Assert
+        expect_persisted_download_metrics_to_be(&downloads_repository, &stats_repository, Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_continue_after_lag_then_handle_an_event_then_stop_when_the_persistent_receiver_is_closed() {
+        // Arrange
+        clock::Stopped::local_set_to_unix_epoch();
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let receiver = Box::new(ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(peer_download_completed_event()),
+            Err(RecvError::Closed),
+        ]));
+
+        // Act
+        dispatch_persistent_completed_statistics_events(
+            receiver,
+            CancellationToken::new(),
+            downloads_repository.clone(),
+            stats_repository.clone(),
+        )
+        .await;
+
+        // Assert
+        expect_persisted_download_metrics_to_be(&downloads_repository, &stats_repository, Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_stop_when_the_persistent_receiver_is_closed() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let receiver = Box::new(ScriptedReceiver::new([Err(RecvError::Closed)]));
+
+        // Act
+        dispatch_persistent_completed_statistics_events(
+            receiver,
+            CancellationToken::new(),
+            downloads_repository.clone(),
+            stats_repository.clone(),
+        )
+        .await;
+
+        // Assert
+        expect_persisted_download_metrics_to_be(&downloads_repository, &stats_repository, None).await;
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_a_pre_cancelled_token_over_a_ready_persistent_event() {
+        // Arrange
+        let stats_repository = Arc::new(Repository::new(true, true));
+        let downloads_repository = database_downloads_repository().await;
+        let receiver = Box::new(ScriptedReceiver::new([Ok(peer_download_completed_event())]));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        // Act
+        dispatch_persistent_completed_statistics_events(
+            receiver,
+            cancellation_token,
+            downloads_repository.clone(),
+            stats_repository.clone(),
+        )
+        .await;
+
+        // Assert
+        expect_persisted_download_metrics_to_be(&downloads_repository, &stats_repository, None).await;
     }
 }

--- a/packages/tracker-core/src/statistics/mod.rs
+++ b/packages/tracker-core/src/statistics/mod.rs
@@ -1,5 +1,7 @@
-//! Tracker completed-download counters use the retention terminology defined
-//! by ADR [`20260901113500_define_completed_download_metric_retention_names`](../../../../docs/adrs/20260901113500_define_completed_download_metric_retention_names.md).
+//! Tracker completed-download counters use explicit retention terminology.
+//!
+//! The terminology is defined by ADR
+//! [`20260901113500_define_completed_download_metric_retention_names`](../../../../docs/adrs/20260901113500_define_completed_download_metric_retention_names.md).
 pub mod event;
 pub mod metrics;
 pub mod persisted;

--- a/packages/tracker-core/src/statistics/persisted/downloads.rs
+++ b/packages/tracker-core/src/statistics/persisted/downloads.rs
@@ -40,7 +40,7 @@ impl DatabaseDownloadsMetricRepository {
     /// A new `DatabaseDownloadsMetricRepository` instance with a cloned
     /// reference to the provided store.
     #[must_use]
-    pub fn new(database: &Arc<dyn TorrentMetricsStore>) -> DatabaseDownloadsMetricRepository {
+    pub fn new(database: &Arc<dyn TorrentMetricsStore>) -> Self {
         Self {
             database: database.clone(),
         }

--- a/packages/tracker-core/src/statistics/repository.rs
+++ b/packages/tracker-core/src/statistics/repository.rs
@@ -178,17 +178,11 @@ impl Repository {
     }
 
     async fn get_counter_value(&self, metric_name: &str) -> u64 {
-        let metrics = self.get_metrics().await;
-
-        let downloads = metrics
+        self.get_metrics()
+            .await
             .metric_collection
-            .get_counter_value(&metric_name!(metric_name), &LabelSet::default());
-
-        if let Some(downloads) = downloads {
-            downloads.value()
-        } else {
-            0
-        }
+            .get_counter_value(&metric_name!(metric_name), &LabelSet::default())
+            .map_or(0, |downloads| downloads.value())
     }
 }
 
@@ -226,6 +220,7 @@ mod tests {
                 .metric_collection
                 .contains_counter(&metric_name!(TRACKER_CORE_PERSISTED_TORRENTS_DOWNLOADS_TOTAL))
         );
+        drop(metrics);
     }
 
     #[tokio::test]
@@ -242,6 +237,7 @@ mod tests {
                 .metric_collection
                 .contains_counter(&metric_name!(TRACKER_CORE_PERSISTED_TORRENTS_DOWNLOADS_TOTAL))
         );
+        drop(metrics);
         assert_eq!(repository.get_torrents_downloads_persisted_total().await, 0);
     }
 }

--- a/packages/tracker-core/src/test_helpers.rs
+++ b/packages/tracker-core/src/test_helpers.rs
@@ -134,7 +134,7 @@ pub(crate) mod tests {
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
         let whitelist_authorization = Arc::new(whitelist::authorization::WhitelistAuthorization::new(
             &config.core,
-            &in_memory_whitelist.clone(),
+            &in_memory_whitelist,
         ));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
         let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&stores.torrent_metrics_store));

--- a/packages/tracker-core/src/torrent/manager.rs
+++ b/packages/tracker-core/src/torrent/manager.rs
@@ -10,11 +10,10 @@ use super::repository::in_memory::InMemoryTorrentRepository;
 use crate::statistics::persisted::downloads::DatabaseDownloadsMetricRepository;
 use crate::{CurrentClock, databases};
 
-/// The `TorrentsManager` is responsible for managing torrent entries by
-/// integrating persistent storage and in-memory state. It provides methods to
-/// load torrent data from the database into memory, and to periodically clean
-/// up stale torrent entries by removing inactive peers or entire torrent
-/// entries that no longer have active peers.
+/// Manages torrent entries in persistent storage and in-memory state.
+///
+/// It loads persisted torrent data into memory and periodically removes stale
+/// peers or torrent entries without active peers.
 ///
 /// This manager relies on two repositories:
 ///

--- a/packages/tracker-core/src/torrent/repository/in_memory.rs
+++ b/packages/tracker-core/src/torrent/repository/in_memory.rs
@@ -25,7 +25,7 @@ pub struct InMemoryTorrentRepository {
 
 impl InMemoryTorrentRepository {
     #[must_use]
-    pub fn new(swarms: Arc<Registry>) -> Self {
+    pub const fn new(swarms: Arc<Registry>) -> Self {
         Self { swarms }
     }
 

--- a/packages/tracker-core/src/torrent/services.rs
+++ b/packages/tracker-core/src/torrent/services.rs
@@ -25,7 +25,7 @@ use crate::torrent::repository::in_memory::InMemoryTorrentRepository;
 /// This struct contains all the information that the tracker holds about a
 /// torrent, including the infohash, aggregate swarm metrics (seeders, leechers,
 /// completed downloads), and the complete list of peers in the swarm.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Info {
     /// The infohash of the torrent this data is related to
     pub info_hash: InfoHash,
@@ -52,7 +52,7 @@ pub struct Info {
 /// This struct contains the same aggregate metrics as [`Info`] (infohash,
 /// seeders, completed, leechers) but omits the peer list. It is used when only
 /// summary information is needed.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct BasicInfo {
     /// The infohash of the torrent this data is related to
     pub info_hash: InfoHash,
@@ -443,12 +443,12 @@ mod tests {
 
             assert_eq!(
                 torrent_info,
-                vec!(BasicInfo {
+                vec![BasicInfo {
                     info_hash,
                     seeders: 1,
                     completed: 0,
                     leechers: 0,
-                })
+                }]
             );
         }
     }

--- a/packages/tracker-core/src/whitelist/authorization.rs
+++ b/packages/tracker-core/src/whitelist/authorization.rs
@@ -63,7 +63,7 @@ impl WhitelistAuthorization {
     }
 
     /// Checks if the tracker is running in "listed" mode.
-    fn is_listed(&self) -> bool {
+    const fn is_listed(&self) -> bool {
         self.config.listed
     }
 
@@ -94,7 +94,7 @@ mod tests {
             config: &Core,
         ) -> (Arc<WhitelistAuthorization>, Arc<InMemoryWhitelist>) {
             let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-            let whitelist_authorization = Arc::new(WhitelistAuthorization::new(config, &in_memory_whitelist.clone()));
+            let whitelist_authorization = Arc::new(WhitelistAuthorization::new(config, &in_memory_whitelist));
 
             (whitelist_authorization, in_memory_whitelist)
         }

--- a/packages/tracker-core/src/whitelist/manager.rs
+++ b/packages/tracker-core/src/whitelist/manager.rs
@@ -35,7 +35,7 @@ impl WhitelistManager {
     ///
     /// A new `WhitelistManager` instance.
     #[must_use]
-    pub fn new(database_whitelist: Arc<DatabaseWhitelist>, in_memory_whitelist: Arc<InMemoryWhitelist>) -> Self {
+    pub const fn new(database_whitelist: Arc<DatabaseWhitelist>, in_memory_whitelist: Arc<InMemoryWhitelist>) -> Self {
         Self {
             in_memory_whitelist,
             database_whitelist,

--- a/packages/tracker-core/src/whitelist/repository/persisted.rs
+++ b/packages/tracker-core/src/whitelist/repository/persisted.rs
@@ -86,7 +86,7 @@ mod tests {
 
             let _result = whitelist.add(&infohash).await;
 
-            assert_eq!(whitelist.load_from_database().await.unwrap(), vec!(infohash));
+            assert_eq!(whitelist.load_from_database().await.unwrap(), vec![infohash]);
         }
 
         #[tokio::test]
@@ -99,7 +99,7 @@ mod tests {
 
             let _result = whitelist.remove(&infohash).await;
 
-            assert_eq!(whitelist.load_from_database().await.unwrap(), vec!());
+            assert_eq!(whitelist.load_from_database().await.unwrap(), vec![]);
         }
 
         #[tokio::test]
@@ -112,7 +112,7 @@ mod tests {
 
             let result = whitelist.load_from_database().await.unwrap();
 
-            assert_eq!(result, vec!(infohash));
+            assert_eq!(result, vec![infohash]);
         }
 
         #[tokio::test]
@@ -124,7 +124,7 @@ mod tests {
             let _result = whitelist.add(&infohash).await;
             let _result = whitelist.add(&infohash).await;
 
-            assert_eq!(whitelist.load_from_database().await.unwrap(), vec!(infohash));
+            assert_eq!(whitelist.load_from_database().await.unwrap(), vec![infohash]);
         }
 
         #[tokio::test]

--- a/packages/tracker-core/src/whitelist/test_helpers.rs
+++ b/packages/tracker-core/src/whitelist/test_helpers.rs
@@ -20,8 +20,8 @@ pub(crate) mod tests {
     pub async fn initialize_whitelist_services(config: &Configuration) -> (Arc<WhitelistAuthorization>, Arc<WhitelistManager>) {
         let stores = initialize_database(&config.core).await;
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
-        let whitelist_manager = initialize_whitelist_manager(stores.whitelist_store.clone(), in_memory_whitelist.clone());
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
+        let whitelist_manager = initialize_whitelist_manager(stores.whitelist_store.clone(), in_memory_whitelist);
 
         (whitelist_authorization, whitelist_manager)
     }

--- a/packages/tracker-core/tests/common/test_env.rs
+++ b/packages/tracker-core/tests/common/test_env.rs
@@ -24,7 +24,7 @@ pub struct TestEnv {
 impl TestEnv {
     #[must_use]
     pub async fn started(core_config: Core) -> Self {
-        let test_env = TestEnv::new(core_config).await;
+        let test_env = Self::new(core_config).await;
         test_env.start().await;
         test_env
     }
@@ -82,23 +82,20 @@ impl TestEnv {
     }
 
     async fn run_jobs(&self) {
-        let mut jobs = vec![];
         let cancellation_token = CancellationToken::new();
 
-        let job = torrust_tracker_swarm_coordination_registry::statistics::event::listener::run_event_listener(
-            self.swarm_coordination_registry_container.event_bus.receiver(),
-            cancellation_token.clone(),
-            &self.swarm_coordination_registry_container.stats_repository,
-        );
+        let _swarm_statistics_listener =
+            torrust_tracker_swarm_coordination_registry::statistics::event::listener::run_event_listener(
+                self.swarm_coordination_registry_container.event_bus.receiver(),
+                cancellation_token.clone(),
+                &self.swarm_coordination_registry_container.stats_repository,
+            );
 
-        jobs.push(job);
-
-        let job = torrust_tracker_core::statistics::event::listener::run_in_memory_event_listener(
+        let _in_memory_statistics_listener = torrust_tracker_core::statistics::event::listener::run_in_memory_event_listener(
             self.swarm_coordination_registry_container.event_bus.receiver(),
             cancellation_token.clone(),
             &self.tracker_core_container.stats_repository,
         );
-        jobs.push(job);
 
         if self
             .tracker_core_container
@@ -106,18 +103,18 @@ impl TestEnv {
             .tracker_policy
             .persistent_torrent_completed_stat
         {
-            let job = torrust_tracker_core::statistics::event::listener::run_persistent_completed_statistics_event_listener(
-                self.swarm_coordination_registry_container.event_bus.receiver(),
-                cancellation_token.clone(),
-                &self
-                    .tracker_core_container
-                    .persistence
-                    .as_ref()
-                    .expect("tracker core test environment requires persistence")
-                    .db_downloads_metric_repository,
-                &self.tracker_core_container.stats_repository,
-            );
-            jobs.push(job);
+            let _persistent_statistics_listener =
+                torrust_tracker_core::statistics::event::listener::run_persistent_completed_statistics_event_listener(
+                    self.swarm_coordination_registry_container.event_bus.receiver(),
+                    cancellation_token.clone(),
+                    &self
+                        .tracker_core_container
+                        .persistence
+                        .as_ref()
+                        .expect("tracker core test environment requires persistence")
+                        .db_downloads_metric_repository,
+                    &self.tracker_core_container.stats_repository,
+                );
         }
 
         // Give the event listeners some time to start
@@ -125,12 +122,7 @@ impl TestEnv {
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 
-    pub async fn announce_peer_started(
-        &mut self,
-        mut peer: Peer,
-        remote_client_ip: &IpAddr,
-        info_hash: &InfoHash,
-    ) -> AnnounceData {
+    pub async fn announce_peer_started(&self, mut peer: Peer, remote_client_ip: &IpAddr, info_hash: &InfoHash) -> AnnounceData {
         peer.event = AnnounceEvent::Started;
 
         let announce_data = self
@@ -146,12 +138,7 @@ impl TestEnv {
         announce_data
     }
 
-    pub async fn announce_peer_completed(
-        &mut self,
-        mut peer: Peer,
-        remote_client_ip: &IpAddr,
-        info_hash: &InfoHash,
-    ) -> AnnounceData {
+    pub async fn announce_peer_completed(&self, mut peer: Peer, remote_client_ip: &IpAddr, info_hash: &InfoHash) -> AnnounceData {
         peer.event = AnnounceEvent::Completed;
 
         let announce_data = self
@@ -175,7 +162,7 @@ impl TestEnv {
             .unwrap()
     }
 
-    pub async fn increase_number_of_downloads(&mut self, peer: Peer, remote_client_ip: &IpAddr, info_hash: &InfoHash) {
+    pub async fn increase_number_of_downloads(&self, peer: Peer, remote_client_ip: &IpAddr, info_hash: &InfoHash) {
         let _announce_data = self.announce_peer_started(peer, remote_client_ip, info_hash).await;
         let announce_data = self.announce_peer_completed(peer, remote_client_ip, info_hash).await;
 

--- a/packages/tracker-core/tests/integration.rs
+++ b/packages/tracker-core/tests/integration.rs
@@ -7,7 +7,7 @@ use torrust_tracker_primitives::{AnnounceData, AnnouncePolicy};
 
 #[tokio::test]
 async fn it_should_handle_the_announce_request() {
-    let mut test_env = TestEnv::started(ephemeral_configuration()).await;
+    let test_env = TestEnv::started(ephemeral_configuration()).await;
 
     let announce_data = test_env
         .announce_peer_started(sample_peer(), &remote_client_ip(), &sample_info_hash())
@@ -33,7 +33,7 @@ async fn it_should_handle_the_announce_request() {
 
 #[tokio::test]
 async fn it_should_not_return_the_peer_making_the_announce_request() {
-    let mut test_env = TestEnv::started(ephemeral_configuration()).await;
+    let test_env = TestEnv::started(ephemeral_configuration()).await;
 
     let announce_data = test_env
         .announce_peer_started(sample_peer(), &remote_client_ip(), &sample_info_hash())
@@ -44,7 +44,7 @@ async fn it_should_not_return_the_peer_making_the_announce_request() {
 
 #[tokio::test]
 async fn it_should_handle_the_scrape_request() {
-    let mut test_env = TestEnv::started(ephemeral_configuration()).await;
+    let test_env = TestEnv::started(ephemeral_configuration()).await;
 
     let info_hash = sample_info_hash();
 
@@ -62,7 +62,7 @@ async fn it_should_persist_the_number_of_completed_peers_for_each_torrent_into_t
     let mut core_config = ephemeral_configuration();
     core_config.tracker_policy.persistent_torrent_completed_stat = true;
 
-    let mut test_env = TestEnv::started(core_config).await;
+    let test_env = TestEnv::started(core_config).await;
 
     let info_hash = sample_info_hash();
 
@@ -121,7 +121,7 @@ async fn it_should_persist_the_global_number_of_completed_peers_into_the_databas
 
     core_config.tracker_policy.persistent_torrent_completed_stat = true;
 
-    let mut test_env = TestEnv::started(core_config.clone()).await;
+    let test_env = TestEnv::started(core_config.clone()).await;
 
     test_env
         .increase_number_of_downloads(sample_peer(), &remote_client_ip(), &sample_info_hash())
@@ -167,7 +167,7 @@ async fn it_should_reset_in_session_completed_downloads_after_a_persistence_free
     // Arrange
     let mut core_config = ephemeral_configuration();
     core_config.database = None;
-    let mut test_env = TestEnv::started(core_config.clone()).await;
+    let test_env = TestEnv::started(core_config.clone()).await;
 
     test_env
         .increase_number_of_downloads(sample_peer(), &remote_client_ip(), &sample_info_hash())

--- a/packages/udp-core/Cargo.toml
+++ b/packages/udp-core/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust-info-hash = "=0.2.0"
 torrust-tracker-core = { version = "0.1.0", path = "../tracker-core" }

--- a/packages/udp-core/benches/ban_service_benchmark.rs
+++ b/packages/udp-core/benches/ban_service_benchmark.rs
@@ -14,7 +14,7 @@ enum AddressFamily {
 }
 
 impl AddressFamily {
-    fn name(self) -> &'static str {
+    const fn name(self) -> &'static str {
         match self {
             Self::Ipv4 => "ipv4",
             Self::Ipv6 => "ipv6",

--- a/packages/udp-core/benches/helpers/sync.rs
+++ b/packages/udp-core/benches/helpers/sync.rs
@@ -18,7 +18,7 @@ pub async fn connect_once(samples: u64) -> Duration {
     let server_service_binding = ServiceBinding::new(Protocol::UDP, server_socket_addr).unwrap();
 
     let udp_core_broadcaster = Broadcaster::default();
-    let event_bus = Arc::new(EventBus::new(SenderStatus::Disabled, udp_core_broadcaster.clone()));
+    let event_bus = Arc::new(EventBus::new(SenderStatus::Disabled, udp_core_broadcaster));
 
     let udp_core_stats_event_sender = event_bus.sender();
     let connect_service = Arc::new(ConnectService::new(

--- a/packages/udp-core/benches/helpers/utils.rs
+++ b/packages/udp-core/benches/helpers/utils.rs
@@ -5,15 +5,15 @@ use mockall::mock;
 use torrust_tracker_events::sender::SendError;
 use torrust_tracker_udp_core::event::Event;
 
-pub(crate) fn sample_ipv4_remote_addr() -> SocketAddr {
+pub const fn sample_ipv4_remote_addr() -> SocketAddr {
     sample_ipv4_socket_address()
 }
 
-pub(crate) fn sample_ipv4_socket_address() -> SocketAddr {
+pub const fn sample_ipv4_socket_address() -> SocketAddr {
     SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
 }
 
-pub(crate) fn sample_issue_time() -> f64 {
+pub const fn sample_issue_time() -> f64 {
     1_000_000_000_f64
 }
 

--- a/packages/udp-core/src/container.rs
+++ b/packages/udp-core/src/container.rs
@@ -44,7 +44,7 @@ impl UdpTrackerCoreContainer {
         udp_tracker_config: &Arc<UdpTracker>,
         max_connection_id_errors_per_ip: u32,
         configuration_instance_id: ConfigurationInstanceId,
-    ) -> Arc<UdpTrackerCoreContainer> {
+    ) -> Arc<Self> {
         let swarm_coordination_registry_container = Arc::new(SwarmCoordinationRegistryContainer::initialize(
             core_config.tracker_usage_statistics.into(),
         ));
@@ -73,7 +73,7 @@ impl UdpTrackerCoreContainer {
         udp_tracker_config: &Arc<UdpTracker>,
         max_connection_id_errors_per_ip: u32,
         configuration_instance_id: ConfigurationInstanceId,
-    ) -> Arc<UdpTrackerCoreContainer> {
+    ) -> Arc<Self> {
         let udp_tracker_core_services =
             UdpTrackerCoreServices::initialize_from(tracker_core_container, max_connection_id_errors_per_ip);
 
@@ -153,7 +153,7 @@ impl UdpTrackerCoreServices {
         // the shared statistics listener, so it must not suppress publication.
         // A future consumer-demand optimization needs an inventory and benchmark
         // evidence before this can become conditional.
-        let event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, udp_core_broadcaster.clone()));
+        let event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, udp_core_broadcaster));
 
         let udp_core_stats_event_sender = event_bus.sender();
         let ban_service = Arc::new(RwLock::new(BanService::new(max_connection_id_errors_per_ip)));

--- a/packages/udp-core/src/event.rs
+++ b/packages/udp-core/src/event.rs
@@ -51,7 +51,7 @@ pub struct ConnectionContext {
 
 impl ConnectionContext {
     #[must_use]
-    pub fn new(
+    pub const fn new(
         configuration_instance_id: ConfigurationInstanceId,
         client_socket_addr: SocketAddr,
         server_service_binding: ServiceBinding,
@@ -76,7 +76,7 @@ impl ConnectionContext {
     }
 
     #[must_use]
-    pub fn client_socket_addr(&self) -> SocketAddr {
+    pub const fn client_socket_addr(&self) -> SocketAddr {
         self.client_socket_addr
     }
 
@@ -96,7 +96,7 @@ impl ConnectionContext {
     }
 
     #[must_use]
-    pub fn client_address_ip_type(&self) -> IpType {
+    pub const fn client_address_ip_type(&self) -> IpType {
         match self.client_socket_addr.ip() {
             IpAddr::V6(v6) if v6.to_ipv4_mapped().is_some() => IpType::V4MappedV6,
             _ => IpType::Plain,
@@ -106,7 +106,7 @@ impl ConnectionContext {
 
 impl From<ConnectionContext> for LabelSet {
     fn from(connection_context: ConnectionContext) -> Self {
-        let mut label_set = LabelSet::from([
+        let mut label_set = Self::from([
             (
                 label_name!("server_binding_protocol"),
                 LabelValue::new(&connection_context.server_service_binding.protocol().to_string()),

--- a/packages/udp-core/src/services/banning.rs
+++ b/packages/udp-core/src/services/banning.rs
@@ -101,8 +101,6 @@ mod tests {
         ban_service.increase_counter(&ip); // Counter = 1
         ban_service.increase_counter(&ip); // Counter = 2
 
-        println!("Counter: {}", ban_service.get_count(&ip).unwrap());
-
         assert!(ban_service.is_banned(&ip));
     }
 

--- a/packages/udp-core/src/services/mod.rs
+++ b/packages/udp-core/src/services/mod.rs
@@ -15,23 +15,23 @@ pub(crate) mod tests {
     use crate::connection_cookie::gen_remote_fingerprint;
     use crate::event::Event;
 
-    pub(crate) fn sample_ipv4_remote_addr() -> SocketAddr {
+    pub fn sample_ipv4_remote_addr() -> SocketAddr {
         sample_ipv4_socket_address()
     }
 
-    pub(crate) fn sample_ipv4_remote_addr_fingerprint() -> u64 {
+    pub fn sample_ipv4_remote_addr_fingerprint() -> u64 {
         gen_remote_fingerprint(&sample_ipv4_socket_address())
     }
 
-    pub(crate) fn sample_ipv6_remote_addr() -> SocketAddr {
+    pub fn sample_ipv6_remote_addr() -> SocketAddr {
         sample_ipv6_socket_address()
     }
 
-    pub(crate) fn sample_ipv6_remote_addr_fingerprint() -> u64 {
+    pub fn sample_ipv6_remote_addr_fingerprint() -> u64 {
         gen_remote_fingerprint(&sample_ipv6_socket_address())
     }
 
-    pub(crate) fn sample_ipv4_socket_address() -> SocketAddr {
+    pub fn sample_ipv4_socket_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
     }
 
@@ -39,7 +39,7 @@ pub(crate) mod tests {
         SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
     }
 
-    pub(crate) fn sample_issue_time() -> f64 {
+    pub fn sample_issue_time() -> f64 {
         1_000_000_000_f64
     }
 

--- a/packages/udp-core/src/statistics/event/handler.rs
+++ b/packages/udp-core/src/statistics/event/handler.rs
@@ -10,46 +10,25 @@ use crate::statistics::repository::Repository;
 ///
 /// This function panics if the IP version does not match the event type.
 pub async fn handle_event(event: Event, stats_repository: &Repository, now: DurationSinceUnixEpoch) {
-    match event {
-        Event::UdpConnect { connection: context } => {
-            let mut label_set = LabelSet::from(context);
-            label_set.upsert(label_name!("request_kind"), LabelValue::new("connect"));
+    let (mut label_set, request_kind) = labels_and_request_kind(event);
+    label_set.upsert(label_name!("request_kind"), LabelValue::new(request_kind));
 
-            match stats_repository
-                .increase_counter(&metric_name!(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
-                .await
-            {
-                Ok(()) => {}
-                Err(err) => tracing::error!("Failed to increase the counter: {}", err),
-            }
-        }
-        Event::UdpAnnounce { connection: context, .. } => {
-            let mut label_set = LabelSet::from(context);
-            label_set.upsert(label_name!("request_kind"), LabelValue::new("announce"));
-
-            match stats_repository
-                .increase_counter(&metric_name!(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
-                .await
-            {
-                Ok(()) => {}
-                Err(err) => tracing::error!("Failed to increase the counter: {}", err),
-            }
-        }
-        Event::UdpScrape { connection: context } => {
-            let mut label_set = LabelSet::from(context);
-            label_set.upsert(label_name!("request_kind"), LabelValue::new("scrape"));
-
-            match stats_repository
-                .increase_counter(&metric_name!(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
-                .await
-            {
-                Ok(()) => {}
-                Err(err) => tracing::error!("Failed to increase the counter: {}", err),
-            }
-        }
+    if let Err(err) = stats_repository
+        .increase_counter(&metric_name!(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &label_set, now)
+        .await
+    {
+        tracing::error!("Failed to increase the counter: {}", err);
     }
 
     tracing::debug!("stats: {:?}", stats_repository.get_stats().await);
+}
+
+fn labels_and_request_kind(event: Event) -> (LabelSet, &'static str) {
+    match event {
+        Event::UdpConnect { connection } => (LabelSet::from(connection), "connect"),
+        Event::UdpAnnounce { connection, .. } => (LabelSet::from(connection), "announce"),
+        Event::UdpScrape { connection } => (LabelSet::from(connection), "scrape"),
+    }
 }
 
 #[cfg(test)]
@@ -57,12 +36,16 @@ mod tests {
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use torrust_clock::clock::Time;
+    use torrust_metrics::label::{LabelSet, LabelValue};
+    use torrust_metrics::metric_collection::aggregate::sum::Sum;
+    use torrust_metrics::{label_name, metric_name};
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_primitives::peer::PeerAnnouncement;
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
 
     use crate::CurrentClock;
     use crate::event::{ConnectionContext, Event};
+    use crate::statistics::UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL;
     use crate::statistics::event::handler::handle_event;
     use crate::statistics::repository::Repository;
     use crate::tests::sample_info_hash;
@@ -231,5 +214,46 @@ mod tests {
         let stats = stats_repository.get_stats().await;
 
         assert_eq!(stats.udp6_scrapes_handled(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_propagate_all_connection_labels_and_request_kind() {
+        // Arrange
+        let stats_repository = Repository::new();
+        let event = Event::UdpScrape {
+            connection: ConnectionContext::new(
+                ConfigurationInstanceId::new(ServiceRole::UdpTracker, 7),
+                SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x0201)), 49152),
+                ServiceBinding::new(Protocol::UDP, SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 7443)).unwrap(),
+            )
+            .with_public_url(Some("udp://tracker.example.test:7443/announce".to_string())),
+        };
+        let expected_labels = LabelSet::from([
+            (label_name!("server_binding_protocol"), LabelValue::new("udp")),
+            (label_name!("server_binding_ip"), LabelValue::new("::1")),
+            (label_name!("server_binding_address_ip_type"), LabelValue::new("plain")),
+            (label_name!("server_binding_address_ip_family"), LabelValue::new("inet6")),
+            (label_name!("server_binding_port"), LabelValue::new("7443")),
+            (label_name!("client_address_ip_family"), LabelValue::new("inet6")),
+            (label_name!("client_address_ip_type"), LabelValue::new("v4_mapped_v6")),
+            (
+                label_name!("public_url"),
+                LabelValue::new("udp://tracker.example.test:7443/announce"),
+            ),
+            (label_name!("request_kind"), LabelValue::new("scrape")),
+        ]);
+
+        // Act
+        handle_event(event, &stats_repository, CurrentClock::now()).await;
+
+        // Assert
+        let counter_value = {
+            let stats = stats_repository.get_stats().await;
+            stats
+                .metric_collection
+                .sum(&metric_name!(UDP_TRACKER_CORE_REQUESTS_RECEIVED_TOTAL), &expected_labels)
+                .unwrap()
+        };
+        assert!((counter_value - 1.0).abs() < f64::EPSILON);
     }
 }

--- a/packages/udp-core/src/statistics/event/listener.rs
+++ b/packages/udp-core/src/statistics/event/listener.rs
@@ -49,31 +49,48 @@ async fn dispatch_events(
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) if metrics_policy.get(&event_connection_id(&event)).copied().unwrap_or(false) => {
-                        handle_event(event, &stats_repository, CurrentClock::now()).await;
-                    }
-                    Ok(event) => {
-                        tracing::warn!(
-                            target: UDP_TRACKER_LOG_TARGET,
-                            configuration_instance_id = ?event_connection_id(&event),
-                            "Ignoring UDP tracker event from an unknown or metrics-disabled listener"
-                        );
-                    }
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker core statistics receiver closed.");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker core statistics receiver lagged by {} events.", n);
-                            }
-                        }
-                    }
+                if should_stop_after_receiving_event(result, &stats_repository, &metrics_policy).await {
+                    break;
                 }
             }
         }
+    }
+}
+
+async fn should_stop_after_receiving_event(
+    result: Result<crate::event::Event, RecvError>,
+    stats_repository: &Arc<Repository>,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) -> bool {
+    match result {
+        Ok(event) => {
+            handle_received_event(event, stats_repository, metrics_policy).await;
+            false
+        }
+        Err(RecvError::Closed) => {
+            tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker core statistics receiver closed.");
+            true
+        }
+        Err(RecvError::Lagged(n)) => {
+            tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker core statistics receiver lagged by {} events.", n);
+            false
+        }
+    }
+}
+
+async fn handle_received_event(
+    event: crate::event::Event,
+    stats_repository: &Arc<Repository>,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) {
+    if metrics_policy.get(&event_connection_id(&event)).copied().unwrap_or(false) {
+        handle_event(event, stats_repository, CurrentClock::now()).await;
+    } else {
+        tracing::warn!(
+            target: UDP_TRACKER_LOG_TARGET,
+            configuration_instance_id = ?event_connection_id(&event),
+            "Ignoring UDP tracker event from an unknown or metrics-disabled listener"
+        );
     }
 }
 
@@ -87,18 +104,40 @@ const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstan
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
 
+    use futures::future::BoxFuture;
+    use tokio_util::sync::CancellationToken;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
-    use torrust_tracker_events::broadcaster::Broadcaster;
-    use torrust_tracker_events::sender::Sender as _;
+    use torrust_tracker_events::receiver::RecvError;
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
 
     use super::dispatch_events;
     use crate::event::receiver::Receiver;
     use crate::event::{ConnectionContext, Event};
     use crate::statistics::repository::Repository;
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> Self {
+            Self {
+                results: results.into_iter().collect(),
+            }
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> BoxFuture<'_, Result<Self::Event, RecvError>> {
+            Box::pin(std::future::ready(self.results.pop_front().unwrap_or(Err(RecvError::Closed))))
+        }
+    }
 
     fn connect_event(configuration_instance_id: ConfigurationInstanceId) -> Event {
         Event::UdpConnect {
@@ -111,28 +150,76 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn it_should_update_metrics_only_for_an_enabled_configuration_instance() {
+    async fn it_should_stop_when_the_receiver_is_closed() {
         // Arrange
-        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
-        let disabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 1);
-        let unknown_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 2);
-        let broadcaster = Broadcaster::default();
-        let receiver: Receiver = Box::new(broadcaster.subscribe());
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Err(RecvError::Closed)]));
         let repository = Arc::new(Repository::new());
 
-        for configuration_instance_id in [enabled_id, disabled_id, unknown_id] {
-            let _unused = broadcaster
-                .send(connect_event(configuration_instance_id))
-                .await
-                .unwrap()
-                .unwrap();
-        }
-        drop(broadcaster);
+        // Act
+        dispatch_events(receiver, CancellationToken::new(), repository.clone(), BTreeMap::new()).await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.udp4_connections_handled(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_continue_after_lag_and_process_an_enabled_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(connect_event(enabled_id)),
+            Err(RecvError::Closed),
+        ]));
+        let repository = Arc::new(Repository::new());
 
         // Act
         dispatch_events(
             receiver,
-            tokio_util::sync::CancellationToken::new(),
+            CancellationToken::new(),
+            repository.clone(),
+            [(enabled_id, true)].into(),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.udp4_connections_handled(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_cancellation_over_a_ready_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([Ok(connect_event(enabled_id))]));
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(receiver, cancellation_token, repository.clone(), [(enabled_id, true)].into()).await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.udp4_connections_handled(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_ignore_disabled_and_unknown_events_before_processing_an_enabled_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
+        let disabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 1);
+        let unknown_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 2);
+        let receiver: Receiver = Box::new(ScriptedReceiver::new([
+            Ok(connect_event(disabled_id)),
+            Ok(connect_event(unknown_id)),
+            Ok(connect_event(enabled_id)),
+            Err(RecvError::Closed),
+        ]));
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(
+            receiver,
+            CancellationToken::new(),
             repository.clone(),
             [(enabled_id, true), (disabled_id, false)].into(),
         )

--- a/packages/udp-core/src/statistics/event/listener.rs
+++ b/packages/udp-core/src/statistics/event/listener.rs
@@ -77,7 +77,7 @@ async fn dispatch_events(
     }
 }
 
-fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
+const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
     match event {
         crate::event::Event::UdpConnect { connection }
         | crate::event::Event::UdpAnnounce { connection, .. }

--- a/packages/udp-protocol/Cargo.toml
+++ b/packages/udp-protocol/Cargo.toml
@@ -14,6 +14,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [features]
 default = [  ]
 

--- a/packages/udp-protocol/src/announce.rs
+++ b/packages/udp-protocol/src/announce.rs
@@ -75,7 +75,7 @@ pub enum AnnounceEvent {
 pub struct AnnounceInterval(pub I32);
 
 impl AnnounceInterval {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(I32::new(v))
     }
 }

--- a/packages/udp-protocol/src/common.rs
+++ b/packages/udp-protocol/src/common.rs
@@ -31,7 +31,7 @@ pub struct InfoHash(pub [u8; 20]);
 pub struct ConnectionId(pub I64);
 
 impl ConnectionId {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(I64::new(v))
     }
 }
@@ -41,7 +41,7 @@ impl ConnectionId {
 pub struct TransactionId(pub I32);
 
 impl TransactionId {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(I32::new(v))
     }
 }
@@ -56,7 +56,7 @@ impl TransactionId {
 pub struct NumberOfBytes(pub I64);
 
 impl NumberOfBytes {
-    pub fn new(v: i64) -> Self {
+    pub const fn new(v: i64) -> Self {
         Self(I64::new(v))
     }
 }
@@ -66,7 +66,7 @@ impl NumberOfBytes {
 pub struct NumberOfPeers(pub I32);
 
 impl NumberOfPeers {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(I32::new(v))
     }
 }
@@ -76,7 +76,7 @@ impl NumberOfPeers {
 pub struct NumberOfDownloads(pub I32);
 
 impl NumberOfDownloads {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(I32::new(v))
     }
 }
@@ -96,7 +96,7 @@ impl Port {
 pub struct PeerKey(pub I32);
 
 impl PeerKey {
-    pub fn new(v: i32) -> Self {
+    pub const fn new(v: i32) -> Self {
         Self(I32::new(v))
     }
 }
@@ -116,13 +116,13 @@ impl Ip for Ipv4AddrBytes {}
 
 impl From<Ipv4AddrBytes> for Ipv4Addr {
     fn from(val: Ipv4AddrBytes) -> Self {
-        Ipv4Addr::from(val.0)
+        Self::from(val.0)
     }
 }
 
 impl From<Ipv4Addr> for Ipv4AddrBytes {
     fn from(val: Ipv4Addr) -> Self {
-        Ipv4AddrBytes(val.octets())
+        Self(val.octets())
     }
 }
 
@@ -134,13 +134,13 @@ impl Ip for Ipv6AddrBytes {}
 
 impl From<Ipv6AddrBytes> for Ipv6Addr {
     fn from(val: Ipv6AddrBytes) -> Self {
-        Ipv6Addr::from(val.0)
+        Self::from(val.0)
     }
 }
 
 impl From<Ipv6Addr> for Ipv6AddrBytes {
     fn from(val: Ipv6Addr) -> Self {
-        Ipv6AddrBytes(val.octets())
+        Self(val.octets())
     }
 }
 

--- a/packages/udp-protocol/src/lib.rs
+++ b/packages/udp-protocol/src/lib.rs
@@ -8,6 +8,10 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::default_trait_access)]
 #![allow(clippy::doc_markdown)]
+// `FromBytes` derives for transparent wire types expand to empty helper enums.
+// Nightly Clippy reports those generated enums as `empty_enums`; the wire types
+// themselves are inhabited and cannot use the suggested replacement.
+#![allow(clippy::empty_enums)]
 #![allow(clippy::explicit_iter_loop)]
 #![allow(clippy::legacy_numeric_constants)]
 #![allow(clippy::match_same_arms)]

--- a/packages/udp-protocol/src/request.rs
+++ b/packages/udp-protocol/src/request.rs
@@ -27,9 +27,9 @@ pub enum Request {
 impl Request {
     pub fn write_bytes(&self, bytes: &mut impl Write) -> Result<(), io::Error> {
         match self {
-            Request::Connect(r) => r.write_bytes(bytes),
-            Request::Announce(r) => r.write_bytes(bytes),
-            Request::Scrape(r) => r.write_bytes(bytes),
+            Self::Connect(r) => r.write_bytes(bytes),
+            Self::Announce(r) => r.write_bytes(bytes),
+            Self::Scrape(r) => r.write_bytes(bytes),
         }
     }
 
@@ -73,7 +73,7 @@ impl Request {
                         request.transaction_id,
                     ))
                 } else {
-                    Ok(Request::Announce(request))
+                    Ok(Self::Announce(request))
                 }
             }
             2 => {
@@ -158,17 +158,17 @@ pub enum RequestParseError {
 }
 
 impl RequestParseError {
-    pub fn sendable_text(text: &'static str, connection_id: ConnectionId, transaction_id: TransactionId) -> Self {
+    pub const fn sendable_text(text: &'static str, connection_id: ConnectionId, transaction_id: TransactionId) -> Self {
         Self::Sendable {
             connection_id,
             transaction_id,
             err: text,
         }
     }
-    pub fn unsendable_io(err: io::Error) -> Self {
+    pub const fn unsendable_io(err: io::Error) -> Self {
         Self::Unsendable { err: Either::Left(err) }
     }
-    pub fn unsendable_text(text: &'static str) -> Self {
+    pub const fn unsendable_text(text: &'static str) -> Self {
         Self::Unsendable {
             err: Either::Right(text),
         }
@@ -244,7 +244,7 @@ mod tests {
     fn same_after_conversion(request: Request) -> bool {
         let mut buf = Vec::new();
 
-        request.clone().write_bytes(&mut buf).unwrap();
+        request.write_bytes(&mut buf).unwrap();
         let r2 = Request::parse_bytes(&buf[..], u8::MAX).unwrap();
 
         let success = request == r2;

--- a/packages/udp-protocol/src/response.rs
+++ b/packages/udp-protocol/src/response.rs
@@ -32,11 +32,11 @@ impl Response {
     #[inline]
     pub fn write_bytes(&self, bytes: &mut impl Write) -> Result<(), io::Error> {
         match self {
-            Response::Connect(r) => r.write_bytes(bytes),
-            Response::AnnounceIpv4(r) => r.write_bytes(bytes),
-            Response::AnnounceIpv6(r) => r.write_bytes(bytes),
-            Response::Scrape(r) => r.write_bytes(bytes),
-            Response::Error(r) => r.write_bytes(bytes),
+            Self::Connect(r) => r.write_bytes(bytes),
+            Self::AnnounceIpv4(r) => r.write_bytes(bytes),
+            Self::AnnounceIpv6(r) => r.write_bytes(bytes),
+            Self::Scrape(r) => r.write_bytes(bytes),
+            Self::Error(r) => r.write_bytes(bytes),
         }
     }
 
@@ -45,7 +45,7 @@ impl Response {
         let action = read_i32_ne(&mut bytes)?;
 
         match action.get() {
-            0 => Ok(Response::Connect(
+            0 => Ok(Self::Connect(
                 ConnectResponse::read_from_prefix(bytes).map_err(|_| invalid_data())?.0,
             )),
             1 if ipv4 => {
@@ -72,7 +72,7 @@ impl Response {
                     Vec::new()
                 };
 
-                Ok(Response::AnnounceIpv4(AnnounceResponse { fixed, peers }))
+                Ok(Self::AnnounceIpv4(AnnounceResponse { fixed, peers }))
             }
             1 if !ipv4 => {
                 let fixed = AnnounceResponseFixedData::read_from_prefix(bytes)
@@ -98,7 +98,7 @@ impl Response {
                     Vec::new()
                 };
 
-                Ok(Response::AnnounceIpv6(AnnounceResponse { fixed, peers }))
+                Ok(Self::AnnounceIpv6(AnnounceResponse { fixed, peers }))
             }
             2 => {
                 let transaction_id = read_i32_ne(&mut bytes).map(TransactionId)?;
@@ -256,7 +256,7 @@ mod tests {
     fn same_after_conversion(response: Response, ipv4: bool) -> bool {
         let mut buf = Vec::new();
 
-        response.clone().write_bytes(&mut buf).unwrap();
+        response.write_bytes(&mut buf).unwrap();
         let r2 = Response::parse_bytes(&buf[..], ipv4).unwrap();
 
         let success = response == r2;

--- a/packages/udp-server/Cargo.toml
+++ b/packages/udp-server/Cargo.toml
@@ -13,6 +13,9 @@ repository.workspace = true
 rust-version.workspace = true
 version = "0.1.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 torrust_tracker_udp_protocol = { package = "torrust-tracker-udp-protocol", version = "0.1.0", path = "../udp-protocol" }
 torrust-peer-id = "0.1.0"

--- a/packages/udp-server/examples/udp_only_public_tracker.rs
+++ b/packages/udp-server/examples/udp_only_public_tracker.rs
@@ -33,6 +33,8 @@
 //! cargo tree -p torrust-tracker-udp-server --example udp_only_public_tracker
 //! ```
 
+#![allow(clippy::print_stdout)]
+
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::Duration;

--- a/packages/udp-server/src/banning/event/handler.rs
+++ b/packages/udp-server/src/banning/event/handler.rs
@@ -26,7 +26,9 @@ pub async fn handle_event(
 
         ban_service.increase_counter(&context.client_socket_addr().ip());
 
-        update_metric_for_banned_ips_total(repository, ban_service.get_banned_ips_total(), now).await;
+        let ips_banned_total = ban_service.get_banned_ips_total();
+        drop(ban_service);
+        update_metric_for_banned_ips_total(repository, ips_banned_total, now).await;
     }
 }
 

--- a/packages/udp-server/src/banning/event/listener.rs
+++ b/packages/udp-server/src/banning/event/listener.rs
@@ -86,7 +86,8 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use futures::{FutureExt as _, future::BoxFuture};
+    use futures::FutureExt as _;
+    use futures::future::BoxFuture;
     use tokio::sync::RwLock;
     use tokio_util::sync::CancellationToken;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};

--- a/packages/udp-server/src/banning/event/listener.rs
+++ b/packages/udp-server/src/banning/event/listener.rs
@@ -43,26 +43,187 @@ async fn dispatch_events(
             biased;
 
             () = cancellation_token.cancelled() => {
-                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received cancellation request, shutting down UDP tracker server event listener.");
+                log_cancellation();
                 break;
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) => handle_event(event, &ban_service, &repository, CurrentClock::now()).await,
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server receiver  (banning) closed.");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server receiver (banning) lagged by {} events.", n);
-                            }
-                        }
-                    }
+                if !handle_received_event(result, &ban_service, &repository).await {
+                    break;
                 }
             }
         }
+    }
+}
+
+async fn handle_received_event(
+    result: Result<crate::event::Event, RecvError>,
+    ban_service: &Arc<RwLock<BanService>>,
+    repository: &Repository,
+) -> bool {
+    match result {
+        Ok(event) => handle_event(event, ban_service, repository, CurrentClock::now()).await,
+        Err(RecvError::Closed) => {
+            tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server receiver  (banning) closed.");
+            return false;
+        }
+        Err(RecvError::Lagged(events)) => {
+            tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server receiver (banning) lagged by {} events.", events);
+        }
+    }
+
+    true
+}
+
+fn log_cancellation() {
+    tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received cancellation request, shutting down UDP tracker server event listener.");
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use futures::{FutureExt as _, future::BoxFuture};
+    use tokio::sync::RwLock;
+    use tokio_util::sync::CancellationToken;
+    use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_events::receiver::RecvError;
+    use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
+    use torrust_tracker_udp_core::event::ConnectionContext;
+    use torrust_tracker_udp_core::services::banning::BanService;
+
+    use super::dispatch_events;
+    use crate::event::{ErrorKind, Event};
+    use crate::statistics::repository::Repository;
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+        receives: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> (Self, Arc<AtomicUsize>) {
+            let receives = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    results: results.into_iter().collect(),
+                    receives: receives.clone(),
+                },
+                receives,
+            )
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> BoxFuture<'_, Result<Self::Event, RecvError>> {
+            self.receives.fetch_add(1, Ordering::SeqCst);
+            futures::future::ready(self.results.pop_front().expect("scripted receive result")).boxed()
+        }
+    }
+
+    fn error_event(error: ErrorKind) -> Event {
+        Event::UdpError {
+            context: ConnectionContext::new(
+                ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0),
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+                ServiceBinding::new(Protocol::UDP, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6969)).unwrap(),
+            ),
+            kind: None,
+            error,
+        }
+    }
+
+    fn ban_service() -> Arc<RwLock<BanService>> {
+        Arc::new(RwLock::new(BanService::new(1)))
+    }
+
+    #[tokio::test]
+    async fn it_should_stop_when_the_receiver_is_closed() {
+        // Arrange
+        let (scripted_receiver, receives) = ScriptedReceiver::new([Err(RecvError::Closed)]);
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            CancellationToken::new(),
+            ban_service(),
+            Arc::new(Repository::new()),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(receives.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_process_connection_cookie_errors_after_lagging() {
+        // Arrange
+        let (scripted_receiver, _receives) = ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(error_event(ErrorKind::ConnectionCookie("expired".into()))),
+            Err(RecvError::Closed),
+        ]);
+        let ban_service = ban_service();
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            CancellationToken::new(),
+            ban_service.clone(),
+            Arc::new(Repository::new()),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(ban_service.read().await.get_banned_ips_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_cancellation_over_a_ready_event() {
+        // Arrange
+        let (scripted_receiver, _receives) =
+            ScriptedReceiver::new([Ok(error_event(ErrorKind::ConnectionCookie("expired".into())))]);
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+        let ban_service = ban_service();
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            cancellation_token,
+            ban_service.clone(),
+            Arc::new(Repository::new()),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(ban_service.read().await.get_banned_ips_total(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_ignore_non_connection_cookie_errors() {
+        // Arrange
+        let (scripted_receiver, _receives) = ScriptedReceiver::new([
+            Ok(error_event(ErrorKind::BadRequest("invalid request".into()))),
+            Err(RecvError::Closed),
+        ]);
+        let ban_service = ban_service();
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            CancellationToken::new(),
+            ban_service.clone(),
+            Arc::new(Repository::new()),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(ban_service.read().await.get_banned_ips_total(), 0);
     }
 }

--- a/packages/udp-server/src/container.rs
+++ b/packages/udp-server/src/container.rs
@@ -45,14 +45,14 @@ impl UdpTrackerServerServices {
         // and the banning listener also requires cookie-error facts regardless
         // of the originating listener's metrics policy. Any future demand-based
         // optimization must first prove that no required consumer is active.
-        let udp_server_stats_event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, udp_server_broadcaster.clone()));
+        let udp_server_stats_event_bus = Arc::new(EventBus::new(SenderStatus::Enabled, udp_server_broadcaster));
 
         let udp_server_stats_event_sender = udp_server_stats_event_bus.sender();
 
         Arc::new(Self {
             event_bus: udp_server_stats_event_bus.clone(),
             stats_event_sender: udp_server_stats_event_sender.clone(),
-            stats_repository: udp_server_stats_repository.clone(),
+            stats_repository: udp_server_stats_repository,
         })
     }
 }

--- a/packages/udp-server/src/event.rs
+++ b/packages/udp-server/src/event.rs
@@ -39,7 +39,7 @@ use torrust_tracker_udp_protocol::AnnounceRequest;
 use crate::error::Error;
 
 /// A UDP server event.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Event {
     UdpRequestReceived {
         context: ConnectionContext,
@@ -79,9 +79,9 @@ pub enum UdpRequestKind {
 impl From<UdpRequestKind> for LabelValue {
     fn from(kind: UdpRequestKind) -> Self {
         match kind {
-            UdpRequestKind::Connect => LabelValue::new("connect"),
-            UdpRequestKind::Announce { .. } => LabelValue::new("announce"),
-            UdpRequestKind::Scrape => LabelValue::new("scrape"),
+            UdpRequestKind::Connect => Self::new("connect"),
+            UdpRequestKind::Announce { .. } => Self::new("announce"),
+            UdpRequestKind::Scrape => Self::new("scrape"),
         }
     }
 }
@@ -89,9 +89,9 @@ impl From<UdpRequestKind> for LabelValue {
 impl fmt::Display for UdpRequestKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let proto_str = match self {
-            UdpRequestKind::Connect => "connect",
-            UdpRequestKind::Announce { .. } => "announce",
-            UdpRequestKind::Scrape => "scrape",
+            Self::Connect => "connect",
+            Self::Announce { .. } => "announce",
+            Self::Scrape => "scrape",
         };
         write!(f, "{proto_str}")
     }
@@ -110,7 +110,7 @@ pub enum UdpResponseKind {
     },
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ErrorKind {
     RequestParse(String),
     ConnectionCookie(String),
@@ -140,7 +140,7 @@ impl From<Error> for ErrorKind {
                 },
                 UdpScrapeError::TrackerCoreWhitelistError { source } => Self::Whitelist(source.to_string()),
             },
-            Error::Internal { location: _, message } => Self::InternalServer(message.clone()),
+            Error::Internal { location: _, message } => Self::InternalServer(message),
             Error::AuthRequired { location } => Self::TrackerAuthentication(location.to_string()),
         }
     }

--- a/packages/udp-server/src/handlers/announce.rs
+++ b/packages/udp-server/src/handlers/announce.rs
@@ -205,7 +205,7 @@ pub(crate) mod tests {
         }
 
         impl AnnounceRequestBuilder {
-            pub fn default() -> AnnounceRequestBuilder {
+            pub fn default() -> Self {
                 let client_ip = Ipv4Addr::new(126, 0, 0, 1);
                 let client_port = 8080;
                 let info_hash_aquatic = torrust_tracker_udp_protocol::InfoHash([0u8; 20]);
@@ -225,7 +225,7 @@ pub(crate) mod tests {
                     peers_wanted: NumberOfPeers::new(1i32),
                     port: Port::new(NonZeroU16::new(client_port).expect("a non-zero client port")),
                 };
-                AnnounceRequestBuilder {
+                Self {
                     request: default_request,
                 }
             }

--- a/packages/udp-server/src/handlers/error.rs
+++ b/packages/udp-server/src/handlers/error.rs
@@ -67,25 +67,55 @@ fn log_error(
     let server_socket_addr = server_service_binding.bind_address();
 
     if is_connection_cookie_error(error) {
-        match opt_transaction_id {
-            Some(transaction_id) => {
-                let transaction_id = transaction_id.0.to_string();
-                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, %transaction_id, "response error");
-            }
-            None => {
-                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, "response error");
-            }
-        }
+        log_connection_cookie_error(
+            error,
+            client_socket_addr,
+            server_service_binding,
+            server_socket_addr,
+            opt_transaction_id,
+            request_id,
+        );
     } else {
-        match opt_transaction_id {
-            Some(transaction_id) => {
-                let transaction_id = transaction_id.0.to_string();
-                tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, %transaction_id, "response error");
-            }
-            None => {
-                tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, "response error");
-            }
-        }
+        log_non_cookie_error(
+            error,
+            client_socket_addr,
+            server_service_binding,
+            server_socket_addr,
+            opt_transaction_id,
+            request_id,
+        );
+    }
+}
+
+fn log_connection_cookie_error(
+    error: &Error,
+    client_socket_addr: SocketAddr,
+    server_service_binding: &ServiceBinding,
+    server_socket_addr: SocketAddr,
+    opt_transaction_id: Option<TransactionId>,
+    request_id: Uuid,
+) {
+    if let Some(transaction_id) = opt_transaction_id {
+        let transaction_id = transaction_id.0.to_string();
+        tracing::warn!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, %transaction_id, "response error");
+    } else {
+        tracing::warn!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, "response error");
+    }
+}
+
+fn log_non_cookie_error(
+    error: &Error,
+    client_socket_addr: SocketAddr,
+    server_service_binding: &ServiceBinding,
+    server_socket_addr: SocketAddr,
+    opt_transaction_id: Option<TransactionId>,
+    request_id: Uuid,
+) {
+    if let Some(transaction_id) = opt_transaction_id {
+        let transaction_id = transaction_id.0.to_string();
+        tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, %transaction_id, "response error");
+    } else {
+        tracing::error!(target: UDP_TRACKER_LOG_TARGET, error = %error, %client_socket_addr, %server_socket_addr, service_binding = %server_service_binding, %request_id, "response error");
     }
 }
 
@@ -118,5 +148,91 @@ async fn trigger_udp_error_event(
                 error: error.clone().into(),
             })
             .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+
+    use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
+    use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
+    use torrust_tracker_udp_protocol::{ErrorResponse, Response, TransactionId};
+    use uuid::Uuid;
+    use zerocopy::byteorder::network_endian::I32;
+
+    use super::handle_error;
+    use crate::error::Error;
+    use crate::event::{ErrorKind, Event, UdpRequestKind};
+
+    fn service_binding() -> ServiceBinding {
+        ServiceBinding::new(Protocol::UDP, SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 6969)).unwrap()
+    }
+
+    fn internal_error() -> Error {
+        Error::Internal {
+            location: std::panic::Location::caller(),
+            message: "failure".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn it_should_publish_the_exact_error_with_the_supplied_transaction_id() {
+        // Arrange
+        let broadcaster = crate::event::sender::Broadcaster::default();
+        let mut receiver = broadcaster.subscribe();
+        let sender = Some(Arc::new(broadcaster) as Arc<dyn torrust_tracker_events::sender::Sender<Event = Event>>);
+        let transaction_id = TransactionId(I32::new(42));
+        let error = internal_error();
+
+        // Act
+        let response = handle_error(
+            Some(UdpRequestKind::Connect),
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+            service_binding(),
+            ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0),
+            None,
+            Uuid::nil(),
+            &sender,
+            0.0..1.0,
+            &error,
+            Some(transaction_id),
+        )
+        .await;
+
+        // Assert
+        assert!(matches!(response, Response::Error(ErrorResponse { transaction_id: actual, .. }) if actual == transaction_id));
+        assert!(matches!(
+            receiver.recv().await.unwrap(),
+            Event::UdpError { kind: Some(UdpRequestKind::Connect), error: ErrorKind::InternalServer(message), .. } if message == "failure"
+        ));
+    }
+
+    #[tokio::test]
+    async fn it_should_return_a_zero_transaction_id_without_an_event_sender() {
+        // Arrange
+        let sender = None;
+        let error = internal_error();
+
+        // Act
+        let response = handle_error(
+            None,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080),
+            service_binding(),
+            ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0),
+            None,
+            Uuid::nil(),
+            &sender,
+            0.0..1.0,
+            &error,
+            None,
+        )
+        .await;
+
+        // Assert
+        assert!(
+            matches!(response, Response::Error(ErrorResponse { transaction_id: TransactionId(value), .. }) if value == I32::new(0))
+        );
     }
 }

--- a/packages/udp-server/src/handlers/error.rs
+++ b/packages/udp-server/src/handlers/error.rs
@@ -89,7 +89,7 @@ fn log_error(
     }
 }
 
-fn is_connection_cookie_error(error: &Error) -> bool {
+const fn is_connection_cookie_error(error: &Error) -> bool {
     matches!(
         error,
         Error::AnnounceFailed {

--- a/packages/udp-server/src/handlers/mod.rs
+++ b/packages/udp-server/src/handlers/mod.rs
@@ -267,7 +267,7 @@ pub(crate) mod tests {
 
     use crate::event as server_event;
 
-    pub(crate) struct CoreTrackerServices {
+    pub struct CoreTrackerServices {
         pub core_config: Arc<Core>,
         pub announce_handler: Arc<AnnounceHandler>,
         pub in_memory_torrent_repository: Arc<InMemoryTorrentRepository>,
@@ -275,12 +275,12 @@ pub(crate) mod tests {
         pub whitelist_authorization: Arc<whitelist::authorization::WhitelistAuthorization>,
     }
 
-    pub(crate) struct CoreUdpTrackerServices {
+    pub struct CoreUdpTrackerServices {
         pub announce_service: Arc<AnnounceService>,
         pub scrape_service: Arc<ScrapeService>,
     }
 
-    pub(crate) struct ServerUdpTrackerServices {
+    pub struct ServerUdpTrackerServices {
         pub udp_server_stats_event_sender: crate::event::sender::Sender,
     }
 
@@ -288,22 +288,22 @@ pub(crate) mod tests {
         configuration::ephemeral()
     }
 
-    pub(crate) async fn initialize_core_tracker_services_for_default_tracker_configuration()
+    pub async fn initialize_core_tracker_services_for_default_tracker_configuration()
     -> (CoreTrackerServices, CoreUdpTrackerServices, ServerUdpTrackerServices) {
         initialize_core_tracker_services(&default_testing_tracker_configuration()).await
     }
 
-    pub(crate) async fn initialize_core_tracker_services_for_public_tracker()
+    pub async fn initialize_core_tracker_services_for_public_tracker()
     -> (CoreTrackerServices, CoreUdpTrackerServices, ServerUdpTrackerServices) {
         initialize_core_tracker_services(&configuration::ephemeral_public()).await
     }
 
-    pub(crate) async fn initialize_core_tracker_services_for_listed_tracker()
+    pub async fn initialize_core_tracker_services_for_listed_tracker()
     -> (CoreTrackerServices, CoreUdpTrackerServices, ServerUdpTrackerServices) {
         initialize_core_tracker_services(&configuration::ephemeral_listed()).await
     }
 
-    pub(crate) async fn initialize_core_tracker_services_with_config(
+    pub async fn initialize_core_tracker_services_with_config(
         config: &Configuration,
     ) -> (CoreTrackerServices, CoreUdpTrackerServices, ServerUdpTrackerServices) {
         initialize_core_tracker_services(config).await
@@ -316,7 +316,7 @@ pub(crate) mod tests {
         let core_config = Arc::new(config.core.clone());
         let database = initialize_database(&config.core).await;
         let in_memory_whitelist = Arc::new(InMemoryWhitelist::default());
-        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist.clone()));
+        let whitelist_authorization = Arc::new(WhitelistAuthorization::new(&config.core, &in_memory_whitelist));
         let in_memory_torrent_repository = Arc::new(InMemoryTorrentRepository::default());
         let db_downloads_metric_repository = Arc::new(DatabaseDownloadsMetricRepository::new(&database.torrent_metrics_store));
         let announce_handler = if config.core.tracker_policy.persistent_torrent_completed_stat {
@@ -336,13 +336,13 @@ pub(crate) mod tests {
         let scrape_handler = Arc::new(ScrapeHandler::new(&whitelist_authorization, &in_memory_torrent_repository));
 
         let udp_core_broadcaster = Broadcaster::default();
-        let core_event_bus = Arc::new(EventBus::new(SenderStatus::Disabled, udp_core_broadcaster.clone()));
+        let core_event_bus = Arc::new(EventBus::new(SenderStatus::Disabled, udp_core_broadcaster));
         let udp_core_stats_event_sender = core_event_bus.sender();
 
         let udp_server_broadcaster = crate::event::sender::Broadcaster::default();
         let server_event_bus = Arc::new(crate::event::bus::EventBus::new(
             SenderStatus::Disabled,
-            udp_server_broadcaster.clone(),
+            udp_server_broadcaster,
         ));
 
         let udp_server_stats_event_sender = server_event_bus.sender();
@@ -359,7 +359,7 @@ pub(crate) mod tests {
         ));
 
         let scrape_service = Arc::new(ScrapeService::new(
-            scrape_handler.clone(),
+            scrape_handler,
             udp_core_stats_event_sender.clone(),
             configuration_instance_id,
         ));
@@ -382,23 +382,23 @@ pub(crate) mod tests {
         )
     }
 
-    pub(crate) fn sample_ipv4_remote_addr() -> SocketAddr {
+    pub fn sample_ipv4_remote_addr() -> SocketAddr {
         sample_ipv4_socket_address()
     }
 
-    pub(crate) fn sample_ipv4_remote_addr_fingerprint() -> u64 {
+    pub fn sample_ipv4_remote_addr_fingerprint() -> u64 {
         gen_remote_fingerprint(&sample_ipv4_socket_address())
     }
 
-    pub(crate) fn sample_ipv6_remote_addr() -> SocketAddr {
+    pub fn sample_ipv6_remote_addr() -> SocketAddr {
         sample_ipv6_socket_address()
     }
 
-    pub(crate) fn sample_ipv6_remote_addr_fingerprint() -> u64 {
+    pub fn sample_ipv6_remote_addr_fingerprint() -> u64 {
         gen_remote_fingerprint(&sample_ipv6_socket_address())
     }
 
-    pub(crate) fn sample_ipv4_socket_address() -> SocketAddr {
+    pub fn sample_ipv4_socket_address() -> SocketAddr {
         SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080)
     }
 
@@ -406,29 +406,29 @@ pub(crate) mod tests {
         SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 8080)
     }
 
-    pub(crate) fn sample_issue_time() -> f64 {
+    pub fn sample_issue_time() -> f64 {
         1_000_000_000_f64
     }
 
-    pub(crate) fn sample_cookie_valid_range() -> Range<f64> {
+    pub fn sample_cookie_valid_range() -> Range<f64> {
         sample_issue_time() - 10.0..sample_issue_time() + 10.0
     }
 
-    pub(crate) fn sample_strict_cookie_validation() -> super::CookieValidationContext {
+    pub fn sample_strict_cookie_validation() -> super::CookieValidationContext {
         super::CookieValidationContext {
             valid_range: sample_cookie_valid_range(),
             connection_id_validation: torrust_tracker_udp_core::ConnectionIdValidationPolicy::Strict,
         }
     }
 
-    pub(crate) struct TrackerConfigurationBuilder {
+    pub struct TrackerConfigurationBuilder {
         configuration: Configuration,
     }
 
     impl TrackerConfigurationBuilder {
-        pub fn default() -> TrackerConfigurationBuilder {
+        pub fn default() -> Self {
             let default_configuration = default_testing_tracker_configuration();
-            TrackerConfigurationBuilder {
+            Self {
                 configuration: default_configuration,
             }
         }

--- a/packages/udp-server/src/lib.rs
+++ b/packages/udp-server/src/lib.rs
@@ -14,7 +14,7 @@
 //! The UDP tracker is more efficient than the HTTP tracker because it uses UDP
 //! instead of TCP.
 //!
-//! Refer to the [`bit_torrent`](crate::shared::bit_torrent) module for more
+//! Refer to the `bit_torrent` module for more
 //! information about the `BitTorrent` protocol.
 //!
 //! Refer to [BEP 15. UDP Tracker Protocol for `BitTorrent`](https://www.bittorrent.org/beps/bep_0015.html)
@@ -139,7 +139,7 @@
 //!
 //! **Connect request (parsed struct)**
 //!
-//! After parsing the UDP packet, the [`ConnectRequest`](torrust_tracker_udp_protocol::request::ConnectRequest)
+//! After parsing the UDP packet, the [`ConnectRequest`](torrust_tracker_udp_protocol::ConnectRequest)
 //! request struct will look like this:
 //!
 //! Field            | Type                                                           | Example
@@ -186,7 +186,7 @@
 //!
 //! **Connect response (struct)**
 //!
-//! Before building the UDP packet, the [`ConnectResponse`](torrust_tracker_udp_protocol::response::ConnectResponse)
+//! Before building the UDP packet, the [`ConnectResponse`](torrust_tracker_udp_protocol::ConnectResponse)
 //! struct will look like this:
 //!
 //! Field            | Type                                                           | Example
@@ -446,7 +446,7 @@
 //!
 //! **Announce response (struct)**
 //!
-//! The [`AnnounceResponse`](torrust_tracker_udp_protocol::response::AnnounceResponse)
+//! The [`AnnounceResponse`](torrust_tracker_udp_protocol::AnnounceResponse)
 //! struct will have the following fields:
 //!
 //! Field               | Type                                                                   | Example
@@ -475,7 +475,7 @@
 //!
 //! > **NOTICE**: up to about 74 torrents can be scraped at once. A full scrape
 //! > can't be done with this protocol. This is a limitation of the UDP protocol.
-//! > Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](torrust_tracker_udp_server::MAX_SCRAPE_TORRENTS).
+//! > Defined with a hardcoded const [`MAX_SCRAPE_TORRENTS`](torrust_tracker_core::MAX_SCRAPE_TORRENTS).
 //! > Refer to [issue 262](https://github.com/torrust/torrust-tracker/issues/262)
 //! > for more information about this limitation.
 //!

--- a/packages/udp-server/src/server/launcher.rs
+++ b/packages/udp-server/src/server/launcher.rs
@@ -56,7 +56,7 @@ impl Launcher {
             );
         }
 
-        let service_binding = bound_socket.service_binding().clone();
+        let service_binding = bound_socket.service_binding();
         let address = bound_socket.address();
         let local_udp_url = bound_socket.url().to_string();
 
@@ -89,7 +89,7 @@ impl Launcher {
             .is_err()
         {
             running.abort();
-            let _ = running.await;
+            drop(running.await);
             return Err(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
                 "UDP startup receiver was dropped",
@@ -105,7 +105,7 @@ impl Launcher {
             () = shutdown_signal_with_message(rx_halt, format!("Halting UDP Service Bound to Socket: {address}")) => {
                 tracing::debug!(target: UDP_TRACKER_LOG_TARGET, local_udp_url, "Udp::run_with_graceful_shutdown (halting)");
                 running.abort();
-                let _ = running.await;
+                drop(running.await);
             }
         }
 

--- a/packages/udp-server/src/server/processor.rs
+++ b/packages/udp-server/src/server/processor.rs
@@ -267,7 +267,9 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {
                 let stats = container.udp_tracker_server_container.stats_repository.get_stats().await;
-                if stats.udp_requests_discarded_total() >= expected {
+                let discarded_count_reached = stats.udp_requests_discarded_total() >= expected;
+                drop(stats);
+                if discarded_count_reached {
                     break;
                 }
                 tokio::time::sleep(Duration::from_millis(1)).await;

--- a/packages/udp-server/src/server/receiver.rs
+++ b/packages/udp-server/src/server/receiver.rs
@@ -17,8 +17,8 @@ pub struct Receiver {
 
 impl Receiver {
     #[must_use]
-    pub fn new(bound_socket: Arc<BoundSocket>) -> Self {
-        Receiver {
+    pub const fn new(bound_socket: Arc<BoundSocket>) -> Self {
+        Self {
             socket: bound_socket,
             data: RefCell::new([0; MAX_PACKET_SIZE]),
         }

--- a/packages/udp-server/src/server/spawner.rs
+++ b/packages/udp-server/src/server/spawner.rs
@@ -39,7 +39,7 @@ impl Spawner {
     /// It spawns a new task to run the UDP server instance.
     ///
     #[must_use]
-    pub fn spawn_launcher(&self, request: LaunchRequest) -> JoinHandle<Result<Spawner, std::io::Error>> {
+    pub fn spawn_launcher(&self, request: LaunchRequest) -> JoinHandle<Result<Self, std::io::Error>> {
         let spawner = Self::new(self.bind_to);
 
         tokio::spawn(async move {

--- a/packages/udp-server/src/server/states.rs
+++ b/packages/udp-server/src/server/states.rs
@@ -51,7 +51,7 @@ pub struct Running {
 impl Server<Stopped> {
     /// Creates a new `UdpServer` instance in `stopped`state.
     #[must_use]
-    pub fn new(spawner: Spawner) -> Self {
+    pub const fn new(spawner: Spawner) -> Self {
         Self {
             state: Stopped { spawner },
         }
@@ -119,7 +119,7 @@ impl Server<Stopped> {
             .await
         {
             let _ = tx_halt.send(Halted::Normal);
-            let _ = task.await;
+            drop(task.await);
             return Err(UdpError::Registration { source: error });
         }
 

--- a/packages/udp-server/src/statistics/event/listener.rs
+++ b/packages/udp-server/src/statistics/event/listener.rs
@@ -118,7 +118,8 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use futures::{FutureExt as _, future::BoxFuture};
+    use futures::FutureExt as _;
+    use futures::future::BoxFuture;
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
     use torrust_tracker_events::receiver::RecvError;
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};

--- a/packages/udp-server/src/statistics/event/listener.rs
+++ b/packages/udp-server/src/statistics/event/listener.rs
@@ -78,7 +78,7 @@ async fn dispatch_events(
     }
 }
 
-fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
+const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
     match event {
         crate::event::Event::UdpRequestReceived { context }
         | crate::event::Event::UdpRequestDiscarded { context }

--- a/packages/udp-server/src/statistics/event/listener.rs
+++ b/packages/udp-server/src/statistics/event/listener.rs
@@ -45,37 +45,58 @@ async fn dispatch_events(
             biased;
 
             () = cancellation_token.cancelled() => {
-                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received cancellation request, shutting down UDP tracker server event listener.");
+                log_cancellation();
                 break;
             }
 
             result = receiver.recv() => {
-                match result {
-                    Ok(event) if metrics_policy.get(&event_connection_id(&event)).copied().unwrap_or(false) => {
-                        handle_event(event, &stats_repository, CurrentClock::now()).await;
-                    }
-                    Ok(event) => {
-                        tracing::warn!(
-                            target: UDP_TRACKER_LOG_TARGET,
-                            configuration_instance_id = ?event_connection_id(&event),
-                            "Ignoring UDP server event from an unknown or metrics-disabled listener"
-                        );
-                    }
-                    Err(e) => {
-                        match e {
-                            RecvError::Closed => {
-                                tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server statistics receiver closed.");
-                                break;
-                            }
-                            RecvError::Lagged(n) => {
-                                tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server statistics receiver lagged by {} events.", n);
-                            }
-                        }
-                    }
+                if !handle_received_event(result, &stats_repository, &metrics_policy).await {
+                    break;
                 }
             }
         }
     }
+}
+
+async fn handle_received_event(
+    result: Result<crate::event::Event, RecvError>,
+    stats_repository: &Repository,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) -> bool {
+    match result {
+        Ok(event) => handle_event_if_enabled(event, stats_repository, metrics_policy).await,
+        Err(RecvError::Closed) => {
+            tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server statistics receiver closed.");
+            return false;
+        }
+        Err(RecvError::Lagged(events)) => {
+            tracing::warn!(target: UDP_TRACKER_LOG_TARGET, "Udp tracker server statistics receiver lagged by {} events.", events);
+        }
+    }
+
+    true
+}
+
+async fn handle_event_if_enabled(
+    event: crate::event::Event,
+    stats_repository: &Repository,
+    metrics_policy: &BTreeMap<ConfigurationInstanceId, bool>,
+) {
+    let configuration_instance_id = event_connection_id(&event);
+
+    if metrics_policy.get(&configuration_instance_id).copied() == Some(true) {
+        handle_event(event, stats_repository, CurrentClock::now()).await;
+    } else {
+        tracing::warn!(
+            target: UDP_TRACKER_LOG_TARGET,
+            ?configuration_instance_id,
+            "Ignoring UDP server event from an unknown or metrics-disabled listener"
+        );
+    }
+}
+
+fn log_cancellation() {
+    tracing::info!(target: UDP_TRACKER_LOG_TARGET, "Received cancellation request, shutting down UDP tracker server event listener.");
 }
 
 const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstanceId {
@@ -92,12 +113,14 @@ const fn event_connection_id(event: &crate::event::Event) -> ConfigurationInstan
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, VecDeque};
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use futures::{FutureExt as _, future::BoxFuture};
     use torrust_net_primitives::service_binding::{Protocol, ServiceBinding};
-    use torrust_tracker_events::broadcaster::Broadcaster;
-    use torrust_tracker_events::sender::Sender as _;
+    use torrust_tracker_events::receiver::RecvError;
     use torrust_tracker_primitives::{ConfigurationInstanceId, ServiceRole};
     use torrust_tracker_udp_core::event::ConnectionContext;
 
@@ -105,6 +128,33 @@ mod tests {
     use crate::event::Event;
     use crate::event::receiver::Receiver;
     use crate::statistics::repository::Repository;
+
+    struct ScriptedReceiver {
+        results: VecDeque<Result<Event, RecvError>>,
+        receives: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedReceiver {
+        fn new(results: impl IntoIterator<Item = Result<Event, RecvError>>) -> (Self, Arc<AtomicUsize>) {
+            let receives = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    results: results.into_iter().collect(),
+                    receives: receives.clone(),
+                },
+                receives,
+            )
+        }
+    }
+
+    impl torrust_tracker_events::receiver::Receiver for ScriptedReceiver {
+        type Event = Event;
+
+        fn recv(&mut self) -> BoxFuture<'_, Result<Self::Event, RecvError>> {
+            self.receives.fetch_add(1, Ordering::SeqCst);
+            futures::future::ready(self.results.pop_front().expect("scripted receive result")).boxed()
+        }
+    }
 
     fn request_received_event(configuration_instance_id: ConfigurationInstanceId) -> Event {
         Event::UdpRequestReceived {
@@ -122,18 +172,14 @@ mod tests {
         let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
         let disabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 1);
         let unknown_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 2);
-        let broadcaster = Broadcaster::default();
-        let receiver: Receiver = Box::new(broadcaster.subscribe());
+        let (scripted_receiver, _receives) = ScriptedReceiver::new([
+            Ok(request_received_event(enabled_id)),
+            Ok(request_received_event(disabled_id)),
+            Ok(request_received_event(unknown_id)),
+            Err(RecvError::Closed),
+        ]);
+        let receiver: Receiver = Box::new(scripted_receiver);
         let repository = Arc::new(Repository::new());
-
-        for configuration_instance_id in [enabled_id, disabled_id, unknown_id] {
-            let _unused = broadcaster
-                .send(request_received_event(configuration_instance_id))
-                .await
-                .unwrap()
-                .unwrap();
-        }
-        drop(broadcaster);
 
         // Act
         dispatch_events(
@@ -146,5 +192,69 @@ mod tests {
 
         // Assert
         assert_eq!(repository.get_stats().await.udp4_requests_received_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_stop_when_the_receiver_is_closed() {
+        // Arrange
+        let (scripted_receiver, receives) = ScriptedReceiver::new([Err(RecvError::Closed)]);
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            tokio_util::sync::CancellationToken::new(),
+            Arc::new(Repository::new()),
+            BTreeMap::new(),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(receives.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_process_enabled_events_after_lagging() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
+        let (scripted_receiver, _receives) = ScriptedReceiver::new([
+            Err(RecvError::Lagged(2)),
+            Ok(request_received_event(enabled_id)),
+            Err(RecvError::Closed),
+        ]);
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            tokio_util::sync::CancellationToken::new(),
+            repository.clone(),
+            [(enabled_id, true)].into(),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.udp4_requests_received_total(), 1);
+    }
+
+    #[tokio::test]
+    async fn it_should_prioritize_cancellation_over_a_ready_event() {
+        // Arrange
+        let enabled_id = ConfigurationInstanceId::new(ServiceRole::UdpTracker, 0);
+        let (scripted_receiver, _receives) = ScriptedReceiver::new([Ok(request_received_event(enabled_id))]);
+        let cancellation_token = tokio_util::sync::CancellationToken::new();
+        cancellation_token.cancel();
+        let repository = Arc::new(Repository::new());
+
+        // Act
+        dispatch_events(
+            Box::new(scripted_receiver),
+            cancellation_token,
+            repository.clone(),
+            [(enabled_id, true)].into(),
+        )
+        .await;
+
+        // Assert
+        assert_eq!(repository.get_stats().await.udp4_requests_received_total(), 0);
     }
 }

--- a/packages/udp-server/src/statistics/repository.rs
+++ b/packages/udp-server/src/statistics/repository.rs
@@ -187,6 +187,7 @@ mod tests {
                 .metric_collection
                 .contains_gauge(&metric_name!(UDP_TRACKER_SERVER_PERFORMANCE_AVG_PROCESSING_TIME_NS))
         );
+        drop(stats);
     }
 
     #[tokio::test]
@@ -349,6 +350,7 @@ mod tests {
 
         assert_eq!(udp_avg_connect_processing_time_ns, 1000);
         assert_eq!(udp_avg_announce_processing_time_ns, 2000);
+        drop(stats);
     }
 
     #[tokio::test]
@@ -662,6 +664,7 @@ mod tests {
 
             // Verify metric collection integrity
             assert_metric_collection_integrity(&stats);
+            drop(stats);
         }
 
         // Test helper functions to hide implementation details

--- a/packages/udp-server/src/statistics/services.rs
+++ b/packages/udp-server/src/statistics/services.rs
@@ -2,14 +2,14 @@
 //!
 //! It includes:
 //!
-//! - A [`factory`](crate::statistics::setup::factory) function to build the structs needed to collect the tracker metrics.
+//! - A `factory` function to build the structs needed to collect the tracker metrics.
 //! - A [`get_metrics`] service to get the tracker [`metrics`](crate::statistics::metrics::Metrics).
 //!
 //! Tracker metrics are collected using a Publisher-Subscribe pattern.
 //!
 //! The factory function builds two structs:
 //!
-//! - An statistics event [`Sender`](crate::statistics::event::sender::Sender)
+//! - An statistics event [`Sender`](crate::event::sender::Sender)
 //! - An statistics [`Repository`]
 //!
 //! ```text
@@ -21,10 +21,12 @@
 //! There is an event listener that is receiving all the events and processing them with an event handler.
 //! Then, the event handler updates the metrics depending on the received event.
 //!
-//! For example, if you send the event [`Event::Udp4Connect`](crate::statistics::event::Event::Udp4Connect):
+//! For example, when a connect request is accepted, the server sends
+//! [`Event::UdpRequestAccepted`](crate::event::Event::UdpRequestAccepted) with
+//! [`UdpRequestKind::Connect`](crate::event::UdpRequestKind::Connect):
 //!
 //! ```text
-//! let result = event_sender.send_event(Event::Udp4Connect).await;
+//! let result = event_sender.send(Event::UdpRequestAccepted { .. }).await;
 //! ```
 //!
 //! Eventually the counter for UDP connections from IPv4 peers will be increased.

--- a/packages/udp-server/src/testing/environment.rs
+++ b/packages/udp-server/src/testing/environment.rs
@@ -85,7 +85,7 @@ impl Environment<Stopped> {
     /// Sets the connection ID validation policy for this test environment.
     #[must_use]
     #[allow(dead_code)]
-    pub fn with_connection_id_validation(mut self, policy: ConnectionIdValidationPolicy) -> Self {
+    pub const fn with_connection_id_validation(mut self, policy: ConnectionIdValidationPolicy) -> Self {
         self.connection_id_validation = policy;
         self
     }
@@ -226,12 +226,12 @@ impl Environment<Running> {
     }
 
     #[must_use]
-    pub fn bind_address(&self) -> SocketAddr {
+    pub const fn bind_address(&self) -> SocketAddr {
         self.server.state.local_addr
     }
 }
 
-fn connection_id_validation_policy(policy: &UdpTrackerServer) -> ConnectionIdValidationPolicy {
+const fn connection_id_validation_policy(policy: &UdpTrackerServer) -> ConnectionIdValidationPolicy {
     match policy.connection_id_validation {
         ConfigurationConnectionIdValidationPolicy::Strict => ConnectionIdValidationPolicy::Strict,
         ConfigurationConnectionIdValidationPolicy::Disabled => ConnectionIdValidationPolicy::Disabled,

--- a/packages/udp-server/tests/common/udp.rs
+++ b/packages/udp-server/tests/common/udp.rs
@@ -10,8 +10,8 @@ pub struct Client {
 
 impl Client {
     #[allow(dead_code)]
-    pub async fn connected(remote_socket_addr: &SocketAddr, local_socket_addr: &SocketAddr) -> Client {
-        let client = Client::bind(local_socket_addr).await;
+    pub async fn connected(remote_socket_addr: &SocketAddr, local_socket_addr: &SocketAddr) -> Self {
+        let client = Self::bind(local_socket_addr).await;
         client.connect(remote_socket_addr).await;
         client
     }

--- a/packages/udp-server/tests/server/asserts.rs
+++ b/packages/udp-server/tests/server/asserts.rs
@@ -14,10 +14,10 @@ pub fn is_connect_response(response: &Response, transaction_id: TransactionId) -
     }
 }
 
-pub fn is_ipv4_announce_response(response: &Response) -> bool {
+pub const fn is_ipv4_announce_response(response: &Response) -> bool {
     matches!(response, Response::AnnounceIpv4(_))
 }
 
-pub fn is_scrape_response(response: &Response) -> bool {
+pub const fn is_scrape_response(response: &Response) -> bool {
     matches!(response, Response::Scrape(_))
 }

--- a/packages/udp-server/tests/server/contract.rs
+++ b/packages/udp-server/tests/server/contract.rs
@@ -15,7 +15,7 @@ use crate::server::asserts::get_error_response_message;
 
 const DEFAULT_UDP_TIMEOUT: Duration = Duration::from_secs(5);
 
-fn empty_udp_request() -> [u8; MAX_PACKET_SIZE] {
+const fn empty_udp_request() -> [u8; MAX_PACKET_SIZE] {
     [0; MAX_PACKET_SIZE]
 }
 

--- a/src/console/profiling.rs
+++ b/src/console/profiling.rs
@@ -164,6 +164,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::app;
+use crate::bootstrap::jobs::manager::JobManager;
 
 /// Errors that cause the profiling executable to exit unsuccessfully.
 #[derive(Debug, thiserror::Error)]
@@ -202,11 +203,16 @@ pub async fn run() -> Result<(), Error> {
         }
     };
 
-    // Run the tracker for a fixed duration
-    let run_duration = sleep(Duration::from_secs(duration_secs));
+    wait_for_shutdown(jobs, Duration::from_secs(duration_secs)).await;
 
+    println!("Torrust successfully shutdown.");
+
+    Ok(())
+}
+
+async fn wait_for_shutdown(jobs: JobManager, run_duration: Duration) {
     tokio::select! {
-        () = run_duration => {
+        () = sleep(run_duration) => {
             tracing::info!("Torrust timed shutdown..");
         },
         _ = tokio::signal::ctrl_c() => {
@@ -215,8 +221,4 @@ pub async fn run() -> Result<(), Error> {
             jobs.wait_for_all(Duration::from_secs(10)).await;
         }
     }
-
-    println!("Torrust successfully shutdown.");
-
-    Ok(())
 }


### PR DESCRIPTION
## Summary

Enables the denied `clippy::cognitive_complexity` workspace lint and makes every workspace package inherit the shared Cargo lint policy.

Refactors all fourteen discovered complexity violations across the swarm registry, tracker core, HTTP/UDP cores, UDP server, and profiling runner without threshold changes or cognitive-complexity allowances. The refactors use focused helpers and deterministic regression tests to preserve metric, persistence, policy-routing, listener-lifecycle, UDP error, and profiling shutdown behavior.

Also corrects stale intra-doc links found by the mandatory nightly documentation build, and migrates the materially expanded issue specification to folder-style layout with an implementation retrospective.

Closes #2134

## Validation

- `cargo clippy --workspace --all-targets --all-features`
- `linter all`
- `cargo test --tests --benches --examples --workspace --all-targets --all-features`
- `pre-push.sh --format=json` — nightly formatting, checks, documentation build, and complete stable suite
- Intentional enforcement trial: restoring the former `profiling::run` shape made `linter all` fail with the expected 27/25 cognitive-complexity diagnostic; the compliant implementation was restored and linting passed.