### PR TITLE
test(axum-http-server): cover private listed HTTP contracts

### DIFF
--- a/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/ISSUE.md
+++ b/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/ISSUE.md
@@ -17,6 +17,8 @@ semantic-links:
     - .github/skills/dev/planning/create-issue/SKILL.md
     - .github/skills/dev/testing/write-unit-test/SKILL.md
     - docs/testing/refactoring-patterns/README.md
+    - docs/issues/open/2140-1347-review-axum-http-server-integration-tests/coverage-evidence.md
+    - docs/issues/open/2140-1347-review-axum-http-server-integration-tests/test-design-review.md
     - packages/axum-http-server/tests/server/v1/contract/configured_as_private_and_whitelisted.rs
     - packages/axum-http-server/tests/server/v1/contract/configured_as_private.rs
     - packages/axum-http-server/tests/server/v1/contract/configured_as_whitelisted.rs
@@ -95,15 +97,15 @@ high-value cases from that backlog.
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`, `DEFERRED`.
 
-| ID  | Status | Task                                     | Expected output                                                                                                                                                                                 |
-| --- | ------ | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| T1  | TODO   | Inventory all integration contracts      | Read every package integration-test file and map its observable behavior, configuration mode, boundary, and existing scenario coverage.                                                         |
-| T2  | TODO   | Measure and analyze coverage             | Record reproducible package-source aggregate and per-file coverage, then compare uncovered areas with package/domain behavior to identify gaps coverage alone does not reveal.                  |
-| T2a | TODO   | Assess mutation-testing feasibility      | Run a bounded `cargo-mutants` sample against this package. Record configuration, duration, limitations, and behavior-relevant surviving mutants; do not add a mutation-score target or CI gate. |
-| T3  | TODO   | Review test design before expansion      | Create a file-by-file integration-test refactor plan covering readability, maintainability, expressiveness, fixture selection, and justified duplication reduction.                             |
-| T4  | TODO   | Approve prioritized improvement plan     | Review the evidence-backed plan with the maintainer; implement one approved refactoring or behavior increment at a time.                                                                        |
-| T5  | TODO   | Improve selected integration contracts   | Add only approved high-value edge cases. The combined private-and-whitelisted announce/scrape matrix is an initial candidate, not a preselected outcome.                                        |
-| T6  | TODO   | Final verification and acceptance review | Run full package tests, linters, required hooks, manual real-server scenarios, and post-implementation acceptance review.                                                                       |
+| ID  | Status      | Task                                     | Expected output                                                                                                                                                                                 |
+| --- | ----------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE        | Inventory all integration contracts      | Read every package integration-test file and map its observable behavior, configuration mode, boundary, and existing scenario coverage.                                                         |
+| T2  | DONE        | Measure and analyze coverage             | Record reproducible package-source aggregate and per-file coverage, then compare uncovered areas with package/domain behavior to identify gaps coverage alone does not reveal.                  |
+| T2a | DONE        | Assess mutation-testing feasibility      | Run a bounded `cargo-mutants` sample against this package. Record configuration, duration, limitations, and behavior-relevant surviving mutants; do not add a mutation-score target or CI gate. |
+| T3  | DONE        | Review test design before expansion      | Create a file-by-file integration-test refactor plan covering readability, maintainability, expressiveness, fixture selection, and justified duplication reduction.                             |
+| T4  | DONE        | Approve prioritized improvement plan     | Review the evidence-backed plan with the maintainer; implement one approved refactoring or behavior increment at a time.                                                                        |
+| T5  | DONE        | Improve selected integration contracts   | Add only approved high-value edge cases. The combined private-and-whitelisted announce/scrape matrix is an initial candidate, not a preselected outcome.                                        |
+| T6  | DONE        | Final verification and acceptance review | Run full package tests, linters, required hooks, manual real-server scenarios, and post-implementation acceptance review.                                                                       |
 
 ## Test Development Loop
 
@@ -129,15 +131,19 @@ Apply this loop to every test-producing task:
 - [x] Maintainer reviewed and approved draft specification.
 - [x] GitHub subissue #2140 created under #1347.
 - [x] Draft moved to `docs/issues/open/` with assigned issue number.
-- [ ] Implementation completed.
-- [ ] Automatic and manual verification completed.
-- [ ] Acceptance criteria reviewed after implementation.
+- [x] Implementation completed.
+- [x] Automatic and manual verification completed.
+- [x] Acceptance criteria reviewed after implementation.
 
 ### Progress Log
 
 - 2026-09-04 - GitHub Copilot - Performed a preliminary review of `packages/axum-http-server/tests/` after #2136. The combined private-and-whitelisted configuration has placeholder modules but no contract tests; private-only and whitelisted-only suites are existing references.
 - 2026-09-04 - User/maintainer - Expanded the draft scope: before selecting new tests, analyze every package integration test, current coverage, and relevant domain behavior; conduct a dedicated test-design review for readability, maintainability, and expressiveness; then propose the prioritized implementation plan.
 - 2026-09-04 - User/maintainer - Approved this specification. GitHub subissue #2140 was created under #1347; this specification is now the open, tracked work item.
+- 2026-09-04 - GitHub Copilot - Completed T1-T3 analysis. All 18 integration-test sources and 55 executable integration tests were inventoried. The coverage baseline is 1,526/1,602 package-source lines (95.26%) across 34 unit and 55 integration tests; see `coverage-evidence.md`. A bounded `cargo-mutants` sample caught the compact-response branch mutation. The prioritized, analysis-first proposal is recorded in `test-design-review.md`; no behavior tests have been added pending maintainer approval.
+- 2026-09-06 - GitHub Copilot - Following maintainer approval, completed T4-T5. Added six combined private-and-listed HTTP listener contracts using one file-local `PrivateListedTracker` scenario fixture, and corrected the IPv6 external-IP scenario to use an IPv6 listener and `::1` client with an availability guard. The refreshed coverage run passed 34 unit and 61 integration tests with unchanged package-source coverage (1,526/1,602, 95.26%); see `coverage-evidence.md`. The maintainer chose to retain dormant local test helpers as future examples, so cleanup remains deferred.
+- 2026-09-06 - GitHub Copilot - Completed package and manual real-server verification: the full package suite passed (34 unit tests and 61 integration tests), nightly Rustfmt passed, `linter all` passed, and `git diff --check` passed. The mandatory pre-commit hook remains to be run before committing.
+- 2026-09-06 - GitHub Copilot - The mandatory pre-commit hook passed: dictionary formatting, dependency analysis, workspace-ban checks, linters, Containerfile linting, and documentation tests all passed. No issue-local implementation retrospective is required because the implemented approach follows the approved plan without a material design deviation; the focused `PrivateListedTracker` fixture is already captured in the test-pattern analysis.
 
 ## Acceptance Criteria
 
@@ -172,24 +178,24 @@ Apply this loop to every test-producing task:
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario                                    | Command/steps                                                     | Expected result                                                                               | Status | Evidence |
-| --- | ------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------ | -------- |
-| M1  | Selected HTTP tracker integration contracts | Run focused real-server tests selected by the approved plan.      | Each selected configuration and edge case has its documented observable response/side effect. | TODO   | —        |
-| M2  | Full package integration suite              | Run the full package integration target after the last increment. | Existing and newly selected HTTP listener contracts pass together.                            | TODO   | —        |
+| ID  | Scenario                                    | Command/steps                                                     | Expected result                                                                               | Status | Evidence                                                                                          |
+| --- | ------------------------------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| M1  | Selected HTTP tracker integration contracts | Run focused real-server tests selected by the approved plan.      | Each selected configuration and edge case has its documented observable response/side effect. | DONE   | Six combined private-and-listed contracts passed; the corrected IPv6 external-IP contract passed. |
+| M2  | Full package integration suite              | Run the full package integration target after the last increment. | Existing and newly selected HTTP listener contracts pass together.                            | DONE   | `cargo test -p torrust-tracker-axum-http-server` passed 34 unit and 61 integration tests.         |
 
 ### Acceptance Verification
 
-| AC ID | Status | Evidence |
-| ----- | ------ | -------- |
-| AC1   | TODO   | —        |
-| AC2   | TODO   | —        |
-| AC3   | TODO   | —        |
-| AC4   | TODO   | —        |
-| AC5   | TODO   | —        |
-| AC6   | TODO   | —        |
-| AC7   | TODO   | —        |
-| AC8   | TODO   | —        |
-| AC9   | TODO   | —        |
+| AC ID | Status      | Evidence                                                                                           |
+| ----- | ----------- | -------------------------------------------------------------------------------------------------- |
+| AC1   | DONE        | `test-design-review.md` inventories all 18 integration-test sources.                               |
+| AC2   | DONE        | `coverage-evidence.md` records coverage and domain-behavior analysis.                              |
+| AC3   | DONE        | `coverage-evidence.md` records the bounded `cargo-mutants` assessment.                             |
+| AC4   | DONE        | `test-design-review.md` records the dedicated design review and prioritization.                    |
+| AC5   | DONE        | Six combined private-and-listed real-listener contracts assert bencoded HTTP responses.            |
+| AC6   | DONE        | `PrivateListedTracker` exposes causal state while tests retain HTTP Act and response Assert steps. |
+| AC7   | DONE        | No out-of-scope test categories were added; dormant local helpers were retained.                   |
+| AC8   | DONE        | Package tests, nightly Rustfmt, `linter all`, and the mandatory pre-commit hook passed.            |
+| AC9   | DONE        | M1 and M2 passed using real-listener integration tests.                                            |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/coverage-evidence.md
+++ b/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/coverage-evidence.md
@@ -1,0 +1,71 @@
+# Coverage Evidence
+
+## Measurement
+
+Command run on 2026-09-04:
+
+`cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json`
+
+The command ran all package unit tests and the `integration` target: 34 unit tests and 55
+integration tests passed. The figures below include package production source covered by both test
+levels. Therefore, they navigate potential gaps but do not measure integration tests in isolation
+or prove an observable HTTP contract is complete.
+
+## Package-Source Baseline
+
+| Production source                         |     Covered lines |   Coverage |
+| ----------------------------------------- | ----------------: | ---------: |
+| `src/lib.rs`                              |             5 / 5 |    100.00% |
+| `src/server.rs`                           |         321 / 365 |     87.95% |
+| `src/testing/environment.rs`              |         110 / 111 |     99.10% |
+| `src/v1/extractors/announce_request.rs`   |           60 / 60 |    100.00% |
+| `src/v1/extractors/authentication_key.rs` |           70 / 84 |     83.33% |
+| `src/v1/extractors/client_ip_sources.rs`  |           13 / 14 |     92.86% |
+| `src/v1/extractors/scrape_request.rs`     |           67 / 67 |    100.00% |
+| `src/v1/handlers/announce.rs`             |         409 / 414 |     98.79% |
+| `src/v1/handlers/health_check.rs`         |             4 / 4 |    100.00% |
+| `src/v1/handlers/scrape.rs`               |         339 / 341 |     99.41% |
+| `src/v1/routes.rs`                        |         128 / 137 |     93.43% |
+| **Aggregate**                             | **1,526 / 1,602** | **95.26%** |
+
+## Current Measurement
+
+The same command was rerun on 2026-09-06 after adding the six combined private-and-listed
+listener contracts and correcting the IPv6 loopback-client scenario. All 34 unit tests and 61
+integration tests passed. Package-source coverage remains **1,526 / 1,602 lines (95.26%)**.
+
+The unchanged percentage is expected: the additions prove configuration interaction and correct an
+existing scenario's network boundary; they do not target previously uncovered production lines.
+This confirms that the selected tests were behavior-driven rather than percentage-driven.
+
+## Interpretation and Candidate Gaps
+
+- The lowest coverage is in lifecycle/bootstrap (`server.rs`) and authentication-key extraction.
+  The former includes startup and registration failure paths deliberately covered at the unit
+  boundary; the latter already has focused extractor and invalid-key response unit coverage. No
+  additional real-listener test is selected solely to raise either percentage.
+- Announce and scrape handlers are already near-completely exercised by unit and integration
+  tests. This does not cover their interaction when **both** private authentication and whitelist
+  authorization are active: the corresponding integration-test module has no executable tests.
+- `AnnounceService::handle_announce` authenticates before authorizing; `ScrapeService::handle_scrape`
+  first hides data for unauthenticated private requests, then delegates authenticated requests to
+  whitelist-aware scrape handling. The observable combined-mode ordering and visibility contracts
+  are not evidenced at the HTTP listener boundary.
+- The enabled query-IP policy is explicitly deferred until the v3.0.0 schema is runtime-active.
+  It remains outside this issue rather than becoming a coverage-driven test addition.
+
+## Bounded Mutation-Testing Assessment
+
+`cargo-mutants 27.0.0` is installed and can run in this workspace. An initial filter aimed at the
+error-variant name produced no generated mutants; this was a filter-discovery result, not a test
+result. A subsequent bounded sample used one generated branch mutation:
+
+`cargo mutants --no-config --in-place --baseline run --package torrust-tracker-axum-http-server --file packages/axum-http-server/src/v1/handlers/announce.rs --re 'replace == with != in build_response' --test-package torrust-tracker-axum-http-server --timeout 180 --output .tmp/2140-cargo-mutants --colors never --no-times`
+
+The baseline without mutation passed and the one mutant was caught. The mutation inverts compact-response
+selection in `build_response`; existing normal and compact response assertions are sufficiently
+strong to detect it. No behavior-relevant surviving mutant was found in this one-mutant sample.
+
+The tool is practical for narrow, targeted checks, but this result is not a mutation score and is
+not evidence for a CI gate. A full package mutation run would create a separate, potentially large
+backlog and is deferred unless separately approved.

--- a/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/test-design-review.md
+++ b/docs/issues/open/2140-1347-review-axum-http-server-integration-tests/test-design-review.md
@@ -1,0 +1,78 @@
+# Integration-Test Design Review
+
+## Review Boundary
+
+All 18 Rust files under `packages/axum-http-server/tests/` were reviewed. The test target contains
+55 executable real-listener tests: 54 HTTP/lifecycle contracts and one lifecycle smoke test. The
+remaining files are module wiring or test support. The package boundary is appropriate: tests
+exercise an actual listener, Axum routing/extractors, HTTP client requests, bencoded responses,
+and selected persisted state and statistics.
+
+## Phase 1: Problems Identified
+
+| Area                                  | Evidence                                                                                                                            | Effect                                                                                                                                         | Decision                                                                                                                                                                                                                           |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Combined private-and-whitelisted mode | `configured_as_private_and_whitelisted.rs` contains two TODO-only modules.                                                          | The interaction and precedence of authentication, whitelist authorization, and scrape data hiding are not proven at the package HTTP boundary. | Resolved with six real-listener contracts using one file-local `PrivateListedTracker` scenario fixture.                                                                                                                            |
+| Misleading IPv6 scenario              | `a_loopback_ipv6_client_uses_the_external_ip_when_ip_is_absent` configures an IPv6 external IP but binds its client to `127.0.0.1`. | The name inaccurately claims IPv6 client coverage.                                                                                             | Resolved: the tracker and client now use IPv6, with an IPv6 loopback availability guard.                                                                                                                                           |
+| Repeated test bootstrap               | Most tests repeat logging setup, config extraction, `Arc` wrapping, environment creation, and teardown.                             | Boilerplate is substantial.                                                                                                                    | Do not introduce a generic factory: local configuration choice is the causal state and must remain visible. Consider only narrowly scoped scenario fixtures when combined-mode tests make multiple setup steps obscure that state. |
+| Support and legacy clutter            | `common/http.rs` has no call sites; `server/requests/mod.rs` and `server/responses/mod.rs` are migration notices only.              | Test tree contains unused or non-contract support.                                                                                             | Remove only as a separately reviewed cleanup after confirming no intended near-term use.                                                                                                                                           |
+| Minor stale annotations               | `should_fail_when_the_request_is_empty` has `#[allow(dead_code)]`; `assert_empty_announce_response` is unused.                      | Unnecessary suppression/unused helper masks test-code maintenance signals.                                                                     | Remove in a small cleanup increment if compilation remains clean.                                                                                                                                                                  |
+| Naming and assertion scope            | `for_all_config_modes` is a shared-contract grouping, not a literal matrix; whitelist tests additionally assert log content.        | Names can mislead; log text is more brittle than the HTTP/bencoded contract.                                                                   | Do not rename the tree or weaken existing observability assertions in this issue without a distinct approved rationale. Do not add new log-text contracts.                                                                         |
+
+## File-by-File Inventory
+
+| Source                                     | Current contracts or role                                                                                                                   |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `integration.rs`                           | Test crate wiring and stopped-clock alias; no contract.                                                                                     |
+| `common/mod.rs`                            | Module wiring.                                                                                                                              |
+| `common/fixtures.rs`                       | Shared malformed info hashes and random unlisted hash fixture.                                                                              |
+| `common/http.rs`                           | Unused query helper; no call sites.                                                                                                         |
+| `server/mod.rs`                            | Module wiring.                                                                                                                              |
+| `server/asserts.rs`                        | Shared HTTP-200 and bencoded announce/scrape/error response assertions.                                                                     |
+| `server/requests/mod.rs`                   | Legacy migration notice only.                                                                                                               |
+| `server/responses/mod.rs`                  | Legacy migration notice only.                                                                                                               |
+| `server/v1/mod.rs`                         | Module wiring.                                                                                                                              |
+| `server/v1/contract/mod.rs`                | Environment start/stop smoke test.                                                                                                          |
+| `for_all_config_modes/mod.rs`              | Health endpoint returns HTTP 200, JSON media type, and `Report::Ok`.                                                                        |
+| `receiving_an_announce_request.rs`         | Public/default announce parsing, protocol errors, response encodings, peer selection/state, stats, external IP, and reverse-proxy behavior. |
+| `receiving_an_scrape_request.rs`           | Public scrape parsing, response counts, multiple hashes, and stats.                                                                         |
+| `and_running_on_reverse_proxy.rs`          | Missing/invalid X-Forwarded-For announce errors.                                                                                            |
+| `configured_as_private.rs`                 | Private announce authentication and private scrape visibility.                                                                              |
+| `configured_as_whitelisted.rs`             | Listed announce authorization and listed scrape visibility.                                                                                 |
+| `configured_as_private_and_whitelisted.rs` | Six private-and-listed announce/scrape interaction contracts, using one focused scenario fixture.                                           |
+| `using_ipv6_v6only.rs`                     | IPv6-only listener health reachability.                                                                                                     |
+
+## Phase 2: Proposed Refactorings and Test Increments
+
+Ordered from high-impact/low-effort to lower-impact/higher-effort. Each item remains a proposal
+until maintainer approval, and only one approved item will be implemented at a time.
+
+1. **Completed: add a six-scenario combined-mode contract matrix** in
+   `configured_as_private_and_whitelisted.rs`. For announce: unauthenticated/unlisted returns the
+   authentication failure (authentication precedes authorization); authenticated/unlisted returns
+   the whitelist failure; authenticated/listed succeeds. For scrape with existing peer data:
+   unauthenticated/listed returns zeroed data; authenticated/unlisted returns zeroed data;
+   authenticated/listed returns real data. Use a small scenario fixture only if it names the causal
+   state—authentication plus whitelist membership—without hiding the HTTP Act or bencoded Assert.
+2. **Completed: correct the IPv6 external-IP test** to bind an IPv6 loopback client and explicitly skip when
+   IPv6 cannot be bound, matching the suite's portability approach. This is a correctness and
+   naming repair, not a coverage increase.
+3. **Deferred: remove dead test support and stale suppression.** The dormant `common/http.rs`
+   helper remains by maintainer decision because it can document a future local query-construction
+   pattern. Retain the legacy migration notes and make no cleanup change in this issue.
+4. **Consider a narrow local fixture for repeated combined-mode setup only** if item 1 proves its
+   repeated persistence/key/whitelist setup obscures causal state. Do not create a cross-file
+   factory and do not migrate the existing suite preemptively.
+5. **Defer broad directory renaming and logging-contract changes.** The benefit is low relative to
+   churn and can be reconsidered in a dedicated test-organization or observability issue.
+
+## Test-Method Assessment
+
+| Test level            | Assessment                                                                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit tests            | Strong handler, extractor, route, and lifecycle seams already exist. Keep protocol-to-domain mapping and framework rejection details there.                               |
+| Package integration   | Correct real-listener boundary is well represented; combined private-and-whitelisted behavior is the meaningful missing configuration interaction.                        |
+| Examples              | No public example API needs this package-specific contract. No example is proposed.                                                                                       |
+| E2E                   | Root composition/container E2E is outside this package boundary; no evidence requires it.                                                                                 |
+| Mutation testing      | Narrow sample is practical and caught the tested compact-response mutation. No target or CI gate is proposed.                                                             |
+| Property/fuzz testing | Parser input variation is chiefly owned by `http-protocol` and extractors, which already carry focused tests. No package-listener property/fuzz case has been identified. |

--- a/packages/axum-http-server/tests/server/v1/contract/configured_as_private_and_whitelisted.rs
+++ b/packages/axum-http-server/tests/server/v1/contract/configured_as_private_and_whitelisted.rs
@@ -1,9 +1,217 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use torrust_info_hash::InfoHash;
+use torrust_tracker_axum_http_server::testing::environment::Started;
+use torrust_tracker_client::http::client::{Client, Key as TrackerClientKey};
+use torrust_tracker_primitives::PeerId;
+use torrust_tracker_primitives::peer::fixture::PeerBuilder;
+use torrust_tracker_test_helpers::{configuration, logging};
+
+const CLIENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+struct PrivateListedTracker {
+    environment: Started,
+}
+
+impl PrivateListedTracker {
+    async fn start() -> Self {
+        logging::setup();
+
+        let cfg = configuration::ephemeral_private_and_listed();
+        let core_config = Arc::new(cfg.core.clone());
+        let http_tracker_config =
+            Arc::new(cfg.http_trackers.expect("private listed tracker requires an HTTP tracker")[0].clone());
+
+        Self {
+            environment: Started::new(&core_config, &http_tracker_config).await,
+        }
+    }
+
+    fn unauthenticated_client(&self) -> Client {
+        Client::new(self.environment.base_url(), CLIENT_TIMEOUT).expect("should create an unauthenticated tracker client")
+    }
+
+    async fn authenticated_client(&self) -> Client {
+        let authentication_key = self
+            .environment
+            .container
+            .tracker_core_container
+            .persistence
+            .as_ref()
+            .expect("private listed tracker requires persistence")
+            .keys_handler
+            .generate_expiring_peer_key(Some(Duration::from_secs(60)))
+            .await
+            .expect("should generate an authentication key");
+
+        Client::authenticated(
+            self.environment.base_url(),
+            CLIENT_TIMEOUT,
+            TrackerClientKey::new(authentication_key.key().value()),
+        )
+        .expect("should create an authenticated tracker client")
+    }
+
+    async fn list_torrent(&self, info_hash: &InfoHash) {
+        self.environment
+            .container
+            .tracker_core_container
+            .persistence
+            .as_ref()
+            .expect("private listed tracker requires persistence")
+            .whitelist_manager
+            .add_torrent_to_whitelist(info_hash)
+            .await
+            .expect("should add the torrent to the whitelist");
+    }
+
+    async fn add_incomplete_peer(&self, info_hash: &InfoHash) {
+        self.environment
+            .add_torrent_peer(
+                info_hash,
+                &PeerBuilder::default()
+                    .with_peer_id(&PeerId(*b"-qB00000000000000001"))
+                    .with_bytes_left_to_download(1)
+                    .build(),
+            )
+            .await;
+    }
+
+    async fn stop(self) {
+        self.environment.stop().await;
+    }
+}
+
 mod and_receiving_an_announce_request {
-    // TODO: add tests for announce requests when the tracker is configured as both private and whitelisted.
-    //       See `configured_as_private` and `configured_as_whitelisted` modules for the individual test patterns.
+    use torrust_tracker_http_protocol::v1::requests::announce::AnnounceBuilder;
+
+    use super::PrivateListedTracker;
+    use crate::common::fixtures::random_info_hash;
+    use crate::server::asserts::{
+        assert_authentication_error_response, assert_is_announce_response, assert_torrent_not_in_whitelist_error_response,
+    };
+
+    #[tokio::test]
+    async fn it_should_return_an_authentication_error_for_an_unauthenticated_peer_announcing_an_unlisted_torrent() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let unlisted_torrent = random_info_hash();
+        let client = tracker.unauthenticated_client();
+        let announce = AnnounceBuilder::default().with_info_hash(&unlisted_torrent).query();
+
+        // Act
+        let response = client.announce(&announce).await.unwrap();
+
+        // Assert
+        assert_authentication_error_response(response).await;
+        tracker.stop().await;
+    }
+
+    #[tokio::test]
+    async fn it_should_return_a_whitelist_error_for_an_authenticated_peer_announcing_an_unlisted_torrent() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let unlisted_torrent = random_info_hash();
+        let client = tracker.authenticated_client().await;
+        let announce = AnnounceBuilder::default().with_info_hash(&unlisted_torrent).query();
+
+        // Act
+        let response = client.announce(&announce).await.unwrap();
+
+        // Assert
+        assert_torrent_not_in_whitelist_error_response(response).await;
+        tracker.stop().await;
+    }
+
+    #[tokio::test]
+    async fn it_should_respond_to_an_authenticated_peer_announcing_a_listed_torrent() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let listed_torrent = random_info_hash();
+        tracker.list_torrent(&listed_torrent).await;
+        let client = tracker.authenticated_client().await;
+        let announce = AnnounceBuilder::default().with_info_hash(&listed_torrent).query();
+
+        // Act
+        let response = client.announce(&announce).await.unwrap();
+
+        // Assert
+        assert_is_announce_response(response).await;
+        tracker.stop().await;
+    }
 }
 
 mod receiving_an_scrape_request {
-    // TODO: add tests for scrape requests when the tracker is configured as both private and whitelisted.
-    //       See `configured_as_private` and `configured_as_whitelisted` modules for the individual test patterns.
+    use torrust_tracker_http_protocol::v1::requests::scrape_builder::QueryBuilder;
+    use torrust_tracker_http_protocol::v1::responses::scrape::deserialization::{File, ResponseBuilder};
+
+    use super::PrivateListedTracker;
+    use crate::common::fixtures::random_info_hash;
+    use crate::server::asserts::assert_scrape_response;
+
+    #[tokio::test]
+    async fn it_should_hide_listed_torrent_stats_from_an_unauthenticated_peer() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let listed_torrent = random_info_hash();
+        tracker.add_incomplete_peer(&listed_torrent).await;
+        tracker.list_torrent(&listed_torrent).await;
+        let client = tracker.unauthenticated_client();
+        let scrape = QueryBuilder::default().with_one_info_hash(&listed_torrent).query();
+
+        // Act
+        let response = client.scrape(&scrape).await.unwrap();
+
+        // Assert
+        let expected_response = ResponseBuilder::default().add_file(listed_torrent, File::zeroed()).build();
+        assert_scrape_response(response, &expected_response).await;
+        tracker.stop().await;
+    }
+
+    #[tokio::test]
+    async fn it_should_hide_unlisted_torrent_stats_from_an_authenticated_peer() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let unlisted_torrent = random_info_hash();
+        tracker.add_incomplete_peer(&unlisted_torrent).await;
+        let client = tracker.authenticated_client().await;
+        let scrape = QueryBuilder::default().with_one_info_hash(&unlisted_torrent).query();
+
+        // Act
+        let response = client.scrape(&scrape).await.unwrap();
+
+        // Assert
+        let expected_response = ResponseBuilder::default().add_file(unlisted_torrent, File::zeroed()).build();
+        assert_scrape_response(response, &expected_response).await;
+        tracker.stop().await;
+    }
+
+    #[tokio::test]
+    async fn it_should_return_listed_torrent_stats_to_an_authenticated_peer() {
+        // Arrange
+        let tracker = PrivateListedTracker::start().await;
+        let listed_torrent = random_info_hash();
+        tracker.add_incomplete_peer(&listed_torrent).await;
+        tracker.list_torrent(&listed_torrent).await;
+        let client = tracker.authenticated_client().await;
+        let scrape = QueryBuilder::default().with_one_info_hash(&listed_torrent).query();
+
+        // Act
+        let response = client.scrape(&scrape).await.unwrap();
+
+        // Assert
+        let expected_response = ResponseBuilder::default()
+            .add_file(
+                listed_torrent,
+                File {
+                    complete: 0,
+                    downloaded: 0,
+                    incomplete: 1,
+                },
+            )
+            .build();
+        assert_scrape_response(response, &expected_response).await;
+        tracker.stop().await;
+    }
 }

--- a/packages/axum-http-server/tests/server/v1/contract/for_all_config_modes/receiving_an_announce_request.rs
+++ b/packages/axum-http-server/tests/server/v1/contract/for_all_config_modes/receiving_an_announce_request.rs
@@ -1041,19 +1041,31 @@ mod when_the_ip_parameter_is_not_accepted {
     async fn a_loopback_ipv6_client_uses_the_external_ip_when_ip_is_absent() {
         logging::setup();
 
+        if TcpListener::bind(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0))
+            .await
+            .is_err()
+        {
+            return; // the environment does not support IPv6 loopback connections
+        }
+
         /* We assume that both the client and tracker share the same public IP.
 
            client     <-> tracker                                                  <-> Internet
            ::1            external_ip = "2345:0425:2CA1:0000:0000:0567:5673:23b5"
         */
 
-        let cfg = configuration::ephemeral_with_external_ip(IpAddr::from_str("2345:0425:2CA1:0000:0000:0567:5673:23b5").unwrap());
+        let mut cfg =
+            configuration::ephemeral_with_external_ip(IpAddr::from_str("2345:0425:2CA1:0000:0000:0567:5673:23b5").unwrap());
+        cfg.http_trackers
+            .as_mut()
+            .expect("test configuration should contain an HTTP tracker")[0]
+            .bind_address = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
         let core_config = Arc::new(cfg.core.clone());
         let http_tracker_config = Arc::new(cfg.http_trackers.unwrap()[0].clone());
         let env = Started::new(&core_config, &http_tracker_config).await;
 
         let info_hash = InfoHash::from_str("9c38422213e30bff212b30c360d26f9a02136422").unwrap(); // DevSkim: ignore DS173237
-        let loopback_ip = IpAddr::from_str("127.0.0.1").unwrap();
+        let loopback_ip = IpAddr::V6(Ipv6Addr::LOCALHOST);
         let client_ip = loopback_ip;
 
         let announce_query = AnnounceBuilder::default().with_info_hash(&info_hash).query();


### PR DESCRIPTION
## Summary

Adds real-listener integration coverage for the private-and-listed HTTP tracker configuration and corrects the IPv6 external-IP scenario so it uses an IPv6 listener and loopback client.

- Add six announce and scrape contracts for authentication, whitelist authorization, and scrape-stat visibility.
- Use one file-local `PrivateListedTracker` scenario fixture so each test exposes only its causal state.
- Record the integration-suite inventory, coverage evidence, mutation-testing assessment, test-design review, and verification results.

## Verification

- `cargo test -p torrust-tracker-axum-http-server`
- `cargo llvm-cov -p torrust-tracker-axum-http-server --all-features --json`
- `cargo +nightly fmt --all -- --check`
- `linter all`
- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh`

Closes #2140