### PR TITLE
docs(issues): add UDP server testing specification (#2149)

### DIFF
--- a/.github/skills/dev/planning/create-issue/SKILL.md
+++ b/.github/skills/dev/planning/create-issue/SKILL.md
@@ -107,6 +107,11 @@ explicitly during implementation:
 
 - YAML frontmatter metadata (including `status`, `epic`, `github-issue`, `spec-path`, and `last-updated-utc`)
 - `Implementation Plan` (or `Subissues` for epics) with explicit status values
+- For Task, Bug, and Feature specifications, `Commit Points` that map each code-, test-,
+  configuration-, or documentation-changing implementation task to a small, coherent,
+  independently reviewable commit opportunity. EPICs track delivery through `Subissues`; their
+  implementation commit points belong in the linked subissue specifications. Record justified
+  no-change decisions in task evidence without creating an empty commit.
 - `Architectural Decisions`, linking relevant ADRs and listing any ADRs expected from the work
 - `Progress Tracking` (`Workflow Checkpoints` and first `Progress Log` entry)
 - `Acceptance Criteria` and `Acceptance Verification`

--- a/docs/copilot-pr-reviews/pr-2152-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2152-copilot-suggestions.md
@@ -1,0 +1,51 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2152 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2152
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-07 10:33 UTC: Started processing two Copilot suggestions.
+
+## Suggestions
+
+| # | Thread ID | Path | URL | Suggestion Summary | Decision | Reply URL | Status | Thread State |
+| - | --------- | ---- | --- | ------------------ | -------- | --------- | ------ | ------------ |
+| 1 | `PRRT_kwDOGp2yqc6f4Fpo` | `.github/skills/dev/planning/create-issue/SKILL.md` | https://github.com/torrust/torrust-tracker/pull/2152#discussion_r3948837445 | Clarify how `Commit Points` apply to EPIC specifications. | action | Pending | OPEN | OPEN |
+| 2 | `PRRT_kwDOGp2yqc6f4FqS` | `docs/issues/open/1347-overhaul-packages-testing/EPIC.md` | https://github.com/torrust/torrust-tracker/pull/2152#discussion_r3948837510 | Use a UTC timestamp for the new EPIC progress-log entry. | action | Pending | OPEN | OPEN |
+
+## Notes
+
+- This is a spec-only PR; the review fixes are limited to the existing planning skill and EPIC specification.
+- Every suggestion is replied to before it is resolved.

--- a/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+++ b/docs/issues/open/1347-overhaul-packages-testing/EPIC.md
@@ -4,7 +4,7 @@ status: open
 github-issue: 1347
 spec-path: docs/issues/open/1347-overhaul-packages-testing/EPIC.md
 epic-owner: josecelano
-last-updated-utc: 2026-09-01 17:48
+last-updated-utc: 2026-09-07 10:33
 semantic-links:
   skill-links:
     - create-issue
@@ -67,7 +67,8 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | 2     | #1349 - Add tests to the http-core package        | Not yet created                                                                 | TODO   | Existing subissue; package-level test work.                                                                          |
 | 3     | #2136 - Add tests to the axum-http-server package | `docs/issues/open/2136-1347-add-tests-axum-http-server/ISSUE.md`                | DONE   | Added fast package-local response, request-ID, and lifecycle tests; verification and final review evidence recorded. |
 | 4     | #2140 - Review axum-http-server integration tests | `docs/issues/open/2140-1347-review-axum-http-server-integration-tests/ISSUE.md` | TODO   | Inventory, coverage/domain analysis, and test-design review precede approved test additions.                         |
-| 5     | Additional package-testing subissues              | Create a folder-style spec when a concrete package need is identified           | TODO   | Permitted but not required upfront; retain scope in this EPIC.                                                       |
+| 5     | #2149 - Add focused UDP server package tests      | `docs/issues/open/2149-1347-add-focused-udp-server-package-tests/ISSUE.md`      | TODO   | Baseline recorded; spec-only PR precedes focused transport, dispatch, socket, and overload test/refactor increments. |
+| 6     | Additional package-testing subissues              | Create a folder-style spec when a concrete package need is identified           | TODO   | Permitted but not required upfront; retain scope in this EPIC.                                                       |
 
 ## Package Coverage Tracking
 
@@ -77,9 +78,10 @@ its latest measurement after implementation. Link each row to the subissue's iss
 and prioritized gaps. These aggregate values show progress across the EPIC; they do not determine
 whether a subissue has adequately covered critical behavior.
 
-| Package                            | Subissue                                               | Baseline                                          | Latest                                            | Change                                                  | Evidence                                                                       |
-| ---------------------------------- | ------------------------------------------------------ | ------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| `torrust-tracker-axum-http-server` | [#2136](2136-1347-add-tests-axum-http-server/ISSUE.md) | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.07%; regions: 92.99%; functions: 90.86% | Lines: +1.25 pp; regions: +1.33 pp; functions: +1.32 pp | [Coverage evidence](2136-1347-add-tests-axum-http-server/coverage-evidence.md) |
+| Package                            | Subissue                                                         | Baseline                                          | Latest                                            | Change                                                  | Evidence                                                                                 |
+| ---------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `torrust-tracker-axum-http-server` | [#2136](2136-1347-add-tests-axum-http-server/ISSUE.md)           | Lines: 93.82%; regions: 91.66%; functions: 89.54% | Lines: 95.07%; regions: 92.99%; functions: 90.86% | Lines: +1.25 pp; regions: +1.33 pp; functions: +1.32 pp | [Coverage evidence](2136-1347-add-tests-axum-http-server/coverage-evidence.md)           |
+| `torrust-tracker-udp-server`       | [#2149](2149-1347-add-focused-udp-server-package-tests/ISSUE.md) | Lines: 96.96%; regions: 95.79%; functions: 97.19% | Not yet measured                                  | Not yet measured                                        | [Coverage evidence](2149-1347-add-focused-udp-server-package-tests/coverage-evidence.md) |
 
 ## Delivery Strategy
 
@@ -148,6 +150,10 @@ For each subissue implementation, the completion policy is:
 - 2026-09-01 18:00 UTC - User/maintainer - Approved the EPIC direction and clarified that each package should build a local safety net: establish and increase the coverage baseline, prioritize fast tests close to the code, and use unit, integration, or end-to-end tests whenever they provide valuable regression protection. - https://github.com/torrust/torrust-tracker/issues/1347
 - 2026-09-01 - GitHub Copilot - Completed Axum HTTP server package-local response-adapter, request-ID middleware, and registration-cleanup tests. The work was initially recorded under the wrong historical #1348 identity.
 - 2026-09-03 - User/maintainer - Corrected the package-to-subissue mapping after package renames: #1348 remains `udp-core`, #1349 remains `http-core`, and #2136 is the Axum HTTP server subissue. The completed Axum HTTP evidence moved to #2136. - https://github.com/torrust/torrust-tracker/issues/2136
+- 2026-09-07 10:33 UTC - User/maintainer - Approved and created #2149 for focused `udp-server` package
+  testing. Its spec-only PR records the 96.96% line, 95.79% region, and 97.19% function baseline,
+  then requires per-file test-refactor plans and small, reviewed commit points before implementation.
+  - https://github.com/torrust/torrust-tracker/issues/2149
 
 ## Acceptance Criteria
 
@@ -185,7 +191,7 @@ For each subissue implementation, the completion policy is:
 ## References
 
 - GitHub EPIC: https://github.com/torrust/torrust-tracker/issues/1347
-- Related issues: #1348, #1349, #2136
+- Related issues: #1348, #1349, #2136, #2149
 - Package inventory: `docs/packages.md`
 - Reference package: `packages/tracker-core/`
 - Coverage tooling: `cargo llvm-cov`

--- a/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/ISSUE.md
+++ b/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/ISSUE.md
@@ -1,0 +1,332 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+epic: 1347
+github-issue: 2149
+spec-path: docs/issues/open/2149-1347-add-focused-udp-server-package-tests/ISSUE.md
+branch: "2149-add-focused-udp-server-package-tests-spec"
+related-pr: 2152
+last-updated-utc: 2026-09-07 09:42
+semantic-links:
+  skill-links:
+    - create-issue
+    - write-unit-test
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - .github/skills/dev/testing/write-unit-test/SKILL.md
+    - docs/testing/refactoring-patterns/README.md
+    - docs/issues/open/1347-overhaul-packages-testing/EPIC.md
+    - docs/issues/open/1488-overhaul-tracker-shutdown/ISSUE.md
+    - docs/issues/drafts/1488-si-14-migrate-udp-receive-reset-token-lifecycle/ISSUE.md
+    - docs/issues/drafts/1488-si-15-define-udp-active-request-policy/ISSUE.md
+    - docs/issues/drafts/1488-si-17-migrate-standalone-udp-environment/ISSUE.md
+    - packages/udp-server/src/server/request_buffer.rs
+    - packages/udp-server/src/server/launcher.rs
+    - packages/udp-server/tests/server/contract.rs
+    - docs/issues/open/2149-1347-add-focused-udp-server-package-tests/coverage-evidence.md
+    - docs/issues/open/2149-1347-add-focused-udp-server-package-tests/test-refactor-plans/README.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #2149 - Add Focused UDP Server Package Tests
+
+Parent EPIC: #1347 - Overhaul: Packages Testing
+
+## Goal
+
+Improve the maintainable package-local test safety net for
+`torrust-tracker-udp-server`, concentrating on its UDP transport adaptation, packet-dispatch,
+socket, and normal-operation overload contracts. Record evidence-based coverage decisions without
+duplicating `udp-core`, `udp-protocol`, root composition, or pending shutdown work.
+
+## Background
+
+The UDP server is the BEP 15 delivery layer: it binds and receives UDP datagrams, applies
+admission decisions, dispatches parsed packets to UDP-core-backed handlers, and publishes its
+server facts for statistics and banning. It already has broad handler and metrics unit coverage,
+plus eleven real-loopback UDP integration contracts. Important package-owned seams remain
+untested, notably request-buffer capacity/cleanup, socket metadata, packet-error conversion, and
+event/error classifications.
+
+The active shutdown EPIC and its planned UDP subissues own cancellation, child-task joining,
+active-request shutdown policy, and standalone environment/example lifecycle semantics. This task
+must protect current normal-operation behavior without preempting that design.
+
+## Scope
+
+### In Scope
+
+- Establish package-source coverage baseline and final evidence using a reproducible
+  `cargo llvm-cov` command, aggregate comparison, per-file results, and prioritized uncovered
+  behavior.
+- Inventory current unit, real-loopback package integration, example, root integration, and
+  relevant historical coverage before selecting new tests.
+- Add focused, deterministic tests for package-owned transport and dispatch seams where they
+  protect observable behavior: socket binding metadata, packet/error conversion, event/error
+  classification, container composition, and normal-operation request-buffer capacity/cleanup.
+- Assess launcher admission behavior only where it can be tested without timing dependence,
+  production refactoring, or a competing lifecycle design.
+- Review every test-bearing file selected by the evidence inventory. Create one file-local
+  refactor plan for each concrete opportunity, then improve test readability, maintainability,
+  expressiveness, or behavior coverage without reducing valuable existing protection.
+- Review `tests/server/contract.rs` and add only approved real-socket contracts that cover a
+  stable package transport behavior not already protected at a better boundary.
+- Perform a bounded mutation-testing assessment after the evidence and incremental test plan are
+  approved; retain only behavior-relevant survivors as a follow-up queue.
+
+### Out of Scope
+
+- Redesigning UDP receive-loop cancellation, shutdown, active-request draining/deadlines, task
+  joining, or the standalone environment/example lifecycle; these are owned by the #1488
+  shutdown work and its SI-14, SI-15, and SI-17 drafts.
+- Root application-composition tests for multi-listener metrics, shared banning, configuration
+  ordering, or REST-observable aggregation; existing root integration tests remain their proper
+  boundary.
+- Raw-socket or privileged source-port-zero transport tests. Portable direct processor coverage is
+  already the deepest feasible automated boundary.
+- Duplicating UDP protocol parser/serializer fuzzing or property tests that belong to
+  `udp-protocol`, or tracker business-rule tests owned by `udp-core` and `tracker-core`.
+- Arbitrary coverage targets, broad test-factory refactors, new sleep-based tests, container E2E,
+  or example signal tests without separate evidence and approval.
+
+## Architectural Decisions
+
+- Related ADRs: `docs/adrs/20260527175600_keep_protocol_and_domain_types_decoupled.md`
+- Related shutdown governance: `docs/issues/open/1488-overhaul-tracker-shutdown/ISSUE.md`
+- ADRs to create: None expected. Create one if this work identifies a durable package or
+  cross-package ownership/design decision.
+
+## Design and Ownership Review
+
+Non-lifecycle unit seams may be implemented without changing ownership. Before adding, changing,
+or claiming coverage for asynchronous lifecycle fixtures, launcher shutdown, or the example,
+review and record the following, then obtain maintainer approval:
+
+| Resource                                    | Current owner                                        | Required invariant for any proposed test work                                                                       |
+| ------------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| UDP receive-loop task                       | `Launcher::run_with_graceful_shutdown`               | The owner retains the task outcome; normal, failure, cancellation, and drop paths have explicit cleanup.            |
+| Request processor tasks                     | `Launcher::run_udp_server_main` and `ActiveRequests` | Normal capacity eviction remains distinct from the shutdown drain/deadline policy owned by SI-15.                   |
+| UDP-core, statistics, and banning listeners | `testing::environment::Environment`                  | Each listener's cancellation and joined/aborted completion is explicit before fixture resources are released.       |
+| Readiness and shutdown waits                | Package test fixture / proposed seam                 | One absolute deadline bounds every awaited readiness, retry, response-decoding, child-exit, and teardown operation. |
+
+The first passing vertical slice must be reviewed for responsibility coherence before another
+lifecycle-related test increment. Do not introduce a generic fixture or new lifecycle abstraction
+without evidence of a shared capability.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`, `DEFERRED`.
+
+| ID  | Status | Task                                        | Notes / Expected Output                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ------ | ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Record baseline and test-boundary inventory | [coverage-evidence.md](coverage-evidence.md) records the exact command, package-source scope, aggregate baseline, per-file detail, priority gaps, and external-coverage/deferral decisions.                                                                                                                                                                                |
+| T2  | TODO   | Review and approve test design              | Inventory test-bearing files and create one file-local plan per concrete opportunity in [test-refactor-plans/](test-refactor-plans/README.md). Each plan identifies strengths, problems, ordered improvements, scope guardrails, and focused validation. Assess unit, package integration, example, root/E2E, mutation, property, and fuzz techniques before adding tests. |
+| T3  | TODO   | Improve request-buffer tests                | Implement the approved `server/request_buffer.rs` plan increment for current normal-operation capacity, finished-task removal, eviction, or drop cleanup. Explicitly exclude shutdown drain/deadline policy. **Commit point:** one reviewed request-buffer plan increment plus its focused validation.                                                                     |
+| T4  | TODO   | Improve dispatch and classification tests   | Implement the approved plan increment(s) for `event.rs`, `error.rs`, or `handlers/mod.rs`. Keep event/error classification and packet-dispatch behavior separate from handler business rules. **Commit point:** one reviewed, coherent classification or dispatch increment plus focused validation.                                                                       |
+| T5  | TODO   | Improve socket-adapter tests                | Implement the approved `server/bound_socket.rs` or `server/receiver.rs` plan increment for stable socket metadata, port-zero allocation, or receive adaptation. Do not assert platform-specific dual-stack defaults. **Commit point:** one reviewed socket-adapter increment plus focused validation.                                                                      |
+| T6  | TODO   | Improve container-composition tests         | Implement a `container.rs` test-plan increment only if review identifies a package-owned composition regression not already proven indirectly. A justified no-change decision completes this task without a commit. **Commit point:** one reviewed composition increment plus focused validation, if code changes are warranted.                                           |
+| T7  | TODO   | Improve admission or UDP contracts          | Implement one approved `server/launcher.rs` or `tests/server/contract.rs` increment only when the package integration boundary adds unique stable value. Record an infeasible seam rather than forcing a production refactor. **Commit point:** one reviewed admission or real-loopback contract increment plus focused validation.                                        |
+| T8  | TODO   | Perform bounded mutation assessment         | Run a time-bounded sample against the completed changed/high-risk seam. Record configuration, duration, limitations, and behavior-relevant surviving mutants; do not create a score target or CI gate. **Commit point:** documentation-only commit if the evidence materially changes the tracked review queue.                                                            |
+| T9  | TODO   | Review, verify, and complete evidence       | Stop for maintainer review after the final test increment, then run checks, manual scenarios, refreshed coverage, acceptance review, and completion review. **Commit point:** final documentation/evidence commit only after the required review and verification.                                                                                                         |
+
+## Commit Points
+
+Each test-producing task is deliberately a small, independently reviewable commit opportunity.
+Finish the current file-local plan increment, its focused validation, and its required review before
+starting the next task. Do not combine unrelated source/test areas merely to reduce commit count.
+
+| Task | Coherent change set                                         | Commit policy                                                                                                                                                     |
+| ---- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1   | Baseline coverage evidence and boundary inventory           | Included in the spec-only PR; no implementation commit.                                                                                                           |
+| T2   | Test-design review and file-local refactor plans            | Included in the spec-only PR when possible. If analysis is performed after the spec-only PR, commit only the reviewed plans and evidence.                         |
+| T3   | One `request_buffer.rs` test refactor or behavior increment | Commit after focused validation and review.                                                                                                                       |
+| T4   | One classification or packet-dispatch file-plan increment   | Commit after focused validation and review; do not mix `event.rs`, `error.rs`, and `handlers/mod.rs` unless one approved plan proves they are inseparable.        |
+| T5   | One socket-adapter file-plan increment                      | Commit after focused validation and review.                                                                                                                       |
+| T6   | One container-composition increment, if warranted           | Commit after focused validation and review; record no-change decisions in the plan without an empty commit.                                                       |
+| T7   | One launcher-admission or real-loopback contract increment  | Commit after focused validation and review. Do not combine with lifecycle redesign.                                                                               |
+| T8   | Mutation evidence that changes the prioritized backlog      | Use a separate documentation-only commit only when it records a material decision or follow-up; otherwise include the evidence in the final documentation commit. |
+| T9   | Refreshed evidence and implementation completion record     | Commit only after the maintainer review, full verification, and acceptance review are complete.                                                                   |
+
+Use Conventional Commit messages that name the narrow changed package area, for example
+`test(udp-server): cover active request eviction` or
+`docs(issues): record udp server mutation evidence`. All commits must remain GPG signed.
+
+## Test Development Loop
+
+Apply this loop to every test-producing task after T1 and T2 are complete:
+
+1. Complete the target file's refactor plan and obtain approval before changing its tests.
+2. Add the smallest approved readability, maintainability, or behavior-focused increment.
+3. Review the changed tests before the next increment. Make the one causal initial-state difference
+   visible; use inline values, a readable builder, or a narrowly named scenario fixture according
+   to the [test-pattern catalog](../../../testing/refactoring-patterns/README.md).
+4. Run focused tests and correct failures. Record the result in the file-local plan.
+5. Commit the coherent increment at its mapped commit point after focused validation and review.
+6. Do not begin the next file's plan until the current plan's approved work has been reviewed and,
+   when changes were made, committed.
+7. After the final test-producing increment, stop for maintainer review before final verification,
+   committing, or opening an implementation pull request.
+8. Address feedback, then perform final verification and acceptance review.
+
+Tests must retain the production Act and concrete expected result visibly. Helpers may encapsulate
+only repeated mechanics and must not derive expected protocol outputs through production code.
+
+## Test Refactor Plans
+
+Test-bearing files are reviewed one at a time under
+[test-refactor-plans/](test-refactor-plans/README.md). Each plan identifies the file's strengths
+to preserve, maintainability problems, behavior gaps, and ordered changes from high-impact/low-
+effort to lower-impact work. A plan may end in a justified no-change decision. Do not create a
+cross-file helper or generic fixture unless a reviewed cross-file plan demonstrates one cohesive
+responsibility.
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Folder-style draft created under `docs/issues/drafts/`.
+- [x] Existing EPIC, completed #2136 and #2140 specifications, package code, tests, and related
+      shutdown work reviewed.
+- [x] Package-source coverage baseline recorded in issue-local evidence before test changes.
+- [x] Per-file test-refactor-plan workflow established before implementation.
+- [x] Draft specification reviewed and approved by user/maintainer.
+- [x] GitHub issue #2149 created and linked to parent EPIC #1347 in this specification.
+- [x] Draft moved to `docs/issues/open/` using the assigned issue number.
+- [x] Spec-only PR #2152 opened against `develop` before implementation.
+- [ ] Implementation completed.
+- [ ] Automatic verification completed.
+- [ ] Manual verification scenarios executed and recorded.
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence.
+- [ ] Evidence-based implementation completion review recorded.
+- [ ] Reviewer validated acceptance criteria and updated checkboxes.
+- [ ] Committer verified specification progress before commit.
+- [ ] Issue closed and specification moved to `docs/issues/closed/`.
+
+### Progress Log
+
+- 2026-09-07 08:49 UTC - GitHub Copilot - Created this draft after reviewing EPIC #1347,
+  completed #2136 and #2140 work, current UDP-server source/tests, package boundaries, and the
+  UDP shutdown drafts. The draft prioritizes package-owned deterministic seams and explicitly
+  defers lifecycle redesign to #1488 SI-14, SI-15, and SI-17.
+- 2026-09-07 09:23 UTC - GitHub Copilot - Completed T1 before any test changes. A clean
+  `cargo llvm-cov` measurement at commit `2054d494` recorded the package-source baseline:
+  4,814/4,965 lines (96.96%), 6,326/6,604 regions (95.79%), and 485/499 functions (97.19%).
+  The reproducible command, per-file detail, priority queue, and boundary decisions are in
+  [coverage-evidence.md](coverage-evidence.md).
+- 2026-09-07 09:25 UTC - User/maintainer - Required the UDP-server work to use the completed
+  #2136 opportunity model: review test-bearing files individually, create and approve refactor
+  plans, then improve maintainability and behavior coverage incrementally rather than pursuing
+  coverage alone.
+- 2026-09-07 09:27 UTC - User/maintainer - Required small, coherent implementation steps with
+  explicit commit points mapped directly to the implementation-plan tasks. The plan now separates
+  request-buffer, dispatch/classification, socket-adapter, container, and listener-contract work.
+- 2026-09-07 09:42 UTC - User/maintainer - Approved the draft specification. GitHub issue #2149
+  was created and linked to parent EPIC #1347, and this folder was moved to its open-issue path
+  for the spec-only PR.
+- 2026-09-07 10:08 UTC - GitHub Copilot - Opened spec-only PR #2152 against `develop` from the
+  fork branch `josecelano:2149-add-focused-udp-server-package-tests-spec`. The PR uses
+  `Related to #2149` and does not close the implementation issue.
+
+## Acceptance Criteria
+
+- [ ] Coverage evidence records reproducible package-source baseline/final measurements, scope,
+      aggregate comparison, per-file detail, and prioritized gaps.
+- [ ] The current unit, package integration, example, root/E2E, mutation, property, and fuzz
+      evidence is assessed, with selected, deferred, and inapplicable levels justified.
+- [ ] Every selected test-bearing file has a reviewed file-local refactor plan that records
+      strengths, concrete problems, ordered improvements, guardrails, validation, and justified
+      no-change decisions where applicable.
+- [ ] Approved tests protect high-value UDP-server transport, dispatch, socket, event/error, or
+      normal-operation overload behavior without duplicating lower or higher package ownership.
+- [ ] Approved test refactors improve readability, maintainability, or expressiveness without
+      reducing existing behavior coverage or hiding causal state, the production Act, or expected
+      output in generic helpers.
+- [ ] Request-buffer tests distinguish current normal-operation capacity/cleanup behavior from
+      the shutdown policy owned by SI-15.
+- [ ] Any asynchronous fixture or lifecycle test change completes the Design and Ownership Review,
+      uses bounded absolute deadlines, and has a post-vertical-slice review.
+- [ ] Package integration tests are added only when the actual loopback UDP boundary provides
+      unique regression value; no sleep-based or privileged raw-socket test is added.
+- [ ] `linter all` exits with code `0`.
+- [ ] Relevant package tests pass.
+- [ ] Manual verification scenarios are executed and documented.
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect observed behavior.
+- [ ] Documentation is updated when behavior or workflow changes.
+
+## Verification Plan
+
+### Automatic Checks
+
+- `cargo llvm-cov -p torrust-tracker-udp-server --all-features --json`
+- `cargo test -p torrust-tracker-udp-server`
+- `cargo test -p torrust-tracker-udp-server --test integration`
+- `linter all`
+- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh`
+- Pre-push checks when applicable
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+| ID  | Scenario                       | Command/Steps                                                                                           | Expected Result                                                                                                | Status | Evidence                                            |
+| --- | ------------------------------ | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------ | --------------------------------------------------- |
+| M1  | Focused UDP transport contract | Manually invoke the selected real-loopback scenarios in `packages/udp-server/tests/server/contract.rs`. | The UDP client receives the documented BEP 15 response and observable side effect for every selected contract. | TODO   | Test names and output recorded after plan approval. |
+| M2  | Full package regression        | Run `cargo test -p torrust-tracker-udp-server` after the final increment.                               | Unit and package integration tests pass together without timing-dependent teardown failures.                   | TODO   | Command output recorded after implementation.       |
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                  |
+| ----- | ---------------------- | --------------------------------------------------------- |
+| AC1   | TODO                   | Issue-local `coverage-evidence.md`                        |
+| AC2   | TODO                   | Test-design review and coverage evidence                  |
+| AC3   | TODO                   | File-local plans in `test-refactor-plans/`                |
+| AC4   | TODO                   | Approved refactor increments and focused validation       |
+| AC5   | TODO                   | Focused test paths and test output                        |
+| AC6   | TODO                   | Request-buffer tests and SI-15 deferral record            |
+| AC7   | TODO                   | Design and Ownership Review or explicit non-applicability |
+| AC8   | TODO                   | Approved real-loopback contract evidence                  |
+| AC9   | TODO                   | `linter all` output                                       |
+| AC10  | TODO                   | Package test output                                       |
+| AC11  | TODO                   | Manual-verification table                                 |
+| AC12  | TODO                   | Post-implementation acceptance review                     |
+| AC13  | TODO                   | Documentation diff and completion review                  |
+
+## Risks and Trade-offs
+
+- UDP receive-loop and request-task behavior is concurrent and potentially timing-sensitive.
+  Prefer isolated deterministic seams; defer shutdown semantics to the already planned lifecycle
+  subissues rather than encoding accidental behavior in a test.
+- Package coverage includes test code and can hide low-value framework or fixture coverage. Use it
+  to navigate per-file gaps, while selecting tests by observable risk and ownership.
+- Socket behavior varies by host IPv6 and dual-stack support. Test port-zero and endpoint metadata
+  invariants, and retain existing availability guards rather than asserting a universal dual-stack
+  default.
+- Mutation testing can be slow and generate a tool-specific backlog. Keep it bounded and use only
+  behavior-relevant surviving mutants to challenge assertions.
+
+## Implementation Completion Review
+
+After implementation, compare the result with this specification. Record invalidated assumptions,
+material design changes, unexpected verification results, and reusable test-design lessons.
+
+- Retrospective: `Not yet assessed`
+- Create `implementation-retrospective.md` from
+  `docs/templates/IMPLEMENTATION-RETROSPECTIVE.md` for a material discovery, design change, or
+  deviation. Otherwise record in the progress log why a separate retrospective was unnecessary.
+
+## References
+
+- Parent EPIC: https://github.com/torrust/torrust-tracker/issues/1347
+- GitHub issue: https://github.com/torrust/torrust-tracker/issues/2149
+- Spec-only PR: https://github.com/torrust/torrust-tracker/pull/2152
+- Completed package-testing predecessors: #2136 and #2140
+- Package: `packages/udp-server/`
+- Current real-loopback contracts: `packages/udp-server/tests/server/contract.rs`
+- Shutdown EPIC: `docs/issues/open/1488-overhaul-tracker-shutdown/ISSUE.md`
+- UDP receive-loop lifecycle draft: `docs/issues/drafts/1488-si-14-migrate-udp-receive-reset-token-lifecycle/ISSUE.md`
+- Active-request policy draft: `docs/issues/drafts/1488-si-15-define-udp-active-request-policy/ISSUE.md`
+- Standalone environment draft: `docs/issues/drafts/1488-si-17-migrate-standalone-udp-environment/ISSUE.md`
+- Portable source-port-zero rationale: `docs/issues/closed/1450-discard-udp-requests-from-clients-with-port-0/ISSUE.md`

--- a/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/coverage-evidence.md
+++ b/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/coverage-evidence.md
@@ -1,0 +1,101 @@
+---
+doc-type: coverage-evidence
+issue: 2149
+package: torrust-tracker-udp-server
+measured-commit: 2054d494
+measured-utc: 2026-09-07
+---
+
+# UDP Server Coverage Evidence
+
+This document records the package-source coverage baseline before Issue #2149 adds or changes
+tests.
+
+## Measurement Method
+
+```text
+cargo llvm-cov clean --workspace
+cargo llvm-cov -p torrust-tracker-udp-server --all-features --json
+```
+
+The raw JSON report was generated at commit `2054d494` and filtered by files below
+`packages/udp-server/src/`. Its 62 MB generated output is deliberately retained only in ignored
+local temporary storage, not committed. The table below sums its file `summary` objects. It
+includes package test and test-support code, so it is navigation evidence rather than a
+production-only coverage measure or proof of behavioral completeness.
+
+## Baseline Package Coverage
+
+| Measurement                   |                  Lines |                Regions |          Functions |
+| ----------------------------- | ---------------------: | ---------------------: | -----------------: |
+| Baseline before issue changes | 4,814 / 4,965 (96.96%) | 6,326 / 6,604 (95.79%) | 485 / 499 (97.19%) |
+| Latest                        |       Not yet measured |       Not yet measured |   Not yet measured |
+
+## Baseline Detailed File Report
+
+Files are ordered by ascending line coverage so the table highlights the review queue. The issue
+will prioritize meaningful package-owned behavior, not every uncovered line or framework branch.
+
+| Source file                                     |               Lines |                Regions |         Functions | Coverage interpretation                                                                                                                  |
+| ----------------------------------------------- | ------------------: | ---------------------: | ----------------: | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/request_buffer.rs`                      |    24 / 45 (53.33%) |       36 / 74 (48.65%) |    3 / 4 (75.00%) | Lowest package-owned seam; review normal capacity eviction, completed-handle removal, and drop cleanup without defining shutdown policy. |
+| `event.rs`                                      |    18 / 30 (60.00%) |       25 / 49 (51.02%) |   3 / 3 (100.00%) | Event labels and display/conversion branches need behavior-based classification coverage.                                                |
+| `error.rs`                                      |    23 / 32 (71.88%) |       22 / 31 (70.97%) |    4 / 5 (80.00%) | Error-kind conversion has a narrow deterministic unit-test seam.                                                                         |
+| `server/bound_socket.rs`                        |    33 / 42 (78.57%) |       66 / 88 (75.00%) |    6 / 7 (85.71%) | Port-zero allocation and endpoint metadata are package-owned; avoid assuming universal dual-stack behavior.                              |
+| `statistics/event/handler/error.rs`             |   86 / 106 (81.13%) |     103 / 173 (59.54%) | 11 / 11 (100.00%) | Review remaining error-category branches after more critical transport seams; do not add tests solely for region percentage.             |
+| `server/launcher.rs`                            |  112 / 135 (82.96%) |     115 / 144 (79.86%) |  11 / 13 (84.62%) | Admission and task-management branches are valuable only if deterministic and not owned by pending shutdown work.                        |
+| `server/states.rs`                              |    45 / 54 (83.33%) |       45 / 57 (78.95%) |  10 / 14 (71.43%) | Existing lifecycle error propagation is strong; defer cancellation redesign to the shutdown subissues.                                   |
+| `handlers/mod.rs`                               |  157 / 166 (94.58%) |     175 / 185 (94.59%) |  30 / 32 (93.75%) | Packet dispatch and parse/handler-error conversion are candidate focused seams.                                                          |
+| `server/receiver.rs`                            |    21 / 22 (95.45%) |       29 / 31 (93.55%) |   3 / 3 (100.00%) | Existing integration coverage exercises receive behavior; select a narrow socket-adapter test only if it demonstrates a clear gap.       |
+| `banning/event/handler.rs`                      |    28 / 29 (96.55%) |       31 / 33 (93.94%) |   4 / 4 (100.00%) | Broadly covered; no percentage-driven expansion proposed.                                                                                |
+| `lib.rs`                                        |    28 / 29 (96.55%) |       27 / 28 (96.43%) |   2 / 2 (100.00%) | Crate documentation/configuration wiring; no direct priority gap identified.                                                             |
+| `statistics/event/handler/request_discarded.rs` |    33 / 34 (97.06%) |       33 / 35 (94.29%) |   4 / 4 (100.00%) | Existing behavior coverage is sufficient unless admission analysis identifies a missing observable fact.                                 |
+| `statistics/event/handler/request_received.rs`  |    33 / 34 (97.06%) |       33 / 35 (94.29%) |   4 / 4 (100.00%) | Existing behavior coverage is sufficient unless admission analysis identifies a missing observable fact.                                 |
+| `statistics/event/listener.rs`                  |  159 / 163 (97.55%) |     206 / 210 (98.10%) | 21 / 21 (100.00%) | Existing listener coverage is strong; lifecycle ownership changes are explicitly deferred.                                               |
+| `statistics/event/handler/request_aborted.rs`   |    56 / 57 (98.25%) |       56 / 58 (96.55%) |   6 / 6 (100.00%) | Existing counter mapping is strong; event production remains an admission/overload review candidate.                                     |
+| `statistics/event/handler/request_banned.rs`    |    56 / 57 (98.25%) |       56 / 58 (96.55%) |   6 / 6 (100.00%) | Existing counter mapping is strong; event production remains an admission review candidate.                                              |
+| `banning/event/listener.rs`                     |  139 / 141 (98.58%) |     174 / 176 (98.86%) | 19 / 19 (100.00%) | Existing listener coverage is strong; shutdown ownership is deferred.                                                                    |
+| `handlers/announce.rs`                          |  790 / 800 (98.75%) | 1,149 / 1,164 (98.71%) | 51 / 51 (100.00%) | Handler behavior is already well covered; avoid duplicating `udp-core` business-rule contracts.                                          |
+| `statistics/event/handler/response_sent.rs`     |    98 / 99 (98.99%) |     141 / 143 (98.60%) |   6 / 6 (100.00%) | Existing behavior coverage is strong.                                                                                                    |
+| `statistics/metrics.rs`                         |  827 / 834 (99.16%) | 1,228 / 1,238 (99.19%) |  86 / 87 (98.85%) | Metrics arithmetic is extensively covered; root integration retains multi-listener aggregation.                                          |
+| `handlers/error.rs`                             |  153 / 154 (99.35%) |     144 / 145 (99.31%) | 14 / 14 (100.00%) | Individual error response behavior is strong; dispatch-to-error integration remains the relevant gap.                                    |
+| `handlers/scrape.rs`                            |  319 / 321 (99.38%) |     385 / 390 (98.72%) |  27 / 28 (96.43%) | Handler behavior is strong; no percentage-driven expansion proposed.                                                                     |
+| `statistics/event/handler/request_accepted.rs`  |  162 / 163 (99.39%) |     165 / 167 (98.80%) | 14 / 14 (100.00%) | Existing behavior coverage is strong.                                                                                                    |
+| `server/mod.rs`                                 |  176 / 177 (99.44%) |     289 / 291 (99.31%) | 13 / 13 (100.00%) | Startup and registration-failure cleanup are already covered.                                                                            |
+| `testing/environment.rs`                        |  183 / 184 (99.46%) |     197 / 201 (98.01%) | 20 / 20 (100.00%) | Do not expand lifecycle coverage until SI-14, SI-15, and SI-17 define ownership and cancellation.                                        |
+| `statistics/repository.rs`                      |  547 / 549 (99.64%) |     771 / 773 (99.74%) |  61 / 62 (98.39%) | Existing repository and concurrency behavior coverage is strong.                                                                         |
+| `container.rs`                                  |   19 / 19 (100.00%) |      29 / 29 (100.00%) |   2 / 2 (100.00%) | Indirect coverage exists; direct composition tests are optional and must demonstrate clearer regression value.                           |
+| `handlers/connect.rs`                           | 251 / 251 (100.00%) |    285 / 285 (100.00%) | 18 / 18 (100.00%) | Existing connect behavior coverage is strong.                                                                                            |
+| `server/processor.rs`                           | 116 / 116 (100.00%) |    157 / 157 (100.00%) | 17 / 17 (100.00%) | Portable direct source-port-zero defensive coverage is intentional; raw transport testing is not proposed.                               |
+| `server/spawner.rs`                             |   17 / 17 (100.00%) |      17 / 17 (100.00%) |   2 / 2 (100.00%) | Existing lifecycle coverage is sufficient pending shutdown design.                                                                       |
+| `statistics/event/handler/mod.rs`               |   21 / 21 (100.00%) |       50 / 52 (96.15%) |   2 / 2 (100.00%) | Module wiring; no direct priority gap identified.                                                                                        |
+| `statistics/mod.rs`                             |   52 / 52 (100.00%) |      60 / 60 (100.00%) |   1 / 1 (100.00%) | Composition is covered; no percentage-driven expansion proposed.                                                                         |
+| `statistics/services.rs`                        |   32 / 32 (100.00%) |      27 / 27 (100.00%) |   4 / 4 (100.00%) | Service aggregation behavior is covered.                                                                                                 |
+
+## Prioritized Behavioral Review Queue
+
+1. `server/request_buffer.rs`: establish the current normal-operation capacity, eviction, and
+   drop cleanup contract without specifying the future shutdown policy.
+2. `event.rs`, `error.rs`, and `handlers/mod.rs`: verify deterministic event/error classification
+   and packet dispatch/error conversion where individual handler tests do not cover the boundary.
+3. `server/bound_socket.rs`: verify stable port-zero and endpoint metadata behavior while treating
+   IPv6/dual-stack availability as platform dependent.
+4. `server/launcher.rs`: consider only a deterministic admission/event contract. Do not expand
+   receive-loop, cancellation, or task-joining coverage before the #1488 UDP lifecycle subissues
+   are approved and implemented.
+5. `tests/server/contract.rs`: add a real-loopback test only when it proves a transport behavior
+   that the preceding unit seams and existing package/root tests cannot express.
+
+## Boundary and Deferral Decisions
+
+| Test level or behavior         | Decision               | Rationale                                                                                                                                          |
+| ------------------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unit tests                     | Selected               | Primary fast, deterministic boundary for the prioritized package-owned seams.                                                                      |
+| Package integration            | Selected selectively   | Existing eleven real-loopback contracts are retained. Add only a stable wire contract with unique transport value.                                 |
+| Runnable example               | Retained               | `examples/udp_only_public_tracker.rs` remains a consumer-facing smoke target; signal and awaited shutdown behavior belongs to SI-17.               |
+| Root integration               | Retained externally    | Multi-listener metrics, shared banning, configuration ordering, and application composition are already correctly covered in root `tests/`.        |
+| Container E2E                  | Deferred               | Outer interoperability protection is not the default mechanism for package coverage.                                                               |
+| Mutation testing               | Bounded assessment     | Run only after approving a focused plan; record behavior-relevant survivors and do not create a score target or CI gate.                           |
+| Property/fuzz testing          | Not currently selected | Protocol parsing/serialization properties belong primarily to `udp-protocol`; no server-orchestration invariant currently justifies a new harness. |
+| Source-port-zero UDP transport | Deferred by constraint | Standard sockets cannot send it; existing direct processor coverage is the deepest portable automated boundary.                                    |
+| Lifecycle shutdown             | Deferred               | SI-14, SI-15, and SI-17 own cancellation, request-task policy, joining, and standalone-environment lifecycle design.                               |

--- a/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/test-refactor-plans/README.md
+++ b/docs/issues/open/2149-1347-add-focused-udp-server-package-tests/test-refactor-plans/README.md
@@ -1,0 +1,57 @@
+# UDP Server Test Refactor Plan Guidance
+
+This folder contains one proposed refactor plan for each test-bearing source or integration-test
+file selected during this issue's T2 review. Create, review, and implement plans one file at a
+time. Do not begin a plan for the next file until the current plan's approved work is completed
+and reviewed.
+
+Draft cross-file plans belong in `drafts/`. They may assess a shared concern, but do not authorize
+a cross-file extraction unless maintainer review establishes a cohesive common responsibility.
+
+## Plans
+
+- No file plans have been created. T2 will inventory each test-bearing file and create a plan only
+  where review identifies a concrete maintainability or behavior-coverage opportunity.
+
+## Shared Purpose
+
+Each plan improves test code without changing production behavior. It applies only to its target
+file and must be reviewed and approved before any proposed item is implemented.
+
+## Shared Quality Goals
+
+The refactoring must improve or preserve:
+
+- **Expressiveness:** each test states its behavior and the initial state that causes it.
+- **Readability:** Arrange, Act, actual result, expected result, and Assert are distinguishable.
+- **Maintainability:** common mechanics have one intentional update site, while behavior-specific
+  values remain near the test.
+- **One behavior-focused contract:** a failure identifies the observable contract; a wire-boundary
+  contract may still have more than one possible internal cause.
+- **Coverage:** retain valuable existing coverage and add only behavior-focused coverage gaps.
+
+The refactoring must reduce or avoid:
+
+- **Flakiness:** no sleeps, retry loops, wall-clock dependencies, uncontrolled networking, or
+  shared mutable state.
+- **Duplication:** share only genuinely repeated mechanics such as deterministic packet decoding
+  or non-behavioral fixture setup.
+- **Complexity:** helpers must not hide the causal state, production Act, expected outcome, or
+  final assertion.
+- **Scope leakage:** do not duplicate `udp-protocol`, `udp-core`, root composition, or #1488
+  shutdown work.
+
+## Plan Structure
+
+Every file plan must contain:
+
+1. **Phase 1 — Identify Problems:** evidence-based, file-specific strengths and opportunities.
+2. **Phase 2 — Proposed Refactorings:** items ordered from high-impact/low-effort to
+   low-impact/high-effort, with behavior and abstraction guardrails.
+3. **Progress Tracking:** status checklist, progress log, and validation evidence.
+4. **Non-Goals, validation, and completion criteria:** constraints that prevent speculative churn
+   and preserve the maintainer-review checkpoint.
+
+Use `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`, or `DEFERRED` for each item. Update one item at a
+time: record its review decision, implementation outcome, and focused validation before starting
+the next item. Do not mark a plan complete until the maintainer has reviewed all approved changes.

--- a/docs/templates/ISSUE.md
+++ b/docs/templates/ISSUE.md
@@ -77,6 +77,23 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | T1  | TODO   | {Task title} | {What "done" means for this task} |
 | T2  | TODO   | {Task title} | {What "done" means for this task} |
 
+## Commit Points
+
+Map implementation-plan tasks that change code, tests, configuration, or documentation to small,
+coherent commit opportunities. A commit point completes one independently reviewable behavior,
+refactor, or evidence increment; do not group unrelated changes merely to reduce commit count.
+
+| Task | Coherent change set                       | Commit policy                                        |
+| ---- | ----------------------------------------- | ---------------------------------------------------- |
+| T1   | {Narrow, independently reviewable change} | Commit after focused validation and required review. |
+| T2   | {Narrow, independently reviewable change} | Commit after focused validation and required review. |
+
+Record a justified no-change decision in the task's evidence without creating an empty commit. For
+test-producing work, commit each reviewed test-design increment before starting the next planned
+file or behavior area. Keep final verification and completion evidence separate when it improves
+reviewability. Use a Conventional Commit message with the narrow affected scope, and sign every
+commit with GPG.
+
 ## Progress Tracking
 
 ### Workflow Checkpoints


### PR DESCRIPTION
## Summary

- Add the repository-local specification for #2149, including the pre-implementation UDP-server package coverage baseline, risk-ranked review queue, test-boundary decisions, file-local test-refactor-plan workflow, and small mapped commit points.
- Link #2149 and its baseline evidence from the #1347 package-testing EPIC.
- Extend the canonical issue template and `create-issue` skill so future issue specifications map coherent implementation tasks to commit points.

## Scope

- `docs/issues/open/2149-1347-add-focused-udp-server-package-tests/`
- `docs/issues/open/1347-overhaul-packages-testing/EPIC.md`
- `docs/templates/ISSUE.md`
- `.github/skills/dev/planning/create-issue/SKILL.md`

## Validation

- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`

Related to #2149
Related to #1347
