### PR TITLE
docs(agents): document AI agent orchestration

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -16,6 +16,9 @@ Repository workflow and policy remain authoritative in `AGENTS.md`, `.github/ski
 scripts, tests, and documentation. Profiles are optional adapters, as defined by the
 [AI agent context, capability, and portability governance ADR](../../docs/adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md).
 
+See the [AI agent orchestration guide](../../docs/agents/orchestration.md) for the documented
+profile handoffs, prerequisites, artifacts, and known enforcement boundary.
+
 ## Planning and Implementation
 
 - [Planner](planner.agent.md)

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,7 @@ For the full project context see the [root AGENTS.md](../AGENTS.md).
 | Path                                                                                      | Purpose                                                                            |
 | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
 | `index.md`                                                                                | Entry point — structured index of every document and subdirectory                  |
+| `agents/`                                                                                 | Current AI-agent workflow documentation, handoffs, and enforcement boundary        |
 | `architecture/`                                                                           | Runtime-composition guides: tracker instances, shared services, and event topology |
 | `benchmarking.md`                                                                         | How to run and interpret torrent-repository benchmarks                             |
 | `containers.md`                                                                           | Running the tracker with Docker / Podman                                           |

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,26 @@
+---
+semantic-links:
+  related-artifacts:
+    - .github/agents/README.md
+    - docs/agents/orchestration.md
+    - docs/index.md
+---
+
+# AI Agent Documentation
+
+This collection documents the repository's current AI-agent workflows in a portable, tracked
+format. It complements the authoritative custom profile definitions in `.github/agents/` and
+the repository instructions and skills they reference.
+
+## Documents
+
+| Document                             | Description                                                                                                     |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| [orchestration.md](orchestration.md) | Current profile handoffs, prerequisites, artifacts, feedback loops, and limits of the documented process model. |
+
+## Authority
+
+This documentation describes observed and declared workflows. It does not replace `AGENTS.md`,
+repository skills, scripts, tests, or profile definitions, and it does not technically enforce
+agent selection or transition order. See the [AI agent context, capability, and portability
+governance ADR](../adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md).

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -1,0 +1,213 @@
+---
+semantic-links:
+  related-artifacts:
+    - AGENTS.md
+    - .github/agents/
+    - .github/agents/README.md
+    - .github/skills/
+    - docs/agents/README.md
+    - docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
+    - docs/issues/open/2160-2003-persist-independent-agent-review-reports/ISSUE.md
+    - docs/adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md
+---
+
+# AI Agent Orchestration
+
+## Purpose
+
+This guide makes the currently declared relationships between repository custom agents explicit.
+It is a portable process model derived from `.github/agents/*.agent.md`, not a runtime controller.
+The profile definitions, `AGENTS.md`, skills, scripts, tests, and GitHub interfaces remain the
+authoritative sources for a particular task.
+
+Solid arrows in the flowchart are mandatory handoffs declared by an agent workflow. Dashed arrows
+are optional, event-driven, or incomplete paths. An arrow documents intent; it does not prevent an
+agent from acting when preceding work is absent.
+
+## Workflow Overview
+
+```mermaid
+flowchart TD
+  user_request[User request]
+
+  subgraph planning_phase[Planning]
+    planner[Planner]
+    issue_spec[Issue specification]
+    approval{User approval}
+  end
+
+  subgraph implementation_phase[Implementation]
+    implementer[Implementer]
+    complexity_auditor[Complexity Auditor]
+    completion_review[Implementation completion review]
+    task_reviewer[Task Reviewer]
+    committer[Committer]
+    signed_commit[Signed commit]
+  end
+
+  subgraph pull_request_phase[Pull request]
+    pull_request[Open pull request]
+    pr_reviewer[PR Reviewer]
+    suggestions_handler[Copilot Suggestions Handler]
+    suggestions_tracker[Copilot suggestions tracker]
+    merge_ready[Ready for merge]
+    merged[Merged]
+  end
+
+  user_request -. request .-> planner
+  planner --> issue_spec
+  issue_spec -. approval required to create a GitHub issue .-> approval
+  approval -. revise .-> planner
+  approval -. approved issue work .-> implementer
+  implementer -->|after every completed step| complexity_auditor
+  complexity_auditor -->|blocking finding| implementer
+  complexity_auditor -->|no blocking finding| implementer
+  implementer -->|all steps and tests complete| completion_review
+  completion_review --> task_reviewer
+  task_reviewer -->|FAIL or PENDING| implementer
+  task_reviewer -->|PASS| committer
+  committer --> signed_commit
+  signed_commit -. pull request when requested .-> pull_request
+  pull_request -. review when requested .-> pr_reviewer
+  pr_reviewer -. verdict; remediation owner is not defined .-> implementer
+  pr_reviewer -. APPROVE or COMMENT .-> merge_ready
+  pull_request -. open Copilot threads .-> suggestions_handler
+  suggestions_handler --> suggestions_tracker
+  suggestions_handler -. action fixes .-> committer
+  suggestions_handler -. all threads resolved .-> merge_ready
+  merge_ready -. merged by repository workflow .-> merged
+
+  researcher[Researcher] -. external evidence when needed .-> planner
+  researcher -. external evidence when needed .-> implementer
+  implementer -. ambiguity or spec mismatch .-> planner
+  github_operator[GitHub Operator] -. issue or PR operation .-> issue_spec
+  github_operator -. issue or PR operation .-> pull_request
+  clippy_fixer[ClippyFixer] -. concrete Clippy output .-> committer
+```
+
+## Implementation and Pre-Commit Workflow
+
+This detailed view expands the mandatory path declared by the Implementer profile. Solid arrows
+are mandatory handoffs. The feedback arrows return a blocking finding to the Implementer; the
+Implementer repeats the relevant work and review before proceeding.
+
+```mermaid
+flowchart TD
+  implementation_start[Approved scoped work]
+  implementer_step[Implementer completes one red-green-refactor step]
+  complexity_auditor_step[Complexity Auditor]
+  audit_blocked{Blocking audit finding?}
+  next_step[Implementer proceeds to the next step]
+  completion_review_step[Implementation completion review]
+  task_reviewer_step[Task Reviewer]
+  task_review_result{Review passed?}
+  committer_step[Committer]
+  signed_commit_step[Signed commit]
+
+  implementation_start --> implementer_step
+  implementer_step --> complexity_auditor_step
+  complexity_auditor_step --> audit_blocked
+  audit_blocked -->|yes: simplify and re-audit| implementer_step
+  audit_blocked -->|no| next_step
+  next_step -->|all steps complete| completion_review_step
+  completion_review_step --> task_reviewer_step
+  task_reviewer_step --> task_review_result
+  task_review_result -->|no: remediate and re-review| implementer_step
+  task_review_result -->|yes| committer_step
+  committer_step --> signed_commit_step
+```
+
+## Pull-Request Feedback Workflow
+
+This view shows conditional paths after a pull request exists. No profile defines a universal PR
+entry, merge transition, remediation owner for a PR Reviewer finding, or mandatory re-review after
+a fix; those paths are therefore dashed. Solid arrows apply only to the Copilot Suggestions
+Handler's required per-thread tracker update.
+
+```mermaid
+flowchart TD
+  existing_pr[Existing pull request]
+  pr_reviewer_detail[PR Reviewer]
+  pr_verdict[Review verdict]
+  remediation[Remediation owner not defined by PR Reviewer]
+  copilot_handler_detail[Copilot Suggestions Handler]
+  copilot_tracker_detail[Copilot suggestions tracker]
+  action_decision{Action needed?}
+  committer_detail[Committer]
+  push_update[Push updated branch]
+  refetch_threads[Fetch unresolved Copilot threads again]
+  merge_ready_detail[Ready for merge]
+  merged_detail[Merged]
+
+  existing_pr -. review when requested .-> pr_reviewer_detail
+  pr_reviewer_detail -. findings and verdict .-> pr_verdict
+  pr_verdict -. changes requested .-> remediation
+  remediation -. updated branch .-> existing_pr
+  pr_verdict -. approve or comment .-> merge_ready_detail
+  existing_pr -. open Copilot threads .-> copilot_handler_detail
+  copilot_handler_detail --> copilot_tracker_detail
+  copilot_handler_detail -. decide per thread .-> action_decision
+  action_decision -. action fix .-> committer_detail
+  committer_detail -. push .-> push_update
+  push_update -. recheck .-> refetch_threads
+  refetch_threads -. new threads .-> copilot_handler_detail
+  action_decision -. no action: reply and resolve .-> copilot_tracker_detail
+  copilot_handler_detail -. all threads resolved .-> merge_ready_detail
+  merge_ready_detail -. merged by repository workflow .-> merged_detail
+```
+
+## Required Delivery Path
+
+The Implementer profile declares the repository's complete mandatory delivery path. A direct user
+request can invoke an Implementer without a Planner-created specification, but this does not remove
+the Implementer's own required review and commit handoffs.
+
+| From          | To                 | Required condition                                                                  | Evidence or output                                                                                          | Failure route                                                                                     |
+| ------------- | ------------------ | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Planner       | Implementer        | Planner completes its planning workflow.                                            | Classified issue specification, acceptance criteria, and scoped tasks.                                      | Implementation ambiguity or a spec/code mismatch returns to Planner or the user.                  |
+| Implementer   | Complexity Auditor | Each red-green-refactor step is complete and focused tests pass.                    | Per-function assessment and `AUDIT PASSED`, `AUDIT WARNED`, or `AUDIT FAILED`.                              | A blocking audit finding returns to Implementer for simplification and re-audit.                  |
+| Implementer   | Task Reviewer      | All implementation steps and tests are complete; completion-review evidence exists. | Acceptance-criteria matrix, convention findings, checklist updates, and `REVIEW PASSED` or `REVIEW FAILED`. | A failure or pending evidence returns to Implementer for remediation and another review.          |
+| Task Reviewer | Committer          | Task Reviewer reports `REVIEW PASSED`.                                              | Verified scope and acceptance-criteria evidence.                                                            | Committer returns stale-spec, policy, implementation, or test blockers to the code-focused owner. |
+| Committer     | Signed commit      | The commit workflow has a coherent scope and passing mandatory validation.          | GPG-signed Conventional Commit with verification result.                                                    | Committer returns stale-spec, policy, implementation, or test blockers to the code-focused owner. |
+
+## Optional and Event-Driven Paths
+
+These paths support the delivery path but are not universal prerequisites.
+
+| Agent                       | Trigger                                                             | Output and handoff                                                              | Boundary                                                                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Researcher                  | A focused external-evidence question.                               | Structured findings to Planner or Implementer.                                  | Research is read-only and does not choose a design. Materially invalidating findings require replanning.                                                              |
+| GitHub Operator             | A requested GitHub-side operation with the required local context.  | Verified issue, subissue, metadata, or PR operation result.                     | Creating an issue requires an approved local spec. Code-changing review feedback returns to a code-focused agent.                                                     |
+| User                        | A task, problem statement, or decision requiring an agent workflow. | A request to the appropriate agent or an approval/revision decision.            | Profiles do not define a universal entry agent; Planning and pull-request creation are conditional workflows.                                                         |
+| ClippyFixer                 | Concrete Clippy warnings from the user or `linter clippy`.          | Focused remediation and documented exceptions; Committer creates commits.       | The profile currently declares no `edit` tool although it describes source modifications. Issue #2158 tracks this capability mismatch.                                |
+| PR Reviewer                 | An existing PR and its actual diff/check context.                   | Findings and `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.                        | The profile does not define a remediation owner, thread-publication step, or required re-review after fixes.                                                          |
+| Copilot Suggestions Handler | Unresolved Copilot review threads on an existing PR.                | Per-thread decision, reply, resolution, and `docs/copilot-pr-reviews/` tracker. | It handles Copilot threads only, replies before resolving, and fetches the threads again after each push. An action fix is validated and committed through Committer. |
+
+## Artifact Ownership
+
+| Artifact                         | Current owner                                                      | Location                                                                                       | Use                                                                       |
+| -------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| Issue or EPIC specification      | Planner or the user; Task Reviewer may update verified checkboxes. | `docs/issues/drafts/`, then `docs/issues/open/` or `docs/issues/closed/`.                      | Scope, acceptance criteria, verification, and progress record.            |
+| Implementation completion review | Implementer.                                                       | Issue specification folder when a retrospective is required; otherwise the issue progress log. | Records material discoveries and lessons before independent verification. |
+| Signed commit                    | Committer.                                                         | Git history.                                                                                   | Records a validated, GPG-signed change.                                   |
+| Copilot suggestions tracker      | Copilot Suggestions Handler.                                       | `docs/copilot-pr-reviews/pr-<number>-copilot-suggestions.md`.                                  | Records per-thread decisions, replies, and resolution state.              |
+| Independent review report        | Currently caller-facing only.                                      | No current issue-local artifact.                                                               | Issue #2160 proposes durable `agent-review-reports.md` records.           |
+
+## Known Gaps and Future Enforcement
+
+The repository does not currently define a universal entry point, state store, automatic agent
+selection mechanism, or machine-enforced transition graph. This guide must not be used to claim
+those capabilities exist.
+
+Future work may model approved workflow transitions as a state machine, graph, or external tool.
+It must first collect evidence from real workflow use, define state ownership, recovery, and
+failure paths, compare alternatives, and record a dedicated ADR before selecting an enforcement
+mechanism. Issue #2155 deliberately does not make that selection.
+
+## References
+
+- [Repository agent profiles](../../.github/agents/README.md)
+- [AI agent documentation index](README.md)
+- [Issue #2155 specification](../issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md)
+- [Issue #2160 specification](../issues/open/2160-2003-persist-independent-agent-review-reports/ISSUE.md)
+- [AI agent context, capability, and portability governance ADR](../adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md)

--- a/docs/agents/orchestration.md
+++ b/docs/agents/orchestration.md
@@ -6,8 +6,8 @@ semantic-links:
     - .github/agents/README.md
     - .github/skills/
     - docs/agents/README.md
-    - docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
-    - docs/issues/open/2160-2003-persist-independent-agent-review-reports/ISSUE.md
+    - issue #2155
+    - issue #2160
     - docs/adrs/20260821172000_establish_ai_agent_context_capability_and_portability_governance.md
 ---
 

--- a/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
@@ -24,9 +24,9 @@ Status legend:
 
 ## Suggestions
 
-| #   | Thread ID               | Path                           | URL                                                                         | Suggestion Summary                                                              | Decision | Reply URL | Status | Thread State |
-| --- | ----------------------- | ------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
-| 1   | `PRRT_kwDOGp2yqc6f9wia` | `docs/agents/orchestration.md` | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951049779 | Replace move-prone issue-spec semantic-link paths with stable issue references. | action   | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951125417 | DONE   | RESOLVED |
+| #   | Thread ID               | Path                           | URL                                                                         | Suggestion Summary                                                              | Decision | Reply URL                                                                   | Status | Thread State |
+| --- | ----------------------- | ------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6f9wia` | `docs/agents/orchestration.md` | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951049779 | Replace move-prone issue-spec semantic-link paths with stable issue references. | action   | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951125417 | DONE   | RESOLVED     |
 
 ## Notes
 

--- a/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
@@ -1,0 +1,33 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+    - docs/agents/orchestration.md
+---
+
+# PR #2163 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2163
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Processing Log
+
+- 2026-09-07 15:15 UTC - Started processing one Copilot suggestion.
+
+## Suggestions
+
+| #   | Thread ID               | Path                           | URL                                                                         | Suggestion Summary                                                              | Decision | Reply URL | Status | Thread State |
+| --- | ----------------------- | ------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6f9wia` | `docs/agents/orchestration.md` | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951049779 | Replace move-prone issue-spec semantic-link paths with stable issue references. | action   | Pending   | OPEN   | OPEN         |
+
+## Notes
+
+- Each resolved thread will receive a reply before resolution.
+- This file is the audit log of Copilot suggestion handling for PR #2163.

--- a/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md
@@ -20,12 +20,13 @@ Status legend:
 ## Processing Log
 
 - 2026-09-07 15:15 UTC - Started processing one Copilot suggestion.
+- 2026-09-07 15:35 UTC - Completed the suggestion: replied before resolving the thread and recorded the result below.
 
 ## Suggestions
 
 | #   | Thread ID               | Path                           | URL                                                                         | Suggestion Summary                                                              | Decision | Reply URL | Status | Thread State |
 | --- | ----------------------- | ------------------------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
-| 1   | `PRRT_kwDOGp2yqc6f9wia` | `docs/agents/orchestration.md` | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951049779 | Replace move-prone issue-spec semantic-link paths with stable issue references. | action   | Pending   | OPEN   | OPEN         |
+| 1   | `PRRT_kwDOGp2yqc6f9wia` | `docs/agents/orchestration.md` | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951049779 | Replace move-prone issue-spec semantic-link paths with stable issue references. | action   | https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951125417 | DONE   | RESOLVED |
 
 ## Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,16 @@ complement ADRs, which record accepted architectural decisions.
 | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
 | [architecture/README.md](architecture/README.md) | Runtime architecture index: tracker instances, shared services, and event topology. |
 
+## AI Agents
+
+Repository-owned documentation of the current workflows between custom AI-agent profiles. It does
+not replace profile definitions or technically enforce agent transitions.
+
+| Document                                           | Description                                                                         |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| [agents/README.md](agents/README.md)               | AI-agent documentation index and workflow references.                               |
+| [agents/orchestration.md](agents/orchestration.md) | Agent handoffs, prerequisites, feedback loops, artifacts, and enforcement boundary. |
+
 ## Architecture Decisions (ADRs)
 
 Records of significant architectural decisions, including context and consequences.

--- a/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
+++ b/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
@@ -8,7 +8,7 @@ github-issue: 2155
 spec-path: docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
 branch: "2155-2003-document-ai-agent-orchestration"
 related-pr: 2163
-last-updated-utc: 2026-09-07 15:30
+last-updated-utc: 2026-09-07 15:35
 semantic-links:
   skill-links:
     - create-issue
@@ -95,6 +95,7 @@ enforcement from being based on reviewed, observed process documentation.
 - 2026-09-07 13:30 UTC - GitHub Copilot - Expanded the guide with focused implementation and pull-request workflow diagrams while retaining the global overview and authoritative handoff tables - Pending final revalidation
 - 2026-09-07 15:00 UTC - GitHub Copilot - Validated all three Mermaid diagrams with syntax checks and previews; `linter all` and `cargo test --doc --workspace` passed - Awaiting final independent task review
 - 2026-09-07 15:30 UTC - GitHub Copilot - Processing a valid Copilot suggestion on PR #2163: replace move-prone issue-spec semantic-link paths with stable issue references - `docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md`
+- 2026-09-07 15:35 UTC - GitHub Copilot - Applied and committed the semantic-link fix, then replied to and resolved the PR #2163 Copilot suggestion; tracker completion record pending its own commit - https://github.com/torrust/torrust-tracker/pull/2163#discussion_r3951125417
 - 2026-09-07 15:00 UTC - Task Reviewer - Independently verified all acceptance criteria against the working-tree documentation diff, all ten custom agent profiles, and rendered Mermaid diagrams - REVIEW PASSED
 
 ## Acceptance Criteria

--- a/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
+++ b/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
@@ -1,14 +1,14 @@
 ---
 doc-type: issue
 issue-type: enhancement
-status: planned
+status: in-review
 priority: p2
 epic: 2003
 github-issue: 2155
 spec-path: docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
 branch: "2155-2003-document-ai-agent-orchestration"
 related-pr: null
-last-updated-utc: 2026-09-07 11:20
+last-updated-utc: 2026-09-07 15:00
 semantic-links:
   skill-links:
     - create-issue
@@ -64,13 +64,13 @@ enforcement from being based on reviewed, observed process documentation.
 
 ## Implementation Plan
 
-| ID  | Status | Task                             | Notes / Expected Output                                                                   |
-| --- | ------ | -------------------------------- | ----------------------------------------------------------------------------------------- |
-| T1  | TODO   | Inventory profile workflows      | Trace every `.github/agents/*.agent.md` profile and its referenced skills.                |
-| T2  | TODO   | Write orchestration guide        | Document phases, prerequisites, artifacts, exceptions, and authority boundaries.          |
-| T3  | TODO   | Add and verify Mermaid flowchart | Include all profiles, feedback loops, required/optional distinction, and terminal states. |
-| T4  | TODO   | Index the guide                  | Update the documentation and agent-profile indexes.                                       |
-| T5  | TODO   | Validate documentation           | Run required checks and manually compare the guide to all profile definitions.            |
+| ID  | Status | Task                             | Notes / Expected Output                                                                                                 |
+| --- | ------ | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Inventory profile workflows      | Traced every `.github/agents/*.agent.md` profile and relevant referenced skills.                                        |
+| T2  | DONE   | Write orchestration guide        | Added `docs/agents/orchestration.md` with authority boundaries and artifact ownership.                                  |
+| T3  | DONE   | Add and verify Mermaid flowchart | Added an overview plus focused implementation and pull-request workflow diagrams with profile-grounded edge semantics.  |
+| T4  | DONE   | Index the guide                  | Added `docs/agents/README.md` and updated documentation and agent-profile indexes.                                      |
+| T5  | DONE   | Validate documentation           | All three Mermaid diagrams passed syntax validation and preview; `linter all` and workspace documentation tests passed. |
 
 ## Progress Tracking
 
@@ -79,25 +79,33 @@ enforcement from being based on reviewed, observed process documentation.
 - [x] Folder-style spec drafted in `docs/issues/drafts/2003-document-ai-agent-orchestration/ISSUE.md`
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue #2155 created and issue number added to this spec
-- [ ] Implementation completed and verified
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Implementation completed and verified
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
 
 ### Progress Log
 
 - 2026-09-07 10:45 UTC - GitHub Copilot - Split from the combined AI-agent process draft into an independently implementable EPIC #2003 child specification - This spec
 - 2026-09-07 11:05 UTC - josecelano - Approved this subissue specification - Chat approval
 - 2026-09-07 11:10 UTC - GitHub Copilot - Created GitHub issue #2155, linked it to EPIC #2003, and promoted this specification to `docs/issues/open/` - https://github.com/torrust/torrust-tracker/issues/2155
+- 2026-09-07 12:40 UTC - GitHub Copilot - Inventoried all custom agent profiles and added the repository-owned orchestration documentation, index, and Mermaid flowchart - Pending validation
+- 2026-09-07 12:45 UTC - GitHub Copilot - Validated Mermaid syntax and preview; `linter all` and `cargo test --doc --workspace` passed; awaiting independent task review - Local validation
+- 2026-09-07 13:00 UTC - Task Reviewer - Independently verified AC1, AC4, and AC5. AC2 and AC3 remain unverified because the diagram labels user-to-Planner and commit-to-pull-request transitions mandatory without profile support. AC6 remains unverified because `linter all` fails CSpell; `cargo test --doc --workspace` passes. No implementation-completion assessment explains why a retrospective was not needed - Independent task review
+- 2026-09-07 13:10 UTC - GitHub Copilot - Corrected unsupported mandatory transitions, added the `docs/agents/` directory-map entry, and created a retrospective for the review finding - Pending revalidation
+- 2026-09-07 13:20 UTC - GitHub Copilot - Reclassified the remaining unsupported approval and PR-stage transitions as conditional after the independent re-review - Pending final revalidation
+- 2026-09-07 13:30 UTC - GitHub Copilot - Expanded the guide with focused implementation and pull-request workflow diagrams while retaining the global overview and authoritative handoff tables - Pending final revalidation
+- 2026-09-07 15:00 UTC - GitHub Copilot - Validated all three Mermaid diagrams with syntax checks and previews; `linter all` and `cargo test --doc --workspace` passed - Awaiting final independent task review
+- 2026-09-07 15:00 UTC - Task Reviewer - Independently verified all acceptance criteria against the working-tree documentation diff, all ten custom agent profiles, and rendered Mermaid diagrams - REVIEW PASSED
 
 ## Acceptance Criteria
 
-- [ ] `docs/agents/` is the discoverable canonical documentation collection for AI-agent workflows.
-- [ ] The Mermaid flowchart includes every custom profile and its documented handoffs.
-- [ ] The guide distinguishes required handoffs from optional/event-driven paths and identifies
+- [x] `docs/agents/` is the discoverable canonical documentation collection for AI-agent workflows.
+- [x] The Mermaid flowchart includes every custom profile and its documented handoffs.
+- [x] The guide distinguishes required handoffs from optional/event-driven paths and identifies
       issue specifications, retrospectives, review reports, commits, and Copilot-thread trackers.
-- [ ] Feedback loops and terminal states are explicit.
-- [ ] The guide declares that it documents current expectations only and reserves enforcement-tool
+- [x] Feedback loops and terminal states are explicit.
+- [x] The guide declares that it documents current expectations only and reserves enforcement-tool
       selection for a separately evidenced ADR.
-- [ ] `linter all` exits with code `0` and relevant documentation checks pass.
+- [x] `linter all` exits with code `0` and relevant documentation checks pass.
 
 ## Verification Plan
 
@@ -108,21 +116,21 @@ enforcement from being based on reviewed, observed process documentation.
 
 ### Manual Verification Scenarios
 
-| ID  | Scenario             | Command/Steps                                                             | Expected Result                                      | Status | Evidence               |
-| --- | -------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ---------------------- |
-| M1  | Trace every profile  | Compare the guide and flowchart to each `.github/agents/*.agent.md` file. | Every profile and handoff is represented accurately. | TODO   | Pending implementation |
-| M2  | Render the flowchart | Open the documentation in a Mermaid-capable Markdown renderer.            | The flowchart renders and labels remain readable.    | TODO   | Pending implementation |
+| ID  | Scenario             | Command/Steps                                                                 | Expected Result                                      | Status | Evidence                                                                                        |
+| --- | -------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| M1  | Trace every profile  | Compared the guide and all diagrams to each `.github/agents/*.agent.md` file. | Every profile and handoff is represented accurately. | DONE   | Profile inventory, edge reclassification, and final independent review requested on 2026-09-07. |
+| M2  | Render the flowchart | Opened `docs/agents/orchestration.md` in a Mermaid preview.                   | All diagrams render and labels remain readable.      | DONE   | Overview and both focused diagrams passed syntax validation and preview on 2026-09-07.          |
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence               |
-| ----- | ---------------------- | ---------------------- |
-| AC1   | TODO                   | Pending implementation |
-| AC2   | TODO                   | Pending implementation |
-| AC3   | TODO                   | Pending implementation |
-| AC4   | TODO                   | Pending implementation |
-| AC5   | TODO                   | Pending implementation |
-| AC6   | TODO                   | Pending implementation |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                                                                                                                                                                                                                    |
+| ----- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC1   | DONE                   | `docs/agents/README.md`, `docs/index.md`, and `.github/agents/README.md` provide discoverable canonical entry points; semantic-link targets exist.                                                                                                                                          |
+| AC2   | DONE                   | Final independent review matched all ten profiles to the overview diagram and handoff tables. Solid delivery edges trace to declared Planner, Implementer, Complexity Auditor, Task Reviewer, Committer, and Copilot Suggestions Handler workflows; unsupported paths are dashed.           |
+| AC3   | DONE                   | Final independent review verified the legend, required and event-driven tables, and artifact-ownership table distinguish declared mandatory handoffs from conditional paths and identify issue specifications, retrospectives, review reports, signed commits, and Copilot-thread trackers. |
+| AC4   | DONE                   | The flowchart explicitly shows revision, audit, task-review, and review-feedback loops, plus the `Merged` terminal state.                                                                                                                                                                   |
+| AC5   | DONE                   | The guide expressly describes a non-enforcing model and requires a separately evidenced ADR before enforcement-tool selection.                                                                                                                                                              |
+| AC6   | DONE                   | `linter all` and `cargo test --doc --workspace` passed on 2026-09-07; the independent re-run of `linter all` included successful CSpell and Markdown checks.                                                                                                                                |
 
 ## Risks and Trade-offs
 

--- a/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
+++ b/docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
@@ -7,8 +7,8 @@ epic: 2003
 github-issue: 2155
 spec-path: docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
 branch: "2155-2003-document-ai-agent-orchestration"
-related-pr: null
-last-updated-utc: 2026-09-07 15:00
+related-pr: 2163
+last-updated-utc: 2026-09-07 15:30
 semantic-links:
   skill-links:
     - create-issue
@@ -94,6 +94,7 @@ enforcement from being based on reviewed, observed process documentation.
 - 2026-09-07 13:20 UTC - GitHub Copilot - Reclassified the remaining unsupported approval and PR-stage transitions as conditional after the independent re-review - Pending final revalidation
 - 2026-09-07 13:30 UTC - GitHub Copilot - Expanded the guide with focused implementation and pull-request workflow diagrams while retaining the global overview and authoritative handoff tables - Pending final revalidation
 - 2026-09-07 15:00 UTC - GitHub Copilot - Validated all three Mermaid diagrams with syntax checks and previews; `linter all` and `cargo test --doc --workspace` passed - Awaiting final independent task review
+- 2026-09-07 15:30 UTC - GitHub Copilot - Processing a valid Copilot suggestion on PR #2163: replace move-prone issue-spec semantic-link paths with stable issue references - `docs/copilot-pr-reviews/pr-2163-copilot-suggestions.md`
 - 2026-09-07 15:00 UTC - Task Reviewer - Independently verified all acceptance criteria against the working-tree documentation diff, all ten custom agent profiles, and rendered Mermaid diagrams - REVIEW PASSED
 
 ## Acceptance Criteria

--- a/docs/issues/open/2155-2003-document-ai-agent-orchestration/implementation-retrospective.md
+++ b/docs/issues/open/2155-2003-document-ai-agent-orchestration/implementation-retrospective.md
@@ -1,0 +1,53 @@
+---
+semantic-links:
+  related-artifacts:
+    - docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md
+    - docs/agents/orchestration.md
+---
+
+# Implementation Retrospective — Issue #2155
+
+## Purpose
+
+Record the material process-model correction discovered while documenting the repository's
+current custom-agent workflows.
+
+## Outcome
+
+The workflow guide now separates transitions explicitly mandated by agent profiles from entry,
+approval, and pull-request paths that are conditional or defined outside an individual profile.
+
+## What Went Well
+
+1. The independent Task Reviewer compared the diagram against profile definitions instead of
+   accepting a plausible lifecycle model.
+2. Mermaid syntax validation and preview verified that the correction remains readable.
+
+## What Changed During Implementation
+
+The initial flowchart represented user-to-Planner and signed-commit-to-pull-request transitions
+with solid arrows. The review found that no profile declares either transition as universally
+mandatory. The guide now uses dashed arrows and explains the conditional boundary in its
+event-driven paths table.
+
+## Root Cause
+
+The initial diagram inferred a common project lifecycle instead of limiting solid arrows to
+mandatory handoffs stated in profile workflows.
+
+## Improvements for Future Work
+
+1. Treat each diagram edge as a claim that must trace to a profile, skill, or repository policy.
+2. Use dashed edges and an explicit boundary for workflow steps that are common but not universally
+   declared by the profiles.
+
+## Avoiding Overcorrection
+
+Do not remove useful entry and pull-request context from the diagram. It remains valuable when
+clearly presented as conditional rather than enforced.
+
+## Evidence
+
+- Issue specification: `docs/issues/open/2155-2003-document-ai-agent-orchestration/ISSUE.md`
+- Independent review: Task Reviewer review on 2026-09-07
+- Corrected guide: `docs/agents/orchestration.md`


### PR DESCRIPTION
## Summary

- add `docs/agents/` as the canonical, repository-owned AI-agent workflow documentation collection;
- document a profile-grounded overview plus focused implementation and pull-request Mermaid workflows;
- distinguish mandatory profile handoffs from conditional and event-driven paths;
- document artifact ownership, known profile gaps, and the boundary before future orchestration enforcement;
- index the guide from the repository documentation and agent-profile catalogs.

## Validation

- Mermaid syntax validation and preview for all three diagrams
- `./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`
- `linter all`
- `cargo test --doc --workspace`
- independent Task Reviewer acceptance-criteria review

Closes #2155

Related to #2003
