### PR TITLE
docs(templates): [#2203] catalog templates and add Cargo update PR template

### DIFF
--- a/.github/skills/dev/maintenance/update-dependencies/SKILL.md
+++ b/.github/skills/dev/maintenance/update-dependencies/SKILL.md
@@ -47,10 +47,11 @@ Use `cargo update --dry-run` or read the dependency changelog to classify before
 # Get one high-resolution timestamp (YYYYMMDD-HHMMSS) for this invocation.
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 UPDATE_OUTPUT=".tmp/${TIMESTAMP}-cargo-update.txt"
+UPDATE_BRANCH="${TIMESTAMP}-update-dependencies"
 
 # Create branch
 git checkout develop && git pull --ff-only
-git checkout -b "${TIMESTAMP}-update-dependencies"
+git checkout -b "$UPDATE_BRANCH"
 
 # Ensure the workspace-local ignored log directory exists.
 mkdir -p .tmp
@@ -66,7 +67,7 @@ cargo update 2>&1 | tee "$UPDATE_OUTPUT"
 # Commit and push (using the captured `cargo update` output as the commit body)
 git add Cargo.lock
 git commit -S -m "chore: update dependencies" -m "$(cat "$UPDATE_OUTPUT")"
-git push {your-fork-remote} "${TIMESTAMP}-update-dependencies"
+git push {your-fork-remote} "$UPDATE_BRANCH"
 
 # Open a PR targeting torrust/torrust-tracker:develop. Use
 # docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md and replace its Cargo-output
@@ -84,9 +85,10 @@ from overwriting another's:
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 UPDATE_OUTPUT=".tmp/${TIMESTAMP}-cargo-update.txt"
+UPDATE_BRANCH="${TIMESTAMP}-update-dependencies"
 git checkout develop
 git pull --ff-only
-git checkout -b "${TIMESTAMP}-update-dependencies"
+git checkout -b "$UPDATE_BRANCH"
 
 mkdir -p .tmp
 ```
@@ -94,7 +96,8 @@ mkdir -p .tmp
 For breaking-change updates that require a tracked issue:
 
 ```bash
-git checkout -b "${TIMESTAMP}-{issue-number}-update-dependencies"
+UPDATE_BRANCH="${TIMESTAMP}-{issue-number}-update-dependencies"
+git checkout -b "$UPDATE_BRANCH"
 ```
 
 ### Step 2: Run Cargo Update
@@ -150,7 +153,7 @@ body unless it contains information that must not be committed.
 ```bash
 git add Cargo.lock
 git commit -S -m "chore: update dependencies" -m "$(cat "$UPDATE_OUTPUT")"
-git push {your-fork-remote} "${TIMESTAMP}-update-dependencies"
+git push {your-fork-remote} "$UPDATE_BRANCH"
 ```
 
 ### Step 6: Open PR

--- a/.github/skills/dev/maintenance/update-dependencies/SKILL.md
+++ b/.github/skills/dev/maintenance/update-dependencies/SKILL.md
@@ -10,6 +10,7 @@ semantic-links:
   related-artifacts:
     - .github/dependabot.yaml
     - .github/skills/dev/maintenance/update-github-workflow-actions/SKILL.md
+    - docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md
 ---
 
 # Updating Dependencies
@@ -43,8 +44,9 @@ Use `cargo update --dry-run` or read the dependency changelog to classify before
 ## Quick Reference
 
 ```bash
-# Get a timestamp (YYYYMMDD)
-TIMESTAMP=$(date +%Y%m%d)
+# Get one high-resolution timestamp (YYYYMMDD-HHMMSS) for this invocation.
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+UPDATE_OUTPUT=".tmp/${TIMESTAMP}-cargo-update.txt"
 
 # Create branch
 git checkout develop && git pull --ff-only
@@ -54,7 +56,7 @@ git checkout -b "${TIMESTAMP}-update-dependencies"
 mkdir -p .tmp
 
 # Update dependencies
-cargo update 2>&1 | tee .tmp/cargo-update.txt
+cargo update 2>&1 | tee "$UPDATE_OUTPUT"
 
 # If Cargo.lock has no changes, nothing to do — stop here.
 
@@ -63,22 +65,25 @@ cargo update 2>&1 | tee .tmp/cargo-update.txt
 
 # Commit and push (using the captured `cargo update` output as the commit body)
 git add Cargo.lock
-git commit -S -m "chore: update dependencies" -m "$(cat .tmp/cargo-update.txt)"
+git commit -S -m "chore: update dependencies" -m "$(cat "$UPDATE_OUTPUT")"
 git push {your-fork-remote} "${TIMESTAMP}-update-dependencies"
 
-# Open a PR targeting torrust/torrust-tracker:develop. Include the complete
-# .tmp/cargo-update.txt output verbatim under a "cargo update output" heading
-# in a fenced text block in the PR description.
+# Open a PR targeting torrust/torrust-tracker:develop. Use
+# docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md and replace its Cargo-output
+# placeholder with the complete "$UPDATE_OUTPUT" contents verbatim.
 ```
 
 ## Complete Workflow
 
 ### Step 1: Create a Branch
 
-Generate a timestamp prefix to avoid branch name conflicts across repeated runs:
+Generate one high-resolution timestamp for both the branch and captured output filename. This
+avoids ordinary same-day/same-second collisions and prevents the output capture of one invocation
+from overwriting another's:
 
 ```bash
-TIMESTAMP=$(date +%Y%m%d)
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+UPDATE_OUTPUT=".tmp/${TIMESTAMP}-cargo-update.txt"
 git checkout develop
 git pull --ff-only
 git checkout -b "${TIMESTAMP}-update-dependencies"
@@ -89,19 +94,22 @@ mkdir -p .tmp
 For breaking-change updates that require a tracked issue:
 
 ```bash
-git checkout -b {issue-number}-update-dependencies
+git checkout -b "${TIMESTAMP}-{issue-number}-update-dependencies"
 ```
 
 ### Step 2: Run Cargo Update
 
 ```bash
 mkdir -p .tmp
-cargo update 2>&1 | tee .tmp/cargo-update.txt
+cargo update 2>&1 | tee "$UPDATE_OUTPUT"
 ```
 
 If `Cargo.lock` has no changes, there is nothing to update — exit early.
 
-Review `.tmp/cargo-update.txt` to identify any major version bumps that may be breaking.
+Review `"$UPDATE_OUTPUT"` to identify any major version bumps that may be breaking.
+
+This unique filename prevents captured-output collisions only. Concurrent update workflows must
+not share a Git working tree because Git's branch checkout and index remain shared.
 
 ### Step 3: Handle Breaking Changes
 
@@ -141,7 +149,7 @@ body unless it contains information that must not be committed.
 
 ```bash
 git add Cargo.lock
-git commit -S -m "chore: update dependencies" -m "$(cat .tmp/cargo-update.txt)"
+git commit -S -m "chore: update dependencies" -m "$(cat "$UPDATE_OUTPUT")"
 git push {your-fork-remote} "${TIMESTAMP}-update-dependencies"
 ```
 
@@ -150,10 +158,11 @@ git push {your-fork-remote} "${TIMESTAMP}-update-dependencies"
 Target: `torrust/torrust-tracker:develop`  
 Title: `chore: update dependencies`
 
-Include the complete `.tmp/cargo-update.txt` output in the PR description as well as the commit
-body. Place it verbatim under a `## cargo update output` heading in a fenced `text` code block.
-Do not replace it with a manually abbreviated package list unless the output contains information
-that must not be published.
+Use [the Cargo dependency-update PR template](../../../../../docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md)
+for the PR-body structure. Include the complete `"$UPDATE_OUTPUT"` contents in the PR description
+as well as the commit body, replacing the template's placeholder verbatim. Do not replace it with
+a manually abbreviated package list unless the output contains information that must not be
+published.
 
 ## Decision Guide
 

--- a/.github/skills/dev/planning/create-markdown-template/SKILL.md
+++ b/.github/skills/dev/planning/create-markdown-template/SKILL.md
@@ -4,13 +4,14 @@ description: Create or maintain reusable Markdown document templates in the torr
 metadata:
   author: torrust
   version: "1.0"
-  semantic-links:
-    related-artifacts:
-      - docs/templates/
-      - docs/index.md
-      - docs/AGENTS.md
-      - .github/skills/add-new-skill/SKILL.md
-      - .github/skills/dev/planning/write-markdown-docs/SKILL.md
+semantic-links:
+  related-artifacts:
+    - docs/templates/
+    - docs/templates/README.md
+    - docs/index.md
+    - docs/AGENTS.md
+    - .github/skills/add-new-skill/SKILL.md
+    - .github/skills/dev/planning/write-markdown-docs/SKILL.md
 ---
 
 # Creating Markdown Templates
@@ -40,7 +41,10 @@ resembles a template.
 
 ## Create or Update the Template
 
-1. Place the reusable Markdown file in `docs/templates/`.
+1. Place the reusable Markdown file in `docs/templates/`. Exception: use
+   `.github/PULL_REQUEST_TEMPLATE/` only for templates that must be offered through GitHub's
+   contributor-facing template picker. Do not create a GitHub-native adapter merely to duplicate
+   a canonical repository template.
 2. Use an uppercase descriptive filename, such as `SECURITY-ANALYSIS.md`.
 3. Add YAML frontmatter with high-signal `semantic-links.related-artifacts` entries. Follow the
    [semantic skill-link convention](../../../../../docs/skills/semantic-skill-link-convention.md).
@@ -48,7 +52,9 @@ resembles a template.
    logs, or stale concrete data into a reusable template.
 5. State whether the template is intended for new concrete documents only and where those documents
    belong.
-6. Add the template to the catalog in `docs/index.md` and update a relevant collection README when
+6. Add or materially update the template's entry in `docs/templates/README.md`, which catalogs its
+   purpose, intended destination, and primary workflow or agent.
+7. Add the template to the catalog in `docs/index.md` and update a relevant collection README when
    authors need local procedural context.
 
 ## Link Instead of Duplicating
@@ -73,7 +79,7 @@ linter cspell
 Run `linter all` when the template or related workflow changes affect more than Markdown. Validate
 that:
 
-- the template appears in `docs/templates/` and `docs/index.md`;
+- the template appears in `docs/templates/`, `docs/templates/README.md`, and `docs/index.md`;
 - the linked collection README and skills point to the template;
 - the template has valid frontmatter and no accidental `#NUMBER` enumeration; and
 - retained inline examples have a recorded rationale.

--- a/.github/skills/dev/planning/create-markdown-template/SKILL.md
+++ b/.github/skills/dev/planning/create-markdown-template/SKILL.md
@@ -52,10 +52,14 @@ resembles a template.
    logs, or stale concrete data into a reusable template.
 5. State whether the template is intended for new concrete documents only and where those documents
    belong.
-6. Add or materially update the template's entry in `docs/templates/README.md`, which catalogs its
-   purpose, intended destination, and primary workflow or agent.
-7. Add the template to the catalog in `docs/index.md` and update a relevant collection README when
-   authors need local procedural context.
+6. For a canonical repository template in `docs/templates/`, add or materially update its entry in
+   `docs/templates/README.md`, which catalogs its purpose, intended destination, and primary
+   workflow or agent.
+7. For a canonical repository template in `docs/templates/`, add the template to the catalog in
+   `docs/index.md` and update a relevant collection README when authors need local procedural
+   context. For a GitHub-native template in `.github/PULL_REQUEST_TEMPLATE/`, use GitHub's picker
+   placement and maintain only the applicable GitHub-facing documentation; do not create a duplicate
+   `docs/templates/` entry solely to satisfy this workflow.
 
 ## Link Instead of Duplicating
 
@@ -79,7 +83,8 @@ linter cspell
 Run `linter all` when the template or related workflow changes affect more than Markdown. Validate
 that:
 
-- the template appears in `docs/templates/`, `docs/templates/README.md`, and `docs/index.md`;
+- a canonical repository template appears in `docs/templates/`, `docs/templates/README.md`, and
+   `docs/index.md`, while a GitHub-native template appears in `.github/PULL_REQUEST_TEMPLATE/`;
 - the linked collection README and skills point to the template;
 - the template has valid frontmatter and no accidental `#NUMBER` enumeration; and
 - retained inline examples have a recorded rationale.

--- a/docs/copilot-pr-reviews/pr-2205-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2205-copilot-suggestions.md
@@ -1,0 +1,55 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2205 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for https://github.com/torrust/torrust-tracker/pull/2205
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-11 11:30 UTC: Started processing suggestions.
+- 2026-09-11 11:45 UTC: Processed and resolved all three initially unresolved Copilot suggestion threads; each action was validated with `linter all` before its signed fix commit.
+- 2026-09-11 11:45 UTC: Refreshed review threads and confirmed no unresolved threads remained.
+
+## Suggestions
+
+| #   | Thread ID               | Path                                                                               | URL                                                                         | Suggestion Summary                                                              | Decision | Reply URL                                                                   | Status | Thread State |
+| --- | ----------------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- | ------ | ------------ |
+| 1   | `PRRT_kwDOGp2yqc6hdB4k` | `.github/skills/dev/maintenance/update-dependencies/SKILL.md`                      | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3988801812 | The tracked breaking-update branch name differs from the later push target.     | action   | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3989015123 | DONE   | RESOLVED     |
+| 2   | `PRRT_kwDOGp2yqc6hdB4-` | `.github/skills/dev/planning/create-markdown-template/SKILL.md`                    | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3988801847 | Catalog and index requirements must be conditional for GitHub-native templates. | action   | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3989021558 | DONE   | RESOLVED     |
+| 3   | `PRRT_kwDOGp2yqc6hdB5R` | `docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md` | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3988801872 | The issue specification status must be `in-review` while its PR is pending.     | action   | https://github.com/torrust/torrust-tracker/pull/2205#discussion_r3989028134 | DONE   | RESOLVED     |
+
+## Notes
+
+- Keep this file as an audit log of review handling for the PR.
+- Prefer concise decisions with explicit rationale.
+- If no code changes are needed, explain why in `Decision`.
+- Reply on every PR suggestion thread before resolving it so the decision is visible to reviewers.

--- a/docs/index.md
+++ b/docs/index.md
@@ -152,8 +152,10 @@ that type.
 
 | Template                                                                               | Description                                                       |
 | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [templates/README.md](templates/README.md)                                             | Template catalog, purpose, destinations, and usage policy         |
 | [templates/ADR.md](templates/ADR.md)                                                   | Template for Architectural Decision Records                       |
 | [templates/AGENT-REVIEW-REPORTS.md](templates/AGENT-REVIEW-REPORTS.md)                 | Template for chronological issue-local independent-review reports |
+| [templates/CARGO-DEPENDENCY-UPDATE-PR.md](templates/CARGO-DEPENDENCY-UPDATE-PR.md)     | Template for Cargo dependency-update PR descriptions              |
 | [templates/EPIC.md](templates/EPIC.md)                                                 | Template for EPIC issue specifications                            |
 | [templates/IMPLEMENTATION-RETROSPECTIVE.md](templates/IMPLEMENTATION-RETROSPECTIVE.md) | Template for issue-local implementation retrospectives            |
 | [templates/ISSUE.md](templates/ISSUE.md)                                               | Template for task / bug / feature issue specifications            |

--- a/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
+++ b/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
@@ -1,14 +1,14 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: in-review
 priority: p2
 epic: null
 github-issue: 2203
 spec-path: docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
 branch: "2203-template-catalog-and-cargo-dependency-pr-template"
 related-pr: null
-last-updated-utc: 2026-09-11 10:30
+last-updated-utc: 2026-09-11 11:35
 semantic-links:
   skill-links:
     - create-issue
@@ -141,6 +141,7 @@ Append one line per meaningful update.
 - 2026-09-11 10:55 UTC - Task Reviewer - Found malformed semantic-link frontmatter and incomplete issue-state reconciliation; recorded a failed independent review. - `agent-review-reports.md`
 - 2026-09-11 11:00 UTC - GitHub Copilot - Corrected the semantic-link structure, reconciled completed verification states, and assessed that no retrospective is needed because this contained no material discovery beyond a corrected documentation-metadata defect. - `.github/skills/dev/planning/create-markdown-template/SKILL.md`
 - 2026-09-11 11:05 UTC - Task Reviewer - Re-reviewed the remediated change set and passed all acceptance criteria. - `agent-review-reports.md`
+- 2026-09-11 11:35 UTC - GitHub Copilot - Set the specification status to `in-review` while implementation PR #2205 is pending. - `ISSUE.md`
 
 ## Acceptance Criteria
 

--- a/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
+++ b/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
@@ -6,7 +6,7 @@ priority: p2
 epic: null
 github-issue: 2203
 spec-path: docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
-branch: "2203-template-catalog-and-cargo-dependency-pr-template-spec"
+branch: "2203-template-catalog-and-cargo-dependency-pr-template"
 related-pr: null
 last-updated-utc: 2026-09-11 10:30
 semantic-links:
@@ -86,13 +86,13 @@ Not applicable. This is documentation and workflow maintenance with no child pro
 
 Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 
-| ID  | Status | Task                                       | Notes / Expected Output                                                                                                                                                                                                                                                        |
-| --- | ------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| T1  | TODO   | Inventory templates and current references | Confirm all current `docs/templates/` files and their live skill, agent, and documentation consumers.                                                                                                                                                                          |
-| T2  | TODO   | Add template catalog                       | Create `docs/templates/README.md` with concise directory policy and an entry for each existing template.                                                                                                                                                                       |
-| T3  | TODO   | Add dependency-update PR template          | Add `CARGO-DEPENDENCY-UPDATE-PR.md` with placeholders and an explicit verbatim Cargo-output section.                                                                                                                                                                           |
-| T4  | TODO   | Link workflow and catalog                  | Update `docs/index.md`, `update-dependencies`, and `create-markdown-template` to point to the canonical catalog/template; make one high-resolution timestamp (`YYYYMMDD-HHMMSS`) name both the branch and the Cargo-output capture file; preserve the GitHub-native exception. |
-| T5  | TODO   | Review and validate documentation          | Check links and frontmatter, run applicable linters, and review whether the catalog/template remove duplication without obscuring workflow requirements.                                                                                                                       |
+| ID  | Status | Task                                       | Notes / Expected Output                                                                                                                                                                                                             |
+| --- | ------ | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | DONE   | Inventory templates and current references | Confirmed 11 existing templates, their documented destinations, and live skill/agent consumers.                                                                                                                                     |
+| T2  | DONE   | Add template catalog                       | Added `docs/templates/README.md` with directory policy and an entry for every current template.                                                                                                                                     |
+| T3  | DONE   | Add dependency-update PR template          | Added `CARGO-DEPENDENCY-UPDATE-PR.md` with placeholders and an explicit verbatim Cargo-output section.                                                                                                                              |
+| T4  | DONE   | Link workflow and catalog                  | Updated `docs/index.md`, `update-dependencies`, and `create-markdown-template`; one high-resolution timestamp (`YYYYMMDD-HHMMSS`) now names both the branch and Cargo-output capture file; the GitHub-native exception is explicit. |
+| T5  | DONE   | Review and validate documentation          | `linter all` and both manual scenarios passed; independent review passed after remediation.                                                                                                                                         |
 
 ## Commit Points
 
@@ -119,14 +119,14 @@ commit with GPG.
 - [x] Folder-style spec created in `docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md`
 - [x] Spec reviewed and approved by user/maintainer
 - [x] GitHub issue #2203 created and issue number added to this spec
-- [ ] (Optional, recommended for complex issues) Spec-only PR merged into `develop` before implementation
-- [ ] Implementation completed
-- [ ] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
-- [ ] Manual verification scenarios executed and recorded in issue-local `manual-verification-evidence.md`
-- [ ] Acceptance criteria reviewed after implementation and updated with evidence
-- [ ] Evidence-based implementation completion review recorded: issue-local retrospective created for material discoveries, or progress log states why none was needed
-- [ ] Reviewer validated acceptance criteria and updated checkboxes
-- [ ] Independent reviewer reports recorded in issue-local `agent-review-reports.md` when reviewers received this folder-style specification
+- [x] (Optional, recommended for complex issues) Spec-only PR #2204 merged into `develop` before implementation
+- [x] Implementation completed
+- [x] Automatic verification completed (`linter all`, relevant tests, and any pre-push checks)
+- [x] Manual verification scenarios executed and recorded in issue-local `manual-verification-evidence.md`
+- [x] Acceptance criteria reviewed after implementation and updated with evidence
+- [x] Evidence-based implementation completion review recorded: issue-local retrospective created for material discoveries, or progress log states why none was needed
+- [x] Reviewer validated acceptance criteria and updated checkboxes
+- [x] Independent reviewer reports recorded in issue-local `agent-review-reports.md` when reviewers received this folder-style specification
 - [ ] Committer verified spec progress is up to date before commit
 - [ ] Issue closed and spec moved from `docs/issues/open/` to `docs/issues/closed/`
 
@@ -136,21 +136,26 @@ Append one line per meaningful update.
 
 - 2026-09-11 10:25 UTC - GitHub Copilot - Drafted the proposed task specification in the ignored `.tmp/` directory while the unrelated dependency-update PR CI retry runs. - `.tmp/template-catalog-and-cargo-dependency-pr-template/ISSUE.md`
 - 2026-09-11 10:30 UTC - GitHub Copilot - After PR #2201 merged, copied the approved draft into the repository's numbered open-issue directory and linked it to the already-open issue #2203 on the dedicated spec branch. - `docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md`
+- 2026-09-11 10:40 UTC - GitHub Copilot - Implemented template catalog, Cargo dependency-update PR template, timestamped output capture naming, and skill/index integration on the implementation branch. - `docs/templates/README.md`, `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md`, `docs/index.md`, and updated skills
+- 2026-09-11 10:41 UTC - GitHub Copilot - Ran `linter all` successfully and completed manual scenarios M1 and M2; recorded actual inspection evidence. - `manual-verification-evidence.md`
+- 2026-09-11 10:55 UTC - Task Reviewer - Found malformed semantic-link frontmatter and incomplete issue-state reconciliation; recorded a failed independent review. - `agent-review-reports.md`
+- 2026-09-11 11:00 UTC - GitHub Copilot - Corrected the semantic-link structure, reconciled completed verification states, and assessed that no retrospective is needed because this contained no material discovery beyond a corrected documentation-metadata defect. - `.github/skills/dev/planning/create-markdown-template/SKILL.md`
+- 2026-09-11 11:05 UTC - Task Reviewer - Re-reviewed the remediated change set and passed all acceptance criteria. - `agent-review-reports.md`
 
 ## Acceptance Criteria
 
-- [ ] AC1: `docs/templates/README.md` concisely explains the template directory and catalogs every reusable Markdown template currently present, with purpose, intended destination, and primary workflow or agent.
-- [ ] AC2: `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md` provides a reusable Cargo dependency-update PR structure and explicitly requires the complete, unedited invocation-specific Cargo output in a fenced `text` block.
-- [ ] AC3: `docs/index.md` links to the catalog and the new template.
-- [ ] AC4: `update-dependencies` derives a single high-resolution timestamp (`YYYYMMDD-HHMMSS`) once and uses it at the beginning of both the branch name and `.tmp/<timestamp>-cargo-update.txt` output path, preventing ordinary concurrent invocations from overwriting another's captured output and keeping captured files easy to find in directory listings.
-- [ ] AC5: `update-dependencies` links to the canonical template rather than repeating its full reusable PR-body structure, while its mandatory update/validation/commit workflow remains explicit.
-- [ ] AC6: `create-markdown-template` requires catalog maintenance for material template lifecycle changes and records the exception for GitHub-native templates in `.github/PULL_REQUEST_TEMPLATE/`.
-- [ ] AC7: No second independent canonical PR-description template is introduced under `.github/PULL_REQUEST_TEMPLATE/`.
-- [ ] `linter all` exits with code `0`
-- [ ] Relevant tests pass
-- [ ] Manual verification scenarios are executed and documented in issue-local `manual-verification-evidence.md`
-- [ ] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
-- [ ] Documentation is updated when behavior/workflow changes
+- [x] AC1: `docs/templates/README.md` concisely explains the template directory and catalogs every reusable Markdown template currently present, with purpose, intended destination, and primary workflow or agent.
+- [x] AC2: `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md` provides a reusable Cargo dependency-update PR structure and explicitly requires the complete, unedited invocation-specific Cargo output in a fenced `text` block.
+- [x] AC3: `docs/index.md` links to the catalog and the new template.
+- [x] AC4: `update-dependencies` derives a single high-resolution timestamp (`YYYYMMDD-HHMMSS`) once and uses it at the beginning of every dependency-update branch name, including tracked breaking updates, and the `.tmp/<timestamp>-cargo-update.txt` output path, preventing ordinary concurrent invocations from overwriting another's captured output and keeping captured files easy to find in directory listings.
+- [x] AC5: `update-dependencies` links to the canonical template rather than repeating its full reusable PR-body structure, while its mandatory update/validation/commit workflow remains explicit.
+- [x] AC6: `create-markdown-template` requires catalog maintenance for material template lifecycle changes and records the exception for GitHub-native templates in `.github/PULL_REQUEST_TEMPLATE/`.
+- [x] AC7: No second independent canonical PR-description template is introduced under `.github/PULL_REQUEST_TEMPLATE/`.
+- [x] `linter all` exits with code `0`
+- [x] Relevant tests pass
+- [x] Manual verification scenarios are executed and documented in issue-local `manual-verification-evidence.md`
+- [x] Acceptance criteria are re-reviewed after implementation and reflect actual behavior
+- [x] Documentation is updated when behavior/workflow changes
 
 ## Verification Plan
 
@@ -168,8 +173,8 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 
 | ID  | Scenario                       | Human-oriented command/steps                                                                    | Expected Result                                                                                                                                                                        | Status | Evidence                                     |
 | --- | ------------------------------ | ----------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------------- |
-| M1  | Discover a template            | Read `docs/templates/README.md`, identify the Cargo dependency-update PR template, and open it. | A contributor can determine the template purpose and use it without searching the skills tree.                                                                                         | TODO   | `manual-verification-evidence.md` section V1 |
-| M2  | Follow the dependency workflow | Read `update-dependencies` and the PR template together.                                        | The skill gives the process; the template supplies the reusable body; the high-resolution timestamped Cargo-output rule is unambiguous and prevents ordinary concurrent-run overwrite. | TODO   | `manual-verification-evidence.md` section V2 |
+| M1  | Discover a template            | Read `docs/templates/README.md`, identify the Cargo dependency-update PR template, and open it. | A contributor can determine the template purpose and use it without searching the skills tree.                                                                                         | DONE   | `manual-verification-evidence.md` section V1 |
+| M2  | Follow the dependency workflow | Read `update-dependencies` and the PR template together.                                        | The skill gives the process; the template supplies the reusable body; the high-resolution timestamped Cargo-output rule is unambiguous and prevents ordinary concurrent-run overwrite. | DONE   | `manual-verification-evidence.md` section V2 |
 
 Notes:
 
@@ -201,15 +206,15 @@ automatic tests when practical, then remove the disposable script.
 
 ### Acceptance Verification
 
-| AC ID | Status (`TODO`/`DONE`) | Evidence                                               |
-| ----- | ---------------------- | ------------------------------------------------------ |
-| AC1   | TODO                   | Template catalog inspection and link checks            |
-| AC2   | TODO                   | Template content review and manual scenario M2         |
-| AC3   | TODO                   | `docs/index.md` link checks                            |
-| AC4   | TODO                   | Skill review and concurrent-invocation path inspection |
-| AC5   | TODO                   | Skill/template comparison                              |
-| AC6   | TODO                   | Template-creation skill review                         |
-| AC7   | TODO                   | Changed-files review                                   |
+| AC ID | Status (`TODO`/`DONE`) | Evidence                                                                                |
+| ----- | ---------------------- | --------------------------------------------------------------------------------------- |
+| AC1   | DONE                   | `manual-verification-evidence.md`, V1; template-catalog inspection                      |
+| AC2   | DONE                   | `CARGO-DEPENDENCY-UPDATE-PR.md`; manual-verification evidence V2                        |
+| AC3   | DONE                   | `docs/index.md` Templates table                                                         |
+| AC4   | DONE                   | `update-dependencies` timestamp/output-path inspection; manual-verification evidence V2 |
+| AC5   | DONE                   | `update-dependencies` and template comparison; manual-verification evidence V2          |
+| AC6   | DONE                   | `create-markdown-template` review                                                       |
+| AC7   | DONE                   | Changed-files review: no `.github/PULL_REQUEST_TEMPLATE/` path                          |
 
 ## Risks and Trade-offs
 
@@ -224,7 +229,7 @@ After implementation, compare the result with this specification. Record
 invalidated assumptions, material design changes, unexpected validation
 findings, and reusable lessons.
 
-- Retrospective: `Not yet assessed`
+- Retrospective: `Not needed`; the constrained documentation and workflow change had no material discovery, design change, or deviation from the approved plan. The independently found semantic-link metadata defect was corrected before commit and does not warrant a separate retrospective.
 - If needed, create `implementation-retrospective.md` from the repository
   template at `docs/templates/IMPLEMENTATION-RETROSPECTIVE.md` in this issue
   specification's directory.

--- a/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/agent-review-reports.md
+++ b/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/agent-review-reports.md
@@ -1,0 +1,50 @@
+---
+semantic-links:
+  related-artifacts:
+    - .github/agents/complexity-auditor.agent.md
+    - .github/agents/task-reviewer.agent.md
+    - .github/agents/pr-reviewer.agent.md
+    - docs/agents/orchestration.md
+---
+
+# Agent Review Reports - Catalog Markdown templates and add a Cargo dependency update PR template
+
+> Append one completed independent-review entry at a time. Do not modify, reorder, or remove
+> earlier entries. A correction is a new entry that names the earlier conclusion.
+
+## Reports
+
+### 2026-09-11 10:55 UTC - Task Reviewer
+
+- Invocation scope: Issue #2203 pre-commit review of its uncommitted documentation, template, skill, and manual-verification changes.
+- Inputs: `ISSUE.md`; `manual-verification-evidence.md`; changed files; template-directory inventory; semantic-link convention; and focused link/YAML checks.
+- Evidence: `git diff --check` passed; catalog inventory found all 12 non-catalog Markdown templates represented; focused relative-link checks passed; no `.github/PULL_REQUEST_TEMPLATE/` file exists; changed frontmatter was parsed as YAML.
+- Findings:
+  - FAIL: `.github/skills/dev/planning/create-markdown-template/SKILL.md` places `semantic-links` under `metadata` and nests `docs/templates/README.md` beneath the `docs/templates/` list item. This does not produce the canonical top-level `semantic-links.related-artifacts` structure required by `docs/skills/semantic-skill-link-convention.md`; the focused parser consequently reports no top-level semantic links for this skill.
+  - PENDING: `ISSUE.md` still records M1 and M2 as `TODO` even though `manual-verification-evidence.md` reports both as `DONE`; it also leaves the completion-review/retrospective assessment as `Not yet assessed` and retains unchecked completion-review and documentation-update checklist entries. Reconcile this issue-spec state and record whether a retrospective is needed before commit.
+- Verdict: REVIEW FAILED
+- Follow-up actions:
+  - Move and normalize the changed `semantic-links` block in `create-markdown-template/SKILL.md` to the documented top-level structure, with sibling list entries for `docs/templates/` and `docs/templates/README.md`; revalidate the frontmatter.
+  - Update the issue specification only with verification that is complete, mark M1/M2 accurately, and add either the required implementation retrospective or a progress-log rationale that none was needed. Re-run the independent review after remediation.
+
+### 2026-09-11 11:00 UTC - GitHub Copilot
+
+- Invocation scope: Remediation of the failed Task Reviewer review for issue #2203.
+- Inputs: `ISSUE.md`; `manual-verification-evidence.md`; the first review report; and the corrected `create-markdown-template` frontmatter.
+- Evidence: `semantic-links` is now top-level with sibling `related-artifacts` entries; M1 and M2 match their `DONE` evidence; the progress log and completion-review rationale record why no retrospective is needed.
+- Findings:
+  - None.
+- Verdict: REVIEW PASSED
+- Follow-up actions:
+  - Commit the reviewed changes after final required validation.
+
+### 2026-09-11 11:05 UTC - Task Reviewer
+
+- Invocation scope: Final independent review of the remediated, uncommitted issue #2203 documentation, templates, skills, issue specification, and evidence.
+- Inputs: Changed files; `ISSUE.md`; `manual-verification-evidence.md`; prior review reports; template-directory inventory; frontmatter; and validation results.
+- Evidence: All AC1-AC7 passed; `linter all` and `git diff --check` passed; catalog coverage and local Markdown links were checked; manual scenarios M1 and M2 were reconciled as `DONE`; and the completion-review rationale was present.
+- Findings:
+  - None.
+- Verdict: REVIEW PASSED
+- Follow-up actions:
+  - Commit the reviewed changes after final required validation.

--- a/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/manual-verification-evidence.md
+++ b/docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/manual-verification-evidence.md
@@ -1,0 +1,68 @@
+---
+doc-type: manual-verification-evidence
+issue-spec: docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/ISSUE.md
+last-updated-utc: 2026-09-11 10:41
+---
+
+# Manual Verification Evidence
+
+## Purpose
+
+Record real, human-oriented verification of the completed behavior. This is evidence from commands or interactions actually performed against the artifact; do not invent commands, output, logs, or results.
+
+## Environment and Prerequisites
+
+- Date and time (UTC): 2026-09-11 10:41
+- Artifact under test: Documentation changes on branch `2203-template-catalog-and-cargo-dependency-pr-template`
+- Operating system / environment: Linux development workspace
+- Prerequisites and setup performed: Opened `docs/templates/README.md`, `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md`, and `.github/skills/dev/maintenance/update-dependencies/SKILL.md`; inspected their relevant entries and requirements.
+
+## Verification Processes
+
+### V1 - Discover the Cargo dependency-update PR template
+
+- Goal: Verify a contributor can discover the template and its intended use without searching the skills tree.
+- Initial state: `docs/templates/README.md` contains the catalog entries for the existing templates and the new Cargo dependency-update PR template.
+- Status: `DONE`
+
+#### Steps Performed
+
+1. Read `docs/templates/README.md` and located the `CARGO-DEPENDENCY-UPDATE-PR.md` catalog row.
+2. Opened `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md` using the catalog link.
+
+#### Observed Result
+
+```text
+The catalog identifies CARGO-DEPENDENCY-UPDATE-PR.md as the reusable GitHub PR body for Cargo dependency updates, names its intended destination as a GitHub PR description, and names update-dependencies as the primary workflow. The template instructs authors not to commit a populated copy.
+```
+
+#### Conclusion
+
+The observed result met manual scenario M1. The template is discoverable from the template catalog without searching the skills tree.
+
+### V2 - Follow the Cargo dependency-update workflow
+
+- Goal: Verify the workflow and template have unambiguous, separate responsibilities and use the same timestamped output path.
+- Initial state: The `update-dependencies` skill and Cargo dependency-update PR template are present in the working tree.
+- Status: `DONE`
+
+#### Steps Performed
+
+1. Read the Quick Reference and complete workflow in `.github/skills/dev/maintenance/update-dependencies/SKILL.md`.
+2. Confirmed the skill defines `TIMESTAMP=$(date +%Y%m%d-%H%M%S)` once and sets `UPDATE_OUTPUT=".tmp/${TIMESTAMP}-cargo-update.txt"`.
+3. Confirmed the skill uses `UPDATE_OUTPUT` for `cargo update`, the commit body, and the PR-template replacement instruction.
+4. Read `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md` and confirmed it supplies only the reusable PR body structure, including the fenced `cargo update output` placeholder.
+
+#### Observed Result
+
+```text
+The skill retains the update, validation, commit, and push procedure. It derives one high-resolution timestamp for the update branch and capture filename, and it requires the complete captured output in both the commit body and template-based PR description. The template supplies the reusable GitHub body structure without duplicating the procedure.
+```
+
+#### Conclusion
+
+The observed result met manual scenario M2. The separation of workflow and template responsibilities is clear, and the timestamped capture file prevents ordinary output-file overwrites between concurrent invocations while explicitly not claiming that concurrent Git operations in one worktree are safe.
+
+## Failures and Follow-up
+
+No failures or blocked verification processes occurred.

--- a/docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md
+++ b/docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md
@@ -1,0 +1,34 @@
+---
+semantic-links:
+  skill-links:
+    - update-dependencies
+  related-artifacts:
+    - .github/skills/dev/maintenance/update-dependencies/SKILL.md
+---
+
+<!-- skill-link: update-dependencies -->
+
+# Cargo Dependency Update Pull Request
+
+> Use this template only for the GitHub PR body of a Cargo dependency update. Keep the update, validation, commit, and push process in the [`update-dependencies` skill](../../.github/skills/dev/maintenance/update-dependencies/SKILL.md). Do not commit a populated copy of this template.
+
+## Summary
+
+{State that the workspace lockfile was updated to the latest releases compatible with the supported Rust version. Note any deferred breaking dependency separately.}
+
+## Files/packages touched
+
+- `Cargo.lock`
+- {Other changed manifest, source, test, or documentation path, if a small breaking-change rework was required.}
+
+## Validation
+
+- `cargo machete`
+- `./contrib/dev-tools/git/hooks/pre-commit.sh --format=json`
+- {Additional focused checks performed for a breaking-change rework, if any.}
+
+## cargo update output
+
+```text
+{Replace this placeholder with the complete, unedited contents of .tmp/<timestamp>-cargo-update.txt.}
+```

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,31 @@
+---
+semantic-links:
+  skill-links:
+    - create-markdown-template
+  related-artifacts:
+    - docs/index.md
+    - .github/skills/dev/planning/create-markdown-template/SKILL.md
+---
+
+<!-- skill-link: create-markdown-template -->
+
+# Markdown Templates
+
+`docs/templates/` contains the canonical reusable Markdown structures for repository documents and GitHub-surface bodies. Copy the relevant template, replace its placeholders, and keep concrete records in their documented destination.
+
+Templates intended specifically for GitHub's contributor-facing template picker are an exception: place those in `.github/PULL_REQUEST_TEMPLATE/` only when that GitHub-native feature is required. Do not create an adapter merely to duplicate a canonical repository template.
+
+| Template                                                           | Purpose                                                               | Intended destination                                                         | Primary workflow or agent                      |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------- | ---------------------------------------------------------------------------- | ---------------------------------------------- |
+| [ADR.md](ADR.md)                                                   | Records a significant architectural decision.                         | `docs/adrs/` or `packages/<package>/docs/adrs/` according to decision scope. | `create-adr`                                   |
+| [AGENT-REVIEW-REPORTS.md](AGENT-REVIEW-REPORTS.md)                 | Records append-only independent review results.                       | `agent-review-reports.md` in a folder-style issue specification.             | Complexity Auditor, Task Reviewer, PR Reviewer |
+| [CARGO-DEPENDENCY-UPDATE-PR.md](CARGO-DEPENDENCY-UPDATE-PR.md)     | Supplies the reusable GitHub PR body for Cargo dependency updates.    | GitHub PR description; do not commit a populated copy.                       | `update-dependencies`                          |
+| [COPILOT-SUGGESTIONS-TEMPLATE.md](COPILOT-SUGGESTIONS-TEMPLATE.md) | Tracks Copilot review-suggestion decisions and resolutions.           | `docs/copilot-pr-reviews/pr-<number>-copilot-suggestions.md`                 | `process-copilot-suggestions`                  |
+| [EPIC.md](EPIC.md)                                                 | Defines an epic issue specification and its subissues.                | `docs/issues/drafts/` or `docs/issues/open/` in a folder-style spec.         | `create-issue`                                 |
+| [IMPLEMENTATION-RETROSPECTIVE.md](IMPLEMENTATION-RETROSPECTIVE.md) | Records material implementation discoveries and process improvements. | `implementation-retrospective.md` in a folder-style issue specification.     | `create-issue`                                 |
+| [ISSUE.md](ISSUE.md)                                               | Defines a task, bug, feature, or enhancement specification.           | `docs/issues/drafts/` or `docs/issues/open/` in a folder-style spec.         | `create-issue`                                 |
+| [MANUAL-VERIFICATION-EVIDENCE.md](MANUAL-VERIFICATION-EVIDENCE.md) | Records real human-oriented verification evidence.                    | `manual-verification-evidence.md` in a folder-style issue specification.     | `create-issue`                                 |
+| [PR-REVIEW-FEEDBACK-TEMPLATE.md](PR-REVIEW-FEEDBACK-TEMPLATE.md)   | Tracks review findings, decisions, replies, and resolutions.          | `docs/pr-review-feedback/pr-<number>-review-feedback.md`                     | `process-pr-review-feedback`                   |
+| [REFACTOR-PLAN.md](REFACTOR-PLAN.md)                               | Defines a refactor plan and ordered implementation items.             | `docs/refactor-plans/drafts/` or `docs/refactor-plans/open/`                 | `create-refactor-plan`                         |
+| [SECURITY-ANALYSIS.md](SECURITY-ANALYSIS.md)                       | Analyzes an approved public security finding or vulnerability.        | `docs/security/analysis/production/`, `build/`, or `affecting/`              | `catalog-security-vulnerabilities`             |
+| [SECURITY-REPORT.md](SECURITY-REPORT.md)                           | Records handled coordinated-disclosure reports.                       | `docs/security/analysis/reports/`                                            | `docs/security/vulnerability-remediation.md`   |


### PR DESCRIPTION
## Summary

Adds a canonical catalog for reusable Markdown templates and a Cargo dependency-update PR-body template.

Updates the dependency-update workflow to use one `YYYYMMDD-HHMMSS` timestamp at the beginning of every update branch and captured-output path, preventing ordinary output-file collisions while documenting that concurrent Git operations must use separate working trees.

## Files/packages touched

- `docs/templates/README.md`
- `docs/templates/CARGO-DEPENDENCY-UPDATE-PR.md`
- `docs/index.md`
- `.github/skills/dev/maintenance/update-dependencies/SKILL.md`
- `.github/skills/dev/planning/create-markdown-template/SKILL.md`
- Issue #2203 specification and verification evidence

## Validation

- `linter all`
- `git diff --check`
- Manual catalog-discovery and dependency-workflow inspections recorded in `docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/manual-verification-evidence.md`
- Independent Task Reviewer review passed after remediation; report recorded in `docs/issues/open/2203-template-catalog-and-cargo-dependency-pr-template/agent-review-reports.md`

Closes #2203
