### PR TITLE
docs(links): record C2 hosted verification

### DIFF
--- a/docs/copilot-pr-reviews/pr-2206-copilot-suggestions.md
+++ b/docs/copilot-pr-reviews/pr-2206-copilot-suggestions.md
@@ -1,0 +1,50 @@
+---
+semantic-links:
+  skill-links:
+    - process-copilot-suggestions
+  related-artifacts:
+    - .github/skills/dev/pr-reviews/process-copilot-suggestions/SKILL.md
+    - docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md
+---
+
+<!-- cspell:disable -->
+
+<!-- skill-link: process-copilot-suggestions -->
+
+# PR #2206 Copilot Suggestions Tracking
+
+Source: Copilot PR review threads for <https://github.com/torrust/torrust-tracker/pull/2206>
+
+Status legend:
+
+- `action`: code/docs change applied
+- `no-action`: suggestion reviewed; no code change needed
+- `resolved`: thread resolved in PR
+
+## Workflow
+
+1. Download all review threads (including resolved/outdated state and thread IDs).
+2. Add one row per thread in the Suggestions table.
+3. Process suggestions one by one:
+   - decide `action` or `no-action`
+   - if `action`, apply change and validate
+   - if needed, commit changes
+   - reply on the PR thread with the fix commit and outcome, or the no-action rationale
+   - resolve the PR thread
+4. Set `Thread State` to `resolved` once resolved in PR.
+
+## Processing Log
+
+- 2026-09-11: Started processing one Copilot suggestion.
+- 2026-09-11: Clarified the hosted-report loopback wording in signed commit `f27ebebf`, replied to [thread 1](https://github.com/torrust/torrust-tracker/pull/2206#discussion_r3991179616), and resolved it.
+- 2026-09-11: Refreshed the review-thread list; no unresolved threads remained.
+
+## Suggestions
+
+| # | Thread ID | Path | URL | Suggestion Summary | Decision | Reply URL | Status | Thread State |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | `PRRT_kwDOGp2yqc6hjA6b` | `docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md` | <https://github.com/torrust/torrust-tracker/pull/2206#discussion_r3991133528> | Clarify that loopback URLs are absent from report results because they were excluded. | `action`: clarified hosted-report wording in `f27ebebf`. | <https://github.com/torrust/torrust-tracker/pull/2206#discussion_r3991179616> | DONE | RESOLVED |
+
+## Notes
+
+- A visible reply was posted before resolving the thread.

--- a/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/ISSUE.md
+++ b/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/ISSUE.md
@@ -8,7 +8,7 @@ github-issue: 2185
 spec-path: docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/ISSUE.md
 branch: "2185-2003-triage-advisory-external-link-check-findings"
 related-pr: null
-last-updated-utc: 2026-09-11 09:25
+last-updated-utc: 2026-09-11 15:38
 semantic-links:
   skill-links:
     - create-issue
@@ -88,8 +88,8 @@ Status values: `TODO`, `IN_PROGRESS`, `BLOCKED`, `DONE`.
 | --- | ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | T1  | DONE        | Preserve and classify the baseline        | `external-link-baseline.md` maps all 461 report errors to nine recurring categories and dispositions.                      |
 | T2  | TODO        | Repair clearly stale references           | Small, reviewable repairs replace or remove only references confirmed stale, with replacement-target evidence.             |
-| T3  | IN_PROGRESS | Add justified narrow exclusions           | C1/C9 is verified; the C2 loopback-only candidate passed its local boundary test and awaits hosted verification.           |
-| T4  | DONE        | Revalidate hosted signal                  | Hosted run 34578523069 excluded the intended anchors while retaining visible unrelated failures and its report artifact.  |
+| T3  | DONE        | Add justified narrow exclusions           | C1/C9 and C2 online-only rules are verified on merged upstream hosted runs.                                              |
+| T4  | DONE        | Revalidate hosted signal                  | Hosted run 34616458439 excluded C1/C9 and C2 while retaining visible unrelated failures and its report artifact.         |
 | T5  | TODO        | Document operations and review completion | Triage procedure, residual risks, acceptance evidence, and independent review are updated from observed results.           |
 
 ## Commit Points
@@ -132,14 +132,15 @@ A category that needs no repository change is recorded in issue-local evidence w
 - 2026-09-11 08:27 UTC - Copilot - After PR #2197 merged, [run 34577938048](https://github.com/torrust/torrust-tracker/actions/runs/34577938048) was cancelled while its Lychee step was still in progress. Its upload step retained an empty, unusable report artifact, so it provides no usable Lychee output. Replacement [run 34578523069](https://github.com/torrust/torrust-tracker/actions/runs/34578523069) completed on merged revision `427b0c93`: it visibly failed with 52 remaining errors, excluded 476 links, uploaded a 1,743-byte report artifact, and contained no matching C1/C9 `#discussion_r` URLs. Unrelated `404`, `403`, loopback, issue-comment, other-fragment, and rate-limit failures remained visible.
 - 2026-09-11 08:32 UTC - Task Reviewer - Independently reviewed the replacement hosted run and report artifact. The evidence supports T3/T4, AC3-AC5, and M4; the issue remains open for the remaining C2-C8 work. See `agent-review-reports.md`.
 - 2026-09-11 09:25 UTC - Copilot - Added online-only `exclude_loopback = true` for C2. With explicit online configuration, a three-link boundary test excluded `127.0.0.1` and `localhost` while checking `https://www.rust-lang.org/` successfully. Hosted verification remains pending.
+- 2026-09-11 15:38 UTC - Copilot - After PR #2202 merged, [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439) completed on merged revision `f6df96bf`: it visibly failed with 44 remaining errors, excluded 495 links, uploaded a retained 1,533-byte report artifact, and contained no loopback (`localhost` or `127.0.0.1`) or C1/C9 `#discussion_r` URLs. Unrelated `404`, `403`, FSF transport, issue-comment, pull-request-review, and other missing-fragment failures remained visible.
 
 ## Acceptance Criteria
 
 - [x] AC1: An issue-local baseline records the exact hosted run, revision, summary counts, and a disposition for every distinct failing URL or recurring failure pattern.
 - [ ] AC2: Each repair changes only a verified stale reference and records why its replacement target is correct.
-- [ ] AC3: Each added exclusion is online-only, narrowly scoped to a documented durable false-positive category, and does not suppress unrelated external-link failures.
+- [x] AC3: Each added exclusion is online-only, narrowly scoped to a documented durable false-positive category, and does not suppress unrelated external-link failures.
 - [x] AC4: The advisory workflow remains scheduled/manual, visibly fails for remaining external-link failures, and continues to upload its Markdown report on failure.
-- [ ] AC5: At least one hosted rerun after each remediation slice records the resulting counts and explains material differences from the prior run.
+- [x] AC5: At least one hosted rerun after each remediation slice records the resulting counts and explains material differences from the prior run.
 - [ ] AC6: Documentation explains any permanent exclusion rationale and preserves the existing rerun-then-repair-or-narrow-exclusion triage policy.
 - [ ] `linter all` exits with code `0`.
 - [ ] Relevant tests pass or their documented non-applicability is reviewed.
@@ -165,7 +166,7 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 | M1  | Reproduce baseline             | Manually dispatch `external-link-check.yaml` on `develop`; download `lychee-external-link-report`.            | Report is available even when Lychee fails; baseline counts and categories can be reviewed.                                                     | DONE   | [Run 34347690674](https://github.com/torrust/torrust-tracker/actions/runs/34347690674), revision `7abc30b2`, 461 errors, 0 timeouts. |
 | M2  | Classify durable failures      | Review all report entries and group by URL/pattern, response type, owning document, and proposed disposition. | Every baseline failure has a traceable disposition; no broad host-level suppression is proposed.                                                | DONE   | `external-link-baseline.md`; independent reconciliation passed on 2026-09-10.                                                        |
 | M3  | Verify reference repairs       | Check each changed target using the appropriate authoritative source, then run local validation.              | Replacement reference is correct and offline local-link validation remains clean.                                                               | TODO   | Focused commands and review evidence.                                                                                                |
-| M4  | Verify exclusion boundaries    | Dispatch the hosted workflow after adding a proposed exclusion.                                               | The intended durable false-positive category is absent, while representative unrelated external failures remain visible and the report uploads. | DONE   | [Run 34578523069](https://github.com/torrust/torrust-tracker/actions/runs/34578523069) on `427b0c93`: 476 excluded, 52 remaining errors, no C1/C9 matches, and a retained 1,743-byte report artifact. |
+| M4  | Verify exclusion boundaries    | Dispatch the hosted workflow after adding a proposed exclusion.                                               | The intended durable false-positive category is absent, while representative unrelated external failures remain visible and the report uploads. | DONE   | C1/C9: [run 34578523069](https://github.com/torrust/torrust-tracker/actions/runs/34578523069) on `427b0c93` excluded 476 links and retained its report. C2: [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439) on `f6df96bf` excluded 495 links, left 44 errors, retained a 1,533-byte artifact, and contained no loopback URLs. |
 | M5  | Distinguish transient failures | Re-run a newly observed timeout, 403, or other potentially transient result once.                             | The record distinguishes a persistent failure from a transient response before an exclusion or repair decision.                                 | TODO   | Pair of hosted-run URLs and comparison.                                                                                              |
 
 ### Acceptance Verification
@@ -174,9 +175,9 @@ Status values: `TODO`, `IN_PROGRESS`, `DONE`, `FAILED`, `BLOCKED`.
 | ----- | ---------------------- | ----------------------------------------------------------------- |
 | AC1   | DONE                   | `external-link-baseline.md` from run 34347690674.                 |
 | AC2   | TODO                   | Reviewed reference-repair commits and target evidence.            |
-| AC3   | TODO                   | C1/C9 is hosted-verified; C2 awaits a hosted boundary rerun.      |
+| AC3   | DONE                   | C1/C9 and C2 hosted runs show each exact exclusion remains narrow. |
 | AC4   | DONE                   | Run 34578523069 failed visibly and uploaded its report artifact.  |
-| AC5   | TODO                   | C1/C9 run 34578523069 is recorded; C2 awaits a hosted rerun.     |
+| AC5   | DONE                   | Runs 34578523069 and 34616458439 record each exclusion slice.     |
 | AC6   | TODO                   | Updated documentation and reviewer confirmation.                  |
 
 ## Risks and Trade-offs

--- a/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/agent-review-reports.md
+++ b/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/agent-review-reports.md
@@ -29,6 +29,20 @@ semantic-links:
   - Commit and review the hosted-verification evidence without closing issue #2185.
   - Continue with the next independently reviewable category after the evidence is merged.
 
+### 2026-09-11 15:50 UTC - Task Reviewer
+
+- Invocation scope: Read-only review of C2 hosted-verification evidence in `ISSUE.md` and `external-link-baseline.md`.
+- Inputs: GitHub Actions [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439), its downloaded report artifact, and the merged online configuration.
+- Evidence: The run completed with a visible Lychee failure on `f6df96bf1ad59812db47457b84dcd5926c267c61`; `Upload Lychee Report` succeeded. The unexpired `lychee-external-link-report` artifact is 1,533 bytes and expires on 2026-09-25. Its report records 1,857 total checks, 1,318 successes, 25 redirects, 495 exclusions, 44 errors, and no timeouts. No `localhost`, `127.0.0.1`, or exact `#discussion_r` pull-request review-comment URL remained, while unrelated `404`, `403`, FSF transport, issue-comment, pull-request-review, and other missing-fragment failures remained visible.
+- Findings:
+  - Resolved: C2 loopback filtering is hosted-verified and remains narrow.
+  - Resolved: T3, AC3, AC5, and M4 can be complete for the C1/C9+C2 exclusion slices.
+  - Pending: Keep issue #2185 open for C3-C8, AC2/AC6, final quality/manual evidence, acceptance re-review, and completion review.
+- Verdict: REVIEW PASSED.
+- Follow-up actions:
+  - Commit and review the C2 hosted-verification evidence without closing issue #2185.
+  - Continue with the next independently reviewable category after the evidence is merged.
+
 ### 2026-09-11 09:42 UTC - Task Reviewer
 
 - Invocation scope: Independent review of the uncommitted C2 loopback-exclusion slice for issue #2185 in `.github/lychee-online.toml`, `ISSUE.md`, and `external-link-baseline.md`.

--- a/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md
+++ b/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md
@@ -45,7 +45,7 @@ The following nine categories cover all 461 report errors. C1 and C9 share one p
 
     - **Pattern:** `localhost` or `127.0.0.1` service URLs with connection-refused or cached diagnostics.
     - **Disposition:** Resolved with online-only `exclude_loopback = true`. These intentional local configuration and debugging examples cannot resolve on a GitHub-hosted runner.
-    - **Next action:** Complete. The local boundary test excluded `127.0.0.1` and `localhost` while checking `https://www.rust-lang.org/` successfully. Hosted [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439) excluded 495 links and contained no loopback URLs while retaining 44 unrelated errors and its report artifact.
+    - **Next action:** Complete. The local boundary test excluded `127.0.0.1` and `localhost` while checking `https://www.rust-lang.org/` successfully. Hosted [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439) excluded 495 links; its remaining failures contained no loopback URLs because Lychee excluded them, while retaining 44 unrelated errors and its report artifact.
 
 ### C3: Unavailable docs.rs crate pages — 14 occurrences
 

--- a/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md
+++ b/docs/issues/open/2185-2003-triage-advisory-external-link-check-findings/external-link-baseline.md
@@ -44,8 +44,8 @@ The following nine categories cover all 461 report errors. C1 and C9 share one p
 ### C2: Local service examples — 7 occurrences
 
     - **Pattern:** `localhost` or `127.0.0.1` service URLs with connection-refused or cached diagnostics.
-    - **Disposition:** Online-only `exclude_loopback = true` candidate. These intentional local configuration and debugging examples cannot resolve on a GitHub-hosted runner.
-    - **Next action:** Local boundary verification is complete: an explicit online configuration excluded `127.0.0.1` and `localhost` while checking `https://www.rust-lang.org/` successfully. Verify the hosted report removes C2 while retaining unrelated failures and its artifact.
+    - **Disposition:** Resolved with online-only `exclude_loopback = true`. These intentional local configuration and debugging examples cannot resolve on a GitHub-hosted runner.
+    - **Next action:** Complete. The local boundary test excluded `127.0.0.1` and `localhost` while checking `https://www.rust-lang.org/` successfully. Hosted [run 34616458439](https://github.com/torrust/torrust-tracker/actions/runs/34616458439) excluded 495 links and contained no loopback URLs while retaining 44 unrelated errors and its report artifact.
 
 ### C3: Unavailable docs.rs crate pages — 14 occurrences
 


### PR DESCRIPTION
## Summary

- records upstream hosted verification for the C2 loopback/localhost exclusion
- confirms loopback and C1/C9 review anchors are absent while unrelated errors remain visible
- records retained report-artifact evidence and an independent review

## Validation

- `linter markdown`
- `linter cspell`
- `linter lychee`
- `./contrib/dev-tools/git/hooks/pre-commit.sh`
- `./contrib/dev-tools/git/hooks/pre-push.sh`

Related to #2185
Related to #2003
