### PR TITLE
fix(git): repository-local signing key message and TTY guard for the merge tool

### DIFF
--- a/.github/skills/dev/git-workflow/merge-pull-request/SKILL.md
+++ b/.github/skills/dev/git-workflow/merge-pull-request/SKILL.md
@@ -34,6 +34,10 @@ The full provenance, license, deterministic test boundary, and EPIC #2003 relati
 - Verify the target is `develop` and the Git working tree is clean before starting. Preserve
   unrelated work with a commit or a named stash; never use `git reset --hard` to discard it.
 - Run the repository-local wrapper, not a personal path outside this repository.
+- Never start the merge tool without an interactive terminal: its prompts are read from standard
+  input, which must be a terminal. The vendored tool never ends at end of input, so a run with
+  redirected, closed, or piped input loops forever reprinting its prompt; the wrapper refuses to
+  start in that case. Use `--dry-run` for non-interactive validation.
 - Inspect the temporary merge and run the required validation before considering a signature.
 - Never type `s` to sign or `push` to push unless an authorized maintainer has explicitly
   confirmed that action in the current request.
@@ -64,9 +68,13 @@ Replace `<upstream-remote>` with the contributor-local remote name that points t
 
    ```sh
    git config githubmerge.repository torrust/torrust-tracker
-   git config --global user.signingkey <gpg-key-id>
+   git config user.signingkey <gpg-key-id>
    git config user.ghtoken <github-token>
    ```
+
+   Signing configuration is repository-local: set `user.signingkey` in this repository and leave the
+   global scope unset, which is also what the wrapper's preflight message tells you to do. The
+   vendored tool's own missing-key message suggests the global scope; disregard it.
 
    `user.ghtoken` is optional. `githubmerge.host` defaults to `git@github.com`; SSH credentials
    must permit fetching the upstream repository and pushing only after authorization. The wrapper

--- a/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
+++ b/.github/skills/dev/git-workflow/open-pull-request/SKILL.md
@@ -75,7 +75,7 @@ PR title: use Conventional Commit style, include issue reference.
 Examples:
 
 - `feat(tracker-core): [#42] add peer expiry grace period`
-- `docs(agents): set up basic AI agent configuration (#1697)`
+- `docs(agents): [#1697] set up basic AI agent configuration`
 
 PR body must include:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,6 +339,19 @@ Scope should reflect the affected package or area (e.g., `tracker-core`, `udp-pr
 - `develop` → `staging/main` → `main` (release pipeline)
 - PRs must pass all CI status checks before merge
 
+**Pull request titles**: the maintainer merge tool (`contrib/dev-tools/git/merge-pull-request.sh`, which runs the vendored `contrib/dev-tools/git/github-merge.py`) copies the PR title verbatim into the merge commit subject, so the title becomes permanent `develop` history:
+
+```text
+PR title:      feat(tracker-core): [#42] add peer expiry grace period
+Merge subject: Merge torrust/torrust-tracker#123: feat(tracker-core): [#42] add peer expiry grace period
+```
+
+- Write the title as a single Conventional Commits line (`type(scope): summary`, same forms as above) that reads well as that subject
+- Do not put the PR number in the title; the merge tool prepends it
+- Include an issue reference `[#<issue>]` only for the issue the PR implements or closes, so the merge commit links that issue; a merely related or already-closed issue belongs in the PR body (`Related to #N`)
+
+Full title and body conventions: `.github/skills/dev/git-workflow/open-pull-request/SKILL.md`.
+
 See [docs/release_process.md](docs/release_process.md) for the full release workflow.
 
 ## 🧭 Development Principles

--- a/contrib/dev-tools/git/README-github-merge.md
+++ b/contrib/dev-tools/git/README-github-merge.md
@@ -28,12 +28,33 @@ Local changes to the vendored algorithm require a documented security, portabili
 correctness reason and a new provenance hash. This integration deliberately confines
 repository-specific behavior to `merge-pull-request.sh` so the vendor copy remains auditable.
 
+## Known Upstream Issues
+
+These are upstream (Bitcoin Core) behaviors of the vendored copy, recorded here rather than
+patched: the copy stays byte-identical and its provenance hash is unchanged, as the local-change
+policy above requires.
+
+- **A failed comment fetch raises instead of exiting cleanly.** Line 441 adds the results of
+  `retrieve_pr_comments(...)` and `retrieve_pr_reviews(...)` before the `if comments is None` check
+  on line 442, so an unavailable GitHub API makes the addition raise a `TypeError` and the intended
+  "Could not fetch PR comments and reviews" exit is never reached. The `finally` block still deletes
+  the temporary branches; the maintainer sees a Python error report instead of the diagnostic.
+- **The prompts never end at end of input.** `ask_prompt` (line 144) reads a reply with
+  `stdin.readline()` (line 147), and the sign loop (lines 457-470) and push loop (lines 484-492)
+  leave only on `s`, `x`, or `push`. When standard input is not a terminal every read returns
+  immediately at end of input and those loops reprint their prompt forever. `merge-pull-request.sh`
+  mitigates this by refusing to start the tool unless standard input is a terminal.
+- **The missing-key message names the global configuration scope.** Line 297 prints
+  `git config --global user.signingkey <key>`. Signing configuration for this repository is
+  repository-local, so the wrapper's message is the authoritative one.
+
 ## Deterministic Coverage Boundary
 
 Run `bash contrib/dev-tools/git/tests/test-merge-pull-request.sh` to test the wrapper's local,
 non-destructive contract: argument validation, clean-tree protection, fixed repository
-configuration, target-branch selection, signing-key presence, and `--dry-run` behavior. The
-test replaces Python with a local stub to verify delegation without contacting GitHub.
+configuration, target-branch selection, signing-key presence, interactive-terminal refusal, and
+`--dry-run` behavior. The test replaces Python with a local stub to verify delegation without
+contacting GitHub.
 
 The vendored tool's GitHub API, credentials, interactive shell, GPG pinentry, actual merge, and
 push paths are intentionally outside deterministic automated coverage. They require external

--- a/contrib/dev-tools/git/merge-pull-request.sh
+++ b/contrib/dev-tools/git/merge-pull-request.sh
@@ -81,6 +81,17 @@ require_python() {
     fi
 }
 
+require_interactive_stdin() {
+    # The vendored tool reads every prompt with a plain line read and its sign and push loops only
+    # accept 's', 'x', or 'push'. At end of input those loops never terminate, so a run without a
+    # terminal on stdin spins forever instead of failing. Refuse to start it instead; --dry-run and
+    # the environment preconditions above stay usable without a terminal.
+    if [[ ! -t 0 ]]; then
+        echo "ERROR: The vendored merge tool is interactive and loops forever at end of input; run it from a terminal, or use --dry-run for a non-interactive check." >&2
+        exit 1
+    fi
+}
+
 main() {
     local dry_run=false
 
@@ -120,6 +131,7 @@ main() {
 
     require_vendored_tool
     require_python
+    require_interactive_stdin
 
     exec python3 "${VENDORED_TOOL}" "${pull_request}" "${TARGET_BRANCH}"
 }

--- a/contrib/dev-tools/git/merge-pull-request.sh
+++ b/contrib/dev-tools/git/merge-pull-request.sh
@@ -62,7 +62,7 @@ require_signing_key() {
     signing_key=$(git config --get user.signingkey || true)
 
     if [[ -z "${signing_key}" ]]; then
-        echo "ERROR: user.signingkey is not configured; run 'git config --global user.signingkey <gpg-key-id>'." >&2
+        echo "ERROR: user.signingkey is not configured; run 'git config user.signingkey <gpg-key-id>' in this repository (signing configuration is repository-local; do not set it globally)." >&2
         exit 1
     fi
 }

--- a/contrib/dev-tools/git/tests/test-merge-pull-request.sh
+++ b/contrib/dev-tools/git/tests/test-merge-pull-request.sh
@@ -139,7 +139,7 @@ it_should_explain_how_to_configure_an_unset_signing_key() {
     fi
 
     # Assert
-    grep -F -q "ERROR: user.signingkey is not configured; run 'git config --global user.signingkey <gpg-key-id>'." "${output_file}"
+    grep -F -q "ERROR: user.signingkey is not configured; run 'git config user.signingkey <gpg-key-id>' in this repository (signing configuration is repository-local; do not set it globally)." "${output_file}"
 }
 
 it_should_refuse_an_empty_signing_key() {
@@ -162,7 +162,7 @@ it_should_refuse_an_empty_signing_key() {
     fi
 
     # Assert
-    grep -F -q "ERROR: user.signingkey is not configured; run 'git config --global user.signingkey <gpg-key-id>'." "${output_file}"
+    grep -F -q "ERROR: user.signingkey is not configured; run 'git config user.signingkey <gpg-key-id>' in this repository (signing configuration is repository-local; do not set it globally)." "${output_file}"
 }
 
 it_should_invoke_the_vendored_tool_with_the_fixed_target_branch_after_preflight() {

--- a/contrib/dev-tools/git/tests/test-merge-pull-request.sh
+++ b/contrib/dev-tools/git/tests/test-merge-pull-request.sh
@@ -193,7 +193,14 @@ it_should_refuse_to_invoke_a_missing_vendored_tool() {
     # Arrange
     local fixture_root
     fixture_root=$(create_fixture "missing-vendored-tool")
-    rm "${fixture_root}/contrib/dev-tools/git/github-merge.py"
+    # Commit the removal: an uncommitted deletion would trip the clean-tree check first and hide
+    # the vendored-tool assertion this fixture exists to make.
+    (
+        cd "${fixture_root}"
+        rm contrib/dev-tools/git/github-merge.py
+        git add --all
+        git -c commit.gpgsign=false -c core.hooksPath=/dev/null commit --quiet -m 'Remove the vendored tool'
+    )
     local output_file="${TEST_DIRECTORY}/missing-vendored-tool-output.txt"
 
     # Act

--- a/contrib/dev-tools/git/tests/test-merge-pull-request.sh
+++ b/contrib/dev-tools/git/tests/test-merge-pull-request.sh
@@ -8,8 +8,12 @@ TEST_DIRECTORY=$(mktemp -d "${TMPDIR:-/tmp}/test-merge-pull-request.XXXXXX")
 trap 'rm -rf "${TEST_DIRECTORY}"' EXIT
 
 require_pseudo_terminal_support() {
-    if ! command -v script >/dev/null 2>&1; then
-        printf 'ERROR: script(1) from util-linux is required to exercise the interactive-stdin guard.\n' >&2
+    # The suite drives the wrapper through util-linux script(1) with these exact flags. Other
+    # implementations share the command name but reject them, so probe the flags rather than the
+    # command: an absent or incompatible script(1) then fails here by name, not mid-suite with a
+    # usage error from the first test that needs a terminal.
+    if ! script --quiet --return --command true /dev/null >/dev/null 2>&1; then
+        printf 'ERROR: script(1) from util-linux, supporting --command and --return, is required to exercise the interactive-stdin guard.\n' >&2
         exit 1
     fi
 }

--- a/contrib/dev-tools/git/tests/test-merge-pull-request.sh
+++ b/contrib/dev-tools/git/tests/test-merge-pull-request.sh
@@ -7,6 +7,19 @@ PROJECT_ROOT=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../.." && pwd)
 TEST_DIRECTORY=$(mktemp -d "${TMPDIR:-/tmp}/test-merge-pull-request.XXXXXX")
 trap 'rm -rf "${TEST_DIRECTORY}"' EXIT
 
+require_pseudo_terminal_support() {
+    if ! command -v script >/dev/null 2>&1; then
+        printf 'ERROR: script(1) from util-linux is required to exercise the interactive-stdin guard.\n' >&2
+        exit 1
+    fi
+}
+
+run_in_pseudo_terminal() {
+    # The wrapper refuses to start the interactive vendored tool unless stdin is a terminal.
+    # script(1) supplies one, so the delegation contract stays testable from a non-interactive runner.
+    script --quiet --return --command "$1" /dev/null
+}
+
 create_fixture() {
     local fixture_name=$1
     local fixture_root="${TEST_DIRECTORY}/${fixture_name}"
@@ -178,15 +191,55 @@ EOF
     chmod +x "${stub_directory}/python3"
 
     # Act
-    (
-        cd "${fixture_root}"
-        PATH="${stub_directory}:${PATH}" \
-            TEST_PYTHON_ARGUMENTS="${fixture_root}/python-arguments.txt" \
-            ./contrib/dev-tools/git/merge-pull-request.sh 2022
-    )
+    run_in_pseudo_terminal "cd '${fixture_root}' && PATH='${stub_directory}:${PATH}' TEST_PYTHON_ARGUMENTS='${fixture_root}/python-arguments.txt' ./contrib/dev-tools/git/merge-pull-request.sh 2022"
 
     # Assert
     grep -F -q 'contrib/dev-tools/git/github-merge.py 2022 develop' "${fixture_root}/python-arguments.txt"
+}
+
+it_should_refuse_to_start_the_interactive_tool_without_a_terminal_on_stdin() {
+    # Arrange
+    local fixture_root
+    fixture_root=$(create_fixture "non-interactive-stdin")
+    local stub_directory="${TEST_DIRECTORY}/non-interactive-stdin-bin"
+    mkdir -p "${stub_directory}"
+    cat >"${stub_directory}/python3" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"${TEST_PYTHON_ARGUMENTS}"
+EOF
+    chmod +x "${stub_directory}/python3"
+    local output_file="${TEST_DIRECTORY}/non-interactive-stdin-output.txt"
+
+    # Act
+    if (
+        cd "${fixture_root}"
+        PATH="${stub_directory}:${PATH}" \
+            TEST_PYTHON_ARGUMENTS="${fixture_root}/python-arguments.txt" \
+            ./contrib/dev-tools/git/merge-pull-request.sh 2022 >"${output_file}" 2>&1 </dev/null
+    ); then
+        printf 'Expected the interactive-stdin guard to fail.\n' >&2
+        return 1
+    fi
+
+    # Assert
+    grep -F -q 'ERROR: The vendored merge tool is interactive and loops forever at end of input; run it from a terminal, or use --dry-run for a non-interactive check.' "${output_file}"
+    [[ ! -e "${fixture_root}/python-arguments.txt" ]]
+}
+
+it_should_pass_the_dry_run_preflight_without_a_terminal_on_stdin() {
+    # Arrange
+    local fixture_root
+    fixture_root=$(create_fixture "non-interactive-dry-run")
+    local output_file="${TEST_DIRECTORY}/non-interactive-dry-run-output.txt"
+
+    # Act
+    (
+        cd "${fixture_root}"
+        ./contrib/dev-tools/git/merge-pull-request.sh --dry-run 2022 >"${output_file}" </dev/null
+    )
+
+    # Assert
+    grep -F -q 'Dry-run preflight passed for torrust/torrust-tracker PR 2022 targeting develop.' "${output_file}"
 }
 
 it_should_refuse_to_invoke_a_missing_vendored_tool() {
@@ -259,6 +312,8 @@ it_should_reject_a_non_positive_pull_request_number_before_performing_work() {
     grep -F -q 'ERROR: PULL_REQUEST must be a positive integer.' "${output_file}"
 }
 
+require_pseudo_terminal_support
+
 it_should_pass_deterministic_preflight_when_repository_state_is_supported
 it_should_refuse_a_dirty_working_tree_without_invoking_the_vendored_tool
 it_should_refuse_a_repository_configuration_that_is_not_the_upstream_tracker
@@ -266,6 +321,8 @@ it_should_explain_how_to_configure_an_unset_repository
 it_should_explain_how_to_configure_an_unset_signing_key
 it_should_refuse_an_empty_signing_key
 it_should_invoke_the_vendored_tool_with_the_fixed_target_branch_after_preflight
+it_should_refuse_to_start_the_interactive_tool_without_a_terminal_on_stdin
+it_should_pass_the_dry_run_preflight_without_a_terminal_on_stdin
 it_should_refuse_to_invoke_a_missing_vendored_tool
 it_should_refuse_to_invoke_the_vendored_tool_without_python
 it_should_reject_a_non_positive_pull_request_number_before_performing_work

--- a/docs/copilot-pr-reviews/pr-2173-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2173-copilot-suggestions.md
@@ -23,17 +23,16 @@ Status legend:
 ## Processing Log
 
 - 2026-09-08: Started processing suggestions.
-- 2026-09-08: Replaced the `script(1)` existence check with a functional probe of the `--command` and `--return` flags the suite uses, so an incompatible implementation fails by name before the tests run; reply and thread resolution still pending.
+- 2026-09-08: Replaced the `script(1)` existence check with a functional probe of the `--command` and `--return` flags the suite uses, so an incompatible implementation fails by name before the tests run; reply posted and thread resolved.
 
 ## Suggestions
 
 | #   | Thread ID | Path                                                       | URL     | Suggestion Summary                                                                                                                          | Decision | Reply URL | Status | Thread State |
 | --- | --------- | ---------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
-| 1   | Pending   | `contrib/dev-tools/git/tests/test-merge-pull-request.sh`   | Pending | `require_pseudo_terminal_support` checked only that `script` exists; implementations that reject `--command`/`--return` failed later with a confusing usage error. | action   | Pending   | OPEN   | OPEN         |
+| 1 | `PRRT_kwDOGp2yqc6gSaK1` | `contrib/dev-tools/git/tests/test-merge-pull-request.sh` | https://github.com/torrust/torrust-tracker/pull/2173#discussion_r3959144960 | `require_pseudo_terminal_support` checked only that `script` exists; implementations that reject `--command`/`--return` failed later with a confusing usage error. | action | https://github.com/torrust/torrust-tracker/pull/2173#discussion_r3959348891 | DONE | RESOLVED |
 
 ## Notes
 
 - Keep this file as an audit log of review handling for the PR.
 - Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.
 - Fix commit: `dfbc9f48` — probes `script --quiet --return --command true /dev/null`, the exact flags `run_in_pseudo_terminal` uses, and fails fast with a named reason. Verified by running the suite (passes) and by re-running it with a stub `script` that rejects `--command` (fails immediately with the named error).
-- Thread ID and comment URL are pending the review-thread fetch; fill them in with the reply URL when the thread is answered and resolved.

--- a/docs/copilot-pr-reviews/pr-2173-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2173-copilot-suggestions.md
@@ -1,0 +1,39 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2173 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for <https://github.com/torrust/torrust-tracker/pull/2173>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Processing Log
+
+- 2026-09-08: Started processing suggestions.
+- 2026-09-08: Replaced the `script(1)` existence check with a functional probe of the `--command` and `--return` flags the suite uses, so an incompatible implementation fails by name before the tests run; reply and thread resolution still pending.
+
+## Suggestions
+
+| #   | Thread ID | Path                                                       | URL     | Suggestion Summary                                                                                                                          | Decision | Reply URL | Status | Thread State |
+| --- | --------- | ---------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
+| 1   | Pending   | `contrib/dev-tools/git/tests/test-merge-pull-request.sh`   | Pending | `require_pseudo_terminal_support` checked only that `script` exists; implementations that reject `--command`/`--return` failed later with a confusing usage error. | action   | Pending   | OPEN   | OPEN         |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.
+- Fix commit: `dfbc9f48` — probes `script --quiet --return --command true /dev/null`, the exact flags `run_in_pseudo_terminal` uses, and fails fast with a named reason. Verified by running the suite (passes) and by re-running it with a stub `script` that rejects `--command` (fails immediately with the named error).
+- Thread ID and comment URL are pending the review-thread fetch; fill them in with the reply URL when the thread is answered and resolved.


### PR DESCRIPTION
## Summary

The repository-local maintainer merge workflow vendored in #2022 has three rough edges that this PR addresses without touching the vendored `github-merge.py` (its provenance hash `e390eb01…baad2` is unchanged):

- The wrapper's preflight message and the merge skill told maintainers to run `git config --global user.signingkey`. Signing configuration for this repository is repository-local, so both now direct a repository-local `git config user.signingkey` and say the global scope stays unset. The check itself already used `git config --get`, which reads local scope, so only the guidance and the two test assertions that quoted it changed.
- The vendored tool reads every prompt with a plain line read and its sign and push loops only accept `s`, `x`, or `push`, so at end of input (stdin not a terminal, closed, or redirected) it loops forever reprinting its prompt. The wrapper now refuses to start the interactive tool unless stdin is a terminal; `--dry-run` and every preflight diagnostic keep working non-interactively, because the guard runs last, immediately before the `exec`.
- `README-github-merge.md` gains a "Known Upstream Issues" section recording, with verified line numbers, the two upstream behaviours above plus a third: a GitHub API failure while fetching PR comments raises a `TypeError` instead of the intended clean exit.

Two things surfaced while adding tests. The wrapper's own deterministic suite (`contrib/dev-tools/git/tests/test-merge-pull-request.sh`) was failing at the current `develop` tip: the missing-tool fixture deleted the vendored file without committing the deletion, so the clean-tree check fired before the assertion the fixture exists to make. That fixture now commits the removal (`test(git): keep the missing-tool fixture's working tree clean`). Nothing in CI runs this suite, only the skill mentions it, which is why the failure went unnoticed; wiring it into a CI job would be a reasonable follow-up. Secondly, exercising the delegation path now needs a pseudo-terminal, supplied by `script(1)` from util-linux; the suite fails fast with a named reason where `script` is absent (BSD `script` lacks `--command`).

## Files touched

- `contrib/dev-tools/git/merge-pull-request.sh` — repository-local signing-key message; `require_interactive_stdin` guard before the `exec`.
- `contrib/dev-tools/git/tests/test-merge-pull-request.sh` — updated assertions; pseudo-terminal helper; two new cases (non-TTY refusal without invoking the tool, `--dry-run` still passing without a terminal); fixture fix.
- `.github/skills/dev/git-workflow/merge-pull-request/SKILL.md` — repository-local signing prerequisite; interactive-terminal guardrail.
- `contrib/dev-tools/git/README-github-merge.md` — "Known Upstream Issues"; coverage sentence lists the terminal refusal.

## Validation

- `bash contrib/dev-tools/git/tests/test-merge-pull-request.sh`: all 12 cases pass (10 pre-existing, 2 new) in 1.1 s; the non-TTY case was checked for non-vacuity by running the same scenario against the unmodified wrapper, which invoked the stub instead of refusing.
- `shellcheck` on both shell files: clean.
- `linter all` (torrust-linting 0.2.0): all linters passed (markdownlint, lychee, yamllint, taplo, cspell, clippy, rustfmt, shellcheck).
- `sha256sum contrib/dev-tools/git/github-merge.py` matches the provenance hash recorded in the README.

Related to #2022 (already closed; this PR refines the workflow it introduced rather than resolving it).


## Documentation follow-ups in this PR

Because the merge tool copies the PR title verbatim into the merge commit subject, two documentation commits ride along: `AGENTS.md` gains a "Pull request titles" note in the Git Workflow section (one Conventional Commits line, no PR number, `[#<issue>]` only for the issue the PR implements or closes, related or closed issues in the body), and the open-pull-request skill's second title example is aligned to the same bracketed form (`docs(agents): [#1697] …` instead of a trailing `(#1697)`).
