### PR TITLE
docs(issues): add lychee issue specification (#2150)

### DIFF
--- a/docs/issues/open/2150-add-lychee-link-checker/ISSUE.md
+++ b/docs/issues/open/2150-add-lychee-link-checker/ISSUE.md
@@ -1,0 +1,297 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p3
+epic: null
+github-issue: 2150
+spec-path: docs/issues/open/2150-add-lychee-link-checker/ISSUE.md
+branch: "2150-add-lychee-link-checker-spec"
+related-pr: null
+last-updated-utc: 2026-09-07 10:33
+semantic-links:
+  skill-links:
+    - create-issue
+  related-artifacts:
+    - .github/skills/dev/planning/create-issue/SKILL.md
+    - docs/index.md
+    - docs/issues/open/2150-add-lychee-link-checker/link-check-report.md
+---
+
+<!-- skill-link: create-issue -->
+
+# Issue #2150 - Add lychee local Markdown link checker
+
+## Goal
+
+Run [lychee](https://lychee.cli.rs/) locally against this repository's Markdown, fix every genuine
+broken local link it reports, add a checked-in `lychee.toml` config that enables local anchor
+checking and documents intentional exclusions, and open a follow-up GitHub issue in
+[`torrust/torrust-linting`](https://github.com/torrust/torrust-linting) requesting that lychee be
+added as a linter in the shared `linter` tool so link checking can later be enforced automatically
+(in pre-commit and normal CI).
+
+## Background
+
+`torrust-linting` (the shared `linter` binary used by this repository, see
+[`docs/index.md`](../../../index.md) and `AGENTS.md`) currently runs markdownlint, yamllint,
+taplo, cspell, clippy, rustfmt, and shellcheck, but has no link checker. Markdown docs, ADRs, and
+issue specs in this repository accumulate cross-references, and nothing currently detects when
+local links break after a file move or heading rename.
+
+lychee is a fast, async link checker written in Rust with first-class support for Markdown, HTML,
+and plain text, and it is the tool the maintainer wants to standardize on. It is installed via
+`cargo install lychee` (the drafting environment has `lychee 0.24.2`), but the repository has no
+lychee configuration, no baseline report of existing broken links, and no CI/pre-commit
+enforcement.
+
+A quick exploratory offline run during drafting (`lychee --offline` over `docs/`, `README.md`,
+`**/AGENTS.md`, `packages/*/README.md`, `.github/**/*.md`) reported roughly 170 broken
+**local file** links, concentrated in `docs/issues/closed/` (historical specs whose relative
+links broke when they were moved) but also present in ADRs, package READMEs, `.github/skills/`,
+and `tests/AGENTS.md`. This confirms the problem is real and gives a rough size for the triage
+work.
+
+lychee distinguishes two modes that have very different cost and reliability profiles:
+
+- **Offline** (`offline = true`): resolves local file links without making network requests.
+  Combined with `include_fragments = "full"`, it also validates local Markdown heading anchors
+  such as `docs/testing.md#verification-plan`. This is deterministic, sub-second, and suitable
+  for pre-commit and normal CI.
+- **Online** (the default): additionally requests external URLs. It is slow and subject to
+  rate limits and transient network failures, so it must not block pre-push or ordinary CI.
+  This issue does not run or configure online checking. A follow-up tracker issue will define
+  an advisory weekly scheduled workflow, which records a real failure but is not a required PR
+  status check.
+
+Enforcement (wiring lychee into `linter all`, pre-commit, and CI) depends on `torrust-linting`
+adding lychee as a linter first, matching the pattern used for the other tools in that project
+(see its `src/linters/` module and the `README.md` table of expected root-level config files:
+`.markdownlint.json`, `.yamllint-ci.yml`, `.taplo.toml`, `cspell.json`). That upstream change is
+out of scope for this issue and is tracked instead by opening a request issue in
+`torrust/torrust-linting`.
+
+This issue therefore covers two phases:
+
+1. Verify lychee locally, run its deterministic offline local-link and local-fragment check
+   against the repository, classify every finding in an issue-local report, fix genuine broken
+   links, and add a `lychee.toml` config documenting any intentional exclusions.
+2. Open a GitHub issue in `torrust/torrust-linting` requesting lychee be added as a linter there,
+   referencing this issue and the offline `lychee.toml` convention produced in phase 1, then open
+   a tracker follow-up issue to wire the offline check into normal enforcement and add the
+   advisory weekly external-link workflow.
+
+## Scope
+
+### In Scope
+
+- Document the lychee version and install command used for this work in the issue-local report.
+- Add a `lychee.toml` configuration file at the repository root (lychee's default config name),
+  following the existing root-config convention used by other linters (`.markdownlint.json`,
+  `.yamllint-ci.yml`, `.taplo.toml`, `cspell.json`). Every `exclude`/`exclude_path` entry must
+  carry an inline comment with its rationale. Use `lychee.toml` as the single exclusion
+  mechanism; do not add a `.lycheeignore` file.
+- Enable and document `include_fragments = "full"` in `lychee.toml`. This checks the target of
+  local fragment links such as `[Verification](docs/testing.md#verification-plan)`, ensuring that
+  a linked Markdown heading exists as well as its file.
+- Define the checked Markdown set as: `README.md`, `SECURITY.md`, `docs/**/*.md`, `**/AGENTS.md`,
+  `packages/*/README.md`, `console/**/*.md`, `contrib/**/*.md`, `share/**/*.md`, and
+  `.github/**/*.md` (skills and agent definitions are authoritative workflow docs). Record the
+  exact command in the report so the run is reproducible.
+- Run the offline local-link and local-fragment check and record it in the issue-local report.
+- Classify every reported link as one of: genuinely broken (fix), false positive (add a
+  documented exclusion), or historical/out of scope (document why).
+- Fix all genuinely broken links found in the checked Markdown set.
+- Keep an issue-local, human-readable report at `link-check-report.md` (in this spec's folder)
+  summarizing the offline check, classification table, and fixes applied. Do not commit raw
+  lychee output.
+- Re-run the offline check after fixes to confirm zero unresolved errors (excluding documented
+  exclusions).
+- Open a GitHub issue in `torrust/torrust-linting` requesting lychee support, including: the
+  proposed CLI subcommand (`linter lychee`, or `linter links`), the offline
+  `include_fragments = "full"` `lychee.toml` convention this issue establishes, and a link back
+  to this issue for context.
+- After opening the `torrust-linting` issue, open a follow-up issue in this repository to:
+  wire offline local file/fragment checking into pre-commit and normal CI once upstream support
+  is available; and add a weekly, manually re-runnable online external-link workflow. The
+  workflow must be advisory, not a required PR status check: let lychee fail normally so real
+  broken-link findings are visible, but it must not block a merge. The follow-up issue must
+  define `GITHUB_TOKEN` handling, bounded timeout/retries/concurrency, report-artifact retention,
+  and a triage process (re-run once; fix persistently broken links or add narrow documented
+  exclusions).
+
+### Out of Scope
+
+- Adding lychee to `torrust-linting` itself (tracked by the follow-up issue opened in that repo,
+  not implemented here).
+- Wiring lychee into this repository's `pre-commit.sh` or CI workflows; it is planned in the
+  follow-up issue opened by T9 after `torrust-linting` provides the requested linter integration.
+- Checking external URLs in pre-push or normal CI. Those checks are non-deterministic because
+  third-party services and networks are outside repository control.
+- Checking links inside Rust source doc comments (`///`, `//!`) or other non-Markdown files.
+  Intra-doc links are already covered by rustdoc's `broken_intra_doc_links` lint; external URLs in
+  doc comments can be revisited once the Markdown baseline is clean.
+- Auditing/fixing links in `docs/issues/closed/` historical specs. They are excluded via
+  `exclude_path` in `lychee.toml`; their relative links broke when the specs were moved and
+  fixing them adds no value for actively maintained docs.
+
+## Architectural Decisions
+
+- Related ADRs: `None`
+- ADRs to create: `None known`
+
+This is a routine tooling-adoption task consistent with the existing multi-linter setup
+(`torrust-linting`); it does not introduce a new architectural pattern.
+
+## Design and Ownership Review
+
+Not applicable — no child processes, asynchronous I/O, network readiness, resource cleanup, or
+reusable test fixtures are introduced beyond invoking an existing CLI tool.
+
+## Implementation Plan
+
+Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
+
+| ID  | Status | Task                                                                     | Notes / Expected Output                                                                                                              |
+| --- | ------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| T1  | TODO   | Record lychee version and install command                                | First section of `link-check-report.md`                                                                                              |
+| T2  | TODO   | Draft initial `lychee.toml`                                              | Root config: offline mode, full fragment checks, and `exclude_path` for `docs/issues/closed/`; `.gitignore` is respected by default  |
+| T3  | TODO   | Offline baseline pass                                                    | Run lychee over the checked Markdown set; exact command and summary line recorded in the report                                      |
+| T4  | TODO   | Classify every finding                                                   | Report table: link, source file, classification (fix / exclude / historical), rationale for non-fix rows                             |
+| T5  | TODO   | Fix genuinely broken links                                               | Markdown files updated; each fix listed in the report                                                                                |
+| T6  | TODO   | Finalize `lychee.toml` exclusions                                        | Every exclusion has an inline rationale comment                                                                                      |
+| T7  | TODO   | Re-run offline check to confirm a clean result                           | Summary line recorded in the report showing 0 errors                                                                                 |
+| T8  | TODO   | Open GitHub issue in `torrust/torrust-linting` requesting lychee support | Issue references this issue and the offline local-link/local-fragment convention; URL recorded in `References`                       |
+| T9  | TODO   | Open tracker follow-up issue for lychee enforcement and weekly checks    | Blocked on T8; describes normal offline enforcement plus advisory weekly online external-link workflow; URL recorded in `References` |
+
+## Progress Tracking
+
+### Workflow Checkpoints
+
+- [x] Folder-style spec drafted in `docs/issues/drafts/add-lychee-link-checker/ISSUE.md`
+- [x] Spec reviewed and approved by user/maintainer
+- [x] GitHub issue created and issue number added to this spec
+- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
+- [ ] Implementation completed
+- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [ ] Manual verification scenarios executed and recorded (status + evidence)
+- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [ ] Evidence-based implementation completion review recorded: issue-local retrospective created for material discoveries, or progress log states why none was needed
+- [ ] Reviewer validated acceptance criteria and updated checkboxes
+- [ ] Committer verified spec progress is up to date before commit
+- [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
+
+### Progress Log
+
+Append one line per meaningful update.
+
+- 2026-09-07 08:54 UTC - Copilot - Drafted initial issue specification for local lychee adoption plus torrust-linting follow-up issue - `docs/issues/drafts/add-lychee-link-checker/ISSUE.md`
+- 2026-09-07 09:33 UTC - Copilot - Review pass: corrected default config filename (`lychee.toml`), aligned checked-file set with the M1 command, named the report file, and recorded an exploratory `lychee --offline` run (~170 local-link errors)
+- 2026-09-07 09:43 UTC - Copilot - Revised scope: lychee will enforce only offline local Markdown file and fragment links; external URL checks are excluded from pre-push and normal CI because they are non-deterministic
+- 2026-09-07 10:03 UTC - Copilot - Added a final follow-up task: open a tracker issue after the torrust-linting request to enable deterministic offline enforcement and an advisory weekly external-link workflow
+- 2026-09-07 10:07 UTC - Copilot - User approved the specification; created GitHub issue #2150 - https://github.com/torrust/torrust-tracker/issues/2150
+- 2026-09-07 10:33 UTC - Copilot - Created the spec-only branch `2150-add-lychee-link-checker-spec` from `torrust/develop`; spec-only PR pending
+
+## Acceptance Criteria
+
+- [ ] AC1: `link-check-report.md` records the lychee version, install command, and the exact
+      reproducible offline local-link/local-fragment command.
+- [ ] AC2: A `lychee.toml` config file exists at the repository root; every exclusion has an
+      inline rationale comment and it enables `offline = true` and `include_fragments = "full"`.
+- [ ] AC3: Every finding from the offline baseline pass is classified (fix / exclude / historical) in
+      `link-check-report.md`, with rationale for each non-fix row.
+- [ ] AC4: All genuinely broken links identified are fixed in the affected Markdown files.
+- [ ] AC5: Re-running the offline check after fixes reports zero errors (excluding documented
+      exclusions), with the summary line recorded in the report.
+- [ ] AC6: A GitHub issue is opened in `torrust/torrust-linting` requesting lychee support,
+      referencing this issue and the `lychee.toml` convention; the URL is recorded in `References`.
+- [ ] AC7: A tracker follow-up issue is opened after AC6. It describes offline pre-commit/normal
+      CI enforcement and a weekly, advisory, manually re-runnable online external-link workflow;
+      its URL is recorded in `References`.
+- [ ] `linter all` exits with code `0`
+- [ ] Relevant tests pass (no code changes expected; N/A unless links are found in test fixtures).
+- [ ] Manual verification scenarios are executed and documented (status + evidence).
+- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior.
+- [ ] Documentation is updated when behavior/workflow changes.
+
+## Verification Plan
+
+Define verification before implementation starts and execute it before closing the issue.
+
+### Automatic Checks
+
+- `linter all`
+- Offline lychee re-run (M2) showing zero errors
+
+### Manual Verification Scenarios
+
+Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
+
+The checked Markdown set (`INPUTS`) is: `README.md SECURITY.md 'docs/**/*.md' '**/AGENTS.md' 'packages/*/README.md' 'console/**/*.md' 'contrib/**/*.md' 'share/**/*.md' '.github/**/*.md'`. `lychee.toml` supplies `offline = true` and `include_fragments = "full"`.
+
+| ID  | Scenario                               | Command/Steps                                                    | Expected Result                                            | Status | Evidence                  |
+| --- | -------------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------------------- | ------ | ------------------------- |
+| M1  | Offline baseline pass                  | `lychee --no-progress INPUTS`                                    | Command completes; findings captured for triage            | TODO   | `link-check-report.md`    |
+| M2  | Post-fix offline pass                  | Same as M1 after fixes and `lychee.toml` finalization            | `0 Errors` in summary line                                 | TODO   | `link-check-report.md`    |
+| M3  | `torrust-linting` request issue opened | `gh issue create --repo torrust/torrust-linting --body-file ...` | Issue created; URL recorded and cross-linked to this issue | TODO   | issue URL in `References` |
+| M4  | Tracker follow-up issue opened         | `gh issue create --repo torrust/torrust-tracker --body-file ...` | Issue created after M3; URL recorded and cross-linked      | TODO   | issue URL in `References` |
+
+Notes:
+
+- Manual verification is mandatory even when automated tests pass.
+- If a scenario fails, record the failure and diagnosis in the progress log before proceeding.
+
+### Acceptance Verification
+
+| AC ID | Status (`TODO`/`DONE`) | Evidence                    |
+| ----- | ---------------------- | --------------------------- |
+| AC1   | TODO                   | `link-check-report.md`      |
+| AC2   | TODO                   | `lychee.toml`               |
+| AC3   | TODO                   | `link-check-report.md`      |
+| AC4   | TODO                   | {PR link}                   |
+| AC5   | TODO                   | `link-check-report.md` (M2) |
+| AC6   | TODO                   | {torrust-linting issue URL} |
+| AC7   | TODO                   | {torrust-tracker issue URL} |
+
+## Risks and Trade-offs
+
+- **Triage volume**: the exploratory offline run reported ~170 local-link errors before any
+  exclusions. Mitigation: exclude `docs/issues/closed/` first (the bulk of the noise), then
+  triage the remainder; most local-link fixes are mechanical path corrections.
+- **Fragment checking may add work**: `include_fragments = "full"` will flag anchors that
+  markdownlint does not validate. Mitigation: it is intentional: heading-anchor correctness is
+  part of the goal, and broken anchors should be fixed or explicitly excluded with rationale.
+- **Scope creep into non-Markdown files**: including Rust doc comments or generated files could
+  significantly expand the surface area and false-positive rate. Mitigation: explicitly out of
+  scope; revisit once the Markdown baseline is clean.
+- **Enforcement depends on an external project**: pre-commit/CI enforcement cannot land until
+  `torrust-linting` adds lychee support. Mitigation: T8 explicitly requests the upstream work
+  and T9 captures tracker-side follow-up; `lychee.toml` is usable immediately by anyone running
+  lychee manually, independent of the upstream timeline.
+- **Scheduled external checks can fail spuriously**: third-party availability, rate limits, and
+  network faults are outside repository control. Mitigation: T9 makes the workflow advisory,
+  lets true failures remain visible, and requires one manual re-run before triage.
+
+## Implementation Completion Review
+
+After implementation, compare the result with this specification. Record
+invalidated assumptions, material design changes, unexpected validation
+findings, and reusable lessons.
+
+- Retrospective: `Not yet assessed`
+- If needed, create `implementation-retrospective.md` from the repository
+  template at `docs/templates/IMPLEMENTATION-RETROSPECTIVE.md` in this issue
+  specification's directory.
+- If no retrospective is needed, add a concise progress-log entry explaining
+  why the work had no material discovery.
+
+## References
+
+- Related issues:
+  - `torrust/torrust-linting` request issue: `To be created` (T8)
+  - `torrust/torrust-tracker` enforcement and scheduled-check follow-up: `To be created` (T9)
+- Related PRs: `None yet`
+- Related ADRs: `None`
+- lychee: <https://lychee.cli.rs/> — configuration reference:
+  <https://lychee.cli.rs/guides/config/>
+- `torrust-linting`: <https://github.com/torrust/torrust-linting>

--- a/project-words.txt
+++ b/project-words.txt
@@ -301,6 +301,7 @@ libtorrent
 libz
 llist
 lscr
+lycheeignore
 matchmakes
 memcmp
 metainfo


### PR DESCRIPTION
## Summary

- Add the reviewed folder-style specification for lychee local Markdown link checking.
- Define deterministic offline local file and heading-fragment validation as the normal enforcement mode.
- Plan two follow-up issues: shared `torrust-linting` integration, then tracker-side offline enforcement plus advisory weekly external-link monitoring.
- Add `lycheeignore` to the project spell-check dictionary because the specification explicitly rejects a separate `.lycheeignore` file.

## Files changed

- `docs/issues/open/2150-add-lychee-link-checker/ISSUE.md`
- `project-words.txt`

## Validation

- `TORRUST_GIT_HOOKS_LOG_DIR=.tmp ./contrib/dev-tools/git/hooks/pre-commit.sh`
- Pre-push checks: nightly format/check/docs and full stable test suite

Related to #2150
