### PR TITLE
test(integration): [#1419] use explicit config path fixtures

### DIFF
--- a/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
@@ -37,12 +37,13 @@ Status legend:
 ## Processing Log
 
 - 2026-09-10 08:45 UTC: Started processing one Copilot suggestion.
+- 2026-09-10 14:45 UTC: Updated the issue timestamp in `ff3e30ba`; the required documentation checks and pre-commit gate passed. Replied to and resolved the thread.
 
 ## Suggestions
 
 | #   | Thread ID                | Path                                                                    | URL                                                                                      | Suggestion Summary                                                    | Decision | Reply URL | Status | Thread State |
 | --- | ------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
-| 1   | `PRRT_kwDOGp2yqc6gulBd` | `docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md` | [thread](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3970324230) | Add the required `HH:MM` component to `last-updated-utc`. | Pending  | Pending   | OPEN   | OPEN         |
+| 1   | `PRRT_kwDOGp2yqc6gulBd` | `docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md` | [thread](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3970324230) | Add the required `HH:MM` component to `last-updated-utc`. | action — set `last-updated-utc` to `2026-09-10 14:38` in `ff3e30ba`; documentation checks and pre-commit passed. | [reply](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3980405558) | DONE   | RESOLVED     |
 
 ## Notes
 

--- a/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
@@ -1,0 +1,52 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2189 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for
+https://github.com/torrust/torrust-tracker/pull/2189
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-10 08:45 UTC: Started processing one Copilot suggestion.
+
+## Suggestions
+
+| #   | Thread ID                | Path                                                                    | URL                                                                                      | Suggestion Summary                                                    | Decision | Reply URL | Status | Thread State |
+| --- | ------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6gulBd` | `docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md` | [thread](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3970324230) | Add the required `HH:MM` component to `last-updated-utc`. | Pending  | Pending   | OPEN   | OPEN         |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2189-copilot-suggestions.md
@@ -41,8 +41,8 @@ Status legend:
 
 ## Suggestions
 
-| #   | Thread ID                | Path                                                                    | URL                                                                                      | Suggestion Summary                                                    | Decision | Reply URL | Status | Thread State |
-| --- | ------------------------ | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------- | --------- | ------ | ------------ |
+| #   | Thread ID               | Path                                                                                | URL                                                                                   | Suggestion Summary                                        | Decision                                                                                                         | Reply URL                                                                            | Status | Thread State |
+| --- | ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------ | ------------ |
 | 1   | `PRRT_kwDOGp2yqc6gulBd` | `docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md` | [thread](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3970324230) | Add the required `HH:MM` component to `last-updated-utc`. | action — set `last-updated-utc` to `2026-09-10 14:38` in `ff3e30ba`; documentation checks and pre-commit passed. | [reply](https://github.com/torrust/torrust-tracker/pull/2189#discussion_r3980405558) | DONE   | RESOLVED     |
 
 ## Notes

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
@@ -145,7 +145,7 @@ a separate container-runner concern.
    - Storage directory (e.g., `tracker-storage/` for database and runtime data)
 3. Configure the tracker to use these isolated paths
 4. Pass the temp config-file path directly to
-  `app::start_with_explicit_config_toml_path`
+   `app::start_with_explicit_config_toml_path`
 5. The entire temp directory and its contents are automatically cleaned up when the `TempDir`
    handle is dropped
 
@@ -254,8 +254,8 @@ completed work and remaining tasks are recorded after the decision pivot.
 - [x] AC2: Independent main-level integration-test executables are registered and can run
       concurrently as separate Cargo processes without shared environment state.
 - [x] AC3: Current port-zero suites use an isolated temporary workspace with separate config and storage
-  directories. The shared fixture selects its workspace file through the explicit-path startup
-  API, with no base-source environment-variable mutation or shared storage paths.
+      directories. The shared fixture selects its workspace file through the explicit-path startup
+      API, with no base-source environment-variable mutation or shared storage paths.
 - [x] AC4: Tests using port 0 can extract the actual bound ports from `AppContainer` to construct
       request URLs.
 - [x] AC5: Port-zero suites use an isolated temp workspace and port 0 where the scenario does not
@@ -429,7 +429,7 @@ be reviewed before implementation begins.
 | R4  | DONE   | Align test documentation                      | Update `tests/scaffold.rs` references to the removed `stats` target and revise `tests/AGENTS.md` to document the fixture and process-global lifecycle constraints.                                                        |
 | R5  | DONE   | Run mandatory manual integration verification | On 2026-08-24, exit 0: all six targets passed together; `metrics-port-zero` passed with `--nocapture` and in serial mode. Each suite took 60–81 seconds because server jobs can consume the current per-job wait timeout. |
 | R6  | DONE   | Run the full quality gate                     | On 2026-08-24, exit 0: the pre-commit gate passed, including `linter all`.                                                                                                                                                |
-| R6a | DONE   | Remove fixture environment injection          | `TrackerApplicationFixture` now passes its workspace TOML path to `app::start_with_explicit_config_toml_path`, removing its environment lock, restoration guard, and base-source environment mutation. |
+| R6a | DONE   | Remove fixture environment injection          | `TrackerApplicationFixture` now passes its workspace TOML path to `app::start_with_explicit_config_toml_path`, removing its environment lock, restoration guard, and base-source environment mutation.                    |
 | R7  | TODO   | Open partial-improvement PR                   | Submit the fixture, suite migration, focused ordering coverage, and documentation. State that cooperative server shutdown remains owned by #1488.                                                                         |
 | R8  | TODO   | Revisit after shutdown overhaul #1488         | After #1488's production shutdown work merges, review this fixture against its finalized API, update it if needed, and complete AC8a. Keep #1419 open until that review is recorded.                                      |
 | R9  | TODO   | Perform final closure review                  | After the #1488 follow-up, confirm all acceptance criteria, move the issue specification to `docs/issues/closed/`, and close GitHub issue #1419.                                                                          |

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 1419
 spec-path: docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
 branch: 1419-allow-multiple-integration-tests
 related-pr: null
-last-updated-utc: 2026-09-09
+last-updated-utc: 2026-09-10 14:38
 semantic-links:
   skill-links:
     - write-unit-test

--- a/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
+++ b/docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
@@ -7,7 +7,7 @@ github-issue: 1419
 spec-path: docs/issues/open/1419-allow-multiple-integration-tests-at-main-app-level/ISSUE.md
 branch: 1419-allow-multiple-integration-tests
 related-pr: null
-last-updated-utc: 2026-08-24
+last-updated-utc: 2026-09-09
 semantic-links:
   skill-links:
     - write-unit-test
@@ -128,15 +128,14 @@ Additionally, trackers need isolated storage directories for their databases and
 Using a shared `storage/` directory or relying on default paths causes conflicts when multiple
 trackers run concurrently.
 
-The current test uses `unsafe { env::set_var(...) }` with a safety comment acknowledging this
-limitation.
+The original fixture used `unsafe { env::set_var(...) }` with a safety comment acknowledging this
+limitation. It is retained here as the historical problem that the explicit-path fixture migration resolves.
 
-**Note**: The E2E runner ([`src/console/ci/e2e/runner.rs`](../../../../src/console/ci/e2e/runner.rs))
-demonstrates a pattern where CLI arguments (`--config-toml-path`, `--config-toml`) map to these
-same environment variables (`TORRUST_TRACKER_CONFIG_TOML_PATH`, `TORRUST_TRACKER_CONFIG_TOML`).
-However, the main tracker binary ([`src/main.rs`](../../../../src/main.rs)) does not currently
-accept CLI arguments - it only reads configuration from environment variables. Adding CLI argument
-support to the main binary would be a future improvement, but is out of scope for this issue.
+**Update:** Issue #2151 added `--config-toml-path` to the main tracker
+startup boundary. The shared fixture now passes its workspace-local file to
+`app::start_with_explicit_config_toml_path`, so it no longer needs to mutate
+base-source environment variables. The E2E runner's complete-TOML input remains
+a separate container-runner concern.
 
 **Solution**: Use temporary directories (not just temp files) for complete test isolation:
 
@@ -145,7 +144,8 @@ support to the main binary would be a future improvement, but is out of scope fo
    - Config file (e.g., `tracker-config.toml`)
    - Storage directory (e.g., `tracker-storage/` for database and runtime data)
 3. Configure the tracker to use these isolated paths
-4. Set `TORRUST_TRACKER_CONFIG_TOML_PATH` to point to the temp config file
+4. Pass the temp config-file path directly to
+  `app::start_with_explicit_config_toml_path`
 5. The entire temp directory and its contents are automatically cleaned up when the `TempDir`
    handle is dropped
 
@@ -242,6 +242,10 @@ completed work and remaining tasks are recorded after the decision pivot.
   seconds because current server jobs can consume `wait_for_all`'s per-job timeout. Successful
   process exit is not evidence of cooperative server shutdown; that proof remains deferred to
   #1488.
+- 2026-09-09 - GitHub Copilot - Replaced the shared fixture's test-process configuration
+  environment mutation with `app::start_with_explicit_config_toml_path` using its existing
+  workspace-local file. Removed the environment lock and restoration guard. All eight current
+  main-level integration targets passed together; lifecycle completion remains deferred to #1488.
 
 ## Acceptance Criteria
 
@@ -250,7 +254,8 @@ completed work and remaining tasks are recorded after the decision pivot.
 - [x] AC2: Independent main-level integration-test executables are registered and can run
       concurrently as separate Cargo processes without shared environment state.
 - [x] AC3: Current port-zero suites use an isolated temporary workspace with separate config and storage
-      directories (no shared environment variables or storage paths).
+  directories. The shared fixture selects its workspace file through the explicit-path startup
+  API, with no base-source environment-variable mutation or shared storage paths.
 - [x] AC4: Tests using port 0 can extract the actual bound ports from `AppContainer` to construct
       request URLs.
 - [x] AC5: Port-zero suites use an isolated temp workspace and port 0 where the scenario does not
@@ -372,9 +377,11 @@ lifecycle will be placed in another top-level file, such as `tests/bootstrap.rs`
 such executables concurrently; each suite must therefore still use a unique `TempDir` workspace,
 its own database and storage paths, and port `0` for listeners.
 
-`TORRUST_TRACKER_CONFIG_TOML_PATH` remains process-local under this model, so configuration
-injection through the environment is safe between separate test executables. It must not be
-modified concurrently by separate scenarios in one executable.
+Each fixture passes its workspace-local configuration file directly to
+`app::start_with_explicit_config_toml_path`, so main-level test startup does
+not mutate base-source environment variables. This removes one source of shared
+mutable state; it does not change the one-application-per-executable rule
+imposed by remaining process-global lifecycle constraints.
 
 ### Current Implementation Status
 
@@ -422,6 +429,7 @@ be reviewed before implementation begins.
 | R4  | DONE   | Align test documentation                      | Update `tests/scaffold.rs` references to the removed `stats` target and revise `tests/AGENTS.md` to document the fixture and process-global lifecycle constraints.                                                        |
 | R5  | DONE   | Run mandatory manual integration verification | On 2026-08-24, exit 0: all six targets passed together; `metrics-port-zero` passed with `--nocapture` and in serial mode. Each suite took 60–81 seconds because server jobs can consume the current per-job wait timeout. |
 | R6  | DONE   | Run the full quality gate                     | On 2026-08-24, exit 0: the pre-commit gate passed, including `linter all`.                                                                                                                                                |
+| R6a | DONE   | Remove fixture environment injection          | `TrackerApplicationFixture` now passes its workspace TOML path to `app::start_with_explicit_config_toml_path`, removing its environment lock, restoration guard, and base-source environment mutation. |
 | R7  | TODO   | Open partial-improvement PR                   | Submit the fixture, suite migration, focused ordering coverage, and documentation. State that cooperative server shutdown remains owned by #1488.                                                                         |
 | R8  | TODO   | Revisit after shutdown overhaul #1488         | After #1488's production shutdown work merges, review this fixture against its finalized API, update it if needed, and complete AC8a. Keep #1419 open until that review is recorded.                                      |
 | R9  | TODO   | Perform final closure review                  | After the #1488 follow-up, confirm all acceptance criteria, move the issue specification to `docs/issues/closed/`, and close GitHub issue #1419.                                                                          |

--- a/project-words.txt
+++ b/project-words.txt
@@ -381,6 +381,7 @@ programatik
 proot
 proto
 pushmirrors
+pythondontwritebytecode
 qbittorrent
 quickcheck
 randomised

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -83,8 +83,8 @@ async functions that receive the `AppContainer` and assert behavior.
 
 Cargo may run these binaries in parallel. Each binary binds to port `0`
 (OS-assigned ephemeral ports) by default, uses its own `TempDir` workspace,
-and configures its in-process tracker through its own environment, so no
-conflict occurs. Fixed-port binaries (e.g., `metrics-fixed-ports`)
+and passes its workspace file through the explicit configuration-path API, so
+no base-source environment conflict occurs. Fixed-port binaries (e.g., `metrics-fixed-ports`)
 use distinct non-overlapping ports and must not run concurrently with other
 binaries that use the same ports.
 
@@ -100,9 +100,11 @@ outranks both environment base sources; per-value
 `TORRUST_TRACKER_CONFIG_OVERRIDE_*` variables still apply. Each child must use a
 separate `TempDir` workspace and port-zero listener configuration.
 
-In-process application fixtures remain environment-based because they call the
-compatibility wrapper `app::start()`. Do not mutate configuration variables
-without the fixture's synchronization guard.
+In-process application fixtures pass their workspace file to
+`app::start_with_explicit_config_toml_path`. Do not mutate configuration
+variables in in-process tests unless legacy environment-source behavior is the
+contract under test; serialize and restore such mutations within that test
+module.
 
 ### Why one binary per configuration?
 
@@ -115,11 +117,7 @@ in the same process:
    global subscriber. Once set, it cannot be reset for a second tracker
    instance in the same process. This means tracker applications sharing a
    process would share logging state and configuration.
-2. **Environment-variable configuration injection in in-process fixtures**:
-   `app::start()` reads configuration from the environment. Multiple tracker
-   instances in the same process would race on those variables. Native child
-   fixtures instead use the main binary's explicit CLI path.
-3. **Static secrets and clock state**: Values such as seed secrets and the
+2. **Static secrets and clock state**: Values such as seed secrets and the
    deterministic test clock are process-global. While these could be refactored
    into injected dependencies, they remain lifecycle constraints today.
 

--- a/tests/common/workspace.rs
+++ b/tests/common/workspace.rs
@@ -2,7 +2,7 @@
 
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use tempfile::TempDir;
 use torrust_net_primitives::service_binding::ServiceBinding;
@@ -14,51 +14,6 @@ use url::Url;
 
 /// Maximum time to await each tracker job after requesting cancellation.
 const TRACKER_SHUTDOWN_GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(10);
-
-static ENVIRONMENT_LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
-
-struct ConfigurationEnvironmentGuard {
-    original_path: Option<std::ffi::OsString>,
-    original_toml: Option<std::ffi::OsString>,
-}
-
-impl ConfigurationEnvironmentGuard {
-    #[allow(unsafe_code)]
-    fn replace(path: &Path) -> Self {
-        let original_path = std::env::var_os("TORRUST_TRACKER_CONFIG_TOML_PATH");
-        let original_toml = std::env::var_os("TORRUST_TRACKER_CONFIG_TOML");
-
-        // SAFETY: `ENVIRONMENT_LOCK` serializes configuration environment access in this test executable.
-        unsafe {
-            std::env::remove_var("TORRUST_TRACKER_CONFIG_TOML");
-            std::env::set_var("TORRUST_TRACKER_CONFIG_TOML_PATH", path);
-        }
-
-        Self {
-            original_path,
-            original_toml,
-        }
-    }
-}
-
-impl Drop for ConfigurationEnvironmentGuard {
-    #[allow(unsafe_code)]
-    fn drop(&mut self) {
-        // SAFETY: `ENVIRONMENT_LOCK` is held for the full guard lifetime.
-        unsafe {
-            if let Some(path) = &self.original_path {
-                std::env::set_var("TORRUST_TRACKER_CONFIG_TOML_PATH", path);
-            } else {
-                std::env::remove_var("TORRUST_TRACKER_CONFIG_TOML_PATH");
-            }
-            if let Some(toml) = &self.original_toml {
-                std::env::set_var("TORRUST_TRACKER_CONFIG_TOML", toml);
-            } else {
-                std::env::remove_var("TORRUST_TRACKER_CONFIG_TOML");
-            }
-        }
-    }
-}
 
 /// A temporary workspace for an integration test.
 ///
@@ -154,15 +109,13 @@ impl Drop for TrackerApplicationFixture {
 
 /// Starts the tracker application with the given workspace config.
 ///
-/// Configuration environment access is serialized and restored before this
-/// function returns, so tests in the same executable remain isolated.
+/// The explicit path selects the workspace file without mutating the test
+/// process environment.
 ///
 pub async fn start_tracker_with_config(workspace: &EphemeralTrackerWorkspace) -> (Arc<AppContainer>, JobManager) {
-    let (container, jobs) = {
-        let _environment_lock = ENVIRONMENT_LOCK.lock().await;
-        let _environment_guard = ConfigurationEnvironmentGuard::replace(workspace.config_path());
-        app::start().await.expect("tracker application should start")
-    };
+    let (container, jobs) = app::start_with_explicit_config_toml_path(Some(workspace.config_path().to_path_buf()))
+        .await
+        .expect("tracker application should start");
 
     // Each service acknowledges registry insertion only after binding its
     // final listener. Wait for the exact configuration identities, rather than


### PR DESCRIPTION
## Summary

Migrates the shared main-level integration fixture from process-wide configuration environment mutation to the explicit configuration-file startup API added by #2151.

## Changes

- `TrackerApplicationFixture` now passes its existing isolated workspace TOML file to `app::start_with_explicit_config_toml_path`.
- Removes the fixture's global environment lock, environment restoration guard, and unsafe `std::env` mutation.
- Updates `tests/AGENTS.md` and issue #1419 to distinguish the resolved configuration-injection constraint from the still-deferred process-global lifecycle and shutdown constraints.

## Validation

- All eight current main-level integration targets passed together.
- Focused tracker Clippy and `cargo fmt --check` passed.
- Markdown, spelling, local-link, and whitespace checks passed.
- Required pre-commit gate passed.

Related to #1419

This PR does not close #1419. Cooperative server shutdown and the post-#1488 fixture review remain tracked there.